### PR TITLE
docs: add phased pwa briefs and prompt-quality gate

### DIFF
--- a/docs/task-brief-template.md
+++ b/docs/task-brief-template.md
@@ -3,6 +3,32 @@
 Use this template when requesting coding work from an agent.
 Save new briefs in `docs/task-briefs/planned/` with date-based filenames.
 
+## Prompt Quality Gate (before sending to Codex)
+
+Use this quick check so the task execution is precise:
+
+- Reference exact brief path (for example `docs/task-briefs/planned/YYYY-MM-DD-xxx.md`)
+- State execution mode (`end-to-end` or `plan only`)
+- State deliverables (implementation, tests, commit, push, PR handoff)
+- State communication style (for example: one step at a time for manual GitHub actions)
+- State non-negotiables (no secrets in repo, UX quality bar, performance guardrails)
+
+Suggested prompt wrapper:
+
+```md
+Use task brief: <PATH_TO_BRIEF>
+Mode: end-to-end (implement + tests + commit + push on current branch)
+Communication: one manual step at a time; wait for my "done" between manual GitHub/UI steps.
+Handoff must include:
+
+1. what changed
+2. test evidence
+3. PR URL
+4. direct merge URL
+5. post-merge local sync commands
+   Do not store secret values in repo files.
+```
+
 ## Metadata
 
 - `id`: `YYYY-MM-DD-short-title`

--- a/docs/task-briefs/planned/2026-02-15-pwa-foundation-install-and-app-shell.md
+++ b/docs/task-briefs/planned/2026-02-15-pwa-foundation-install-and-app-shell.md
@@ -1,0 +1,99 @@
+# Task Brief: PWA Foundation, Install, and App Shell
+
+## Metadata
+
+- `id`: `2026-02-15-pwa-foundation-install-and-app-shell`
+- `status`: `planned`
+- `owner`: `stianvikra`
+- `created`: `2026-02-15`
+- `updated`: `2026-02-15`
+
+## Goal
+
+FreeSwimming should have a production-grade PWA baseline: installable on supported platforms, consistent install UX, and a reliable app-shell/offline fallback foundation.
+
+## Scope
+
+- Validate and harden web app manifest contract:
+  - stable app identity (`name`, `short_name`, `start_url`, `scope`, `display`, theme/background colors),
+  - icon set quality (maskable + Apple touch icon),
+  - metadata consistency across mobile and desktop install surfaces.
+- Upgrade service worker from lifecycle-only to baseline app-shell strategy:
+  - versioned cache namespace,
+  - pre-cache essential shell assets and an offline fallback route,
+  - safe cleanup of outdated caches on activate.
+- Add a branded offline fallback experience:
+  - clear headline,
+  - short explanation,
+  - primary recovery CTA (`Try again`),
+  - secondary navigation CTA back to key app routes.
+- Define a minimum safe fallback contract for runtime failures:
+  - never show blank/white screen for `network fail + cache miss`,
+  - always route to a usable offline fallback surface,
+  - keep next action obvious (`Try again`, `Home`, `Menu`).
+- Align install entry UX across:
+  - contextual install prompt,
+  - persistent menu install action,
+  - mobile and desktop copy consistency.
+- Ensure installed-state behavior is explicit:
+  - no repeated install nudges when already installed,
+  - clear "already installed" feedback in menu/prompt surfaces.
+- Add/update automated tests for:
+  - manifest contract,
+  - service worker registration,
+  - install entry availability and installed-state behavior,
+  - offline fallback visibility when network is unavailable.
+  - safe fallback behavior after cache/storage removal.
+
+## Out Of Scope
+
+- No background sync queueing.
+- No push notifications.
+- No deep offline-first data rewrite for all dynamic content.
+- No analytics vendor migration.
+
+## Acceptance Criteria
+
+- Installability checks pass on supported browsers (manifest + service worker + HTTPS preview).
+- Offline fallback page is reachable and usable when network is unavailable.
+- Core shell routes render without crash in offline mode after first successful load.
+- If cache is missing (or was cleared), users see fallback UI and recovery actions, not a broken page.
+- Install action surfaces remain accessible and consistent on mobile and desktop.
+- Installed users do not see repetitive install prompts.
+- Actions that require server confirmation do not show permanent success if the network/server is unavailable.
+- No measurable regression in Core Web Vitals or perceived page responsiveness.
+- Unit + e2e tests covering manifest/install/offline behavior are green.
+
+## Validation
+
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test:unit`
+- `npm run test:e2e`
+- `npm run build`
+
+## Manual QA Environments
+
+- Local dev URL (for example `http://127.0.0.1:3000`):
+  - iOS Safari,
+  - Android Chromium,
+  - Desktop Chrome,
+  - Desktop Safari.
+- Vercel preview URL from PR checks:
+  - repeat same install/offline smoke flow on at least one mobile + one desktop browser.
+- Storage-eviction checks (required):
+  - clear website data/cache and verify fallback UX remains usable,
+  - verify app recovers correctly after reconnect/reload.
+
+## Constraints
+
+- Keep install UX non-intrusive and aligned with current FreeSwimming design language.
+- Keep runtime overhead low (small service worker footprint and predictable caching rules).
+- Keep all copy concise and plain-language.
+- Treat server state as source of truth; local cache is performance/offline support only.
+
+## Completion Record (fill when done)
+
+- `PR`: link to merged PR
+- `merge`: source branch -> target branch
+- `result`: short outcome summary

--- a/docs/task-briefs/planned/2026-02-15-pwa-hardening-release-and-observability.md
+++ b/docs/task-briefs/planned/2026-02-15-pwa-hardening-release-and-observability.md
@@ -1,0 +1,93 @@
+# Task Brief: PWA Hardening, Release Gate, and Observability
+
+## Metadata
+
+- `id`: `2026-02-15-pwa-hardening-release-and-observability`
+- `status`: `planned`
+- `owner`: `stianvikra`
+- `created`: `2026-02-15`
+- `updated`: `2026-02-15`
+
+## Goal
+
+PWA quality should be release-safe and repeatable: strong QA gates, measurable outcomes, and a rollback-ready workflow for production.
+
+## Scope
+
+- Define a PWA release quality gate in docs/checklists:
+  - install flow verified,
+  - offline fallback verified,
+  - cache-eviction fallback verified (clear storage -> no blank state),
+  - write-action integrity verified under offline/weak-network conditions,
+  - cross-browser/device matrix verified,
+  - accessibility pass for changed surfaces.
+- Add CI-friendly PWA smoke checks where practical:
+  - manifest contract validation,
+  - service worker/offline response smoke checks,
+  - install surface regression checks in e2e.
+- Establish manual QA matrix for production readiness:
+  - iOS Safari,
+  - Android Chromium,
+  - Desktop Safari,
+  - Desktop Chrome/Edge,
+  - optional tablet regression pass for nav/layout.
+- Add observability hooks (if existing analytics hooks already exist):
+  - install entry viewed,
+  - install action clicked,
+  - install result,
+  - offline fallback shown,
+  - cache-miss fallback shown,
+  - write action blocked/retry shown due to offline state.
+- Define rollout and rollback steps:
+  - release checklist,
+  - fast disable path for problematic prompt behavior,
+  - post-release verification checklist.
+
+## Out Of Scope
+
+- No new analytics vendor procurement.
+- No legal/privacy policy rewrite (unless new tracking requirements force it).
+- No major UI redesign outside PWA-related surfaces.
+
+## Acceptance Criteria
+
+- PWA quality gate is documented and used in PR/release flow.
+- CI and manual QA together catch install/offline regressions before merge.
+- Release checklist explicitly includes storage-clear/cache-eviction scenario and expected fallback behavior.
+- Team has one clear rollback procedure for PWA-facing regressions.
+- Observability events are documented and emitted (or explicitly deferred with reason).
+- Post-merge runbook includes local sync and verification steps.
+- Manual QA evidence always states tested URL, browser/device, and fallback outcome.
+
+## Validation
+
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test:unit`
+- `npm run test:e2e`
+- `npm run build`
+
+## Manual QA Environments
+
+- Local dev URL:
+  - full changed-flow verification,
+  - at least one mobile + one desktop browser.
+- Vercel preview URL:
+  - repeat changed-flow verification in production-like environment before merge.
+- Required scenario coverage:
+  - normal online flow,
+  - offline flow with cached content,
+  - offline flow with cache cleared (fallback path),
+  - reconnect recovery.
+
+## Constraints
+
+- Keep release process lightweight enough for frequent iteration.
+- Keep requirements explicit and binary (pass/fail), not vague.
+- Never store secret values in repo docs; document names only.
+
+## Completion Record (fill when done)
+
+- `PR`: link to merged PR
+- `merge`: source branch -> target branch
+- `result`: short outcome summary

--- a/docs/task-briefs/planned/2026-02-15-pwa-offline-resilience-and-data-strategy.md
+++ b/docs/task-briefs/planned/2026-02-15-pwa-offline-resilience-and-data-strategy.md
@@ -1,0 +1,92 @@
+# Task Brief: PWA Offline Resilience and Data Strategy
+
+## Metadata
+
+- `id`: `2026-02-15-pwa-offline-resilience-and-data-strategy`
+- `status`: `planned`
+- `owner`: `stianvikra`
+- `created`: `2026-02-15`
+- `updated`: `2026-02-15`
+
+## Goal
+
+Learners should get a reliable offline and weak-network experience for core learning flows, with clear status feedback and zero confusion about what is available offline.
+
+## Scope
+
+- Define and implement explicit caching policy by content type:
+  - app shell/static assets,
+  - course/lesson read content,
+  - API responses with safe caching rules.
+- Add deterministic cache strategy per bucket:
+  - `cache-first` for immutable static assets,
+  - `stale-while-revalidate` for low-risk read content,
+  - `network-first` for mutable or sensitive responses.
+- Add user-facing connection and availability feedback:
+  - lightweight online/offline indicator,
+  - clear copy when action requires network,
+  - no blocking or noisy banners.
+- Ensure safe failure behavior:
+  - if offline and content is not cached, show useful fallback with next-best action,
+  - avoid broken/blank states.
+- Add explicit write-safety contract for network-dependent actions:
+  - do not show permanent "saved/done" state until server confirms,
+  - show clear retry path when offline/server unavailable,
+  - keep local UI state honest about sync status.
+- Define cache invalidation/version rules for each release.
+- Add/update tests for:
+  - offline navigation to cached content,
+  - fallback behavior for uncached routes,
+  - online->offline transitions without UI breakage.
+  - behavior after cache/storage is manually cleared.
+
+## Out Of Scope
+
+- No push notifications.
+- No background sync for write operations unless explicitly approved in separate task.
+- No auth/session architecture changes.
+
+## Acceptance Criteria
+
+- Core learner path can be completed in weak/offline mode for already-cached content.
+- Users always understand whether they are offline and what they can do next.
+- Uncached pages show graceful fallback instead of hard errors.
+- Cache deletion/eviction does not break app flow; fallback appears and recovery path is clear.
+- Cache behavior is deterministic and documented.
+- No stale-cache bugs after release (old cache versions are cleaned up safely).
+- Network-dependent actions never end in false-success UI.
+- No visible performance regression in normal online browsing.
+- Unit + e2e coverage for offline transition and fallback paths are green.
+
+## Validation
+
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test:unit`
+- `npm run test:e2e`
+- `npm run build`
+
+## Manual QA Environments
+
+- Local dev URL:
+  - browser devtools offline simulation (desktop Chrome/Safari),
+  - iOS Safari manual network toggling,
+  - Android Chromium manual network toggling.
+- Vercel preview:
+  - repeat offline/weak-network checks on at least one mobile and one desktop browser.
+- Required eviction QA:
+  - clear browser website data/cache, reload while offline, verify fallback path,
+  - reconnect and verify normal state restoration.
+
+## Constraints
+
+- Keep UX calm and confidence-building (no alarmist copy).
+- Do not cache sensitive/private response bodies by default.
+- Keep cache strategy maintainable and easy to reason about.
+- Server remains source of truth for completion/progress state.
+
+## Completion Record (fill when done)
+
+- `PR`: link to merged PR
+- `merge`: source branch -> target branch
+- `result`: short outcome summary


### PR DESCRIPTION
## Summary

- What changed and why?

## Scope

- In scope:
- Out of scope:

## Risk

- Main risk:
- Rollback plan:

## Test Evidence

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
