### PR TITLE
feat(my-library): guest progress, recovery, plans, billing, and interactive guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,7 @@ STRIPE_WEBHOOK_SECRET=
 STRIPE_PRICE_ID_0_1000M_GUIDE=
 STRIPE_PRICE_ID_POOLSIDE_GUIDE=
 STRIPE_PRICE_ID_ANALYSIS=
+
+# Optional server-only path override for protected 0-1000m PDF asset.
+# Must be a safe repo-relative .pdf path (default: assets/guides/0-1000m-guide.pdf)
+GUIDE_0_TO_1000M_PDF_ASSET_PATH=

--- a/app/api/download/resend/route.ts
+++ b/app/api/download/resend/route.ts
@@ -1,0 +1,351 @@
+import { createHash } from "node:crypto";
+import { NextResponse } from "next/server";
+import { createAdminSupabaseClient } from "@/lib/supabase/admin";
+import { getAppUrl } from "@/lib/supabase/env";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import {
+  getSafeDownloadResendNextPath,
+  isValidResendEmail,
+  normalizeResendEmail,
+  RESEND_DOWNLOAD_GENERIC_MESSAGE,
+  toDownloadResendSource,
+} from "@/lib/commerce/download-resend";
+
+type ResendBody = {
+  email?: string;
+  nextPath?: string;
+  source?: string;
+};
+
+type RateLimitRule = {
+  key: string;
+  max: number;
+  windowMs: number;
+};
+
+type RateLimitResult =
+  | {
+      ok: true;
+      remaining: number;
+      resetAt: number;
+    }
+  | {
+      ok: false;
+      remaining: number;
+      resetAt: number;
+      retryAfterMs: number;
+    };
+
+const RESEND_IP_WINDOW_MS = 10 * 60_000;
+const RESEND_IP_MAX = 10;
+const RESEND_EMAIL_WINDOW_MS = 30 * 60_000;
+const RESEND_EMAIL_MAX = 5;
+
+const resendHits = new Map<string, { count: number; resetAt: number }>();
+let hasLoggedUpstashFallback = false;
+
+const GENERIC_OK_BODY = {
+  ok: true,
+  message: RESEND_DOWNLOAD_GENERIC_MESSAGE,
+};
+
+function jsonNoStore(
+  body: unknown,
+  init?: Omit<ResponseInit, "headers"> & { headers?: HeadersInit }
+) {
+  const headers = new Headers(init?.headers);
+  headers.set("Cache-Control", "no-store");
+  return NextResponse.json(body, { ...init, headers });
+}
+
+function splitHeaderValue(value: string | null): string[] {
+  return (value ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function getClientIp(request: Request): string {
+  const forwarded = splitHeaderValue(request.headers.get("x-forwarded-for"))[0];
+  if (forwarded) return forwarded;
+
+  const real = request.headers.get("x-real-ip")?.trim();
+  if (real) return real;
+
+  const cloudflare = request.headers.get("cf-connecting-ip")?.trim();
+  if (cloudflare) return cloudflare;
+
+  return "unknown";
+}
+
+function getEmailHash(email: string): string {
+  return createHash("sha256").update(email).digest("hex").slice(0, 32);
+}
+
+function shouldUseUpstash(): boolean {
+  return (
+    Boolean(process.env.UPSTASH_REDIS_REST_URL) && Boolean(process.env.UPSTASH_REDIS_REST_TOKEN)
+  );
+}
+
+function logUpstashFallbackOnce(error: unknown) {
+  if (hasLoggedUpstashFallback) return;
+  hasLoggedUpstashFallback = true;
+  console.error("[DownloadResend] Upstash rate limit failed. Falling back to in-memory.", error);
+}
+
+async function upstashCommand(parts: string[]) {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+
+  const endpoint = `${url.replace(/\/+$/, "")}/${parts.map((part) => encodeURIComponent(part)).join("/")}`;
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`Upstash command failed (${response.status}) ${text}`);
+  }
+
+  const json = (await response.json().catch(() => null)) as { result?: unknown } | null;
+  return json?.result ?? null;
+}
+
+function rateLimitInMemory(rule: RateLimitRule): RateLimitResult {
+  const now = Date.now();
+  const existing = resendHits.get(rule.key);
+
+  if (!existing || existing.resetAt <= now) {
+    const resetAt = now + rule.windowMs;
+    resendHits.set(rule.key, { count: 1, resetAt });
+    return { ok: true, remaining: Math.max(0, rule.max - 1), resetAt };
+  }
+
+  if (existing.count >= rule.max) {
+    const retryAfterMs = Math.max(1, existing.resetAt - now);
+    return { ok: false, remaining: 0, resetAt: existing.resetAt, retryAfterMs };
+  }
+
+  existing.count += 1;
+  resendHits.set(rule.key, existing);
+  return {
+    ok: true,
+    remaining: Math.max(0, rule.max - existing.count),
+    resetAt: existing.resetAt,
+  };
+}
+
+async function rateLimit(rule: RateLimitRule): Promise<RateLimitResult> {
+  if (!shouldUseUpstash()) {
+    return rateLimitInMemory(rule);
+  }
+
+  try {
+    const countRaw = await upstashCommand(["INCR", rule.key]);
+    const count = Number(countRaw);
+    if (!Number.isFinite(count)) {
+      throw new Error("Invalid INCR response");
+    }
+
+    let ttlMs = Number(await upstashCommand(["PTTL", rule.key]));
+    if (!Number.isFinite(ttlMs) || ttlMs < 0 || count === 1) {
+      await upstashCommand(["PEXPIRE", rule.key, String(rule.windowMs)]);
+      ttlMs = rule.windowMs;
+    }
+
+    const resetAt = Date.now() + Math.max(1, ttlMs);
+    if (count > rule.max) {
+      return {
+        ok: false,
+        remaining: 0,
+        resetAt,
+        retryAfterMs: Math.max(1, ttlMs),
+      };
+    }
+
+    return {
+      ok: true,
+      remaining: Math.max(0, rule.max - count),
+      resetAt,
+    };
+  } catch (error) {
+    logUpstashFallbackOnce(error);
+    return rateLimitInMemory(rule);
+  }
+}
+
+async function enforceRateLimitSet(rules: RateLimitRule[]) {
+  const results = await Promise.all(rules.map((rule) => rateLimit(rule)));
+  const blocked = results.filter(
+    (result): result is Extract<RateLimitResult, { ok: false }> => !result.ok
+  );
+  const minRemaining = Math.min(...results.map((result) => result.remaining));
+  const maxResetAt = Math.max(...results.map((result) => result.resetAt));
+
+  if (blocked.length === 0) {
+    return { ok: true as const, remaining: Math.max(0, minRemaining), resetAt: maxResetAt };
+  }
+
+  const retryAfterMs = Math.max(...blocked.map((result) => result.retryAfterMs));
+  return {
+    ok: false as const,
+    remaining: 0,
+    resetAt: maxResetAt,
+    retryAfterMs,
+  };
+}
+
+function getRetryAfterSeconds(retryAfterMs: number): number {
+  return Math.max(1, Math.ceil(retryAfterMs / 1000));
+}
+
+function getRequestOrigin(request: Request): string {
+  const headerOrigin = request.headers.get("origin");
+  if (!headerOrigin) return getAppUrl();
+
+  try {
+    const parsed = new URL(headerOrigin);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return getAppUrl();
+    }
+
+    return parsed.origin;
+  } catch {
+    return getAppUrl();
+  }
+}
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    return jsonNoStore({ ok: false, error: "Unsupported content type." }, { status: 415 });
+  }
+
+  let body: ResendBody;
+  try {
+    body = (await request.json()) as ResendBody;
+  } catch {
+    return jsonNoStore({ ok: false, error: "Invalid JSON." }, { status: 400 });
+  }
+
+  const email = normalizeResendEmail(String(body.email ?? ""));
+  if (!email || !isValidResendEmail(email)) {
+    return jsonNoStore({ ok: false, error: "Enter a valid email address." }, { status: 400 });
+  }
+
+  const source = toDownloadResendSource(body.source);
+  const nextPath = getSafeDownloadResendNextPath(body.nextPath);
+  const emailHash = getEmailHash(email);
+  const clientIp = getClientIp(request);
+  const limitResult = await enforceRateLimitSet([
+    {
+      key: `rate:download:resend:ip:${clientIp}`,
+      max: RESEND_IP_MAX,
+      windowMs: RESEND_IP_WINDOW_MS,
+    },
+    {
+      key: `rate:download:resend:email:${emailHash}`,
+      max: RESEND_EMAIL_MAX,
+      windowMs: RESEND_EMAIL_WINDOW_MS,
+    },
+  ]);
+
+  const rateHeaders = {
+    "X-RateLimit-Limit": String(Math.min(RESEND_IP_MAX, RESEND_EMAIL_MAX)),
+    "X-RateLimit-Remaining": String(limitResult.remaining),
+    "X-RateLimit-Reset": String(Math.floor(limitResult.resetAt / 1000)),
+  };
+
+  if (!limitResult.ok) {
+    const retryAfter = getRetryAfterSeconds(limitResult.retryAfterMs);
+    return jsonNoStore(
+      { ok: false, error: "Too many requests. Please try again shortly." },
+      {
+        status: 429,
+        headers: {
+          ...rateHeaders,
+          "Retry-After": String(retryAfter),
+        },
+      }
+    );
+  }
+
+  try {
+    const adminSupabase = createAdminSupabaseClient();
+    const { data: entitlement, error: entitlementError } = await adminSupabase
+      .from("entitlements")
+      .select("id")
+      .eq("purchaser_email", email)
+      .limit(1)
+      .maybeSingle();
+
+    if (entitlementError) {
+      console.error("[DownloadResend] Could not check entitlement by email", {
+        source,
+        emailHash,
+        error: entitlementError.message,
+      });
+      return jsonNoStore(GENERIC_OK_BODY, { headers: rateHeaders });
+    }
+
+    if (!entitlement) {
+      console.info("[DownloadResend] No entitlement match for resend request", {
+        source,
+        emailHash,
+      });
+      return jsonNoStore(GENERIC_OK_BODY, { headers: rateHeaders });
+    }
+
+    const origin = getRequestOrigin(request);
+    const emailRedirectTo = `${origin}/auth/callback?next=${encodeURIComponent(nextPath)}`;
+    const supabase = await createServerSupabaseClient();
+    const { error: otpError } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo,
+        shouldCreateUser: true,
+      },
+    });
+
+    if (otpError) {
+      const isRateLimited = otpError.message.toLowerCase().includes("rate limit");
+      if (isRateLimited) {
+        return jsonNoStore(
+          { ok: false, error: "Too many requests. Please try again shortly." },
+          {
+            status: 429,
+            headers: {
+              ...rateHeaders,
+              "Retry-After": "60",
+            },
+          }
+        );
+      }
+
+      console.error("[DownloadResend] Could not send access link", {
+        source,
+        emailHash,
+        message: otpError.message,
+      });
+      return jsonNoStore(GENERIC_OK_BODY, { headers: rateHeaders });
+    }
+
+    console.info("[DownloadResend] Access link sent", {
+      source,
+      emailHash,
+      nextPath,
+    });
+    return jsonNoStore(GENERIC_OK_BODY, { headers: rateHeaders });
+  } catch (error) {
+    console.error("[DownloadResend] Unexpected resend failure", { source, emailHash, error });
+    return jsonNoStore(GENERIC_OK_BODY, { headers: rateHeaders });
+  }
+}

--- a/app/api/guides/0-1000m/pdf/route.ts
+++ b/app/api/guides/0-1000m/pdf/route.ts
@@ -1,0 +1,83 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { NextResponse } from "next/server";
+import { attachGuestEntitlementsByEmail } from "@/lib/commerce/entitlements";
+import {
+  getGuide0To1000PdfAssetPath,
+  GUIDE_0_TO_1000M_PDF_DOWNLOAD_FILENAME,
+  GUIDE_0_TO_1000M_PRODUCT_ID,
+} from "@/lib/guides/guide-0-1000m";
+import { createAdminSupabaseClient } from "@/lib/supabase/admin";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function jsonNoStore(body: unknown, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export async function GET() {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return jsonNoStore({ ok: false, error: "Unauthorized." }, 401);
+  }
+
+  if (user.email) {
+    try {
+      const adminSupabase = createAdminSupabaseClient();
+      await attachGuestEntitlementsByEmail(adminSupabase, user.id, user.email);
+    } catch (error) {
+      console.error("[GuidePdfApi] Could not attach guest entitlements", error);
+    }
+  }
+
+  const { data: entitlement, error: entitlementError } = await supabase
+    .from("entitlements")
+    .select("id")
+    .eq("product_id", GUIDE_0_TO_1000M_PRODUCT_ID)
+    .eq("user_id", user.id)
+    .limit(1)
+    .maybeSingle();
+
+  if (entitlementError) {
+    console.error("[GuidePdfApi] Could not load entitlement", entitlementError);
+    return jsonNoStore({ ok: false, error: "Could not verify access." }, 500);
+  }
+
+  if (!entitlement) {
+    return jsonNoStore({ ok: false, error: "Guide access required." }, 403);
+  }
+
+  const relativePath = getGuide0To1000PdfAssetPath();
+  const absolutePath = path.join(process.cwd(), relativePath);
+
+  try {
+    const pdfBuffer = await readFile(absolutePath);
+    return new NextResponse(new Uint8Array(pdfBuffer), {
+      status: 200,
+      headers: {
+        "Cache-Control": "private, no-store",
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="${GUIDE_0_TO_1000M_PDF_DOWNLOAD_FILENAME}"`,
+        "Content-Length": String(pdfBuffer.byteLength),
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  } catch (error) {
+    console.error("[GuidePdfApi] Could not load PDF asset", { relativePath, error });
+    return jsonNoStore(
+      { ok: false, error: "PDF is temporarily unavailable. Please try again shortly." },
+      503
+    );
+  }
+}

--- a/app/api/portal/route.ts
+++ b/app/api/portal/route.ts
@@ -1,0 +1,152 @@
+import { NextResponse } from "next/server";
+import type Stripe from "stripe";
+import { attachGuestEntitlementsByEmail, normalizeEmail } from "@/lib/commerce/entitlements";
+import { getSafePortalReturnPath, pickActiveStripeCustomerId } from "@/lib/commerce/portal";
+import { createAdminSupabaseClient } from "@/lib/supabase/admin";
+import { getAppUrl } from "@/lib/supabase/env";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { createStripeClient } from "@/lib/stripe/server";
+
+type PortalBody = {
+  returnPath?: string;
+};
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function jsonNoStore(body: unknown, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+async function resolveStripeCustomerId(params: {
+  stripe: Stripe;
+  supabase: Awaited<ReturnType<typeof createServerSupabaseClient>>;
+  userId: string;
+  userEmail: string | null;
+}): Promise<string | null> {
+  const { stripe, supabase, userId, userEmail } = params;
+
+  const { data: entitlementWithCustomer, error: entitlementError } = await supabase
+    .from("entitlements")
+    .select("stripe_customer_id")
+    .eq("user_id", userId)
+    .not("stripe_customer_id", "is", null)
+    .order("granted_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (entitlementError) {
+    throw new Error(`Could not resolve entitlement customer id: ${entitlementError.message}`);
+  }
+
+  const existingCustomerId = entitlementWithCustomer?.stripe_customer_id?.trim();
+  if (existingCustomerId) {
+    return existingCustomerId;
+  }
+
+  const normalizedEmail = userEmail ? normalizeEmail(userEmail) : "";
+  if (!normalizedEmail) {
+    return null;
+  }
+
+  const customers = await stripe.customers.list({
+    email: normalizedEmail,
+    limit: 10,
+  });
+
+  const fallbackCustomerId = pickActiveStripeCustomerId(customers.data);
+  if (!fallbackCustomerId) {
+    return null;
+  }
+
+  // Best effort persistence for faster future portal opens.
+  const { error: persistError } = await supabase
+    .from("entitlements")
+    .update({ stripe_customer_id: fallbackCustomerId })
+    .eq("user_id", userId)
+    .is("stripe_customer_id", null);
+
+  if (persistError) {
+    console.error("[PortalApi] Could not persist stripe_customer_id fallback", persistError);
+  }
+
+  return fallbackCustomerId;
+}
+
+export async function POST(request: Request) {
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    return jsonNoStore({ ok: false, error: "Unsupported content type." }, 415);
+  }
+
+  let body: PortalBody;
+  try {
+    body = (await request.json()) as PortalBody;
+  } catch {
+    return jsonNoStore({ ok: false, error: "Invalid JSON." }, 400);
+  }
+
+  const returnPath = getSafePortalReturnPath(body.returnPath, "/my-library");
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return jsonNoStore({ ok: false, error: "Unauthorized." }, 401);
+  }
+
+  if (user.email) {
+    try {
+      const adminSupabase = createAdminSupabaseClient();
+      await attachGuestEntitlementsByEmail(adminSupabase, user.id, user.email);
+    } catch (error) {
+      console.error("[PortalApi] Could not attach guest entitlements by email", error);
+    }
+  }
+
+  try {
+    const stripe = createStripeClient();
+    const customerId = await resolveStripeCustomerId({
+      stripe,
+      supabase,
+      userId: user.id,
+      userEmail: user.email ?? null,
+    });
+
+    if (!customerId) {
+      return jsonNoStore(
+        {
+          ok: false,
+          error: "No Stripe billing account found for this user.",
+        },
+        404
+      );
+    }
+
+    const portalSession = await stripe.billingPortal.sessions.create({
+      customer: customerId,
+      return_url: new URL(returnPath, getAppUrl()).toString(),
+    });
+
+    if (!portalSession.url) {
+      return jsonNoStore(
+        {
+          ok: false,
+          error: "Could not create billing portal session.",
+        },
+        500
+      );
+    }
+
+    return jsonNoStore({ ok: true, url: portalSession.url });
+  } catch (error) {
+    console.error("[PortalApi] Could not create billing portal session", error);
+    return jsonNoStore({ ok: false, error: "Could not create billing portal session." }, 500);
+  }
+}

--- a/app/api/progress/course/route.ts
+++ b/app/api/progress/course/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from "next/server";
+import {
+  MAX_COURSE_PROGRESS_ROWS,
+  normalizeCourseProgressRows,
+  type CourseProgressRow,
+} from "@/lib/course/progress";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+type ProgressBody = {
+  rows?: unknown;
+};
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function jsonNoStore(body: unknown, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+async function getSignedInUserId() {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  return { supabase, userId: user?.id ?? null };
+}
+
+function normalizeRowsForResponse(rows: unknown): CourseProgressRow[] {
+  return normalizeCourseProgressRows(rows, { maxRows: MAX_COURSE_PROGRESS_ROWS });
+}
+
+export async function GET() {
+  const { supabase, userId } = await getSignedInUserId();
+  if (!userId) {
+    return jsonNoStore({ ok: false, error: "Unauthorized." }, 401);
+  }
+
+  const { data, error } = await supabase
+    .from("course_progress")
+    .select("lesson_id, done, video_seconds, updated_at")
+    .eq("user_id", userId)
+    .order("updated_at", { ascending: false });
+
+  if (error) {
+    console.error("[CourseProgressApi] Could not load progress", error);
+    return jsonNoStore({ ok: false, error: "Could not load course progress." }, 500);
+  }
+
+  return jsonNoStore({
+    ok: true,
+    rows: normalizeRowsForResponse(data ?? []),
+  });
+}
+
+export async function POST(request: Request) {
+  const { supabase, userId } = await getSignedInUserId();
+  if (!userId) {
+    return jsonNoStore({ ok: false, error: "Unauthorized." }, 401);
+  }
+
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    return jsonNoStore({ ok: false, error: "Unsupported content type." }, 415);
+  }
+
+  let body: ProgressBody;
+  try {
+    body = (await request.json()) as ProgressBody;
+  } catch {
+    return jsonNoStore({ ok: false, error: "Invalid JSON." }, 400);
+  }
+
+  if (!Array.isArray(body.rows)) {
+    return jsonNoStore({ ok: false, error: "rows must be an array." }, 400);
+  }
+
+  if (body.rows.length > MAX_COURSE_PROGRESS_ROWS) {
+    return jsonNoStore(
+      {
+        ok: false,
+        error: `Too many rows. Max ${MAX_COURSE_PROGRESS_ROWS} rows per request.`,
+      },
+      413
+    );
+  }
+
+  const normalizedRows = normalizeRowsForResponse(body.rows);
+  if (normalizedRows.length === 0) {
+    return jsonNoStore({ ok: true, upserted: 0 });
+  }
+
+  const { error } = await supabase.from("course_progress").upsert(
+    normalizedRows.map((row) => ({
+      user_id: userId,
+      lesson_id: row.lessonId,
+      done: row.done,
+      video_seconds: row.videoSeconds,
+      updated_at: row.updatedAt,
+    })),
+    { onConflict: "user_id,lesson_id" }
+  );
+
+  if (error) {
+    console.error("[CourseProgressApi] Could not save progress", error);
+    return jsonNoStore({ ok: false, error: "Could not save course progress." }, 500);
+  }
+
+  return jsonNoStore({ ok: true, upserted: normalizedRows.length });
+}

--- a/app/api/progress/guide/route.ts
+++ b/app/api/progress/guide/route.ts
@@ -1,0 +1,116 @@
+import { NextResponse } from "next/server";
+import {
+  MAX_GUIDE_PROGRESS_ROWS,
+  normalizeGuideProgressRows,
+  type GuideProgressRow,
+} from "@/lib/course/guide-progress";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+type ProgressBody = {
+  rows?: unknown;
+};
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function jsonNoStore(body: unknown, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+async function getSignedInUserId() {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  return { supabase, userId: user?.id ?? null };
+}
+
+function normalizeRowsForResponse(rows: unknown): GuideProgressRow[] {
+  return normalizeGuideProgressRows(rows, { maxRows: MAX_GUIDE_PROGRESS_ROWS });
+}
+
+export async function GET() {
+  const { supabase, userId } = await getSignedInUserId();
+  if (!userId) {
+    return jsonNoStore({ ok: false, error: "Unauthorized." }, 401);
+  }
+
+  const { data, error } = await supabase
+    .from("guide_progress")
+    .select("guide_slug, section_id, completed, notes, updated_at")
+    .eq("user_id", userId)
+    .order("updated_at", { ascending: false });
+
+  if (error) {
+    console.error("[GuideProgressApi] Could not load guide progress", error);
+    return jsonNoStore({ ok: false, error: "Could not load guide progress." }, 500);
+  }
+
+  return jsonNoStore({
+    ok: true,
+    rows: normalizeRowsForResponse(data ?? []),
+  });
+}
+
+export async function POST(request: Request) {
+  const { supabase, userId } = await getSignedInUserId();
+  if (!userId) {
+    return jsonNoStore({ ok: false, error: "Unauthorized." }, 401);
+  }
+
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    return jsonNoStore({ ok: false, error: "Unsupported content type." }, 415);
+  }
+
+  let body: ProgressBody;
+  try {
+    body = (await request.json()) as ProgressBody;
+  } catch {
+    return jsonNoStore({ ok: false, error: "Invalid JSON." }, 400);
+  }
+
+  if (!Array.isArray(body.rows)) {
+    return jsonNoStore({ ok: false, error: "rows must be an array." }, 400);
+  }
+
+  if (body.rows.length > MAX_GUIDE_PROGRESS_ROWS) {
+    return jsonNoStore(
+      {
+        ok: false,
+        error: `Too many rows. Max ${MAX_GUIDE_PROGRESS_ROWS} rows per request.`,
+      },
+      413
+    );
+  }
+
+  const normalizedRows = normalizeRowsForResponse(body.rows);
+  if (normalizedRows.length === 0) {
+    return jsonNoStore({ ok: true, upserted: 0 });
+  }
+
+  const { error } = await supabase.from("guide_progress").upsert(
+    normalizedRows.map((row) => ({
+      user_id: userId,
+      guide_slug: row.guideSlug,
+      section_id: row.sectionId,
+      completed: row.completed,
+      notes: row.notes,
+      updated_at: row.updatedAt,
+    })),
+    { onConflict: "user_id,guide_slug,section_id" }
+  );
+
+  if (error) {
+    console.error("[GuideProgressApi] Could not save guide progress", error);
+    return jsonNoStore({ ok: false, error: "Could not save guide progress." }, 500);
+  }
+
+  return jsonNoStore({ ok: true, upserted: normalizedRows.length });
+}

--- a/app/checkout/success/page.tsx
+++ b/app/checkout/success/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import SiteChrome from "@/components/SiteChrome";
+import DownloadResendForm from "@/components/commerce/DownloadResendForm";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>;
 
@@ -13,12 +15,18 @@ export default async function CheckoutSuccessPage({ searchParams }: Props) {
   const params = await searchParams;
   const rawSessionId = typeof params.session_id === "string" ? params.session_id : "";
   const sessionId = rawSessionId.startsWith("{") ? "" : rawSessionId;
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const libraryHref = user ? "/my-library" : "/auth/sign-in?next=%2Fmy-library";
+  const libraryCta = user ? "Download from My Library" : "Sign in to My Library";
 
   return (
     <SiteChrome>
       <section className="mx-auto flex min-h-screen w-full max-w-[760px] items-center px-6 pb-16 pt-28">
         <div className="w-full rounded-3xl border border-blue-100 bg-white/95 p-8 shadow-[0_16px_60px_rgba(24,58,107,0.16)]">
-          <h1 className="text-3xl font-bold text-slate-900">Thanks, your purchase is processing</h1>
+          <h1 className="text-3xl font-bold text-slate-900">Thanks, your payment was received</h1>
           <p className="mt-3 text-sm leading-relaxed text-slate-600">
             We&apos;re confirming payment and adding access to My Library. This usually takes a few
             seconds.
@@ -26,10 +34,10 @@ export default async function CheckoutSuccessPage({ searchParams }: Props) {
 
           <div className="mt-6 flex flex-wrap gap-3">
             <Link
-              href="/my-library"
+              href={libraryHref}
               className="inline-flex h-11 items-center justify-center rounded-xl bg-blue-600 px-5 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700"
             >
-              Open My Library
+              {libraryCta}
             </Link>
             <Link
               href="/programs"
@@ -44,6 +52,20 @@ export default async function CheckoutSuccessPage({ searchParams }: Props) {
               Session reference: <span className="font-mono">{sessionId}</span>
             </p>
           ) : null}
+
+          <div className="mt-8 rounded-2xl border border-slate-200 bg-slate-50/60 p-4">
+            <h2 className="text-sm font-semibold text-slate-900">Need the access email again?</h2>
+            <p className="mt-2 text-xs leading-relaxed text-slate-600">
+              Use the same email you paid with. If that email has a purchase, we&apos;ll send a
+              secure access link to open your library.
+            </p>
+            <DownloadResendForm
+              initialEmail={user?.email ?? ""}
+              nextPath="/my-library"
+              source="checkout_success"
+              className="mt-3"
+            />
+          </div>
         </div>
       </section>
     </SiteChrome>

--- a/app/course/page.tsx
+++ b/app/course/page.tsx
@@ -29,7 +29,18 @@ import {
   parseStoredTimestamp,
   shouldShowAutoInstallPrompt,
 } from "@/components/install/install-rules";
+import {
+  areCourseProgressRowsEqual,
+  buildCourseProgressRowsFromLocal,
+  buildLocalCourseProgressFromRows,
+  mergeCourseProgressRows,
+  normalizeCourseProgressRows,
+  normalizeDoneLessonIds,
+  normalizeVideoProgressRecord,
+  type CourseProgressRow,
+} from "@/lib/course/progress";
 import { COURSE_LAST_LESSON_STORAGE_KEY } from "@/lib/course/resume";
+import { createBrowserSupabaseClient } from "@/lib/supabase/browser";
 
 import {
   COURSE_MODULES,
@@ -53,6 +64,11 @@ const SWIPE_DISTANCE_TO_NAVIGATE_PX = 78;
 const SWIPE_VERTICAL_CANCEL_PX = 24;
 const SWIPE_HINT_REVEAL_PX = 18;
 const A2HS_AUTO_PROMPT_ENABLED = process.env.NEXT_PUBLIC_FS_A2HS_AUTO_PROMPT_ENABLED !== "0";
+const COURSE_PROGRESS_SYNC_API_PATH = "/api/progress/course";
+const COURSE_PROGRESS_SYNC_INTERVAL_MS = 10_000;
+const BACKUP_PROMPT_DISMISSED_AT_KEY = "fs_course_backup_prompt_dismissed_at";
+const BACKUP_PROMPT_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
+const BACKUP_PROMPT_MIN_DONE_LESSONS = 3;
 const DEFAULT_PASS_CRITERIA = [
   "Complete 3 calm repetitions with the same cue.",
   "Breathing stays controlled without rushing.",
@@ -126,6 +142,21 @@ function isSwipeBlockedTarget(target: EventTarget | null) {
   );
 }
 
+function formatSyncStatusAgeLabel(timestampMs: number | null): string {
+  if (!timestampMs) return "Signed in. Progress sync is active.";
+  const ageMs = Math.max(0, Date.now() - timestampMs);
+  if (ageMs < 15_000) return "Synced to your account just now.";
+
+  const ageMinutes = Math.floor(ageMs / 60_000);
+  if (ageMinutes < 1) return "Synced to your account less than a minute ago.";
+  if (ageMinutes === 1) return "Synced to your account 1 minute ago.";
+  if (ageMinutes < 60) return `Synced to your account ${ageMinutes} minutes ago.`;
+
+  const ageHours = Math.floor(ageMinutes / 60);
+  if (ageHours === 1) return "Synced to your account 1 hour ago.";
+  return `Synced to your account ${ageHours} hours ago.`;
+}
+
 export default function CoursePage() {
   return (
     <Suspense fallback={<CoursePageFallback />}>
@@ -156,6 +187,7 @@ function CoursePageClient() {
   const [overviewExpanded, setOverviewExpanded] = useState(false);
   const [commonMistakesExpanded, setCommonMistakesExpanded] = useState(false);
   const [doneLessonIds, setDoneLessonIds] = useState<string[]>([]);
+  const [doneLessonIdsLoaded, setDoneLessonIdsLoaded] = useState(false);
   const [videoStarted, setVideoStarted] = useState(false);
   const [videoPaused, setVideoPaused] = useState(false);
   const [youtubeApiReady, setYoutubeApiReady] = useState(false);
@@ -177,6 +209,13 @@ function CoursePageClient() {
   const progressSaveTimerRef = useRef<number | null>(null);
   const [resumeAvailable, setResumeAvailable] = useState(false);
   const [playbackProgressLoaded, setPlaybackProgressLoaded] = useState(false);
+  const [authStateLoaded, setAuthStateLoaded] = useState(false);
+  const [signedInUserId, setSignedInUserId] = useState<string | null>(null);
+  const [courseSyncStatus, setCourseSyncStatus] = useState<"idle" | "syncing" | "synced" | "error">(
+    "idle"
+  );
+  const [lastCourseSyncAtMs, setLastCourseSyncAtMs] = useState<number | null>(null);
+  const [showBackupPrompt, setShowBackupPrompt] = useState(false);
   const [swipeHint, setSwipeHint] = useState<{
     direction: SwipeDirection;
     progress: number;
@@ -192,6 +231,12 @@ function CoursePageClient() {
   const [installPromptFeedback, setInstallPromptFeedback] = useState<string | null>(null);
   const overviewJumpDraggingRef = useRef(false);
   const installPromptTimerRef = useRef<number | null>(null);
+  const courseSyncTimerRef = useRef<number | null>(null);
+  const courseSyncDirtyRef = useRef(false);
+  const courseSyncDirtyLessonIdsRef = useRef<Set<string>>(new Set());
+  const courseSyncInFlightRef = useRef(false);
+  const knownProgressLessonIdsRef = useRef<Set<string>>(new Set());
+  const hydratedProgressUserIdRef = useRef<string | null>(null);
   const swipeTouchIdRef = useRef<number | null>(null);
   const swipeDirectionRef = useRef<SwipeDirection | null>(null);
   const swipeStartXRef = useRef(0);
@@ -243,6 +288,131 @@ function CoursePageClient() {
     );
   }, []);
 
+  const localCourseProgressLoaded = doneLessonIdsLoaded && playbackProgressLoaded;
+
+  const clearCourseSyncTimer = useCallback(() => {
+    if (courseSyncTimerRef.current == null) return;
+    window.clearInterval(courseSyncTimerRef.current);
+    courseSyncTimerRef.current = null;
+  }, []);
+
+  const markCourseProgressDirty = useCallback((lessonId?: string) => {
+    if (lessonId) {
+      knownProgressLessonIdsRef.current.add(lessonId);
+      courseSyncDirtyLessonIdsRef.current.add(lessonId);
+    } else {
+      for (const knownLessonId of knownProgressLessonIdsRef.current) {
+        courseSyncDirtyLessonIdsRef.current.add(knownLessonId);
+      }
+    }
+    courseSyncDirtyRef.current = courseSyncDirtyLessonIdsRef.current.size > 0;
+  }, []);
+
+  const applyLocalCourseProgress = useCallback(
+    (next: { doneLessonIds: string[]; videoProgressByLessonId: Record<string, number> }) => {
+      const normalizedDoneLessonIds = normalizeDoneLessonIds(next.doneLessonIds);
+      const normalizedVideoProgress = normalizeVideoProgressRecord(next.videoProgressByLessonId);
+
+      for (const lessonId of normalizedDoneLessonIds) {
+        knownProgressLessonIdsRef.current.add(lessonId);
+      }
+
+      for (const lessonId of Object.keys(normalizedVideoProgress)) {
+        knownProgressLessonIdsRef.current.add(lessonId);
+      }
+
+      playbackProgressRef.current = normalizedVideoProgress;
+      setDoneLessonIds(normalizedDoneLessonIds);
+      setResumeAvailable(Math.floor(normalizedVideoProgress[activeLesson.id] ?? 0) >= 2);
+
+      try {
+        localStorage.setItem(DONE_STORAGE_KEY, JSON.stringify(normalizedDoneLessonIds));
+        localStorage.setItem(VIDEO_PROGRESS_STORAGE_KEY, JSON.stringify(normalizedVideoProgress));
+      } catch {}
+    },
+    [activeLesson.id]
+  );
+
+  const buildSyncRows = useCallback(
+    (updatedAt?: string): CourseProgressRow[] => {
+      return buildCourseProgressRowsFromLocal(
+        {
+          doneLessonIds,
+          videoProgressByLessonId: playbackProgressRef.current,
+        },
+        {
+          knownLessonIds: knownProgressLessonIdsRef.current,
+          updatedAt,
+        }
+      );
+    },
+    [doneLessonIds]
+  );
+
+  const persistCourseProgressRows = useCallback(
+    async (rows: CourseProgressRow[]) => {
+      if (!signedInUserId) return;
+
+      const response = await fetch(COURSE_PROGRESS_SYNC_API_PATH, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        cache: "no-store",
+        credentials: "same-origin",
+        body: JSON.stringify({ rows }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Course progress sync failed (${response.status})`);
+      }
+    },
+    [signedInUserId]
+  );
+
+  const syncCourseProgressNow = useCallback(
+    async (options?: { force?: boolean }) => {
+      if (!signedInUserId || !localCourseProgressLoaded) return;
+      if (!options?.force && !courseSyncDirtyRef.current) return;
+      if (courseSyncInFlightRef.current) return;
+
+      const dirtyLessonIds = new Set(courseSyncDirtyLessonIdsRef.current);
+      if (!options?.force && dirtyLessonIds.size === 0) return;
+
+      const rows = buildSyncRows(new Date().toISOString()).filter((row) => {
+        if (options?.force) return true;
+        return dirtyLessonIds.has(row.lessonId);
+      });
+      if (rows.length === 0) {
+        courseSyncDirtyRef.current = courseSyncDirtyLessonIdsRef.current.size > 0;
+        return;
+      }
+
+      courseSyncInFlightRef.current = true;
+      setCourseSyncStatus("syncing");
+
+      try {
+        await persistCourseProgressRows(rows);
+        if (options?.force) {
+          courseSyncDirtyLessonIdsRef.current.clear();
+        } else {
+          for (const row of rows) {
+            courseSyncDirtyLessonIdsRef.current.delete(row.lessonId);
+          }
+        }
+        courseSyncDirtyRef.current = courseSyncDirtyLessonIdsRef.current.size > 0;
+        setCourseSyncStatus("synced");
+        setLastCourseSyncAtMs(Date.now());
+      } catch (error) {
+        console.error("[CoursePage] Could not sync course progress", error);
+        setCourseSyncStatus("error");
+      } finally {
+        courseSyncInFlightRef.current = false;
+      }
+    },
+    [buildSyncRows, localCourseProgressLoaded, persistCourseProgressRows, signedInUserId]
+  );
+
   useEffect(() => {
     try {
       localStorage.setItem(STORAGE_KEY, activeLesson.id);
@@ -273,38 +443,185 @@ function CoursePageClient() {
   useEffect(() => {
     try {
       const raw = localStorage.getItem(DONE_STORAGE_KEY);
-      if (!raw) return;
-      const parsed = JSON.parse(raw);
-      if (Array.isArray(parsed)) {
-        setDoneLessonIds(parsed.filter((v): v is string => typeof v === "string"));
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        const normalizedDoneLessonIds = normalizeDoneLessonIds(parsed);
+        for (const lessonId of normalizedDoneLessonIds) {
+          knownProgressLessonIdsRef.current.add(lessonId);
+        }
+        setDoneLessonIds(normalizedDoneLessonIds);
       }
     } catch {}
+    setDoneLessonIdsLoaded(true);
   }, []);
 
   useEffect(() => {
+    if (!doneLessonIdsLoaded) return;
     try {
       localStorage.setItem(DONE_STORAGE_KEY, JSON.stringify(doneLessonIds));
     } catch {}
-  }, [doneLessonIds]);
+  }, [doneLessonIds, doneLessonIdsLoaded]);
 
   useEffect(() => {
     try {
       const raw = localStorage.getItem(VIDEO_PROGRESS_STORAGE_KEY);
       if (raw) {
         const parsed = JSON.parse(raw);
-        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-          const normalized: Record<string, number> = {};
-          for (const [lessonId, value] of Object.entries(parsed)) {
-            if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
-              normalized[lessonId] = value;
-            }
-          }
-          playbackProgressRef.current = normalized;
+        const normalized = normalizeVideoProgressRecord(parsed);
+        for (const lessonId of Object.keys(normalized)) {
+          knownProgressLessonIdsRef.current.add(lessonId);
         }
+        playbackProgressRef.current = normalized;
       }
     } catch {}
     setPlaybackProgressLoaded(true);
   }, []);
+
+  useEffect(() => {
+    let mounted = true;
+    const supabase = createBrowserSupabaseClient();
+
+    void supabase.auth.getUser().then(({ data, error }) => {
+      if (!mounted) return;
+      if (error) {
+        setSignedInUserId(null);
+        setAuthStateLoaded(true);
+        return;
+      }
+      setSignedInUserId(data.user?.id ?? null);
+      setAuthStateLoaded(true);
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!mounted) return;
+      setSignedInUserId(session?.user?.id ?? null);
+      setAuthStateLoaded(true);
+    });
+
+    return () => {
+      mounted = false;
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (signedInUserId) return;
+    clearCourseSyncTimer();
+    hydratedProgressUserIdRef.current = null;
+    courseSyncDirtyRef.current = false;
+    courseSyncDirtyLessonIdsRef.current.clear();
+    courseSyncInFlightRef.current = false;
+    setCourseSyncStatus("idle");
+    setLastCourseSyncAtMs(null);
+  }, [clearCourseSyncTimer, signedInUserId]);
+
+  useEffect(() => {
+    if (!authStateLoaded || !localCourseProgressLoaded || !signedInUserId) return;
+    if (hydratedProgressUserIdRef.current === signedInUserId) return;
+
+    hydratedProgressUserIdRef.current = signedInUserId;
+    let cancelled = false;
+
+    const hydrateFromServer = async () => {
+      setCourseSyncStatus("syncing");
+
+      try {
+        const response = await fetch(COURSE_PROGRESS_SYNC_API_PATH, {
+          method: "GET",
+          cache: "no-store",
+          credentials: "same-origin",
+        });
+
+        if (!response.ok) {
+          throw new Error(`Course progress hydrate failed (${response.status})`);
+        }
+
+        const payload = (await response.json()) as { rows?: unknown };
+        if (cancelled) return;
+
+        const remoteRows = normalizeCourseProgressRows(payload.rows ?? []);
+        for (const row of remoteRows) {
+          knownProgressLessonIdsRef.current.add(row.lessonId);
+        }
+
+        const localRows = buildSyncRows();
+        const mergedRows = mergeCourseProgressRows(localRows, remoteRows);
+        for (const row of mergedRows) {
+          knownProgressLessonIdsRef.current.add(row.lessonId);
+        }
+
+        applyLocalCourseProgress(buildLocalCourseProgressFromRows(mergedRows));
+
+        if (!areCourseProgressRowsEqual(mergedRows, remoteRows)) {
+          await persistCourseProgressRows(mergedRows);
+        }
+
+        if (cancelled) return;
+        courseSyncDirtyRef.current = false;
+        courseSyncDirtyLessonIdsRef.current.clear();
+        setCourseSyncStatus("synced");
+        setLastCourseSyncAtMs(Date.now());
+      } catch (error) {
+        if (cancelled) return;
+        console.error("[CoursePage] Could not hydrate course progress", error);
+        setCourseSyncStatus("error");
+      }
+    };
+
+    void hydrateFromServer();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    applyLocalCourseProgress,
+    authStateLoaded,
+    buildSyncRows,
+    localCourseProgressLoaded,
+    persistCourseProgressRows,
+    signedInUserId,
+  ]);
+
+  useEffect(() => {
+    if (!signedInUserId || !localCourseProgressLoaded) return;
+    clearCourseSyncTimer();
+    courseSyncTimerRef.current = window.setInterval(() => {
+      void syncCourseProgressNow();
+    }, COURSE_PROGRESS_SYNC_INTERVAL_MS);
+
+    return () => {
+      clearCourseSyncTimer();
+    };
+  }, [clearCourseSyncTimer, localCourseProgressLoaded, signedInUserId, syncCourseProgressNow]);
+
+  useEffect(() => {
+    if (!signedInUserId) return;
+
+    const flushWhenBackgrounded = () => {
+      if (document.visibilityState !== "hidden") return;
+      void syncCourseProgressNow({ force: true });
+    };
+
+    const flushOnPageHide = () => {
+      void syncCourseProgressNow({ force: true });
+    };
+
+    document.addEventListener("visibilitychange", flushWhenBackgrounded);
+    window.addEventListener("pagehide", flushOnPageHide);
+
+    return () => {
+      document.removeEventListener("visibilitychange", flushWhenBackgrounded);
+      window.removeEventListener("pagehide", flushOnPageHide);
+    };
+  }, [signedInUserId, syncCourseProgressNow]);
+
+  useEffect(() => {
+    if (!signedInUserId || !doneLessonIdsLoaded) return;
+    if (!courseSyncDirtyRef.current) return;
+    void syncCourseProgressNow({ force: true });
+  }, [doneLessonIds, doneLessonIdsLoaded, signedInUserId, syncCourseProgressNow]);
 
   useEffect(() => {
     if (!playbackProgressLoaded) return;
@@ -352,21 +669,28 @@ function CoursePageClient() {
         const seconds = player.getCurrentTime();
         if (!Number.isFinite(seconds) || seconds < 0) return;
         const normalizedSeconds = Math.floor(seconds);
+        const previousSeconds = Math.floor(playbackProgressRef.current[lessonId] ?? 0);
+        if (normalizedSeconds === previousSeconds) return;
+
+        knownProgressLessonIdsRef.current.add(lessonId);
         playbackProgressRef.current[lessonId] = normalizedSeconds;
         persistPlaybackProgress();
+        markCourseProgressDirty(lessonId);
         if (lessonId === activeLesson.id) {
           setResumeAvailable(normalizedSeconds >= 2);
         }
       } catch {}
     },
-    [activeLesson.id, persistPlaybackProgress]
+    [activeLesson.id, markCourseProgressDirty, persistPlaybackProgress]
   );
 
   useEffect(() => {
     return () => {
       stopProgressSaveTimer();
+      clearCourseSyncTimer();
+      void syncCourseProgressNow({ force: true });
     };
-  }, [stopProgressSaveTimer]);
+  }, [clearCourseSyncTimer, stopProgressSaveTimer, syncCourseProgressNow]);
 
   const playerTopRef = useRef<HTMLDivElement | null>(null);
 
@@ -553,6 +877,13 @@ function CoursePageClient() {
     setInstallPromptFeedback(null);
   }
 
+  function dismissBackupPrompt() {
+    try {
+      localStorage.setItem(BACKUP_PROMPT_DISMISSED_AT_KEY, String(Date.now()));
+    } catch {}
+    setShowBackupPrompt(false);
+  }
+
   useEffect(() => {
     return () => {
       clearInstallPromptTimer();
@@ -571,6 +902,9 @@ function CoursePageClient() {
 
   function toggleLessonDone() {
     const willMarkAsDone = !doneLessonIds.includes(activeLesson.id);
+    knownProgressLessonIdsRef.current.add(activeLesson.id);
+    markCourseProgressDirty(activeLesson.id);
+
     setDoneLessonIds((prev) => {
       if (prev.includes(activeLesson.id)) {
         return prev.filter((id) => id !== activeLesson.id);
@@ -764,9 +1098,40 @@ function CoursePageClient() {
   const showVideoOverlay = !videoStarted || videoPaused;
   const showResumeState = videoStarted && videoPaused;
   const showResumeCta = showResumeState || (!videoStarted && resumeAvailable);
+  const isSignedIn = Boolean(signedInUserId);
+  const isGuest = authStateLoaded && !signedInUserId;
+  const backupSignInHref = `/auth/sign-in?next=${encodeURIComponent(
+    `${pathname}?lesson=${encodeURIComponent(activeLesson.id)}`
+  )}`;
+  const courseProgressStatusCopy = isSignedIn
+    ? courseSyncStatus === "error"
+      ? "Sync paused right now. We'll retry automatically."
+      : courseSyncStatus === "syncing"
+        ? "Syncing lesson progress to your account..."
+        : formatSyncStatusAgeLabel(lastCourseSyncAtMs)
+    : "Lesson and playback progress saved on this device.";
 
   const supportCardClass =
     "rounded-2xl border border-slate-200/70 bg-[linear-gradient(180deg,rgba(255,255,255,0.92),rgba(248,250,252,0.92))] shadow-[0_10px_24px_rgba(15,23,42,0.065)]";
+
+  useEffect(() => {
+    if (!isGuest) {
+      setShowBackupPrompt(false);
+      return;
+    }
+    if (doneLessonsCount < BACKUP_PROMPT_MIN_DONE_LESSONS) return;
+
+    try {
+      const dismissedAtMs = parseStoredTimestamp(
+        localStorage.getItem(BACKUP_PROMPT_DISMISSED_AT_KEY)
+      );
+      if (dismissedAtMs && Date.now() - dismissedAtMs < BACKUP_PROMPT_COOLDOWN_MS) {
+        return;
+      }
+    } catch {}
+
+    setShowBackupPrompt(true);
+  }, [doneLessonsCount, isGuest]);
 
   useEffect(() => {
     setCommonMistakesExpanded(false);
@@ -966,8 +1331,10 @@ function CoursePageClient() {
             if (state === ps.PAUSED || state === ps.CUED) {
               savePlaybackPosition(lessonIdForPlayer);
             } else if (state === ps.ENDED) {
+              knownProgressLessonIdsRef.current.add(lessonIdForPlayer);
               playbackProgressRef.current[lessonIdForPlayer] = 0;
               persistPlaybackProgress();
+              markCourseProgressDirty(lessonIdForPlayer);
               if (lessonIdForPlayer === activeLesson.id) {
                 setResumeAvailable(false);
               }
@@ -1016,6 +1383,7 @@ function CoursePageClient() {
     activeLesson.id,
     activeLesson.youtubeId,
     persistPlaybackProgress,
+    markCourseProgressDirty,
     savePlaybackPosition,
     stopProgressSaveTimer,
     tryStartPlayback,
@@ -1196,8 +1564,47 @@ function CoursePageClient() {
       </div>
     ) : null;
 
+  const backupProgressPrompt =
+    showBackupPrompt && !drawerOpen ? (
+      <div
+        data-testid="course-backup-prompt"
+        className="fixed inset-x-0 bottom-[calc(84px+env(safe-area-inset-bottom))] z-[75] px-4 sm:bottom-6"
+      >
+        <div className="mx-auto max-w-[520px] rounded-[22px] border border-emerald-200/70 bg-[radial-gradient(520px_170px_at_15%_0%,rgba(16,185,129,0.14),rgba(255,255,255,0)_62%),rgba(255,255,255,0.97)] p-4 shadow-[0_16px_46px_rgba(15,23,42,0.16)] backdrop-blur-sm">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-emerald-700">
+            Progress backup
+          </div>
+          <h3 className="mt-1 text-[17px] font-semibold text-slate-900">
+            Don&apos;t lose your progress
+          </h3>
+          <p className="mt-1 text-[13px] leading-6 text-slate-700">
+            You&apos;ve completed {doneLessonsCount} lessons. Create a free account to back up and
+            sync your progress across devices.
+          </p>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <PressLink
+              tier="cta"
+              href={backupSignInHref}
+              onClick={dismissBackupPrompt}
+              className="inline-flex min-h-[44px] items-center justify-center rounded-2xl bg-gradient-to-b from-emerald-500 to-emerald-600 px-4 py-2 text-[14px] font-semibold text-white shadow-[0_12px_28px_rgba(5,150,105,0.22)]"
+            >
+              Create free account
+            </PressLink>
+            <PressButton
+              tier="nav"
+              onClick={dismissBackupPrompt}
+              className="inline-flex min-h-[44px] items-center justify-center rounded-2xl bg-white/90 px-4 py-2 text-[14px] font-semibold text-slate-700 ring-1 ring-slate-200/75"
+              aria-label="Maybe later"
+            >
+              Maybe later
+            </PressButton>
+          </div>
+        </div>
+      </div>
+    ) : null;
+
   const autoInstallPrompt =
-    showInstallPrompt && !drawerOpen ? (
+    showInstallPrompt && !showBackupPrompt && !drawerOpen ? (
       <div
         data-testid="a2hs-auto-prompt"
         className="fixed inset-x-0 bottom-[calc(84px+env(safe-area-inset-bottom))] z-[70] px-4 sm:bottom-6"
@@ -1639,9 +2046,16 @@ function CoursePageClient() {
                   {isLastLesson
                     ? "Last lesson in this course."
                     : "Use Lessons to jump to any module or lesson."}
-                  <span className="ml-2 text-slate-500">
-                    Lesson and playback progress saved on this device.
-                  </span>
+                  <span className="ml-2 text-slate-500">{courseProgressStatusCopy}</span>
+                  {isSignedIn && courseSyncStatus === "error" ? (
+                    <PressButton
+                      tier="nav"
+                      onClick={() => void syncCourseProgressNow({ force: true })}
+                      className="ml-2 inline-flex min-h-[24px] items-center rounded-full px-2 py-0.5 text-[11px] font-semibold text-slate-700 ring-1 ring-slate-200/70"
+                    >
+                      Retry now
+                    </PressButton>
+                  ) : null}
                 </div>
               </div>
             ) : null}
@@ -1921,6 +2335,7 @@ function CoursePageClient() {
       </PageTemplate>
       {swipeHintOverlay}
       {swipeNuxToast}
+      {backupProgressPrompt}
       {autoInstallPrompt}
     </SiteChrome>
   );

--- a/app/guides/0-1000m/page.tsx
+++ b/app/guides/0-1000m/page.tsx
@@ -1,0 +1,106 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import SiteChrome from "@/components/SiteChrome";
+import GuidePdfDownloadButton from "@/components/guides/GuidePdfDownloadButton";
+import Guide0To1000Tracker from "@/components/guides/Guide0To1000Tracker";
+import { attachGuestEntitlementsByEmail } from "@/lib/commerce/entitlements";
+import { createAdminSupabaseClient } from "@/lib/supabase/admin";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import {
+  GUIDE_0_TO_1000M_PDF_DOWNLOAD_FILENAME,
+  GUIDE_0_TO_1000M_PRODUCT_ID,
+  GUIDE_0_TO_1000M_SESSIONS,
+  GUIDE_0_TO_1000M_SLUG,
+} from "@/lib/guides/guide-0-1000m";
+
+export const dynamic = "force-dynamic";
+
+export default async function Guide0To1000Page() {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/auth/sign-in?next=%2Fguides%2F0-1000m");
+  }
+
+  if (user.email) {
+    try {
+      const adminSupabase = createAdminSupabaseClient();
+      await attachGuestEntitlementsByEmail(adminSupabase, user.id, user.email);
+    } catch (error) {
+      console.error("[Guide0To1000] Could not attach guest entitlements", error);
+    }
+  }
+
+  const { data: entitlement, error } = await supabase
+    .from("entitlements")
+    .select("id")
+    .eq("product_id", GUIDE_0_TO_1000M_PRODUCT_ID)
+    .eq("user_id", user.id)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error("[Guide0To1000] Could not load entitlement", error);
+  }
+
+  if (!entitlement) {
+    return (
+      <SiteChrome>
+        <section className="mx-auto min-h-screen w-full max-w-[980px] px-6 pb-20 pt-28">
+          <div className="rounded-3xl border border-amber-200 bg-amber-50/60 p-8 shadow-[0_14px_45px_rgba(15,23,42,0.10)]">
+            <h1 className="text-3xl font-bold text-slate-900">Guide access required</h1>
+            <p className="mt-3 text-sm leading-relaxed text-slate-700">
+              This interactive plan appears when `0-1000m guide` is in your library.
+            </p>
+            <div className="mt-6 flex flex-wrap gap-3">
+              <Link
+                href="/plans"
+                className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500"
+              >
+                View plans
+              </Link>
+              <Link
+                href="/my-library"
+                className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+              >
+                Back to My Library
+              </Link>
+            </div>
+          </div>
+        </section>
+      </SiteChrome>
+    );
+  }
+
+  return (
+    <SiteChrome>
+      <section className="mx-auto min-h-screen w-full max-w-[980px] px-6 pb-20 pt-28">
+        <div className="mb-4 flex flex-wrap items-start justify-between gap-3 rounded-2xl border border-slate-200 bg-white/90 p-4">
+          <p className="max-w-[600px] text-sm text-slate-600">
+            Keep training in the interactive tracker and download the PDF whenever you need an
+            offline version.
+          </p>
+          <div className="flex flex-wrap items-start gap-2">
+            <GuidePdfDownloadButton
+              apiPath="/api/guides/0-1000m/pdf"
+              fallbackFileName={GUIDE_0_TO_1000M_PDF_DOWNLOAD_FILENAME}
+            />
+            <Link
+              href="/my-library"
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+            >
+              Back to My Library
+            </Link>
+          </div>
+        </div>
+        <Guide0To1000Tracker
+          guideSlug={GUIDE_0_TO_1000M_SLUG}
+          sessions={GUIDE_0_TO_1000M_SESSIONS}
+        />
+      </section>
+    </SiteChrome>
+  );
+}

--- a/app/my-library/item/[slug]/page.tsx
+++ b/app/my-library/item/[slug]/page.tsx
@@ -1,6 +1,11 @@
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import SiteChrome from "@/components/SiteChrome";
+import GuidePdfDownloadButton from "@/components/guides/GuidePdfDownloadButton";
+import {
+  GUIDE_0_TO_1000M_PDF_DOWNLOAD_FILENAME,
+  GUIDE_0_TO_1000M_PRODUCT_ID,
+} from "@/lib/guides/guide-0-1000m";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { getCatalogProductBySlug } from "@/lib/commerce/catalog";
 
@@ -11,6 +16,20 @@ type Props = {
 };
 
 export const dynamic = "force-dynamic";
+
+function getProductOpenHref(productId: string): string | null {
+  if (productId === GUIDE_0_TO_1000M_PRODUCT_ID) {
+    return "/guides/0-1000m";
+  }
+  return null;
+}
+
+function getProductPdfApiHref(productId: string): string | null {
+  if (productId === GUIDE_0_TO_1000M_PRODUCT_ID) {
+    return "/api/guides/0-1000m/pdf";
+  }
+  return null;
+}
 
 export default async function LibraryItemPage({ params }: Props) {
   const { slug } = await params;
@@ -42,16 +61,35 @@ export default async function LibraryItemPage({ params }: Props) {
     redirect("/my-library");
   }
 
+  const openHref = getProductOpenHref(product.id);
+  const pdfApiHref = getProductPdfApiHref(product.id);
+
   return (
     <SiteChrome>
       <section className="mx-auto min-h-screen w-full max-w-[980px] px-6 pb-20 pt-28">
         <div className="rounded-3xl border border-blue-100 bg-white/95 p-8 shadow-[0_16px_60px_rgba(24,58,107,0.14)]">
           <h1 className="text-3xl font-bold text-slate-900">{product.title}</h1>
           <p className="mt-3 text-sm text-slate-600">
-            Owned item detail is active. Download/preview flows will be added in the next step.
+            {openHref
+              ? "This item includes an interactive tracker. Open it to continue your plan."
+              : "Owned item detail is active. Download/preview flows will be added in the next step."}
           </p>
 
-          <div className="mt-6 flex flex-wrap gap-3">
+          <div className="mt-6 flex flex-wrap items-start gap-3">
+            {openHref ? (
+              <Link
+                href={openHref}
+                className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700"
+              >
+                Open interactive plan
+              </Link>
+            ) : null}
+            {pdfApiHref ? (
+              <GuidePdfDownloadButton
+                apiPath={pdfApiHref}
+                fallbackFileName={GUIDE_0_TO_1000M_PDF_DOWNLOAD_FILENAME}
+              />
+            ) : null}
             <Link
               href="/my-library"
               className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50"

--- a/app/my-library/page.tsx
+++ b/app/my-library/page.tsx
@@ -6,6 +6,7 @@ import { signOutFromLibrary } from "@/app/my-library/actions";
 import CheckoutButton from "@/components/my-library/CheckoutButton";
 import ContinueCourseCard from "@/components/my-library/ContinueCourseCard";
 import PortalButton from "@/components/my-library/PortalButton";
+import DownloadResendForm from "@/components/commerce/DownloadResendForm";
 import { getCatalogProductsSafe, type CatalogProduct } from "@/lib/commerce/catalog";
 import { buildLibrarySections } from "@/lib/commerce/library";
 import { createAdminSupabaseClient } from "@/lib/supabase/admin";
@@ -88,6 +89,18 @@ export default async function MyLibraryPage() {
                   <p className="text-sm text-slate-600">
                     You have no purchased items yet. Browse available options below.
                   </p>
+                  <div className="mt-4 border-t border-slate-200/80 pt-4">
+                    <p className="text-xs leading-relaxed text-slate-600">
+                      Already bought with another email? Request an access link and we&apos;ll
+                      restore your library when you sign in.
+                    </p>
+                    <DownloadResendForm
+                      initialEmail={user.email ?? ""}
+                      nextPath="/my-library"
+                      source="library_recovery"
+                      className="mt-3"
+                    />
+                  </div>
                 </div>
               ) : null}
 

--- a/app/my-library/page.tsx
+++ b/app/my-library/page.tsx
@@ -5,6 +5,7 @@ import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { signOutFromLibrary } from "@/app/my-library/actions";
 import CheckoutButton from "@/components/my-library/CheckoutButton";
 import ContinueCourseCard from "@/components/my-library/ContinueCourseCard";
+import PortalButton from "@/components/my-library/PortalButton";
 import { getCatalogProductsSafe, type CatalogProduct } from "@/lib/commerce/catalog";
 import { buildLibrarySections } from "@/lib/commerce/library";
 import { createAdminSupabaseClient } from "@/lib/supabase/admin";
@@ -63,14 +64,17 @@ export default async function MyLibraryPage() {
               <h1 className="text-3xl font-bold text-slate-900">My Library</h1>
               <p className="mt-2 text-sm text-slate-600">Signed in as {user.email}</p>
             </div>
-            <form action={signOutFromLibrary}>
-              <button
-                type="submit"
-                className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
-              >
-                Sign out
-              </button>
-            </form>
+            <div className="flex flex-wrap items-start gap-2">
+              <PortalButton returnPath="/my-library" />
+              <form action={signOutFromLibrary}>
+                <button
+                  type="submit"
+                  className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+                >
+                  Sign out
+                </button>
+              </form>
+            </div>
           </div>
 
           <div className="mt-8 space-y-8">

--- a/app/plans/page.tsx
+++ b/app/plans/page.tsx
@@ -1,0 +1,145 @@
+import Link from "next/link";
+import SiteChrome from "@/components/SiteChrome";
+import PageTemplate from "@/components/PageTemplate";
+import PageIntro from "@/components/PageIntro";
+import CheckoutButton from "@/components/my-library/CheckoutButton";
+import {
+  getCatalogProductsWithAvailability,
+  type CatalogProductAvailability,
+} from "@/lib/commerce/catalog";
+
+function getPlanCopy(product: CatalogProductAvailability) {
+  switch (product.id) {
+    case "guide_0_1000m":
+      return {
+        description:
+          "A structured program designed to take you from starting out with freestyle to completing your first 1000m.",
+        points: [
+          "20-session structure you can follow step by step",
+          "Simple weekly progression with practical focus cues",
+          "Built to work alongside the free course",
+        ],
+      };
+    case "guide_poolside":
+      return {
+        description:
+          "A compact poolside drill guide you can bring to every session when you need quick structure and reminders.",
+        points: [
+          "Fast drill lookup when you are already at the pool",
+          "Clear focus areas for balance, position, and timing",
+          "Ideal add-on when you want a practical session script",
+        ],
+      };
+    case "analysis_video":
+      return {
+        description:
+          "Personal video feedback so you know exactly what to fix first and what to ignore for now.",
+        points: [
+          "Prioritized technique feedback based on your stroke",
+          "Actionable adjustments for your next sessions",
+          "Ideal when you need a clear path to improve faster",
+        ],
+      };
+    default:
+      return {
+        description: "Structured paid offer with practical guidance and clear next actions.",
+        points: ["Practical content", "Clear action steps", "Built for everyday training"],
+      };
+  }
+}
+
+function PlanCard({ product }: { product: CatalogProductAvailability }) {
+  const copy = getPlanCopy(product);
+
+  return (
+    <article className="bg-white/92 relative overflow-hidden rounded-[22px] border border-slate-200/70 p-6 shadow-[0_14px_34px_rgba(15,23,42,0.08)]">
+      <div className="absolute inset-x-0 top-0 h-[2px] bg-gradient-to-r from-[#5aa6ff] via-[#93c8ff] to-transparent opacity-70" />
+
+      <div className="text-[12px] font-semibold uppercase tracking-wide text-slate-500">
+        {product.kind === "analysis" ? "Video feedback" : "Guide"}
+      </div>
+      <h2 className="mt-2 text-[18px] font-semibold text-slate-900">{product.title}</h2>
+      <p className="mt-2 text-[15px] leading-7 text-slate-700">{copy.description}</p>
+      <ul className="mt-4 list-disc space-y-2 pl-5 text-[14px] leading-6 text-slate-700">
+        {copy.points.map((point) => (
+          <li key={point}>{point}</li>
+        ))}
+      </ul>
+
+      <div className="mt-5">
+        {product.available ? (
+          <CheckoutButton productId={product.id} cancelPath="/plans" />
+        ) : (
+          <div className="space-y-2">
+            <button
+              type="button"
+              disabled
+              className="inline-flex h-10 cursor-not-allowed items-center justify-center rounded-xl border border-slate-200 bg-slate-100 px-4 text-sm font-semibold text-slate-500"
+            >
+              Temporarily unavailable
+            </button>
+            <p className="text-xs text-slate-500">
+              Checkout setup missing ({product.missingEnvVar ?? "unknown variable"}).
+            </p>
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}
+
+export default function PlansPage() {
+  const products = getCatalogProductsWithAvailability();
+  const hasAvailableProducts = products.some((product) => product.available);
+  const hasUnavailableProducts = products.some((product) => !product.available);
+
+  return (
+    <SiteChrome>
+      <PageTemplate size="wide">
+        <PageIntro
+          title="Plans"
+          subtitle="Paid guides and feedback to support your next step."
+          belowDivider={
+            <p className="text-[13px] text-slate-600">
+              Pick an option below. Final price and payment details are handled securely in
+              checkout.
+            </p>
+          }
+        />
+
+        {!hasAvailableProducts ? (
+          <div className="mt-4 rounded-2xl border border-rose-200 bg-rose-50/80 p-4">
+            <p className="text-sm font-medium text-rose-800">
+              Plans are temporarily unavailable while checkout configuration is being finalized.
+            </p>
+            <p className="mt-2 text-sm text-rose-700">
+              You can still contact us and we will help you manually.
+            </p>
+            <div className="mt-3">
+              <Link
+                href="/contact"
+                className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-700 transition hover:bg-rose-50"
+              >
+                Contact support
+              </Link>
+            </div>
+          </div>
+        ) : null}
+
+        {hasAvailableProducts && hasUnavailableProducts ? (
+          <div className="mt-4 rounded-2xl border border-amber-200 bg-amber-50/80 p-4">
+            <p className="text-sm text-amber-900">
+              Some offers are temporarily unavailable. Available offers can still be purchased now.
+            </p>
+          </div>
+        ) : null}
+
+        <div className="mt-4 grid gap-4">
+          {products.map((product) => (
+            <PlanCard key={product.id} product={product} />
+          ))}
+        </div>
+      </PageTemplate>
+    </SiteChrome>
+  );
+}

--- a/assets/guides/0-1000m-guide.pdf
+++ b/assets/guides/0-1000m-guide.pdf
@@ -1,0 +1,48 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 694 >>
+stream
+BT
+/F1 14 Tf
+72 760 Td (FreeSwimming - 0-1000m Guide) Tj
+72 736 Td () Tj
+72 712 Td (This PDF is provided for offline access.) Tj
+72 688 Td (Use the interactive plan in My Library for progress tracking,) Tj
+72 664 Td (checkbox completion, and synced notes across devices.) Tj
+72 640 Td () Tj
+72 616 Td (Session overview \(20 sessions\):) Tj
+72 592 Td (S01-S04: breathing and body line) Tj
+72 568 Td (S05-S08: catch, rotation, aerobic build) Tj
+72 544 Td (S09-S12: pacing and mid-plan check) Tj
+72 520 Td (S13-S16: endurance + threshold quality) Tj
+72 496 Td (S17-S20: race prep and full 1000m completion) Tj
+72 472 Td () Tj
+72 448 Td (For latest updates, open the interactive plan in app.) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000986 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+1056
+%%EOF

--- a/components/commerce/DownloadResendForm.tsx
+++ b/components/commerce/DownloadResendForm.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useId, useState, type FormEvent } from "react";
+import {
+  normalizeResendEmail,
+  RESEND_DOWNLOAD_FALLBACK_ERROR,
+  RESEND_DOWNLOAD_GENERIC_MESSAGE,
+} from "@/lib/commerce/download-resend";
+
+type Props = {
+  initialEmail?: string;
+  nextPath?: string;
+  source?: "checkout_success" | "library_recovery";
+  className?: string;
+};
+
+type DownloadResendResponse = {
+  ok: boolean;
+  error?: string;
+  message?: string;
+};
+
+export default function DownloadResendForm({
+  initialEmail = "",
+  nextPath = "/my-library",
+  source = "checkout_success",
+  className = "",
+}: Props) {
+  const [email, setEmail] = useState(initialEmail);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState("");
+  const [successMessage, setSuccessMessage] = useState("");
+  const inputId = useId();
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (pending) return;
+
+    const normalizedEmail = normalizeResendEmail(email);
+    if (!normalizedEmail) {
+      setError("Enter your purchase email.");
+      setSuccessMessage("");
+      return;
+    }
+
+    setPending(true);
+    setError("");
+    setSuccessMessage("");
+
+    try {
+      const response = await fetch("/api/download/resend", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: normalizedEmail,
+          nextPath,
+          source,
+        }),
+      });
+
+      const json = (await response.json()) as DownloadResendResponse;
+      if (!response.ok || !json.ok) {
+        throw new Error(json.error || RESEND_DOWNLOAD_FALLBACK_ERROR);
+      }
+
+      setSuccessMessage(json.message || RESEND_DOWNLOAD_GENERIC_MESSAGE);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : RESEND_DOWNLOAD_FALLBACK_ERROR;
+      setError(message);
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className={`space-y-2 ${className}`}>
+      <label
+        htmlFor={inputId}
+        className="text-xs font-medium uppercase tracking-wide text-slate-600"
+      >
+        Purchase email
+      </label>
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <input
+          id={inputId}
+          type="email"
+          autoComplete="email"
+          inputMode="email"
+          value={email}
+          onChange={(event) => setEmail(event.currentTarget.value)}
+          placeholder="you@example.com"
+          className="h-10 w-full rounded-xl border border-slate-300 bg-white px-3 text-sm text-slate-900 outline-none ring-0 transition placeholder:text-slate-400 focus:border-blue-500"
+        />
+        <button
+          type="submit"
+          disabled={pending}
+          className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {pending ? "Sending..." : "Email me access link"}
+        </button>
+      </div>
+
+      {error ? <p className="text-xs text-rose-700">{error}</p> : null}
+      {!error && successMessage ? (
+        <p className="text-xs text-emerald-700">{successMessage}</p>
+      ) : null}
+    </form>
+  );
+}

--- a/components/guides/Guide0To1000Tracker.tsx
+++ b/components/guides/Guide0To1000Tracker.tsx
@@ -1,0 +1,621 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  MAX_GUIDE_PROGRESS_ROWS,
+  normalizeGuideProgressRows,
+  type GuideProgressRow,
+} from "@/lib/course/guide-progress";
+import { type Guide0To1000Session } from "@/lib/guides/guide-0-1000m";
+
+const GUIDE_PROGRESS_SYNC_API_PATH = "/api/progress/guide";
+const GUIDE_PROGRESS_STORAGE_KEY = "fs_guide_0_1000m_progress_v1";
+const GUIDE_PROGRESS_SYNC_INTERVAL_MS = 10_000;
+const MAX_NOTES_LENGTH = 4000;
+
+type SyncState = "idle" | "syncing" | "synced" | "error" | "offline";
+
+type SessionProgress = {
+  completed: boolean;
+  notes: string;
+  updatedAt: string;
+};
+
+type SessionProgressRecord = Record<string, SessionProgress>;
+
+type Props = {
+  guideSlug: string;
+  sessions: Guide0To1000Session[];
+};
+
+function getInitialOnlineState(): boolean {
+  if (typeof navigator === "undefined") return true;
+  return navigator.onLine;
+}
+
+function getSafeIsoTimestamp(value: string | undefined): string {
+  if (!value) return new Date().toISOString();
+  const ts = Date.parse(value);
+  if (!Number.isFinite(ts)) return new Date().toISOString();
+  return new Date(ts).toISOString();
+}
+
+function toProgressRecord(rows: GuideProgressRow[]): SessionProgressRecord {
+  const next: SessionProgressRecord = {};
+  for (const row of rows) {
+    next[row.sectionId] = {
+      completed: row.completed,
+      notes: row.notes,
+      updatedAt: getSafeIsoTimestamp(row.updatedAt),
+    };
+  }
+  return next;
+}
+
+function toProgressRows(
+  record: SessionProgressRecord,
+  guideSlug: string,
+  allowedSectionIds: Set<string>
+): GuideProgressRow[] {
+  const rows = Object.entries(record)
+    .filter(([sectionId]) => allowedSectionIds.has(sectionId))
+    .map(([sectionId, value]) => ({
+      guideSlug,
+      sectionId,
+      completed: value.completed,
+      notes: value.notes,
+      updatedAt: getSafeIsoTimestamp(value.updatedAt),
+    }));
+
+  return normalizeGuideProgressRows(rows, { maxRows: MAX_GUIDE_PROGRESS_ROWS });
+}
+
+function filterRowsForGuide(
+  rows: unknown,
+  guideSlug: string,
+  allowedSectionIds: Set<string>
+): GuideProgressRow[] {
+  return normalizeGuideProgressRows(rows, { maxRows: MAX_GUIDE_PROGRESS_ROWS }).filter(
+    (row) => row.guideSlug === guideSlug && allowedSectionIds.has(row.sectionId)
+  );
+}
+
+function areRowsEqual(left: GuideProgressRow[], right: GuideProgressRow[]): boolean {
+  if (left.length !== right.length) return false;
+
+  for (let i = 0; i < left.length; i += 1) {
+    const a = left[i];
+    const b = right[i];
+    if (a.guideSlug !== b.guideSlug) return false;
+    if (a.sectionId !== b.sectionId) return false;
+    if (a.completed !== b.completed) return false;
+    if (a.notes !== b.notes) return false;
+    if (a.updatedAt !== b.updatedAt) return false;
+  }
+
+  return true;
+}
+
+function readLocalRows(guideSlug: string, allowedSectionIds: Set<string>): GuideProgressRow[] {
+  if (typeof window === "undefined") return [];
+
+  try {
+    const raw = localStorage.getItem(GUIDE_PROGRESS_STORAGE_KEY);
+    if (!raw) return [];
+    return filterRowsForGuide(JSON.parse(raw), guideSlug, allowedSectionIds);
+  } catch {
+    return [];
+  }
+}
+
+function persistLocalRows(rows: GuideProgressRow[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(GUIDE_PROGRESS_STORAGE_KEY, JSON.stringify(rows));
+  } catch {}
+}
+
+function formatRelativeAge(timestampMs: number | null): string {
+  if (!timestampMs) return "Saved recently.";
+
+  const ageMs = Math.max(0, Date.now() - timestampMs);
+  if (ageMs < 15_000) return "Saved just now.";
+
+  const ageMinutes = Math.floor(ageMs / 60_000);
+  if (ageMinutes < 1) return "Saved less than a minute ago.";
+  if (ageMinutes === 1) return "Saved 1 minute ago.";
+  if (ageMinutes < 60) return `Saved ${ageMinutes} minutes ago.`;
+
+  const ageHours = Math.floor(ageMinutes / 60);
+  if (ageHours === 1) return "Saved 1 hour ago.";
+  return `Saved ${ageHours} hours ago.`;
+}
+
+function formatSessionUpdatedLabel(updatedAt: string | undefined): string {
+  if (!updatedAt) return "Not updated yet";
+  const ts = Date.parse(updatedAt);
+  if (!Number.isFinite(ts)) return "Not updated yet";
+
+  const ageMs = Math.max(0, Date.now() - ts);
+  if (ageMs < 10_000) return "Updated just now";
+  if (ageMs < 60_000) return "Updated <1 min ago";
+
+  const minutes = Math.floor(ageMs / 60_000);
+  if (minutes < 60) return `Updated ${minutes} min ago`;
+
+  const hours = Math.floor(minutes / 60);
+  return `Updated ${hours}h ago`;
+}
+
+export default function Guide0To1000Tracker({ guideSlug, sessions }: Props) {
+  const allowedSectionIds = useMemo(
+    () => new Set(sessions.map((session) => session.id)),
+    [sessions]
+  );
+  const [progressBySessionId, setProgressBySessionId] = useState<SessionProgressRecord>({});
+  const progressBySessionIdRef = useRef<SessionProgressRecord>({});
+  const [hydrationState, setHydrationState] = useState<"loading" | "ready">("loading");
+  const [syncState, setSyncState] = useState<SyncState>("idle");
+  const [syncError, setSyncError] = useState("");
+  const [lastSyncAtMs, setLastSyncAtMs] = useState<number | null>(null);
+  const [isOnline, setIsOnline] = useState(getInitialOnlineState);
+  const dirtySectionIdsRef = useRef<Set<string>>(new Set());
+  const syncInFlightRef = useRef(false);
+
+  const applyProgressRows = useCallback(
+    (rows: GuideProgressRow[]) => {
+      const normalizedRows = filterRowsForGuide(rows, guideSlug, allowedSectionIds);
+      const nextRecord = toProgressRecord(normalizedRows);
+      progressBySessionIdRef.current = nextRecord;
+      setProgressBySessionId(nextRecord);
+      persistLocalRows(normalizedRows);
+    },
+    [allowedSectionIds, guideSlug]
+  );
+
+  const persistRowsToServer = useCallback(async (rows: GuideProgressRow[]) => {
+    const response = await fetch(GUIDE_PROGRESS_SYNC_API_PATH, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      cache: "no-store",
+      credentials: "same-origin",
+      body: JSON.stringify({ rows }),
+    });
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        throw new Error("Session expired. Sign in again to keep syncing your guide progress.");
+      }
+      throw new Error(`Guide progress sync failed (${response.status}).`);
+    }
+  }, []);
+
+  const syncGuideProgressNow = useCallback(
+    async (options?: { force?: boolean }) => {
+      if (syncInFlightRef.current) return;
+      if (!isOnline) {
+        setSyncState("offline");
+        return;
+      }
+
+      const dirtyIds = new Set(dirtySectionIdsRef.current);
+      if (!options?.force && dirtyIds.size === 0) return;
+
+      const allRows = toProgressRows(progressBySessionIdRef.current, guideSlug, allowedSectionIds);
+      const rows = allRows.filter((row) => options?.force || dirtyIds.has(row.sectionId));
+      if (rows.length === 0) return;
+
+      syncInFlightRef.current = true;
+      setSyncState("syncing");
+      setSyncError("");
+
+      try {
+        await persistRowsToServer(rows);
+        if (options?.force) {
+          dirtySectionIdsRef.current.clear();
+        } else {
+          for (const row of rows) {
+            dirtySectionIdsRef.current.delete(row.sectionId);
+          }
+        }
+        setSyncState("synced");
+        setLastSyncAtMs(Date.now());
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Could not sync guide progress right now. Try again.";
+        setSyncError(message);
+        setSyncState("error");
+      } finally {
+        syncInFlightRef.current = false;
+      }
+    },
+    [allowedSectionIds, guideSlug, isOnline, persistRowsToServer]
+  );
+
+  useEffect(() => {
+    progressBySessionIdRef.current = progressBySessionId;
+  }, [progressBySessionId]);
+
+  useEffect(() => {
+    const onOnline = () => {
+      setIsOnline(true);
+      setSyncState("idle");
+    };
+    const onOffline = () => {
+      setIsOnline(false);
+      setSyncState("offline");
+    };
+
+    window.addEventListener("online", onOnline);
+    window.addEventListener("offline", onOffline);
+
+    return () => {
+      window.removeEventListener("online", onOnline);
+      window.removeEventListener("offline", onOffline);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (hydrationState !== "ready") return;
+    if (!isOnline) return;
+    if (dirtySectionIdsRef.current.size === 0) return;
+    void syncGuideProgressNow();
+  }, [hydrationState, isOnline, syncGuideProgressNow]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const hydrate = async () => {
+      const localRows = readLocalRows(guideSlug, allowedSectionIds);
+      applyProgressRows(localRows);
+
+      if (!navigator.onLine) {
+        if (!cancelled) {
+          setHydrationState("ready");
+          setSyncState("offline");
+        }
+        return;
+      }
+
+      setSyncState("syncing");
+      setSyncError("");
+
+      try {
+        const response = await fetch(GUIDE_PROGRESS_SYNC_API_PATH, {
+          method: "GET",
+          cache: "no-store",
+          credentials: "same-origin",
+        });
+
+        if (!response.ok) {
+          if (response.status === 401) {
+            throw new Error("Session expired. Sign in again to load your guide progress.");
+          }
+          throw new Error(`Guide progress hydrate failed (${response.status}).`);
+        }
+
+        const payload = (await response.json()) as { rows?: unknown };
+        if (cancelled) return;
+
+        const remoteRows = filterRowsForGuide(payload.rows ?? [], guideSlug, allowedSectionIds);
+        const mergedRows = normalizeGuideProgressRows([...localRows, ...remoteRows], {
+          maxRows: MAX_GUIDE_PROGRESS_ROWS,
+        });
+        applyProgressRows(mergedRows);
+
+        if (!areRowsEqual(mergedRows, remoteRows)) {
+          await persistRowsToServer(mergedRows);
+        }
+
+        if (cancelled) return;
+        setSyncState("synced");
+        setLastSyncAtMs(Date.now());
+      } catch (error) {
+        if (cancelled) return;
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Could not load guide progress right now. You can continue locally.";
+        setSyncError(message);
+        setSyncState(navigator.onLine ? "error" : "offline");
+      } finally {
+        if (!cancelled) {
+          setHydrationState("ready");
+        }
+      }
+    };
+
+    void hydrate();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [allowedSectionIds, applyProgressRows, guideSlug, persistRowsToServer]);
+
+  useEffect(() => {
+    if (hydrationState !== "ready") return;
+
+    const syncTimer = window.setInterval(() => {
+      void syncGuideProgressNow();
+    }, GUIDE_PROGRESS_SYNC_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(syncTimer);
+    };
+  }, [hydrationState, syncGuideProgressNow]);
+
+  useEffect(() => {
+    if (hydrationState !== "ready") return;
+
+    const flushWhenBackgrounded = () => {
+      if (document.visibilityState !== "hidden") return;
+      void syncGuideProgressNow({ force: true });
+    };
+    const flushOnPageHide = () => {
+      void syncGuideProgressNow({ force: true });
+    };
+
+    document.addEventListener("visibilitychange", flushWhenBackgrounded);
+    window.addEventListener("pagehide", flushOnPageHide);
+
+    return () => {
+      document.removeEventListener("visibilitychange", flushWhenBackgrounded);
+      window.removeEventListener("pagehide", flushOnPageHide);
+    };
+  }, [hydrationState, syncGuideProgressNow]);
+
+  const updateSessionProgress = useCallback(
+    (
+      sessionId: string,
+      updater: (current: SessionProgress) => SessionProgress,
+      options?: { markDirty?: boolean }
+    ) => {
+      setProgressBySessionId((previous) => {
+        const current = previous[sessionId] ?? {
+          completed: false,
+          notes: "",
+          updatedAt: new Date().toISOString(),
+        };
+        const next = updater(current);
+        if (
+          next.completed === current.completed &&
+          next.notes === current.notes &&
+          next.updatedAt === current.updatedAt
+        ) {
+          return previous;
+        }
+
+        const nextRecord = {
+          ...previous,
+          [sessionId]: {
+            completed: next.completed,
+            notes: next.notes.slice(0, MAX_NOTES_LENGTH),
+            updatedAt: getSafeIsoTimestamp(next.updatedAt),
+          },
+        };
+
+        progressBySessionIdRef.current = nextRecord;
+        const localRows = toProgressRows(nextRecord, guideSlug, allowedSectionIds);
+        persistLocalRows(localRows);
+
+        if (options?.markDirty !== false) {
+          dirtySectionIdsRef.current.add(sessionId);
+          setSyncState((state) => (state === "offline" ? state : "idle"));
+          setSyncError("");
+        }
+
+        return nextRecord;
+      });
+    },
+    [allowedSectionIds, guideSlug]
+  );
+
+  const sessionsByWeek = useMemo(() => {
+    const grouped = new Map<number, Guide0To1000Session[]>();
+    for (const session of sessions) {
+      const existing = grouped.get(session.weekNumber) ?? [];
+      existing.push(session);
+      grouped.set(session.weekNumber, existing);
+    }
+
+    return Array.from(grouped.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([weekNumber, weekSessions]) => ({
+        weekNumber,
+        sessions: weekSessions.sort((left, right) => left.id.localeCompare(right.id)),
+      }));
+  }, [sessions]);
+
+  const completedCount = useMemo(() => {
+    return sessions.reduce((total, session) => {
+      const progress = progressBySessionId[session.id];
+      return progress?.completed ? total + 1 : total;
+    }, 0);
+  }, [progressBySessionId, sessions]);
+
+  const remainingCount = Math.max(0, sessions.length - completedCount);
+  const completionPercent =
+    sessions.length === 0 ? 0 : Math.round((completedCount / sessions.length) * 100);
+
+  const syncLabel = useMemo(() => {
+    if (syncState === "syncing") return "Saving guide progress...";
+    if (syncState === "offline" || !isOnline) {
+      return "Offline mode: changes stay on this device and sync when connection returns.";
+    }
+    if (syncState === "error") {
+      return syncError || "Could not sync guide progress right now.";
+    }
+    if (syncState === "synced") return formatRelativeAge(lastSyncAtMs);
+    return "Signed in. Guide progress sync is active.";
+  }, [isOnline, lastSyncAtMs, syncError, syncState]);
+
+  if (sessions.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50/80 p-6">
+        <h2 className="text-base font-semibold text-slate-900">Guide content unavailable</h2>
+        <p className="mt-2 text-sm text-slate-600">
+          Sessions are not configured yet. Please try again shortly.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <section className="rounded-3xl border border-blue-100 bg-white/95 p-6 shadow-[0_12px_40px_rgba(24,58,107,0.12)]">
+        <h1 className="text-3xl font-bold text-slate-900">0-1000m interactive plan</h1>
+        <p className="mt-2 text-sm leading-relaxed text-slate-600">
+          Track each session with completion and notes. Progress is stored locally immediately and
+          synced to your account in the background.
+        </p>
+
+        <div className="mt-5 grid gap-3 sm:grid-cols-3">
+          <div className="rounded-2xl border border-emerald-200 bg-emerald-50/60 p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-emerald-700">
+              Completed
+            </p>
+            <p className="mt-1 text-2xl font-bold text-slate-900">
+              {completedCount}/{sessions.length}
+            </p>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-600">
+              Remaining
+            </p>
+            <p className="mt-1 text-2xl font-bold text-slate-900">{remainingCount}</p>
+          </div>
+          <div className="rounded-2xl border border-blue-100 bg-blue-50/60 p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Progress</p>
+            <p className="mt-1 text-2xl font-bold text-slate-900">{completionPercent}%</p>
+          </div>
+        </div>
+
+        <div className="mt-5 flex flex-wrap items-center gap-3">
+          <p className="text-xs text-slate-600" aria-live="polite">
+            {syncLabel}
+          </p>
+          {(syncState === "error" || syncState === "offline") && (
+            <button
+              type="button"
+              onClick={() => {
+                void syncGuideProgressNow({ force: true });
+              }}
+              className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-xs font-semibold text-slate-700 transition hover:bg-slate-50"
+            >
+              Retry sync
+            </button>
+          )}
+        </div>
+      </section>
+
+      {hydrationState === "loading" ? (
+        <div className="space-y-3" aria-label="Loading guide progress">
+          <div className="h-28 animate-pulse rounded-2xl border border-slate-200/70 bg-white/80" />
+          <div className="h-28 animate-pulse rounded-2xl border border-slate-200/70 bg-white/80" />
+          <div className="h-28 animate-pulse rounded-2xl border border-slate-200/70 bg-white/80" />
+        </div>
+      ) : (
+        <div className="space-y-5">
+          {sessionsByWeek.map((week) => (
+            <section
+              key={week.weekNumber}
+              className="rounded-3xl border border-slate-200 bg-white/95 p-5 shadow-[0_8px_30px_rgba(15,23,42,0.08)]"
+            >
+              <h2 className="text-lg font-semibold text-slate-900">Week {week.weekNumber}</h2>
+              <div className="mt-4 grid gap-3">
+                {week.sessions.map((session) => {
+                  const progress = progressBySessionId[session.id];
+                  const completed = progress?.completed ?? false;
+                  const notes = progress?.notes ?? "";
+                  const textareaId = `guide-${session.id}-notes`;
+
+                  return (
+                    <article
+                      key={session.id}
+                      className={`rounded-2xl border p-4 transition ${
+                        completed
+                          ? "border-emerald-200 bg-emerald-50/50"
+                          : "border-slate-200 bg-white"
+                      }`}
+                    >
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                            Session {session.id}
+                          </p>
+                          <h3 className="mt-1 text-base font-semibold text-slate-900">
+                            {session.title}
+                          </h3>
+                        </div>
+
+                        <label className="inline-flex items-center gap-2 text-sm font-medium text-slate-700">
+                          <input
+                            type="checkbox"
+                            checked={completed}
+                            onChange={() => {
+                              const timestamp = new Date().toISOString();
+                              updateSessionProgress(session.id, (current) => ({
+                                completed: !current.completed,
+                                notes: current.notes,
+                                updatedAt: timestamp,
+                              }));
+                            }}
+                            className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                          />
+                          {completed ? "Completed" : "Mark complete"}
+                        </label>
+                      </div>
+
+                      <p className="mt-2 text-sm text-slate-600">
+                        <span className="font-medium text-slate-700">Focus:</span> {session.focus}
+                      </p>
+                      <p className="mt-1 text-sm text-slate-600">
+                        <span className="font-medium text-slate-700">Target set:</span>{" "}
+                        {session.targetSet}
+                      </p>
+
+                      <div className="mt-3 space-y-2">
+                        <label
+                          htmlFor={textareaId}
+                          className="text-xs font-semibold text-slate-700"
+                        >
+                          Session notes
+                        </label>
+                        <textarea
+                          id={textareaId}
+                          value={notes}
+                          onChange={(event) => {
+                            const timestamp = new Date().toISOString();
+                            const nextNotes = event.currentTarget.value.slice(0, MAX_NOTES_LENGTH);
+                            updateSessionProgress(session.id, (current) => ({
+                              completed: current.completed,
+                              notes: nextNotes,
+                              updatedAt: timestamp,
+                            }));
+                          }}
+                          rows={3}
+                          placeholder="Write what felt good, what to adjust next time, and pacing notes."
+                          className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-blue-500"
+                        />
+                        <div className="flex items-center justify-between gap-3 text-xs text-slate-500">
+                          <span>
+                            {notes.length}/{MAX_NOTES_LENGTH}
+                          </span>
+                          <span>{formatSessionUpdatedLabel(progress?.updatedAt)}</span>
+                        </div>
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/guides/GuidePdfDownloadButton.tsx
+++ b/components/guides/GuidePdfDownloadButton.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+
+type Props = {
+  apiPath: string;
+  fallbackFileName?: string;
+  className?: string;
+};
+
+const DEFAULT_ERROR_MESSAGE = "Could not download PDF right now. Please try again.";
+
+function toFileNameFromDisposition(disposition: string | null, fallback: string): string {
+  if (!disposition) return fallback;
+
+  const utf8Match = disposition.match(/filename\*=UTF-8''([^;]+)/i);
+  if (utf8Match?.[1]) {
+    try {
+      return decodeURIComponent(utf8Match[1]);
+    } catch {
+      return fallback;
+    }
+  }
+
+  const simpleMatch = disposition.match(/filename="?([^"]+)"?/i);
+  if (simpleMatch?.[1]) {
+    return simpleMatch[1];
+  }
+
+  return fallback;
+}
+
+export default function GuidePdfDownloadButton({
+  apiPath,
+  fallbackFileName = "guide.pdf",
+  className = "",
+}: Props) {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState("");
+
+  async function onClick() {
+    if (pending) return;
+    setPending(true);
+    setError("");
+
+    try {
+      const response = await fetch(apiPath, {
+        method: "GET",
+        cache: "no-store",
+        credentials: "same-origin",
+      });
+
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(payload?.error || DEFAULT_ERROR_MESSAGE);
+      }
+
+      const blob = await response.blob();
+      const filename = toFileNameFromDisposition(
+        response.headers.get("content-disposition"),
+        fallbackFileName
+      );
+
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = filename;
+      anchor.rel = "noopener";
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : DEFAULT_ERROR_MESSAGE;
+      setError(message);
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className={`space-y-2 ${className}`}>
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={pending}
+        className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {pending ? "Downloading PDF..." : "Download PDF"}
+      </button>
+      {error ? <p className="text-xs text-rose-700">{error}</p> : null}
+    </div>
+  );
+}

--- a/components/my-library/PortalButton.tsx
+++ b/components/my-library/PortalButton.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+
+type Props = {
+  returnPath?: string;
+  className?: string;
+  onNavigate?: (url: string) => void;
+};
+
+type PortalResponse = {
+  ok: boolean;
+  url?: string;
+  error?: string;
+};
+
+const DEFAULT_ERROR_MESSAGE = "Could not open billing portal right now. Please try again.";
+
+export function redirectToUrl(url: string) {
+  window.location.assign(url);
+}
+
+export default function PortalButton({
+  returnPath = "/my-library",
+  className = "",
+  onNavigate = redirectToUrl,
+}: Props) {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string>("");
+
+  async function onClick() {
+    if (pending) return;
+
+    setPending(true);
+    setError("");
+
+    try {
+      const response = await fetch("/api/portal", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ returnPath }),
+      });
+
+      const json = (await response.json()) as PortalResponse;
+      if (!response.ok || !json.ok || !json.url) {
+        throw new Error(json.error || DEFAULT_ERROR_MESSAGE);
+      }
+
+      onNavigate(json.url);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : DEFAULT_ERROR_MESSAGE;
+      setError(message);
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={pending}
+        data-testid="my-library-portal-button"
+        className={`inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60 ${className}`}
+      >
+        {pending ? "Opening billing..." : "Manage billing"}
+      </button>
+      {error ? <p className="text-xs text-rose-700">{error}</p> : null}
+    </div>
+  );
+}

--- a/components/navigation/mainMenuItems.ts
+++ b/components/navigation/mainMenuItems.ts
@@ -8,6 +8,7 @@ export const MAIN_MENU_ITEMS: MainMenuItem[] = [
   { href: "/", title: "Home", subtitle: "Back to start" },
   { href: "/course", title: "Free Course", subtitle: "Modules & lessons" },
   { href: "/my-library", title: "My Library", subtitle: "Owned content & resume" },
+  { href: "/plans", title: "Plans", subtitle: "Paid guides & feedback" },
   { href: "/programs", title: "Swim Programs", subtitle: "Structured plans & PDFs" },
   { href: "/analysis", title: "Video Analysis", subtitle: "Personal feedback — optional" },
   { href: "/our-method", title: "Our Method", subtitle: "Learn. Drill. Swim." },

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -54,3 +54,53 @@
 - `X-RateLimit-Remaining`
 - `X-RateLimit-Reset`
 - `Retry-After` (on `429`)
+
+## `POST /api/download/resend`
+
+### Request
+
+- Headers:
+  - `Content-Type: application/json`
+- Body:
+
+```json
+{
+  "email": "buyer@example.com",
+  "nextPath": "/my-library",
+  "source": "checkout_success"
+}
+```
+
+### Response
+
+- Success (non-enumerating):
+
+```json
+{
+  "ok": true,
+  "message": "If this email exists, we sent a secure access link."
+}
+```
+
+- Failure:
+
+```json
+{
+  "ok": false,
+  "error": "Too many requests. Please try again shortly."
+}
+```
+
+### Status Codes
+
+- `200`: accepted (`ok: true` with non-enumerating message)
+- `400`: invalid JSON or invalid email input
+- `415`: unsupported content type
+- `429`: rate limited
+
+### Rate-Limit Headers
+
+- `X-RateLimit-Limit`
+- `X-RateLimit-Remaining`
+- `X-RateLimit-Reset`
+- `Retry-After` (on `429`)

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -104,3 +104,79 @@
 - `X-RateLimit-Remaining`
 - `X-RateLimit-Reset`
 - `Retry-After` (on `429`)
+
+## `GET|POST /api/progress/guide`
+
+### Request
+
+- Auth: signed-in user session required
+
+`GET`:
+
+- no body
+
+`POST`:
+
+- Headers:
+  - `Content-Type: application/json`
+- Body:
+
+```json
+{
+  "rows": [
+    {
+      "guideSlug": "0-1000m",
+      "sectionId": "s01",
+      "completed": true,
+      "notes": "Felt better rhythm today",
+      "updatedAt": "2026-02-17T10:00:00.000Z"
+    }
+  ]
+}
+```
+
+### Response
+
+`GET` success:
+
+```json
+{
+  "ok": true,
+  "rows": [
+    {
+      "guideSlug": "0-1000m",
+      "sectionId": "s01",
+      "completed": true,
+      "notes": "Felt better rhythm today",
+      "updatedAt": "2026-02-17T10:00:00.000Z"
+    }
+  ]
+}
+```
+
+`POST` success:
+
+```json
+{
+  "ok": true,
+  "upserted": 1
+}
+```
+
+Failure:
+
+```json
+{
+  "ok": false,
+  "error": "Unauthorized."
+}
+```
+
+### Status Codes
+
+- `200`: success
+- `400`: invalid JSON or invalid payload (`rows` missing/not array)
+- `401`: unauthorized
+- `413`: too many rows in one request
+- `415`: unsupported content type
+- `500`: database failure

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -180,3 +180,33 @@ Failure:
 - `413`: too many rows in one request
 - `415`: unsupported content type
 - `500`: database failure
+
+## `GET /api/guides/0-1000m/pdf`
+
+### Request
+
+- Auth: signed-in user session required
+- Access: user must own `guide_0_1000m` entitlement
+
+### Response
+
+- Success:
+  - `200` with `application/pdf`
+  - `Content-Disposition: attachment; filename="freeswimming-0-1000m-guide.pdf"`
+
+- Failure:
+
+```json
+{
+  "ok": false,
+  "error": "Guide access required."
+}
+```
+
+### Status Codes
+
+- `200`: pdf download stream
+- `401`: unauthorized
+- `403`: user does not own guide entitlement
+- `500`: entitlement verification failure
+- `503`: PDF asset temporarily unavailable

--- a/docs/task-brief-template.md
+++ b/docs/task-brief-template.md
@@ -13,6 +13,7 @@ Use this quick check so the task execution is precise:
 - State communication style (for example: one step at a time for manual GitHub actions)
 - State non-negotiables (no secrets in repo, UX quality bar, performance guardrails)
 - State continuity rules (commit cadence + resume protocol if chat/session is interrupted)
+- State git rhythm defaults (commit/push cadence and PR cut cadence to `main`)
 
 Suggested prompt wrapper:
 
@@ -20,6 +21,7 @@ Suggested prompt wrapper:
 Use task brief: <PATH_TO_BRIEF>
 Mode: end-to-end (implement + tests + commit + push on current branch)
 Communication: one manual step at a time; wait for my "done" between manual GitHub/UI steps.
+Git rhythm: commit + push each validated step; ask me before opening/updating PR to main.
 Handoff must include:
 
 1. what changed
@@ -130,6 +132,20 @@ Define how work remains recoverable if chat/session context is lost.
   1. `git status -sb`
   2. `git log --oneline -n 10`
   3. reopen task brief and continue from recorded next step.
+
+## Git Rhythm Defaults (Required)
+
+Define concrete git execution defaults so quality does not depend on memory.
+
+- Commit + push cadence:
+  - commit and push after each validated implementation step (`lint` + `typecheck` + relevant tests for that step),
+  - avoid batching unrelated scope into one checkpoint commit.
+- PR cadence to `main`:
+  - open or update PR at least once per day of active implementation,
+  - cut/refresh PR after `2-4` validated checkpoint commits, or after one complete vertical slice, whichever comes first.
+- Assistant prompting contract:
+  - after each validated step, assistant must explicitly ask whether to commit+push now,
+  - after every `2` pushed checkpoints (or one completed slice), assistant must explicitly ask whether to open/refresh PR to `main`.
 
 ## Implementation Checkpoint Log (Required For In-Progress Briefs)
 

--- a/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
+++ b/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
@@ -131,6 +131,9 @@ Users can start instantly in guest mode, buy optional paid products without acco
   - product cards for all paid offers,
   - checkout CTA wiring to `/api/checkout/session`,
   - empty/error recovery state when product env configuration is incomplete.
+- Stripe billing self-service baseline is implemented:
+  - `/api/portal` route with auth + safe return handling,
+  - `My Library` exposes `Manage billing` action and error fallback copy.
 - Guest purchase attach-by-email on sign-in is implemented.
 - Free-course account sync baseline is implemented:
   - `/api/progress/course` (authenticated read/write),
@@ -152,7 +155,6 @@ Users can start instantly in guest mode, buy optional paid products without acco
   - `/claim`,
   - `/guides/0-1000m` interactive guide.
 - Missing API endpoints from architecture contract:
-  - `/api/portal`,
   - `/api/download/resend`,
   - `/api/progress/guide`,
   - `/api/user/export`,
@@ -179,7 +181,6 @@ Users can start instantly in guest mode, buy optional paid products without acco
 ## Next Delivery Order (Execution)
 
 1. Commerce completion slice:
-   - implement `/api/portal`,
    - implement `/api/download/resend`,
    - update `/checkout/success` with immediate download + confirmation UX.
 2. Progress sync slice:
@@ -808,8 +809,36 @@ At each phase:
 - Branch safety:
   - push checkpoint commits to remote branch after major milestones so work survives local interruption.
 
+## Git Rhythm (Locked For This Brief)
+
+- Commit + push cadence:
+  - commit and push after each validated implementation step,
+  - minimum validation gate per step:
+    - `npm run lint`,
+    - `npm run typecheck`,
+    - targeted tests for changed scope (unit/e2e as relevant).
+- PR cadence to `main`:
+  - cut or refresh PR after every `2-4` validated checkpoint commits, or one completed vertical slice, whichever comes first,
+  - if active implementation continues across days, ensure PR is updated daily.
+- Assistant prompt contract (required):
+  - after each validated step, assistant explicitly asks: `Commit + push this checkpoint now?`,
+  - after every second pushed checkpoint (or one completed slice), assistant explicitly asks:
+    - `Open/update PR to main now?`
+  - this prompt contract is mandatory even if owner does not explicitly request it each time.
+
 ## Implementation Checkpoint Log (In Progress)
 
+- `2026-02-17` | `working tree` | `/api/portal` implementation complete:
+  - added `POST /api/portal` with auth guard, `no-store` headers, safe local `returnPath` handling, and explicit `401/404/500` responses,
+  - customer resolution now checks entitlement `stripe_customer_id` first, then Stripe customer lookup by signed-in email fallback,
+  - best-effort persistence of fallback `stripe_customer_id` to entitlements for subsequent requests,
+  - added helper utils + unit tests for safe return path and active customer selection,
+  - wired `My Library` `Manage billing` action to call `/api/portal` and redirect on success with user-visible fallback error copy.
+  - validation run completed:
+    - `npm run lint`,
+    - `npm run typecheck`,
+    - `npm run test:unit`.
+  - next step: implement `/api/download/resend` and connect success/library recovery flows.
 - `2026-02-17` | `working tree` | progress-sync + backup-prompt slice in implementation:
   - added `/api/progress/course` authenticated read/write route,
   - added shared course-progress normalization/merge helpers + unit tests,
@@ -821,7 +850,7 @@ At each phase:
     - `npm run test:unit`,
     - `npm run build`,
     - `npx playwright test tests/e2e/install-prompt.spec.ts --project=mobile-chromium`.
-  - next step: owner review + continue remaining `/api/progress/guide` scope.
+  - next step: implement `/api/portal` using the commerce quality contract before `/api/progress/guide`.
 - `2026-02-16` | `44cecac` | completed core implementation through:
   - Supabase schema + RLS baseline,
   - auth/session wiring + guarded `My Library`,
@@ -900,6 +929,7 @@ Use task brief: docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-
 Mode: end-to-end (implement + tests + commit + push on current branch)
 Communication: one actionable step at a time for manual/external actions; wait for my "done" before next step.
 Non-negotiables: no secrets in repo files, preserve accessibility semantics, keep current visual language, run npm run verify.
+Git rhythm: commit + push each validated step; ask me explicitly before PR cut/refresh to main.
 ```
 
 ## External References (Primary)

--- a/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
+++ b/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
@@ -6,7 +6,7 @@
 - `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-02-15`
-- `updated`: `2026-02-16`
+- `updated`: `2026-02-17`
 
 ## Goal
 
@@ -106,7 +106,7 @@ Users can start instantly in guest mode, buy optional paid products without acco
 - `npm run test:e2e`
 - `npm run build`
 
-## Current Delivery Status (2026-02-16)
+## Current Delivery Status (2026-02-17)
 
 ### Implemented (verified)
 
@@ -132,6 +132,14 @@ Users can start instantly in guest mode, buy optional paid products without acco
   - checkout CTA wiring to `/api/checkout/session`,
   - empty/error recovery state when product env configuration is incomplete.
 - Guest purchase attach-by-email on sign-in is implemented.
+- Free-course account sync baseline is implemented:
+  - `/api/progress/course` (authenticated read/write),
+  - signed-in course clients hydrate from server and merge local progress on first sign-in,
+  - local progress updates are synced back to server for cross-device continuity.
+- Guest progress-safety milestone prompt is implemented:
+  - appears after 3 completed lessons in guest mode,
+  - includes free-account CTA to preserve progress across devices,
+  - dismiss suppresses prompt for 7 days.
 - Auth abuse controls are implemented:
   - request/verify rate limits,
   - cooldown messaging,
@@ -146,7 +154,6 @@ Users can start instantly in guest mode, buy optional paid products without acco
 - Missing API endpoints from architecture contract:
   - `/api/portal`,
   - `/api/download/resend`,
-  - `/api/progress/course`,
   - `/api/progress/guide`,
   - `/api/user/export`,
   - `/api/user/delete`.
@@ -154,10 +161,9 @@ Users can start instantly in guest mode, buy optional paid products without acco
   - preview/download/re-download behavior not implemented yet.
 - Checkout success criteria is only partially met:
   - page currently shows processing state, but not immediate download action.
-- Progress sync criteria is not met yet:
-  - free course still writes to local storage only,
-  - no server progress sync on second device.
-- Guest progress-safety milestone prompt (exactly after 3 completed lessons) is not implemented.
+- Progress sync criteria is partially met:
+  - free-course progress now supports signed-in server sync and local->account merge,
+  - paid-guide progress sync (`/api/progress/guide`) is still pending.
 - Goals MVP UI/state flow is not implemented.
 - Analytics/KPI event pipeline is not implemented.
 - GDPR operational requirements are not complete:
@@ -177,12 +183,11 @@ Users can start instantly in guest mode, buy optional paid products without acco
    - implement `/api/download/resend`,
    - update `/checkout/success` with immediate download + confirmation UX.
 2. Progress sync slice:
-   - implement `/api/progress/course` and wire course writes/reads to Supabase for signed-in users,
    - implement `/api/progress/guide` baseline contract.
 3. Library/content slice:
    - implement `/guides/0-1000m` interactive 20-session plan,
    - implement owned item preview/download/re-download in `/my-library/item/[slug]`,
-   - implement guest milestone backup prompt at lesson 3.
+   - expand claim/restore UX around owned content recovery.
 4. Trust/ops slice:
    - implement `/api/user/export` + `/api/user/delete`,
    - implement analytics event contract baseline,
@@ -756,7 +761,7 @@ npx supabase start
 3. **Progress (Week 3-4)**
    - free-course progress sync migration from localStorage,
    - paid interactive guide progress sync.
-   - status: `not started`.
+   - status: `in-progress` (free-course sync + guest backup prompt delivered; paid-guide sync pending).
 4. **Trust + QA (Week 4)**
    - data export/delete controls, tests, accessibility polish, verify gate.
    - status: `in-progress` (partial auth hardening done; export/delete/GDPR workflow pending).
@@ -805,6 +810,18 @@ At each phase:
 
 ## Implementation Checkpoint Log (In Progress)
 
+- `2026-02-17` | `working tree` | progress-sync + backup-prompt slice in implementation:
+  - added `/api/progress/course` authenticated read/write route,
+  - added shared course-progress normalization/merge helpers + unit tests,
+  - wired `/course` to hydrate from account, merge local progress, and sync updates for signed-in users,
+  - added guest milestone backup prompt after 3 completed lessons with free-account CTA and 7-day dismiss cooldown.
+  - validation run completed:
+    - `npm run lint`,
+    - `npm run typecheck`,
+    - `npm run test:unit`,
+    - `npm run build`,
+    - `npx playwright test tests/e2e/install-prompt.spec.ts --project=mobile-chromium`.
+  - next step: owner review + continue remaining `/api/progress/guide` scope.
 - `2026-02-16` | `44cecac` | completed core implementation through:
   - Supabase schema + RLS baseline,
   - auth/session wiring + guarded `My Library`,

--- a/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
+++ b/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
@@ -127,6 +127,10 @@ Users can start instantly in guest mode, buy optional paid products without acco
   - `Owned` section,
   - `Explore More` section,
   - checkout CTA for not-owned products.
+- `/plans` paid-offers hub route is implemented:
+  - product cards for all paid offers,
+  - checkout CTA wiring to `/api/checkout/session`,
+  - empty/error recovery state when product env configuration is incomplete.
 - Guest purchase attach-by-email on sign-in is implemented.
 - Auth abuse controls are implemented:
   - request/verify rate limits,
@@ -137,7 +141,6 @@ Users can start instantly in guest mode, buy optional paid products without acco
 ### Outstanding (blocking move to `done`)
 
 - Missing routes from architecture contract:
-  - `/plans`,
   - `/claim`,
   - `/guides/0-1000m` interactive guide.
 - Missing API endpoints from architecture contract:
@@ -170,7 +173,6 @@ Users can start instantly in guest mode, buy optional paid products without acco
 ## Next Delivery Order (Execution)
 
 1. Commerce completion slice:
-   - implement `/plans`,
    - implement `/api/portal`,
    - implement `/api/download/resend`,
    - update `/checkout/success` with immediate download + confirmation UX.
@@ -198,7 +200,8 @@ Users can start instantly in guest mode, buy optional paid products without acco
     - free-course progress resume across devices when signed in (server-backed),
     - paid guide progress resume (interactive guide),
     - owned item preview/download/re-download from `My Library` item detail,
-    - `/plans`, `/claim`, and data export/delete user flows.
+    - `/plans` final UX sweep on mobile + desktop preview,
+    - `/claim`, and data export/delete user flows.
   - browsers/devices:
     - iOS Safari (phone),
     - Android Chromium (phone),

--- a/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
+++ b/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
@@ -134,6 +134,14 @@ Users can start instantly in guest mode, buy optional paid products without acco
 - Stripe billing self-service baseline is implemented:
   - `/api/portal` route with auth + safe return handling,
   - `My Library` exposes `Manage billing` action and error fallback copy.
+- Download-access recovery baseline is implemented:
+  - `/api/download/resend` endpoint with per-IP + per-email rate limits,
+  - non-enumerating response contract (`If this email exists, we sent a secure access link.`),
+  - access-link resend uses magic-link auth callback to return users to `My Library`.
+- Checkout/library recovery UX baseline is implemented:
+  - `/checkout/success` now includes immediate `Download from My Library` CTA,
+  - `/checkout/success` includes purchase-email resend form for secure access link recovery,
+  - `My Library` empty-owned state includes `already bought?` recovery resend entry.
 - Guest purchase attach-by-email on sign-in is implemented.
 - Free-course account sync baseline is implemented:
   - `/api/progress/course` (authenticated read/write),
@@ -155,14 +163,11 @@ Users can start instantly in guest mode, buy optional paid products without acco
   - `/claim`,
   - `/guides/0-1000m` interactive guide.
 - Missing API endpoints from architecture contract:
-  - `/api/download/resend`,
   - `/api/progress/guide`,
   - `/api/user/export`,
   - `/api/user/delete`.
 - `My Library` item detail is still placeholder text:
   - preview/download/re-download behavior not implemented yet.
-- Checkout success criteria is only partially met:
-  - page currently shows processing state, but not immediate download action.
 - Progress sync criteria is partially met:
   - free-course progress now supports signed-in server sync and local->account merge,
   - paid-guide progress sync (`/api/progress/guide`) is still pending.
@@ -180,16 +185,13 @@ Users can start instantly in guest mode, buy optional paid products without acco
 
 ## Next Delivery Order (Execution)
 
-1. Commerce completion slice:
-   - implement `/api/download/resend`,
-   - update `/checkout/success` with immediate download + confirmation UX.
-2. Progress sync slice:
+1. Progress sync slice:
    - implement `/api/progress/guide` baseline contract.
-3. Library/content slice:
+2. Library/content slice:
    - implement `/guides/0-1000m` interactive 20-session plan,
    - implement owned item preview/download/re-download in `/my-library/item/[slug]`,
    - expand claim/restore UX around owned content recovery.
-4. Trust/ops slice:
+3. Trust/ops slice:
    - implement `/api/user/export` + `/api/user/delete`,
    - implement analytics event contract baseline,
    - close GDPR/privacy/cookie documentation and operational runbook items.
@@ -828,6 +830,19 @@ At each phase:
 
 ## Implementation Checkpoint Log (In Progress)
 
+- `2026-02-17` | `working tree` | `/api/download/resend` + checkout/library recovery slice complete:
+  - added `POST /api/download/resend` with JSON/content-type guard, `no-store` responses, and non-enumerating success copy,
+  - endpoint enforces per-IP + per-email rate limits (Upstash-first with in-memory fallback),
+  - resend now verifies entitlement by purchase email and sends magic-link access flow back to `next` path,
+  - added reusable `DownloadResendForm` client component and connected it to:
+    - `/checkout/success` recovery module,
+    - `My Library` empty-owned recovery module.
+  - updated `/checkout/success` with immediate `Download from My Library` CTA and clearer post-payment confirmation copy.
+  - validation run completed:
+    - `npm run lint`,
+    - `npm run typecheck`,
+    - `npm run test:unit`.
+  - next step: implement `/api/progress/guide` baseline contract.
 - `2026-02-17` | `working tree` | `/api/portal` implementation complete:
   - added `POST /api/portal` with auth guard, `no-store` headers, safe local `returnPath` handling, and explicit `401/404/500` responses,
   - customer resolution now checks entitlement `stripe_customer_id` first, then Stripe customer lookup by signed-in email fallback,

--- a/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
+++ b/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
@@ -106,15 +106,99 @@ Users can start instantly in guest mode, buy optional paid products without acco
 - `npm run test:e2e`
 - `npm run build`
 
+## Current Delivery Status (2026-02-16)
+
+### Implemented (verified)
+
+- Supabase schema + RLS baseline is implemented and committed in:
+  - `supabase/migrations/20260216141500_my_library_schema.sql`
+- Typed DB contract exists in:
+  - `types/database.ts`
+- Auth/session baseline is implemented:
+  - `/auth/sign-in` (code-first UX),
+  - `/auth/callback` token/code handling,
+  - guarded `My Library` access.
+- Stripe checkout + webhook entitlement fulfillment is implemented:
+  - `/api/checkout/session`,
+  - `/api/stripe/webhook`,
+  - idempotent entitlement write by `stripe_checkout_session_id`.
+- `My Library` page exists with:
+  - signed-in state,
+  - `Owned` section,
+  - `Explore More` section,
+  - checkout CTA for not-owned products.
+- Guest purchase attach-by-email on sign-in is implemented.
+- Auth abuse controls are implemented:
+  - request/verify rate limits,
+  - cooldown messaging,
+  - Upstash support with in-memory fallback.
+- Soft-launch public UX exists with under-construction banner.
+
+### Outstanding (blocking move to `done`)
+
+- Missing routes from architecture contract:
+  - `/plans`,
+  - `/claim`,
+  - `/guides/0-1000m` interactive guide.
+- Missing API endpoints from architecture contract:
+  - `/api/portal`,
+  - `/api/download/resend`,
+  - `/api/progress/course`,
+  - `/api/progress/guide`,
+  - `/api/user/export`,
+  - `/api/user/delete`.
+- `My Library` item detail is still placeholder text:
+  - preview/download/re-download behavior not implemented yet.
+- Checkout success criteria is only partially met:
+  - page currently shows processing state, but not immediate download action.
+- Progress sync criteria is not met yet:
+  - free course still writes to local storage only,
+  - no server progress sync on second device.
+- Guest progress-safety milestone prompt (exactly after 3 completed lessons) is not implemented.
+- Goals MVP UI/state flow is not implemented.
+- Analytics/KPI event pipeline is not implemented.
+- GDPR operational requirements are not complete:
+  - export/delete endpoints missing,
+  - rights workflow + privacy/cookie disclosure updates not completed in app docs/routes.
+- Library tab contract decision required:
+  - implement explicit query tabs (`?tab=library|explore`) or revise contract to section layout.
+- Security follow-up items remain deferred:
+  - live rate-limit verification,
+  - progressive Turnstile gate,
+  - auth abuse observability baseline.
+
+## Next Delivery Order (Execution)
+
+1. Commerce completion slice:
+   - implement `/plans`,
+   - implement `/api/portal`,
+   - implement `/api/download/resend`,
+   - update `/checkout/success` with immediate download + confirmation UX.
+2. Progress sync slice:
+   - implement `/api/progress/course` and wire course writes/reads to Supabase for signed-in users,
+   - implement `/api/progress/guide` baseline contract.
+3. Library/content slice:
+   - implement `/guides/0-1000m` interactive 20-session plan,
+   - implement owned item preview/download/re-download in `/my-library/item/[slug]`,
+   - implement guest milestone backup prompt at lesson 3.
+4. Trust/ops slice:
+   - implement `/api/user/export` + `/api/user/delete`,
+   - implement analytics event contract baseline,
+   - close GDPR/privacy/cookie documentation and operational runbook items.
+
 ## Manual QA Environments
 
 - Local environment:
   - URL: `http://127.0.0.1:3000`
-  - flows tested:
+  - current verified manual checks:
     - buy flow -> webhook fulfilled entitlement -> `My Library` visible,
-    - free-course progress resume across sign-in/sign-out states,
-    - paid guide progress resume,
-    - `Owned`/`Not Owned` ordering and CTA clarity.
+    - sign-in code flow + cooldown UX,
+    - soft-launch under-construction banner visibility on public routes.
+  - remaining manual checks (after pending implementation):
+    - free-course progress resume across devices when signed in (server-backed),
+    - paid guide progress resume (interactive guide),
+    - owned item preview/download/re-download from `My Library` item detail,
+    - `/plans`, `/claim`, and data export/delete user flows.
   - browsers/devices:
     - iOS Safari (phone),
     - Android Chromium (phone),
@@ -662,16 +746,21 @@ npx supabase start
 
 1. **Foundation (Week 1-2)**
    - auth, DB schema, Stripe checkout + webhook, entitlement persistence.
+   - status: `done`.
 2. **Library (Week 2-3)**
    - `My Library` page, owned/not-owned sections, receipt portal link, support links.
+   - status: `in-progress` (owned/explore done; portal/support/download actions pending).
 3. **Progress (Week 3-4)**
    - free-course progress sync migration from localStorage,
    - paid interactive guide progress sync.
+   - status: `not started`.
 4. **Trust + QA (Week 4)**
    - data export/delete controls, tests, accessibility polish, verify gate.
+   - status: `in-progress` (partial auth hardening done; export/delete/GDPR workflow pending).
 5. **Monetization Expansion (Post-MVP)**
    - enable `M1` first behind flag and observe KPIs,
    - if stable, enable `M2`, then `M3`.
+   - status: `deferred until MVP gate`.
 
 ## Step-By-Step Delivery Plan (Agent Execution)
 
@@ -739,7 +828,7 @@ At each phase:
 - `2026-02-16` | `75ef38c` | auth abuse protection refinement:
   - added sign-in request and code verification rate limits (IP + hashed email), with Upstash support and safe in-memory fallback,
   - replaced raw provider auth errors with user-friendly cooldown/generic messages to improve UX and reduce abuse signal leakage.
-- `2026-02-16` | `working-tree` | auth cooldown UX + cadence refinement:
+- `2026-02-16` | `ce9e82e` | auth cooldown UX + cadence refinement (merged via PR #19):
   - sign-in cooldown now returns `cooldownUntil` and the error banner counts down live in the UI (no manual refresh needed),
   - added stepped per-email resend cadence for login code requests (`30s` -> `60s` -> `5m`) while retaining hard anti-abuse limits.
 - `2026-02-16` | `ec8d2fb` | soft-launch public UX refinement:
@@ -747,7 +836,7 @@ At each phase:
   - added a utility footer on public routes with clear `Login/My Library` and `Contact` actions,
   - made header auth action explicit (`Login` when signed out, `My Library` when signed in) to improve navigation clarity,
   - increased mobile screenshot E2E timeout to avoid false failures while capturing full-page core-flow snapshots.
-- `2026-02-16` | `working-tree` | soft-launch simplification per owner direction:
+- `2026-02-16` | `7cd6190` | soft-launch simplification per owner direction (merged via PR #21):
   - replaced `Public beta` copy with a simple `under construction` banner on public routes,
   - removed extra banner CTA buttons (`Login`, `Programs`) to reduce noise,
   - removed the temporary utility footer links (`Login`, `Contact`),
@@ -761,8 +850,8 @@ At each phase:
 - `75ef38c`: auth verify rate limits added for sign-in code attempts (IP + hashed email).
 - `75ef38c`: auth error UX hardened to friendly/generic cooldown copy (reduced provider leakage to user-facing UI).
 - `75ef38c`: env access helper fixed for `NEXT_PUBLIC_*` runtime safety in client/server contexts.
-- `working-tree`: cooldown error now includes live countdown behavior via `cooldownUntil` parameter.
-- `working-tree`: login code resend cadence now uses progressive cooldown (`30s`, `60s`, then `5m`) for better UX and lower provider abuse risk.
+- `ce9e82e` (includes PR #19 scope): cooldown error now includes live countdown behavior via `cooldownUntil` parameter.
+- `ce9e82e` (includes PR #19 scope): login code resend cadence now uses progressive cooldown (`30s`, `60s`, then `5m`) for better UX and lower provider abuse risk.
 
 ### Deferred (Required Before "done" Or Immediately After Launch)
 

--- a/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
+++ b/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
@@ -150,6 +150,17 @@ Users can start instantly in guest mode, buy optional paid products without acco
 - Paid-guide progress sync API baseline is implemented:
   - `/api/progress/guide` (authenticated read/write),
   - payload normalization + row caps aligned with course-progress API guardrails.
+- `0-1000m` interactive guide baseline is implemented:
+  - `/guides/0-1000m` authenticated + entitlement-gated route,
+  - 20-session (`S01-S20`) interactive tracker with per-session completion + notes,
+  - local-first persistence + background sync to `/api/progress/guide`,
+  - sync UX states include loading, offline, error, and retry.
+- `0-1000m` dual-action owned-item UX is implemented:
+  - owned-item detail now exposes both:
+    - `Open interactive plan`,
+    - `Download PDF`.
+  - PDF download is served through entitlement-gated API (`/api/guides/0-1000m/pdf`) with no public paid-file exposure.
+  - download UI includes explicit loading + failure state with retry option.
 - Guest progress-safety milestone prompt is implemented:
   - appears after 3 completed lessons in guest mode,
   - includes free-account CTA to preserve progress across devices,
@@ -163,16 +174,16 @@ Users can start instantly in guest mode, buy optional paid products without acco
 ### Outstanding (blocking move to `done`)
 
 - Missing routes from architecture contract:
-  - `/claim`,
-  - `/guides/0-1000m` interactive guide.
+  - `/claim`.
 - Missing API endpoints from architecture contract:
   - `/api/user/export`,
   - `/api/user/delete`.
 - `My Library` item detail is still placeholder text:
-  - preview/download/re-download behavior not implemented yet.
+  - dual-action flow is now implemented for `0-1000m`,
+  - preview/download/re-download behavior for remaining owned products is still pending.
 - Progress sync criteria is partially met:
   - free-course progress now supports signed-in server sync and local->account merge,
-  - paid-guide progress sync API is implemented, but interactive guide UX + client sync wiring is still pending.
+  - paid-guide interactive sync is implemented for `0-1000m`, but cross-device resume still needs manual QA confirmation.
 - Goals MVP UI/state flow is not implemented.
 - Analytics/KPI event pipeline is not implemented.
 - GDPR operational requirements are not complete:
@@ -188,7 +199,6 @@ Users can start instantly in guest mode, buy optional paid products without acco
 ## Next Delivery Order (Execution)
 
 1. Library/content slice:
-   - implement `/guides/0-1000m` interactive 20-session plan,
    - implement owned item preview/download/re-download in `/my-library/item/[slug]`,
    - expand claim/restore UX around owned content recovery.
 2. Trust/ops slice:
@@ -830,6 +840,31 @@ At each phase:
 
 ## Implementation Checkpoint Log (In Progress)
 
+- `2026-02-17` | `working tree` | `0-1000m` dual-action UX + protected PDF download complete:
+  - added secure entitlement-gated PDF endpoint: `GET /api/guides/0-1000m/pdf`,
+  - added private PDF asset path handling with safe path validation (`GUIDE_0_TO_1000M_PDF_ASSET_PATH` optional override),
+  - updated owned-item detail to show dual actions for `0-1000m`:
+    - `Open interactive plan`,
+    - `Download PDF`.
+  - updated `/guides/0-1000m` header actions with direct `Download PDF` and `Back to My Library`,
+  - added tests for:
+    - guide pdf asset path safety,
+    - download button success/error behavior.
+  - validation run completed:
+    - `npm run lint`,
+    - `npm run typecheck`,
+    - `npm run test:unit`.
+  - next step: implement preview/download/re-download behavior for remaining owned products in `/my-library/item/[slug]`.
+- `2026-02-17` | `working tree` | `/guides/0-1000m` interactive plan baseline complete:
+  - added authenticated + entitlement-gated `/guides/0-1000m` route,
+  - delivered 20-session interactive tracker (`S01-S20`) with per-session completion and notes,
+  - guide tracker now stores progress locally and syncs to `/api/progress/guide` with loading/offline/error/retry states,
+  - wired `My Library` item detail for `guide_0_1000m` to open the interactive plan.
+  - validation run completed:
+    - `npm run lint`,
+    - `npm run typecheck`,
+    - `npm run test:unit`.
+  - next step: implement owned item preview/download/re-download in `/my-library/item/[slug]`.
 - `2026-02-17` | `working tree` | `/api/progress/guide` baseline contract complete:
   - added `GET/POST /api/progress/guide` with auth guard, `no-store` responses, JSON/content-type validation, and explicit `401/415/413/500` handling,
   - added shared guide-progress normalization module with row de-duplication, identifier bounds, and stable sort behavior,

--- a/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
+++ b/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
@@ -147,6 +147,9 @@ Users can start instantly in guest mode, buy optional paid products without acco
   - `/api/progress/course` (authenticated read/write),
   - signed-in course clients hydrate from server and merge local progress on first sign-in,
   - local progress updates are synced back to server for cross-device continuity.
+- Paid-guide progress sync API baseline is implemented:
+  - `/api/progress/guide` (authenticated read/write),
+  - payload normalization + row caps aligned with course-progress API guardrails.
 - Guest progress-safety milestone prompt is implemented:
   - appears after 3 completed lessons in guest mode,
   - includes free-account CTA to preserve progress across devices,
@@ -163,14 +166,13 @@ Users can start instantly in guest mode, buy optional paid products without acco
   - `/claim`,
   - `/guides/0-1000m` interactive guide.
 - Missing API endpoints from architecture contract:
-  - `/api/progress/guide`,
   - `/api/user/export`,
   - `/api/user/delete`.
 - `My Library` item detail is still placeholder text:
   - preview/download/re-download behavior not implemented yet.
 - Progress sync criteria is partially met:
   - free-course progress now supports signed-in server sync and local->account merge,
-  - paid-guide progress sync (`/api/progress/guide`) is still pending.
+  - paid-guide progress sync API is implemented, but interactive guide UX + client sync wiring is still pending.
 - Goals MVP UI/state flow is not implemented.
 - Analytics/KPI event pipeline is not implemented.
 - GDPR operational requirements are not complete:
@@ -185,13 +187,11 @@ Users can start instantly in guest mode, buy optional paid products without acco
 
 ## Next Delivery Order (Execution)
 
-1. Progress sync slice:
-   - implement `/api/progress/guide` baseline contract.
-2. Library/content slice:
+1. Library/content slice:
    - implement `/guides/0-1000m` interactive 20-session plan,
    - implement owned item preview/download/re-download in `/my-library/item/[slug]`,
    - expand claim/restore UX around owned content recovery.
-3. Trust/ops slice:
+2. Trust/ops slice:
    - implement `/api/user/export` + `/api/user/delete`,
    - implement analytics event contract baseline,
    - close GDPR/privacy/cookie documentation and operational runbook items.
@@ -830,6 +830,16 @@ At each phase:
 
 ## Implementation Checkpoint Log (In Progress)
 
+- `2026-02-17` | `working tree` | `/api/progress/guide` baseline contract complete:
+  - added `GET/POST /api/progress/guide` with auth guard, `no-store` responses, JSON/content-type validation, and explicit `401/415/413/500` handling,
+  - added shared guide-progress normalization module with row de-duplication, identifier bounds, and stable sort behavior,
+  - POST now upserts normalized guide progress rows by (`user_id`, `guide_slug`, `section_id`) in `guide_progress`.
+  - updated API contract docs with request/response/status details for `/api/progress/guide`.
+  - validation run completed:
+    - `npm run lint`,
+    - `npm run typecheck`,
+    - `npm run test:unit`.
+  - next step: implement `/guides/0-1000m` interactive 20-session plan and connect client sync to `/api/progress/guide`.
 - `2026-02-17` | `working tree` | `/api/download/resend` + checkout/library recovery slice complete:
   - added `POST /api/download/resend` with JSON/content-type guard, `no-store` responses, and non-enumerating success copy,
   - endpoint enforces per-IP + per-email rate limits (Upstash-first with in-memory fallback),

--- a/lib/commerce/catalog.ts
+++ b/lib/commerce/catalog.ts
@@ -16,6 +16,16 @@ export type CatalogProduct = {
   stripePriceId: string;
 };
 
+export type CatalogProductAvailability = {
+  id: CatalogProductId;
+  slug: string;
+  title: string;
+  kind: "course_addon" | "analysis";
+  available: boolean;
+  stripePriceId: string | null;
+  missingEnvVar: string | null;
+};
+
 const CATALOG_DEFINITIONS: CatalogDefinition[] = [
   {
     id: "guide_0_1000m",
@@ -98,4 +108,23 @@ export function getCatalogProductsSafe(env: NodeJS.ProcessEnv = process.env): Ca
     console.error("[Catalog] Could not load product catalog", error);
     return [];
   }
+}
+
+export function getCatalogProductsWithAvailability(
+  env: NodeJS.ProcessEnv = process.env
+): CatalogProductAvailability[] {
+  return CATALOG_DEFINITIONS.map((definition) => {
+    const stripePriceId = env[definition.envVar] ?? null;
+    const available = Boolean(stripePriceId);
+
+    return {
+      id: definition.id,
+      slug: definition.slug,
+      title: definition.title,
+      kind: definition.kind,
+      available,
+      stripePriceId,
+      missingEnvVar: available ? null : definition.envVar,
+    };
+  });
 }

--- a/lib/commerce/download-resend.ts
+++ b/lib/commerce/download-resend.ts
@@ -1,0 +1,29 @@
+import { getSafeNextPath } from "@/lib/auth/next-path";
+
+export const RESEND_DOWNLOAD_GENERIC_MESSAGE =
+  "If this email exists, we sent a secure access link.";
+
+export const RESEND_DOWNLOAD_FALLBACK_ERROR =
+  "Could not process request right now. Please try again.";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+
+export type DownloadResendSource = "checkout_success" | "library_recovery" | "unknown";
+
+export function normalizeResendEmail(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function isValidResendEmail(email: string): boolean {
+  return EMAIL_REGEX.test(email);
+}
+
+export function getSafeDownloadResendNextPath(input: string | undefined): string {
+  return getSafeNextPath(input, "/my-library");
+}
+
+export function toDownloadResendSource(input: string | undefined): DownloadResendSource {
+  if (input === "checkout_success") return input;
+  if (input === "library_recovery") return input;
+  return "unknown";
+}

--- a/lib/commerce/portal.ts
+++ b/lib/commerce/portal.ts
@@ -1,0 +1,27 @@
+export function getSafePortalReturnPath(
+  input: string | undefined,
+  fallback = "/my-library"
+): string {
+  if (!input) return fallback;
+  if (!input.startsWith("/")) return fallback;
+  if (input.startsWith("//")) return fallback;
+  return input;
+}
+
+type StripeCustomerLike = {
+  id?: unknown;
+  deleted?: unknown;
+};
+
+export function pickActiveStripeCustomerId(customers: StripeCustomerLike[]): string | null {
+  for (const customer of customers) {
+    if (!customer || customer.deleted === true) continue;
+    if (typeof customer.id !== "string") continue;
+
+    const customerId = customer.id.trim();
+    if (!customerId) continue;
+    return customerId;
+  }
+
+  return null;
+}

--- a/lib/course/guide-progress.ts
+++ b/lib/course/guide-progress.ts
@@ -1,0 +1,115 @@
+export const MAX_GUIDE_PROGRESS_ROWS = 600;
+const MAX_GUIDE_SLUG_LENGTH = 120;
+const MAX_GUIDE_SECTION_ID_LENGTH = 160;
+const MAX_GUIDE_NOTES_LENGTH = 4000;
+
+export type GuideProgressRow = {
+  guideSlug: string;
+  sectionId: string;
+  completed: boolean;
+  notes: string;
+  updatedAt: string;
+};
+
+type NormalizeRowsOptions = {
+  fallbackUpdatedAt?: string;
+  maxRows?: number;
+};
+
+type GuideProgressLike = {
+  guideSlug?: unknown;
+  guide_slug?: unknown;
+  sectionId?: unknown;
+  section_id?: unknown;
+  completed?: unknown;
+  notes?: unknown;
+  updatedAt?: unknown;
+  updated_at?: unknown;
+};
+
+function normalizeIdentifier(value: unknown, maxLength: number): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  if (!normalized) return null;
+  if (normalized.length > maxLength) return null;
+  return normalized;
+}
+
+function normalizeNotes(value: unknown): string {
+  if (typeof value !== "string") return "";
+  if (value.length <= MAX_GUIDE_NOTES_LENGTH) return value;
+  return value.slice(0, MAX_GUIDE_NOTES_LENGTH);
+}
+
+function normalizeUpdatedAt(value: unknown, fallback: string): string {
+  if (typeof value !== "string") return fallback;
+  const ts = Date.parse(value);
+  if (!Number.isFinite(ts)) return fallback;
+  return new Date(ts).toISOString();
+}
+
+function compareIso(a: string, b: string): number {
+  const at = Date.parse(a);
+  const bt = Date.parse(b);
+  if (!Number.isFinite(at) && !Number.isFinite(bt)) return 0;
+  if (!Number.isFinite(at)) return -1;
+  if (!Number.isFinite(bt)) return 1;
+  return at - bt;
+}
+
+function mergeGuideRow(existing: GuideProgressRow, incoming: GuideProgressRow): GuideProgressRow {
+  if (compareIso(existing.updatedAt, incoming.updatedAt) >= 0) {
+    return existing;
+  }
+
+  return incoming;
+}
+
+export function normalizeGuideProgressRows(
+  input: unknown,
+  options?: NormalizeRowsOptions
+): GuideProgressRow[] {
+  if (!Array.isArray(input)) return [];
+
+  const fallback = normalizeUpdatedAt(options?.fallbackUpdatedAt, new Date().toISOString());
+  const maxRows = Math.max(0, options?.maxRows ?? input.length);
+  const merged = new Map<string, GuideProgressRow>();
+
+  for (let i = 0; i < input.length && i < maxRows; i += 1) {
+    const candidate = input[i];
+    if (!candidate || typeof candidate !== "object") continue;
+
+    const row = candidate as GuideProgressLike;
+    const guideSlug = normalizeIdentifier(row.guideSlug ?? row.guide_slug, MAX_GUIDE_SLUG_LENGTH);
+    if (!guideSlug) continue;
+
+    const sectionId = normalizeIdentifier(
+      row.sectionId ?? row.section_id,
+      MAX_GUIDE_SECTION_ID_LENGTH
+    );
+    if (!sectionId) continue;
+
+    const normalizedRow: GuideProgressRow = {
+      guideSlug,
+      sectionId,
+      completed: row.completed === true,
+      notes: normalizeNotes(row.notes),
+      updatedAt: normalizeUpdatedAt(row.updatedAt ?? row.updated_at, fallback),
+    };
+
+    const compositeId = `${guideSlug}::${sectionId}`;
+    const existing = merged.get(compositeId);
+    if (!existing) {
+      merged.set(compositeId, normalizedRow);
+      continue;
+    }
+
+    merged.set(compositeId, mergeGuideRow(existing, normalizedRow));
+  }
+
+  return Array.from(merged.values()).sort((a, b) => {
+    const guideCmp = a.guideSlug.localeCompare(b.guideSlug);
+    if (guideCmp !== 0) return guideCmp;
+    return a.sectionId.localeCompare(b.sectionId);
+  });
+}

--- a/lib/course/progress.ts
+++ b/lib/course/progress.ts
@@ -1,0 +1,244 @@
+export const MAX_COURSE_PROGRESS_ROWS = 400;
+const MAX_LESSON_ID_LENGTH = 120;
+const MAX_VIDEO_SECONDS = 86_400;
+
+export type CourseProgressRow = {
+  lessonId: string;
+  done: boolean;
+  videoSeconds: number;
+  updatedAt: string;
+};
+
+export type LocalCourseProgress = {
+  doneLessonIds: string[];
+  videoProgressByLessonId: Record<string, number>;
+};
+
+type NormalizeRowsOptions = {
+  fallbackUpdatedAt?: string;
+  maxRows?: number;
+};
+
+function normalizeLessonId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const lessonId = value.trim();
+  if (!lessonId) return null;
+  if (lessonId.length > MAX_LESSON_ID_LENGTH) return null;
+  return lessonId;
+}
+
+function normalizeVideoSeconds(value: unknown): number {
+  const raw =
+    typeof value === "number" ? value : typeof value === "string" ? Number(value) : Number.NaN;
+
+  if (!Number.isFinite(raw) || raw <= 0) return 0;
+  return Math.min(MAX_VIDEO_SECONDS, Math.floor(raw));
+}
+
+function normalizeUpdatedAt(value: unknown, fallback: string): string {
+  if (typeof value !== "string") return fallback;
+  const ts = Date.parse(value);
+  if (!Number.isFinite(ts)) return fallback;
+  return new Date(ts).toISOString();
+}
+
+function compareIso(a: string, b: string): number {
+  const at = Date.parse(a);
+  const bt = Date.parse(b);
+  if (!Number.isFinite(at) && !Number.isFinite(bt)) return 0;
+  if (!Number.isFinite(at)) return -1;
+  if (!Number.isFinite(bt)) return 1;
+  return at - bt;
+}
+
+function mergeProgressRow(
+  existing: CourseProgressRow,
+  incoming: CourseProgressRow
+): CourseProgressRow {
+  return {
+    lessonId: existing.lessonId,
+    done: existing.done || incoming.done,
+    videoSeconds: Math.max(existing.videoSeconds, incoming.videoSeconds),
+    updatedAt:
+      compareIso(existing.updatedAt, incoming.updatedAt) >= 0
+        ? existing.updatedAt
+        : incoming.updatedAt,
+  };
+}
+
+type ProgressLike = {
+  lessonId?: unknown;
+  lesson_id?: unknown;
+  done?: unknown;
+  videoSeconds?: unknown;
+  video_seconds?: unknown;
+  updatedAt?: unknown;
+  updated_at?: unknown;
+};
+
+export function normalizeCourseProgressRows(
+  input: unknown,
+  options?: NormalizeRowsOptions
+): CourseProgressRow[] {
+  if (!Array.isArray(input)) return [];
+
+  const fallback = normalizeUpdatedAt(options?.fallbackUpdatedAt, new Date().toISOString());
+  const maxRows = Math.max(0, options?.maxRows ?? input.length);
+  const merged = new Map<string, CourseProgressRow>();
+
+  for (let i = 0; i < input.length && i < maxRows; i += 1) {
+    const candidate = input[i];
+    if (!candidate || typeof candidate !== "object") continue;
+
+    const row = candidate as ProgressLike;
+    const lessonId = normalizeLessonId(row.lessonId ?? row.lesson_id);
+    if (!lessonId) continue;
+
+    const normalizedRow: CourseProgressRow = {
+      lessonId,
+      done: row.done === true,
+      videoSeconds: normalizeVideoSeconds(row.videoSeconds ?? row.video_seconds),
+      updatedAt: normalizeUpdatedAt(row.updatedAt ?? row.updated_at, fallback),
+    };
+
+    const existing = merged.get(lessonId);
+    if (!existing) {
+      merged.set(lessonId, normalizedRow);
+      continue;
+    }
+
+    merged.set(lessonId, mergeProgressRow(existing, normalizedRow));
+  }
+
+  return Array.from(merged.values()).sort((a, b) => a.lessonId.localeCompare(b.lessonId));
+}
+
+export function normalizeDoneLessonIds(input: unknown): string[] {
+  if (!Array.isArray(input)) return [];
+
+  const unique = new Set<string>();
+  for (const item of input) {
+    const lessonId = normalizeLessonId(item);
+    if (lessonId) unique.add(lessonId);
+  }
+
+  return Array.from(unique).sort((a, b) => a.localeCompare(b));
+}
+
+export function normalizeVideoProgressRecord(input: unknown): Record<string, number> {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return {};
+  }
+
+  const normalized: Record<string, number> = {};
+  for (const [rawLessonId, rawValue] of Object.entries(input)) {
+    const lessonId = normalizeLessonId(rawLessonId);
+    if (!lessonId) continue;
+
+    const seconds = normalizeVideoSeconds(rawValue);
+    if (seconds <= 0) continue;
+
+    normalized[lessonId] = seconds;
+  }
+
+  return normalized;
+}
+
+function normalizeKnownLessonIds(knownLessonIds: Iterable<string> | undefined): Set<string> {
+  const normalized = new Set<string>();
+  if (!knownLessonIds) return normalized;
+
+  for (const lessonIdRaw of knownLessonIds) {
+    const lessonId = normalizeLessonId(lessonIdRaw);
+    if (!lessonId) continue;
+    normalized.add(lessonId);
+  }
+
+  return normalized;
+}
+
+export function buildCourseProgressRowsFromLocal(
+  local: LocalCourseProgress,
+  options?: {
+    knownLessonIds?: Iterable<string>;
+    updatedAt?: string;
+  }
+): CourseProgressRow[] {
+  const fallbackUpdatedAt = normalizeUpdatedAt(options?.updatedAt, new Date().toISOString());
+  const doneLessonIds = normalizeDoneLessonIds(local.doneLessonIds);
+  const doneSet = new Set(doneLessonIds);
+  const videoProgress = normalizeVideoProgressRecord(local.videoProgressByLessonId);
+  const knownLessonIds = normalizeKnownLessonIds(options?.knownLessonIds);
+
+  for (const lessonId of doneSet) {
+    knownLessonIds.add(lessonId);
+  }
+
+  for (const lessonId of Object.keys(videoProgress)) {
+    knownLessonIds.add(lessonId);
+  }
+
+  const rows: CourseProgressRow[] = [];
+  for (const lessonId of knownLessonIds) {
+    const done = doneSet.has(lessonId);
+    const videoSeconds = videoProgress[lessonId] ?? 0;
+
+    // Keep previously-known lesson rows even when done/video reset, so server can clear stale values.
+    rows.push({
+      lessonId,
+      done,
+      videoSeconds,
+      updatedAt: fallbackUpdatedAt,
+    });
+  }
+
+  return rows.sort((a, b) => a.lessonId.localeCompare(b.lessonId));
+}
+
+export function buildLocalCourseProgressFromRows(rows: unknown): LocalCourseProgress {
+  const normalizedRows = normalizeCourseProgressRows(rows);
+
+  const doneLessonIds: string[] = [];
+  const videoProgressByLessonId: Record<string, number> = {};
+
+  for (const row of normalizedRows) {
+    if (row.done) doneLessonIds.push(row.lessonId);
+    if (row.videoSeconds > 0) {
+      videoProgressByLessonId[row.lessonId] = row.videoSeconds;
+    }
+  }
+
+  return {
+    doneLessonIds,
+    videoProgressByLessonId,
+  };
+}
+
+export function mergeCourseProgressRows(
+  localRows: unknown,
+  remoteRows: unknown
+): CourseProgressRow[] {
+  return normalizeCourseProgressRows(
+    [...normalizeCourseProgressRows(localRows), ...normalizeCourseProgressRows(remoteRows)],
+    {
+      maxRows: MAX_COURSE_PROGRESS_ROWS,
+    }
+  );
+}
+
+export function areCourseProgressRowsEqual(localRows: unknown, remoteRows: unknown): boolean {
+  const left = normalizeCourseProgressRows(localRows);
+  const right = normalizeCourseProgressRows(remoteRows);
+
+  if (left.length !== right.length) return false;
+
+  for (let i = 0; i < left.length; i += 1) {
+    const a = left[i];
+    const b = right[i];
+    if (a.lessonId !== b.lessonId) return false;
+    if (a.done !== b.done) return false;
+    if (a.videoSeconds !== b.videoSeconds) return false;
+  }
+
+  return true;
+}

--- a/lib/guides/guide-0-1000m.ts
+++ b/lib/guides/guide-0-1000m.ts
@@ -1,0 +1,168 @@
+export type Guide0To1000Session = {
+  id: string;
+  weekNumber: number;
+  title: string;
+  focus: string;
+  targetSet: string;
+};
+
+export const GUIDE_0_TO_1000M_SLUG = "0-1000m";
+export const GUIDE_0_TO_1000M_PRODUCT_ID = "guide_0_1000m";
+export const GUIDE_0_TO_1000M_PDF_DOWNLOAD_FILENAME = "freeswimming-0-1000m-guide.pdf";
+
+const DEFAULT_GUIDE_0_TO_1000M_PDF_ASSET_PATH = "assets/guides/0-1000m-guide.pdf";
+const SAFE_PDF_PATH_REGEX = /^[A-Za-z0-9/_\-.]+\.pdf$/;
+
+export function getGuide0To1000PdfAssetPath(
+  env: Readonly<Record<string, string | undefined>> = process.env
+): string {
+  const candidate = env.GUIDE_0_TO_1000M_PDF_ASSET_PATH?.trim();
+  if (!candidate) return DEFAULT_GUIDE_0_TO_1000M_PDF_ASSET_PATH;
+  if (candidate.startsWith("/")) return DEFAULT_GUIDE_0_TO_1000M_PDF_ASSET_PATH;
+  if (candidate.includes("..")) return DEFAULT_GUIDE_0_TO_1000M_PDF_ASSET_PATH;
+  if (!SAFE_PDF_PATH_REGEX.test(candidate)) return DEFAULT_GUIDE_0_TO_1000M_PDF_ASSET_PATH;
+  return candidate;
+}
+
+export const GUIDE_0_TO_1000M_SESSIONS: Guide0To1000Session[] = [
+  {
+    id: "S01",
+    weekNumber: 1,
+    title: "Baseline and breathing rhythm",
+    focus: "Set calm breathing cadence and smooth exhale.",
+    targetSet: "6 x 50m easy + 4 x 25m drill focus",
+  },
+  {
+    id: "S02",
+    weekNumber: 1,
+    title: "Body line and head position",
+    focus: "Hold long shape with neutral head.",
+    targetSet: "8 x 50m with 20s rest",
+  },
+  {
+    id: "S03",
+    weekNumber: 2,
+    title: "Kick support without over-kicking",
+    focus: "Use small kick for balance, not speed.",
+    targetSet: "4 x 100m aerobic + 4 x 25m kick control",
+  },
+  {
+    id: "S04",
+    weekNumber: 2,
+    title: "Front quadrant timing",
+    focus: "Keep stroke patient and connected.",
+    targetSet: "10 x 50m negative split",
+  },
+  {
+    id: "S05",
+    weekNumber: 3,
+    title: "Catch setup and early pressure",
+    focus: "Build stable catch before pull-through.",
+    targetSet: "6 x 75m technique + 4 x 25m fist drill",
+  },
+  {
+    id: "S06",
+    weekNumber: 3,
+    title: "Rotation control",
+    focus: "Rotate from core without crossing line.",
+    targetSet: "5 x 100m with bilateral breathing",
+  },
+  {
+    id: "S07",
+    weekNumber: 4,
+    title: "Aerobic durability",
+    focus: "Stay relaxed while distance grows.",
+    targetSet: "3 x 200m steady + 4 x 50m easy",
+  },
+  {
+    id: "S08",
+    weekNumber: 4,
+    title: "Pace awareness",
+    focus: "Hold even pacing across reps.",
+    targetSet: "12 x 50m at controlled threshold",
+  },
+  {
+    id: "S09",
+    weekNumber: 5,
+    title: "Turns and push-off line",
+    focus: "Protect momentum out of wall.",
+    targetSet: "8 x 75m with turn focus",
+  },
+  {
+    id: "S10",
+    weekNumber: 5,
+    title: "Stroke length under fatigue",
+    focus: "Keep distance-per-stroke late in set.",
+    targetSet: "4 x 150m + 4 x 50m build",
+  },
+  {
+    id: "S11",
+    weekNumber: 6,
+    title: "Tempo and relaxation balance",
+    focus: "Increase tempo without losing form.",
+    targetSet: "16 x 25m tempo ladder + 4 x 100m easy",
+  },
+  {
+    id: "S12",
+    weekNumber: 6,
+    title: "Mid-plan check session",
+    focus: "Re-check breathing, body line, and catch.",
+    targetSet: "1 x 400m continuous + technique reset reps",
+  },
+  {
+    id: "S13",
+    weekNumber: 7,
+    title: "Endurance extension",
+    focus: "Stay efficient across longer repeats.",
+    targetSet: "3 x 250m with 30s rest",
+  },
+  {
+    id: "S14",
+    weekNumber: 7,
+    title: "Broken 500 prep",
+    focus: "Manage effort and stroke quality.",
+    targetSet: "5 x 100m + 1 x 50m at target effort",
+  },
+  {
+    id: "S15",
+    weekNumber: 8,
+    title: "Technique under threshold effort",
+    focus: "Protect form when heart rate rises.",
+    targetSet: "8 x 75m threshold + 4 x 25m reset",
+  },
+  {
+    id: "S16",
+    weekNumber: 8,
+    title: "Race-pace rhythm control",
+    focus: "Lock in repeatable target pace.",
+    targetSet: "10 x 50m at target 1000m pace",
+  },
+  {
+    id: "S17",
+    weekNumber: 9,
+    title: "Long aerobic confidence",
+    focus: "Build confidence for uninterrupted swim.",
+    targetSet: "2 x 300m + 4 x 50m easy",
+  },
+  {
+    id: "S18",
+    weekNumber: 9,
+    title: "Broken 800 rehearsal",
+    focus: "Practice fueling and pacing strategy.",
+    targetSet: "4 x 200m with stable split times",
+  },
+  {
+    id: "S19",
+    weekNumber: 10,
+    title: "Pre-test sharpening",
+    focus: "Stay crisp and relaxed before test day.",
+    targetSet: "6 x 50m build + 4 x 25m easy",
+  },
+  {
+    id: "S20",
+    weekNumber: 10,
+    title: "1000m completion session",
+    focus: "Swim controlled, confident, and continuous.",
+    targetSet: "1 x 1000m continuous + easy cooldown",
+  },
+];

--- a/tests/e2e/install-prompt.spec.ts
+++ b/tests/e2e/install-prompt.spec.ts
@@ -213,3 +213,33 @@ test("contextual install prompt shows success confirmation after accepted instal
   await prompt.getByRole("button", { name: "Done" }).click();
   await expect(prompt).toBeHidden();
 });
+
+test("guest sees free-account backup prompt after completing three lessons", async ({
+  page,
+}, testInfo) => {
+  test.skip(
+    !isMobileProject(testInfo),
+    "Progress backup prompt flow is validated on mobile projects."
+  );
+
+  await page.goto("/course?lesson=mod3-l1");
+  await page.evaluate(() => {
+    localStorage.removeItem("fs_course_done_lessons");
+    localStorage.removeItem("fs_course_backup_prompt_dismissed_at");
+  });
+  await page.reload();
+
+  await page.getByRole("button", { name: "Mark as done" }).click();
+  await page.getByTestId("course-nav-right").click();
+
+  await page.getByRole("button", { name: "Mark as done" }).click();
+  await page.getByTestId("course-nav-right").click();
+
+  await page.getByRole("button", { name: "Mark as done" }).click();
+
+  const backupPrompt = page.getByTestId("course-backup-prompt");
+  await expect(backupPrompt).toBeVisible();
+  await expect(backupPrompt.getByRole("link", { name: "Create free account" })).toBeVisible();
+  await backupPrompt.getByRole("button", { name: "Maybe later" }).click();
+  await expect(backupPrompt).toBeHidden();
+});

--- a/tests/unit/commerce-catalog.test.ts
+++ b/tests/unit/commerce-catalog.test.ts
@@ -3,6 +3,7 @@ import {
   getCatalogProductById,
   getCatalogProductByStripePriceId,
   getCatalogProducts,
+  getCatalogProductsWithAvailability,
 } from "@/lib/commerce/catalog";
 
 const ENV: NodeJS.ProcessEnv = {
@@ -34,5 +35,36 @@ describe("commerce catalog", () => {
     expect(() => getCatalogProducts({} as unknown as NodeJS.ProcessEnv)).toThrow(
       "Missing required environment variable: STRIPE_PRICE_ID_0_1000M_GUIDE"
     );
+  });
+
+  it("returns per-product availability without throwing", () => {
+    const partialEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      STRIPE_PRICE_ID_0_1000M_GUIDE: "price_1000",
+      STRIPE_PRICE_ID_ANALYSIS: "price_analysis",
+    };
+
+    const availability = getCatalogProductsWithAvailability(partialEnv);
+    expect(availability).toHaveLength(3);
+    expect(availability.map((product) => product.id)).toEqual([
+      "guide_0_1000m",
+      "guide_poolside",
+      "analysis_video",
+    ]);
+    expect(availability.find((product) => product.id === "guide_0_1000m")).toMatchObject({
+      available: true,
+      stripePriceId: "price_1000",
+      missingEnvVar: null,
+    });
+    expect(availability.find((product) => product.id === "guide_poolside")).toMatchObject({
+      available: false,
+      stripePriceId: null,
+      missingEnvVar: "STRIPE_PRICE_ID_POOLSIDE_GUIDE",
+    });
+    expect(availability.find((product) => product.id === "analysis_video")).toMatchObject({
+      available: true,
+      stripePriceId: "price_analysis",
+      missingEnvVar: null,
+    });
   });
 });

--- a/tests/unit/course-progress.test.ts
+++ b/tests/unit/course-progress.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import {
+  areCourseProgressRowsEqual,
+  buildCourseProgressRowsFromLocal,
+  buildLocalCourseProgressFromRows,
+  mergeCourseProgressRows,
+  normalizeCourseProgressRows,
+  normalizeDoneLessonIds,
+  normalizeVideoProgressRecord,
+} from "@/lib/course/progress";
+
+describe("course progress helpers", () => {
+  it("normalizes local done lesson ids", () => {
+    expect(normalizeDoneLessonIds([" mod1-l1 ", "", null, "mod1-l1", "mod1-l2"])).toEqual([
+      "mod1-l1",
+      "mod1-l2",
+    ]);
+  });
+
+  it("normalizes local video progress map", () => {
+    expect(
+      normalizeVideoProgressRecord({
+        " mod1-l1 ": 14.8,
+        "mod1-l2": -2,
+        "mod1-l3": "9",
+        "": 22,
+      })
+    ).toEqual({
+      "mod1-l1": 14,
+      "mod1-l3": 9,
+    });
+  });
+
+  it("merges duplicate rows by lesson id using done=OR and max video seconds", () => {
+    const rows = normalizeCourseProgressRows([
+      {
+        lessonId: "mod1-l1",
+        done: false,
+        videoSeconds: 20,
+        updatedAt: "2026-02-16T10:00:00.000Z",
+      },
+      {
+        lesson_id: "mod1-l1",
+        done: true,
+        video_seconds: 12,
+        updated_at: "2026-02-16T10:05:00.000Z",
+      },
+    ]);
+
+    expect(rows).toEqual([
+      {
+        lessonId: "mod1-l1",
+        done: true,
+        videoSeconds: 20,
+        updatedAt: "2026-02-16T10:05:00.000Z",
+      },
+    ]);
+  });
+
+  it("includes known lesson ids when building local rows so reset values can sync", () => {
+    const rows = buildCourseProgressRowsFromLocal(
+      {
+        doneLessonIds: [],
+        videoProgressByLessonId: {},
+      },
+      {
+        knownLessonIds: ["mod1-l1"],
+        updatedAt: "2026-02-16T10:10:00.000Z",
+      }
+    );
+
+    expect(rows).toEqual([
+      {
+        lessonId: "mod1-l1",
+        done: false,
+        videoSeconds: 0,
+        updatedAt: "2026-02-16T10:10:00.000Z",
+      },
+    ]);
+  });
+
+  it("merges local + remote rows and keeps strongest progress", () => {
+    const merged = mergeCourseProgressRows(
+      [
+        {
+          lessonId: "mod1-l1",
+          done: true,
+          videoSeconds: 30,
+          updatedAt: "2026-02-16T10:00:00.000Z",
+        },
+      ],
+      [
+        {
+          lessonId: "mod1-l1",
+          done: false,
+          videoSeconds: 35,
+          updatedAt: "2026-02-16T09:00:00.000Z",
+        },
+        {
+          lessonId: "mod1-l2",
+          done: true,
+          videoSeconds: 0,
+          updatedAt: "2026-02-16T11:00:00.000Z",
+        },
+      ]
+    );
+
+    expect(merged).toEqual([
+      {
+        lessonId: "mod1-l1",
+        done: true,
+        videoSeconds: 35,
+        updatedAt: "2026-02-16T10:00:00.000Z",
+      },
+      {
+        lessonId: "mod1-l2",
+        done: true,
+        videoSeconds: 0,
+        updatedAt: "2026-02-16T11:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("compares rows by effective progress fields, not timestamp noise", () => {
+    expect(
+      areCourseProgressRowsEqual(
+        [
+          {
+            lessonId: "mod1-l1",
+            done: true,
+            videoSeconds: 35,
+            updatedAt: "2026-02-16T10:00:00.000Z",
+          },
+        ],
+        [
+          {
+            lessonId: "mod1-l1",
+            done: true,
+            videoSeconds: 35,
+            updatedAt: "2026-02-16T11:00:00.000Z",
+          },
+        ]
+      )
+    ).toBe(true);
+  });
+
+  it("builds local state from normalized rows", () => {
+    const local = buildLocalCourseProgressFromRows([
+      {
+        lessonId: "mod1-l1",
+        done: true,
+        videoSeconds: 42,
+        updatedAt: "2026-02-16T10:00:00.000Z",
+      },
+      {
+        lessonId: "mod1-l2",
+        done: false,
+        videoSeconds: 0,
+        updatedAt: "2026-02-16T10:00:00.000Z",
+      },
+    ]);
+
+    expect(local).toEqual({
+      doneLessonIds: ["mod1-l1"],
+      videoProgressByLessonId: {
+        "mod1-l1": 42,
+      },
+    });
+  });
+});

--- a/tests/unit/download-resend-form.test.tsx
+++ b/tests/unit/download-resend-form.test.tsx
@@ -1,0 +1,67 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import DownloadResendForm from "@/components/commerce/DownloadResendForm";
+import { RESEND_DOWNLOAD_GENERIC_MESSAGE } from "@/lib/commerce/download-resend";
+
+describe("DownloadResendForm", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("posts resend request and shows non-enumerating success message", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        message: RESEND_DOWNLOAD_GENERIC_MESSAGE,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <DownloadResendForm
+        initialEmail="  Buyer@Example.com "
+        nextPath="/my-library"
+        source="checkout_success"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Email me access link" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/download/resend", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: "buyer@example.com",
+          nextPath: "/my-library",
+          source: "checkout_success",
+        }),
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(RESEND_DOWNLOAD_GENERIC_MESSAGE)).toBeInTheDocument();
+    });
+  });
+
+  it("shows API error when resend endpoint fails", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({
+        ok: false,
+        error: "Too many requests. Please try again shortly.",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<DownloadResendForm initialEmail="buyer@example.com" source="library_recovery" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Email me access link" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Too many requests. Please try again shortly.")).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/unit/download-resend-utils.test.ts
+++ b/tests/unit/download-resend-utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  getSafeDownloadResendNextPath,
+  isValidResendEmail,
+  normalizeResendEmail,
+  toDownloadResendSource,
+} from "@/lib/commerce/download-resend";
+
+describe("download resend helpers", () => {
+  it("normalizes email by trimming and lowercasing", () => {
+    expect(normalizeResendEmail("  User@Example.COM ")).toBe("user@example.com");
+  });
+
+  it("validates email format", () => {
+    expect(isValidResendEmail("buyer@example.com")).toBe(true);
+    expect(isValidResendEmail("buyer@@example.com")).toBe(false);
+    expect(isValidResendEmail("missing-at.example.com")).toBe(false);
+  });
+
+  it("keeps only safe local next paths", () => {
+    expect(getSafeDownloadResendNextPath("/my-library?tab=library")).toBe(
+      "/my-library?tab=library"
+    );
+    expect(getSafeDownloadResendNextPath("https://evil.test/path")).toBe("/my-library");
+    expect(getSafeDownloadResendNextPath("//evil.test")).toBe("/my-library");
+    expect(getSafeDownloadResendNextPath(undefined)).toBe("/my-library");
+  });
+
+  it("normalizes source values into allowed source enum", () => {
+    expect(toDownloadResendSource("checkout_success")).toBe("checkout_success");
+    expect(toDownloadResendSource("library_recovery")).toBe("library_recovery");
+    expect(toDownloadResendSource("anything-else")).toBe("unknown");
+    expect(toDownloadResendSource(undefined)).toBe("unknown");
+  });
+});

--- a/tests/unit/guide-0-1000m-plan.test.ts
+++ b/tests/unit/guide-0-1000m-plan.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  GUIDE_0_TO_1000M_PRODUCT_ID,
+  GUIDE_0_TO_1000M_PDF_DOWNLOAD_FILENAME,
+  GUIDE_0_TO_1000M_SESSIONS,
+  GUIDE_0_TO_1000M_SLUG,
+  getGuide0To1000PdfAssetPath,
+} from "@/lib/guides/guide-0-1000m";
+
+describe("guide 0-1000m plan data", () => {
+  it("has stable identifiers", () => {
+    expect(GUIDE_0_TO_1000M_SLUG).toBe("0-1000m");
+    expect(GUIDE_0_TO_1000M_PRODUCT_ID).toBe("guide_0_1000m");
+    expect(GUIDE_0_TO_1000M_PDF_DOWNLOAD_FILENAME).toBe("freeswimming-0-1000m-guide.pdf");
+  });
+
+  it("contains exactly 20 sessions with unique ids", () => {
+    expect(GUIDE_0_TO_1000M_SESSIONS).toHaveLength(20);
+
+    const idSet = new Set(GUIDE_0_TO_1000M_SESSIONS.map((session) => session.id));
+    expect(idSet.size).toBe(20);
+  });
+
+  it("has 10 weeks with 2 sessions in each week", () => {
+    const weekCounts = GUIDE_0_TO_1000M_SESSIONS.reduce<Record<number, number>>((acc, session) => {
+      acc[session.weekNumber] = (acc[session.weekNumber] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    const weeks = Object.keys(weekCounts)
+      .map(Number)
+      .sort((a, b) => a - b);
+
+    expect(weeks).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+    for (const week of weeks) {
+      expect(weekCounts[week]).toBe(2);
+    }
+  });
+
+  it("uses safe PDF asset path with fallback on invalid values", () => {
+    expect(getGuide0To1000PdfAssetPath({})).toBe("assets/guides/0-1000m-guide.pdf");
+    expect(
+      getGuide0To1000PdfAssetPath({
+        GUIDE_0_TO_1000M_PDF_ASSET_PATH: "assets/guides/custom.pdf",
+      })
+    ).toBe("assets/guides/custom.pdf");
+    expect(
+      getGuide0To1000PdfAssetPath({
+        GUIDE_0_TO_1000M_PDF_ASSET_PATH: "../secret.pdf",
+      })
+    ).toBe("assets/guides/0-1000m-guide.pdf");
+    expect(
+      getGuide0To1000PdfAssetPath({
+        GUIDE_0_TO_1000M_PDF_ASSET_PATH: "/absolute/path.pdf",
+      })
+    ).toBe("assets/guides/0-1000m-guide.pdf");
+    expect(
+      getGuide0To1000PdfAssetPath({
+        GUIDE_0_TO_1000M_PDF_ASSET_PATH: "assets/guides/not-pdf.txt",
+      })
+    ).toBe("assets/guides/0-1000m-guide.pdf");
+  });
+});

--- a/tests/unit/guide-pdf-download-button.test.tsx
+++ b/tests/unit/guide-pdf-download-button.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import GuidePdfDownloadButton from "@/components/guides/GuidePdfDownloadButton";
+
+describe("GuidePdfDownloadButton", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("downloads PDF on successful response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === "content-disposition"
+            ? 'attachment; filename=\"freeswimming-0-1000m-guide.pdf\"'
+            : null,
+      },
+      blob: async () => new Blob(["%PDF-1.4"], { type: "application/pdf" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const createUrlSpy = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:http://127.0.0.1/mock-pdf");
+    const revokeUrlSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+
+    render(
+      <GuidePdfDownloadButton
+        apiPath="/api/guides/0-1000m/pdf"
+        fallbackFileName="freeswimming-0-1000m-guide.pdf"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Download PDF" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/guides/0-1000m/pdf", {
+        method: "GET",
+        cache: "no-store",
+        credentials: "same-origin",
+      });
+    });
+
+    await waitFor(() => {
+      expect(createUrlSpy).toHaveBeenCalledTimes(1);
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.queryByText("Could not download PDF right now. Please try again.")).toBeNull();
+    expect(revokeUrlSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("shows API error when download fails", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ ok: false, error: "PDF is temporarily unavailable." }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<GuidePdfDownloadButton apiPath="/api/guides/0-1000m/pdf" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Download PDF" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("PDF is temporarily unavailable.")).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/unit/guide-progress.test.ts
+++ b/tests/unit/guide-progress.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { MAX_GUIDE_PROGRESS_ROWS, normalizeGuideProgressRows } from "@/lib/course/guide-progress";
+
+describe("normalizeGuideProgressRows", () => {
+  it("normalizes snake_case/camelCase fields and sorts stable by guide+section", () => {
+    const rows = normalizeGuideProgressRows([
+      {
+        guide_slug: "0-1000m",
+        section_id: "s02",
+        completed: true,
+        notes: "keep elbow high",
+        updated_at: "2026-02-17T10:00:00.000Z",
+      },
+      {
+        guideSlug: "0-1000m",
+        sectionId: "s01",
+        completed: false,
+        notes: "focus on breathing",
+        updatedAt: "2026-02-17T09:00:00.000Z",
+      },
+    ]);
+
+    expect(rows).toEqual([
+      {
+        guideSlug: "0-1000m",
+        sectionId: "s01",
+        completed: false,
+        notes: "focus on breathing",
+        updatedAt: "2026-02-17T09:00:00.000Z",
+      },
+      {
+        guideSlug: "0-1000m",
+        sectionId: "s02",
+        completed: true,
+        notes: "keep elbow high",
+        updatedAt: "2026-02-17T10:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("deduplicates by guide+section and keeps newest updatedAt row", () => {
+    const rows = normalizeGuideProgressRows([
+      {
+        guideSlug: "poolside",
+        sectionId: "drill-1",
+        completed: false,
+        notes: "old",
+        updatedAt: "2026-02-17T08:00:00.000Z",
+      },
+      {
+        guideSlug: "poolside",
+        sectionId: "drill-1",
+        completed: true,
+        notes: "new",
+        updatedAt: "2026-02-17T11:00:00.000Z",
+      },
+    ]);
+
+    expect(rows).toEqual([
+      {
+        guideSlug: "poolside",
+        sectionId: "drill-1",
+        completed: true,
+        notes: "new",
+        updatedAt: "2026-02-17T11:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("drops invalid rows and respects maxRows option", () => {
+    const rows = normalizeGuideProgressRows(
+      [
+        {
+          guideSlug: "guide-a",
+          sectionId: "s1",
+          completed: true,
+        },
+        {
+          guideSlug: "",
+          sectionId: "s2",
+          completed: true,
+        },
+        {
+          guideSlug: "guide-a",
+          sectionId: "s3",
+          completed: true,
+        },
+      ],
+      { maxRows: 1 }
+    );
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        guideSlug: "guide-a",
+        sectionId: "s1",
+      }),
+    ]);
+  });
+
+  it("returns empty list for non-array input", () => {
+    expect(normalizeGuideProgressRows(null)).toEqual([]);
+    expect(normalizeGuideProgressRows({ rows: [] })).toEqual([]);
+  });
+
+  it("caps parsing to MAX_GUIDE_PROGRESS_ROWS when requested", () => {
+    const input = new Array(MAX_GUIDE_PROGRESS_ROWS + 5).fill(null).map((_, index) => ({
+      guideSlug: "guide",
+      sectionId: `s${index}`,
+      completed: true,
+    }));
+
+    const rows = normalizeGuideProgressRows(input, {
+      maxRows: MAX_GUIDE_PROGRESS_ROWS,
+    });
+
+    expect(rows.length).toBe(MAX_GUIDE_PROGRESS_ROWS);
+  });
+});

--- a/tests/unit/portal-button.test.tsx
+++ b/tests/unit/portal-button.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import PortalButton from "@/components/my-library/PortalButton";
+
+describe("PortalButton", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls /api/portal and redirects on success", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, url: "https://billing.stripe.com/session/test" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const onNavigate = vi.fn();
+
+    render(<PortalButton returnPath="/my-library" onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByRole("button", { name: "Manage billing" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/portal", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ returnPath: "/my-library" }),
+      });
+    });
+
+    await waitFor(() => {
+      expect(onNavigate).toHaveBeenCalledWith("https://billing.stripe.com/session/test");
+    });
+  });
+
+  it("shows API error in UI when portal cannot be opened", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ ok: false, error: "No Stripe billing account found for this user." }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const onNavigate = vi.fn();
+
+    render(<PortalButton returnPath="/my-library" onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByRole("button", { name: "Manage billing" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No Stripe billing account found for this user.")
+      ).toBeInTheDocument();
+    });
+
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/portal-utils.test.ts
+++ b/tests/unit/portal-utils.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { getSafePortalReturnPath, pickActiveStripeCustomerId } from "@/lib/commerce/portal";
+
+describe("getSafePortalReturnPath", () => {
+  it("accepts safe local return paths", () => {
+    expect(getSafePortalReturnPath("/my-library?tab=library")).toBe("/my-library?tab=library");
+    expect(getSafePortalReturnPath("/checkout/success")).toBe("/checkout/success");
+  });
+
+  it("falls back for unsafe or empty paths", () => {
+    expect(getSafePortalReturnPath(undefined)).toBe("/my-library");
+    expect(getSafePortalReturnPath("")).toBe("/my-library");
+    expect(getSafePortalReturnPath("my-library")).toBe("/my-library");
+    expect(getSafePortalReturnPath("https://evil.example")).toBe("/my-library");
+    expect(getSafePortalReturnPath("//evil.example/path")).toBe("/my-library");
+  });
+});
+
+describe("pickActiveStripeCustomerId", () => {
+  it("returns first non-deleted customer id", () => {
+    const result = pickActiveStripeCustomerId([
+      { id: "cus_deleted", deleted: true },
+      { id: "cus_123" },
+      { id: "cus_456" },
+    ]);
+
+    expect(result).toBe("cus_123");
+  });
+
+  it("returns null when no active customer id is found", () => {
+    const result = pickActiveStripeCustomerId([
+      { id: "", deleted: false },
+      { id: "cus_deleted", deleted: true },
+      {},
+    ]);
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- syncs guest lesson progress into account on sign up/sign in
- adds `/plans` route with plan availability states
- adds Stripe billing portal endpoint (`/api/portal`) and `Manage billing` action in My Library
- adds `/api/download/resend` with non-enumerating response + per-IP/per-email rate limiting
- updates checkout success and My Library empty-owned recovery UX with secure access-link resend form
- adds `/api/progress/guide` baseline (`GET|POST`) with auth guard, payload normalization, and upsert contract
- adds `/guides/0-1000m` interactive 20-session tracker with local-first + synced progress
- adds dual-action owned UX for `0-1000m` (`Open interactive plan` + `Download PDF`)
- adds entitlement-gated PDF endpoint (`/api/guides/0-1000m/pdf`) with protected asset delivery
- updates active task brief + task brief template with commit/push + PR rhythm defaults

## Validation
- npm run lint
- npm run typecheck
- npm run test:unit

## Commits
- 1ef8872 docs: audit and update my-library brief status and next delivery order
- cb9a2f3 feat(commerce): add /plans hub and catalog availability states
- ea57060 feat(course): sync guest progress to account and add backup prompt
- 930b20a feat(library): add manage billing portal flow and lock git rhythm
- ad69e76 feat(commerce): add download resend api and recovery UI
- a7bc7df feat(progress): add guide progress api baseline
- 94371a3 feat(guide): add 0-1000m dual-action UX with protected pdf download
