### PR TITLE
feat(guide): add interactive 0-1000m dual-action and protected pdf

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,7 @@ STRIPE_WEBHOOK_SECRET=
 STRIPE_PRICE_ID_0_1000M_GUIDE=
 STRIPE_PRICE_ID_POOLSIDE_GUIDE=
 STRIPE_PRICE_ID_ANALYSIS=
+
+# Optional server-only path override for protected 0-1000m PDF asset.
+# Must be a safe repo-relative .pdf path (default: assets/guides/0-1000m-guide.pdf)
+GUIDE_0_TO_1000M_PDF_ASSET_PATH=

--- a/app/api/guides/0-1000m/pdf/route.ts
+++ b/app/api/guides/0-1000m/pdf/route.ts
@@ -1,0 +1,83 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { NextResponse } from "next/server";
+import { attachGuestEntitlementsByEmail } from "@/lib/commerce/entitlements";
+import {
+  getGuide0To1000PdfAssetPath,
+  GUIDE_0_TO_1000M_PDF_DOWNLOAD_FILENAME,
+  GUIDE_0_TO_1000M_PRODUCT_ID,
+} from "@/lib/guides/guide-0-1000m";
+import { createAdminSupabaseClient } from "@/lib/supabase/admin";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function jsonNoStore(body: unknown, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export async function GET() {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return jsonNoStore({ ok: false, error: "Unauthorized." }, 401);
+  }
+
+  if (user.email) {
+    try {
+      const adminSupabase = createAdminSupabaseClient();
+      await attachGuestEntitlementsByEmail(adminSupabase, user.id, user.email);
+    } catch (error) {
+      console.error("[GuidePdfApi] Could not attach guest entitlements", error);
+    }
+  }
+
+  const { data: entitlement, error: entitlementError } = await supabase
+    .from("entitlements")
+    .select("id")
+    .eq("product_id", GUIDE_0_TO_1000M_PRODUCT_ID)
+    .eq("user_id", user.id)
+    .limit(1)
+    .maybeSingle();
+
+  if (entitlementError) {
+    console.error("[GuidePdfApi] Could not load entitlement", entitlementError);
+    return jsonNoStore({ ok: false, error: "Could not verify access." }, 500);
+  }
+
+  if (!entitlement) {
+    return jsonNoStore({ ok: false, error: "Guide access required." }, 403);
+  }
+
+  const relativePath = getGuide0To1000PdfAssetPath();
+  const absolutePath = path.join(process.cwd(), relativePath);
+
+  try {
+    const pdfBuffer = await readFile(absolutePath);
+    return new NextResponse(new Uint8Array(pdfBuffer), {
+      status: 200,
+      headers: {
+        "Cache-Control": "private, no-store",
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="${GUIDE_0_TO_1000M_PDF_DOWNLOAD_FILENAME}"`,
+        "Content-Length": String(pdfBuffer.byteLength),
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  } catch (error) {
+    console.error("[GuidePdfApi] Could not load PDF asset", { relativePath, error });
+    return jsonNoStore(
+      { ok: false, error: "PDF is temporarily unavailable. Please try again shortly." },
+      503
+    );
+  }
+}

--- a/app/guides/0-1000m/page.tsx
+++ b/app/guides/0-1000m/page.tsx
@@ -1,0 +1,106 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import SiteChrome from "@/components/SiteChrome";
+import GuidePdfDownloadButton from "@/components/guides/GuidePdfDownloadButton";
+import Guide0To1000Tracker from "@/components/guides/Guide0To1000Tracker";
+import { attachGuestEntitlementsByEmail } from "@/lib/commerce/entitlements";
+import { createAdminSupabaseClient } from "@/lib/supabase/admin";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import {
+  GUIDE_0_TO_1000M_PDF_DOWNLOAD_FILENAME,
+  GUIDE_0_TO_1000M_PRODUCT_ID,
+  GUIDE_0_TO_1000M_SESSIONS,
+  GUIDE_0_TO_1000M_SLUG,
+} from "@/lib/guides/guide-0-1000m";
+
+export const dynamic = "force-dynamic";
+
+export default async function Guide0To1000Page() {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/auth/sign-in?next=%2Fguides%2F0-1000m");
+  }
+
+  if (user.email) {
+    try {
+      const adminSupabase = createAdminSupabaseClient();
+      await attachGuestEntitlementsByEmail(adminSupabase, user.id, user.email);
+    } catch (error) {
+      console.error("[Guide0To1000] Could not attach guest entitlements", error);
+    }
+  }
+
+  const { data: entitlement, error } = await supabase
+    .from("entitlements")
+    .select("id")
+    .eq("product_id", GUIDE_0_TO_1000M_PRODUCT_ID)
+    .eq("user_id", user.id)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error("[Guide0To1000] Could not load entitlement", error);
+  }
+
+  if (!entitlement) {
+    return (
+      <SiteChrome>
+        <section className="mx-auto min-h-screen w-full max-w-[980px] px-6 pb-20 pt-28">
+          <div className="rounded-3xl border border-amber-200 bg-amber-50/60 p-8 shadow-[0_14px_45px_rgba(15,23,42,0.10)]">
+            <h1 className="text-3xl font-bold text-slate-900">Guide access required</h1>
+            <p className="mt-3 text-sm leading-relaxed text-slate-700">
+              This interactive plan appears when `0-1000m guide` is in your library.
+            </p>
+            <div className="mt-6 flex flex-wrap gap-3">
+              <Link
+                href="/plans"
+                className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500"
+              >
+                View plans
+              </Link>
+              <Link
+                href="/my-library"
+                className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+              >
+                Back to My Library
+              </Link>
+            </div>
+          </div>
+        </section>
+      </SiteChrome>
+    );
+  }
+
+  return (
+    <SiteChrome>
+      <section className="mx-auto min-h-screen w-full max-w-[980px] px-6 pb-20 pt-28">
+        <div className="mb-4 flex flex-wrap items-start justify-between gap-3 rounded-2xl border border-slate-200 bg-white/90 p-4">
+          <p className="max-w-[600px] text-sm text-slate-600">
+            Keep training in the interactive tracker and download the PDF whenever you need an
+            offline version.
+          </p>
+          <div className="flex flex-wrap items-start gap-2">
+            <GuidePdfDownloadButton
+              apiPath="/api/guides/0-1000m/pdf"
+              fallbackFileName={GUIDE_0_TO_1000M_PDF_DOWNLOAD_FILENAME}
+            />
+            <Link
+              href="/my-library"
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+            >
+              Back to My Library
+            </Link>
+          </div>
+        </div>
+        <Guide0To1000Tracker
+          guideSlug={GUIDE_0_TO_1000M_SLUG}
+          sessions={GUIDE_0_TO_1000M_SESSIONS}
+        />
+      </section>
+    </SiteChrome>
+  );
+}

--- a/app/my-library/item/[slug]/page.tsx
+++ b/app/my-library/item/[slug]/page.tsx
@@ -1,6 +1,11 @@
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import SiteChrome from "@/components/SiteChrome";
+import GuidePdfDownloadButton from "@/components/guides/GuidePdfDownloadButton";
+import {
+  GUIDE_0_TO_1000M_PDF_DOWNLOAD_FILENAME,
+  GUIDE_0_TO_1000M_PRODUCT_ID,
+} from "@/lib/guides/guide-0-1000m";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { getCatalogProductBySlug } from "@/lib/commerce/catalog";
 
@@ -11,6 +16,20 @@ type Props = {
 };
 
 export const dynamic = "force-dynamic";
+
+function getProductOpenHref(productId: string): string | null {
+  if (productId === GUIDE_0_TO_1000M_PRODUCT_ID) {
+    return "/guides/0-1000m";
+  }
+  return null;
+}
+
+function getProductPdfApiHref(productId: string): string | null {
+  if (productId === GUIDE_0_TO_1000M_PRODUCT_ID) {
+    return "/api/guides/0-1000m/pdf";
+  }
+  return null;
+}
 
 export default async function LibraryItemPage({ params }: Props) {
   const { slug } = await params;
@@ -42,16 +61,35 @@ export default async function LibraryItemPage({ params }: Props) {
     redirect("/my-library");
   }
 
+  const openHref = getProductOpenHref(product.id);
+  const pdfApiHref = getProductPdfApiHref(product.id);
+
   return (
     <SiteChrome>
       <section className="mx-auto min-h-screen w-full max-w-[980px] px-6 pb-20 pt-28">
         <div className="rounded-3xl border border-blue-100 bg-white/95 p-8 shadow-[0_16px_60px_rgba(24,58,107,0.14)]">
           <h1 className="text-3xl font-bold text-slate-900">{product.title}</h1>
           <p className="mt-3 text-sm text-slate-600">
-            Owned item detail is active. Download/preview flows will be added in the next step.
+            {openHref
+              ? "This item includes an interactive tracker. Open it to continue your plan."
+              : "Owned item detail is active. Download/preview flows will be added in the next step."}
           </p>
 
-          <div className="mt-6 flex flex-wrap gap-3">
+          <div className="mt-6 flex flex-wrap items-start gap-3">
+            {openHref ? (
+              <Link
+                href={openHref}
+                className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700"
+              >
+                Open interactive plan
+              </Link>
+            ) : null}
+            {pdfApiHref ? (
+              <GuidePdfDownloadButton
+                apiPath={pdfApiHref}
+                fallbackFileName={GUIDE_0_TO_1000M_PDF_DOWNLOAD_FILENAME}
+              />
+            ) : null}
             <Link
               href="/my-library"
               className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50"

--- a/assets/guides/0-1000m-guide.pdf
+++ b/assets/guides/0-1000m-guide.pdf
@@ -1,0 +1,48 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 694 >>
+stream
+BT
+/F1 14 Tf
+72 760 Td (FreeSwimming - 0-1000m Guide) Tj
+72 736 Td () Tj
+72 712 Td (This PDF is provided for offline access.) Tj
+72 688 Td (Use the interactive plan in My Library for progress tracking,) Tj
+72 664 Td (checkbox completion, and synced notes across devices.) Tj
+72 640 Td () Tj
+72 616 Td (Session overview \(20 sessions\):) Tj
+72 592 Td (S01-S04: breathing and body line) Tj
+72 568 Td (S05-S08: catch, rotation, aerobic build) Tj
+72 544 Td (S09-S12: pacing and mid-plan check) Tj
+72 520 Td (S13-S16: endurance + threshold quality) Tj
+72 496 Td (S17-S20: race prep and full 1000m completion) Tj
+72 472 Td () Tj
+72 448 Td (For latest updates, open the interactive plan in app.) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000986 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+1056
+%%EOF

--- a/components/guides/Guide0To1000Tracker.tsx
+++ b/components/guides/Guide0To1000Tracker.tsx
@@ -1,0 +1,621 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  MAX_GUIDE_PROGRESS_ROWS,
+  normalizeGuideProgressRows,
+  type GuideProgressRow,
+} from "@/lib/course/guide-progress";
+import { type Guide0To1000Session } from "@/lib/guides/guide-0-1000m";
+
+const GUIDE_PROGRESS_SYNC_API_PATH = "/api/progress/guide";
+const GUIDE_PROGRESS_STORAGE_KEY = "fs_guide_0_1000m_progress_v1";
+const GUIDE_PROGRESS_SYNC_INTERVAL_MS = 10_000;
+const MAX_NOTES_LENGTH = 4000;
+
+type SyncState = "idle" | "syncing" | "synced" | "error" | "offline";
+
+type SessionProgress = {
+  completed: boolean;
+  notes: string;
+  updatedAt: string;
+};
+
+type SessionProgressRecord = Record<string, SessionProgress>;
+
+type Props = {
+  guideSlug: string;
+  sessions: Guide0To1000Session[];
+};
+
+function getInitialOnlineState(): boolean {
+  if (typeof navigator === "undefined") return true;
+  return navigator.onLine;
+}
+
+function getSafeIsoTimestamp(value: string | undefined): string {
+  if (!value) return new Date().toISOString();
+  const ts = Date.parse(value);
+  if (!Number.isFinite(ts)) return new Date().toISOString();
+  return new Date(ts).toISOString();
+}
+
+function toProgressRecord(rows: GuideProgressRow[]): SessionProgressRecord {
+  const next: SessionProgressRecord = {};
+  for (const row of rows) {
+    next[row.sectionId] = {
+      completed: row.completed,
+      notes: row.notes,
+      updatedAt: getSafeIsoTimestamp(row.updatedAt),
+    };
+  }
+  return next;
+}
+
+function toProgressRows(
+  record: SessionProgressRecord,
+  guideSlug: string,
+  allowedSectionIds: Set<string>
+): GuideProgressRow[] {
+  const rows = Object.entries(record)
+    .filter(([sectionId]) => allowedSectionIds.has(sectionId))
+    .map(([sectionId, value]) => ({
+      guideSlug,
+      sectionId,
+      completed: value.completed,
+      notes: value.notes,
+      updatedAt: getSafeIsoTimestamp(value.updatedAt),
+    }));
+
+  return normalizeGuideProgressRows(rows, { maxRows: MAX_GUIDE_PROGRESS_ROWS });
+}
+
+function filterRowsForGuide(
+  rows: unknown,
+  guideSlug: string,
+  allowedSectionIds: Set<string>
+): GuideProgressRow[] {
+  return normalizeGuideProgressRows(rows, { maxRows: MAX_GUIDE_PROGRESS_ROWS }).filter(
+    (row) => row.guideSlug === guideSlug && allowedSectionIds.has(row.sectionId)
+  );
+}
+
+function areRowsEqual(left: GuideProgressRow[], right: GuideProgressRow[]): boolean {
+  if (left.length !== right.length) return false;
+
+  for (let i = 0; i < left.length; i += 1) {
+    const a = left[i];
+    const b = right[i];
+    if (a.guideSlug !== b.guideSlug) return false;
+    if (a.sectionId !== b.sectionId) return false;
+    if (a.completed !== b.completed) return false;
+    if (a.notes !== b.notes) return false;
+    if (a.updatedAt !== b.updatedAt) return false;
+  }
+
+  return true;
+}
+
+function readLocalRows(guideSlug: string, allowedSectionIds: Set<string>): GuideProgressRow[] {
+  if (typeof window === "undefined") return [];
+
+  try {
+    const raw = localStorage.getItem(GUIDE_PROGRESS_STORAGE_KEY);
+    if (!raw) return [];
+    return filterRowsForGuide(JSON.parse(raw), guideSlug, allowedSectionIds);
+  } catch {
+    return [];
+  }
+}
+
+function persistLocalRows(rows: GuideProgressRow[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(GUIDE_PROGRESS_STORAGE_KEY, JSON.stringify(rows));
+  } catch {}
+}
+
+function formatRelativeAge(timestampMs: number | null): string {
+  if (!timestampMs) return "Saved recently.";
+
+  const ageMs = Math.max(0, Date.now() - timestampMs);
+  if (ageMs < 15_000) return "Saved just now.";
+
+  const ageMinutes = Math.floor(ageMs / 60_000);
+  if (ageMinutes < 1) return "Saved less than a minute ago.";
+  if (ageMinutes === 1) return "Saved 1 minute ago.";
+  if (ageMinutes < 60) return `Saved ${ageMinutes} minutes ago.`;
+
+  const ageHours = Math.floor(ageMinutes / 60);
+  if (ageHours === 1) return "Saved 1 hour ago.";
+  return `Saved ${ageHours} hours ago.`;
+}
+
+function formatSessionUpdatedLabel(updatedAt: string | undefined): string {
+  if (!updatedAt) return "Not updated yet";
+  const ts = Date.parse(updatedAt);
+  if (!Number.isFinite(ts)) return "Not updated yet";
+
+  const ageMs = Math.max(0, Date.now() - ts);
+  if (ageMs < 10_000) return "Updated just now";
+  if (ageMs < 60_000) return "Updated <1 min ago";
+
+  const minutes = Math.floor(ageMs / 60_000);
+  if (minutes < 60) return `Updated ${minutes} min ago`;
+
+  const hours = Math.floor(minutes / 60);
+  return `Updated ${hours}h ago`;
+}
+
+export default function Guide0To1000Tracker({ guideSlug, sessions }: Props) {
+  const allowedSectionIds = useMemo(
+    () => new Set(sessions.map((session) => session.id)),
+    [sessions]
+  );
+  const [progressBySessionId, setProgressBySessionId] = useState<SessionProgressRecord>({});
+  const progressBySessionIdRef = useRef<SessionProgressRecord>({});
+  const [hydrationState, setHydrationState] = useState<"loading" | "ready">("loading");
+  const [syncState, setSyncState] = useState<SyncState>("idle");
+  const [syncError, setSyncError] = useState("");
+  const [lastSyncAtMs, setLastSyncAtMs] = useState<number | null>(null);
+  const [isOnline, setIsOnline] = useState(getInitialOnlineState);
+  const dirtySectionIdsRef = useRef<Set<string>>(new Set());
+  const syncInFlightRef = useRef(false);
+
+  const applyProgressRows = useCallback(
+    (rows: GuideProgressRow[]) => {
+      const normalizedRows = filterRowsForGuide(rows, guideSlug, allowedSectionIds);
+      const nextRecord = toProgressRecord(normalizedRows);
+      progressBySessionIdRef.current = nextRecord;
+      setProgressBySessionId(nextRecord);
+      persistLocalRows(normalizedRows);
+    },
+    [allowedSectionIds, guideSlug]
+  );
+
+  const persistRowsToServer = useCallback(async (rows: GuideProgressRow[]) => {
+    const response = await fetch(GUIDE_PROGRESS_SYNC_API_PATH, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      cache: "no-store",
+      credentials: "same-origin",
+      body: JSON.stringify({ rows }),
+    });
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        throw new Error("Session expired. Sign in again to keep syncing your guide progress.");
+      }
+      throw new Error(`Guide progress sync failed (${response.status}).`);
+    }
+  }, []);
+
+  const syncGuideProgressNow = useCallback(
+    async (options?: { force?: boolean }) => {
+      if (syncInFlightRef.current) return;
+      if (!isOnline) {
+        setSyncState("offline");
+        return;
+      }
+
+      const dirtyIds = new Set(dirtySectionIdsRef.current);
+      if (!options?.force && dirtyIds.size === 0) return;
+
+      const allRows = toProgressRows(progressBySessionIdRef.current, guideSlug, allowedSectionIds);
+      const rows = allRows.filter((row) => options?.force || dirtyIds.has(row.sectionId));
+      if (rows.length === 0) return;
+
+      syncInFlightRef.current = true;
+      setSyncState("syncing");
+      setSyncError("");
+
+      try {
+        await persistRowsToServer(rows);
+        if (options?.force) {
+          dirtySectionIdsRef.current.clear();
+        } else {
+          for (const row of rows) {
+            dirtySectionIdsRef.current.delete(row.sectionId);
+          }
+        }
+        setSyncState("synced");
+        setLastSyncAtMs(Date.now());
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Could not sync guide progress right now. Try again.";
+        setSyncError(message);
+        setSyncState("error");
+      } finally {
+        syncInFlightRef.current = false;
+      }
+    },
+    [allowedSectionIds, guideSlug, isOnline, persistRowsToServer]
+  );
+
+  useEffect(() => {
+    progressBySessionIdRef.current = progressBySessionId;
+  }, [progressBySessionId]);
+
+  useEffect(() => {
+    const onOnline = () => {
+      setIsOnline(true);
+      setSyncState("idle");
+    };
+    const onOffline = () => {
+      setIsOnline(false);
+      setSyncState("offline");
+    };
+
+    window.addEventListener("online", onOnline);
+    window.addEventListener("offline", onOffline);
+
+    return () => {
+      window.removeEventListener("online", onOnline);
+      window.removeEventListener("offline", onOffline);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (hydrationState !== "ready") return;
+    if (!isOnline) return;
+    if (dirtySectionIdsRef.current.size === 0) return;
+    void syncGuideProgressNow();
+  }, [hydrationState, isOnline, syncGuideProgressNow]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const hydrate = async () => {
+      const localRows = readLocalRows(guideSlug, allowedSectionIds);
+      applyProgressRows(localRows);
+
+      if (!navigator.onLine) {
+        if (!cancelled) {
+          setHydrationState("ready");
+          setSyncState("offline");
+        }
+        return;
+      }
+
+      setSyncState("syncing");
+      setSyncError("");
+
+      try {
+        const response = await fetch(GUIDE_PROGRESS_SYNC_API_PATH, {
+          method: "GET",
+          cache: "no-store",
+          credentials: "same-origin",
+        });
+
+        if (!response.ok) {
+          if (response.status === 401) {
+            throw new Error("Session expired. Sign in again to load your guide progress.");
+          }
+          throw new Error(`Guide progress hydrate failed (${response.status}).`);
+        }
+
+        const payload = (await response.json()) as { rows?: unknown };
+        if (cancelled) return;
+
+        const remoteRows = filterRowsForGuide(payload.rows ?? [], guideSlug, allowedSectionIds);
+        const mergedRows = normalizeGuideProgressRows([...localRows, ...remoteRows], {
+          maxRows: MAX_GUIDE_PROGRESS_ROWS,
+        });
+        applyProgressRows(mergedRows);
+
+        if (!areRowsEqual(mergedRows, remoteRows)) {
+          await persistRowsToServer(mergedRows);
+        }
+
+        if (cancelled) return;
+        setSyncState("synced");
+        setLastSyncAtMs(Date.now());
+      } catch (error) {
+        if (cancelled) return;
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Could not load guide progress right now. You can continue locally.";
+        setSyncError(message);
+        setSyncState(navigator.onLine ? "error" : "offline");
+      } finally {
+        if (!cancelled) {
+          setHydrationState("ready");
+        }
+      }
+    };
+
+    void hydrate();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [allowedSectionIds, applyProgressRows, guideSlug, persistRowsToServer]);
+
+  useEffect(() => {
+    if (hydrationState !== "ready") return;
+
+    const syncTimer = window.setInterval(() => {
+      void syncGuideProgressNow();
+    }, GUIDE_PROGRESS_SYNC_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(syncTimer);
+    };
+  }, [hydrationState, syncGuideProgressNow]);
+
+  useEffect(() => {
+    if (hydrationState !== "ready") return;
+
+    const flushWhenBackgrounded = () => {
+      if (document.visibilityState !== "hidden") return;
+      void syncGuideProgressNow({ force: true });
+    };
+    const flushOnPageHide = () => {
+      void syncGuideProgressNow({ force: true });
+    };
+
+    document.addEventListener("visibilitychange", flushWhenBackgrounded);
+    window.addEventListener("pagehide", flushOnPageHide);
+
+    return () => {
+      document.removeEventListener("visibilitychange", flushWhenBackgrounded);
+      window.removeEventListener("pagehide", flushOnPageHide);
+    };
+  }, [hydrationState, syncGuideProgressNow]);
+
+  const updateSessionProgress = useCallback(
+    (
+      sessionId: string,
+      updater: (current: SessionProgress) => SessionProgress,
+      options?: { markDirty?: boolean }
+    ) => {
+      setProgressBySessionId((previous) => {
+        const current = previous[sessionId] ?? {
+          completed: false,
+          notes: "",
+          updatedAt: new Date().toISOString(),
+        };
+        const next = updater(current);
+        if (
+          next.completed === current.completed &&
+          next.notes === current.notes &&
+          next.updatedAt === current.updatedAt
+        ) {
+          return previous;
+        }
+
+        const nextRecord = {
+          ...previous,
+          [sessionId]: {
+            completed: next.completed,
+            notes: next.notes.slice(0, MAX_NOTES_LENGTH),
+            updatedAt: getSafeIsoTimestamp(next.updatedAt),
+          },
+        };
+
+        progressBySessionIdRef.current = nextRecord;
+        const localRows = toProgressRows(nextRecord, guideSlug, allowedSectionIds);
+        persistLocalRows(localRows);
+
+        if (options?.markDirty !== false) {
+          dirtySectionIdsRef.current.add(sessionId);
+          setSyncState((state) => (state === "offline" ? state : "idle"));
+          setSyncError("");
+        }
+
+        return nextRecord;
+      });
+    },
+    [allowedSectionIds, guideSlug]
+  );
+
+  const sessionsByWeek = useMemo(() => {
+    const grouped = new Map<number, Guide0To1000Session[]>();
+    for (const session of sessions) {
+      const existing = grouped.get(session.weekNumber) ?? [];
+      existing.push(session);
+      grouped.set(session.weekNumber, existing);
+    }
+
+    return Array.from(grouped.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([weekNumber, weekSessions]) => ({
+        weekNumber,
+        sessions: weekSessions.sort((left, right) => left.id.localeCompare(right.id)),
+      }));
+  }, [sessions]);
+
+  const completedCount = useMemo(() => {
+    return sessions.reduce((total, session) => {
+      const progress = progressBySessionId[session.id];
+      return progress?.completed ? total + 1 : total;
+    }, 0);
+  }, [progressBySessionId, sessions]);
+
+  const remainingCount = Math.max(0, sessions.length - completedCount);
+  const completionPercent =
+    sessions.length === 0 ? 0 : Math.round((completedCount / sessions.length) * 100);
+
+  const syncLabel = useMemo(() => {
+    if (syncState === "syncing") return "Saving guide progress...";
+    if (syncState === "offline" || !isOnline) {
+      return "Offline mode: changes stay on this device and sync when connection returns.";
+    }
+    if (syncState === "error") {
+      return syncError || "Could not sync guide progress right now.";
+    }
+    if (syncState === "synced") return formatRelativeAge(lastSyncAtMs);
+    return "Signed in. Guide progress sync is active.";
+  }, [isOnline, lastSyncAtMs, syncError, syncState]);
+
+  if (sessions.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50/80 p-6">
+        <h2 className="text-base font-semibold text-slate-900">Guide content unavailable</h2>
+        <p className="mt-2 text-sm text-slate-600">
+          Sessions are not configured yet. Please try again shortly.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <section className="rounded-3xl border border-blue-100 bg-white/95 p-6 shadow-[0_12px_40px_rgba(24,58,107,0.12)]">
+        <h1 className="text-3xl font-bold text-slate-900">0-1000m interactive plan</h1>
+        <p className="mt-2 text-sm leading-relaxed text-slate-600">
+          Track each session with completion and notes. Progress is stored locally immediately and
+          synced to your account in the background.
+        </p>
+
+        <div className="mt-5 grid gap-3 sm:grid-cols-3">
+          <div className="rounded-2xl border border-emerald-200 bg-emerald-50/60 p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-emerald-700">
+              Completed
+            </p>
+            <p className="mt-1 text-2xl font-bold text-slate-900">
+              {completedCount}/{sessions.length}
+            </p>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-600">
+              Remaining
+            </p>
+            <p className="mt-1 text-2xl font-bold text-slate-900">{remainingCount}</p>
+          </div>
+          <div className="rounded-2xl border border-blue-100 bg-blue-50/60 p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Progress</p>
+            <p className="mt-1 text-2xl font-bold text-slate-900">{completionPercent}%</p>
+          </div>
+        </div>
+
+        <div className="mt-5 flex flex-wrap items-center gap-3">
+          <p className="text-xs text-slate-600" aria-live="polite">
+            {syncLabel}
+          </p>
+          {(syncState === "error" || syncState === "offline") && (
+            <button
+              type="button"
+              onClick={() => {
+                void syncGuideProgressNow({ force: true });
+              }}
+              className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-xs font-semibold text-slate-700 transition hover:bg-slate-50"
+            >
+              Retry sync
+            </button>
+          )}
+        </div>
+      </section>
+
+      {hydrationState === "loading" ? (
+        <div className="space-y-3" aria-label="Loading guide progress">
+          <div className="h-28 animate-pulse rounded-2xl border border-slate-200/70 bg-white/80" />
+          <div className="h-28 animate-pulse rounded-2xl border border-slate-200/70 bg-white/80" />
+          <div className="h-28 animate-pulse rounded-2xl border border-slate-200/70 bg-white/80" />
+        </div>
+      ) : (
+        <div className="space-y-5">
+          {sessionsByWeek.map((week) => (
+            <section
+              key={week.weekNumber}
+              className="rounded-3xl border border-slate-200 bg-white/95 p-5 shadow-[0_8px_30px_rgba(15,23,42,0.08)]"
+            >
+              <h2 className="text-lg font-semibold text-slate-900">Week {week.weekNumber}</h2>
+              <div className="mt-4 grid gap-3">
+                {week.sessions.map((session) => {
+                  const progress = progressBySessionId[session.id];
+                  const completed = progress?.completed ?? false;
+                  const notes = progress?.notes ?? "";
+                  const textareaId = `guide-${session.id}-notes`;
+
+                  return (
+                    <article
+                      key={session.id}
+                      className={`rounded-2xl border p-4 transition ${
+                        completed
+                          ? "border-emerald-200 bg-emerald-50/50"
+                          : "border-slate-200 bg-white"
+                      }`}
+                    >
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                            Session {session.id}
+                          </p>
+                          <h3 className="mt-1 text-base font-semibold text-slate-900">
+                            {session.title}
+                          </h3>
+                        </div>
+
+                        <label className="inline-flex items-center gap-2 text-sm font-medium text-slate-700">
+                          <input
+                            type="checkbox"
+                            checked={completed}
+                            onChange={() => {
+                              const timestamp = new Date().toISOString();
+                              updateSessionProgress(session.id, (current) => ({
+                                completed: !current.completed,
+                                notes: current.notes,
+                                updatedAt: timestamp,
+                              }));
+                            }}
+                            className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                          />
+                          {completed ? "Completed" : "Mark complete"}
+                        </label>
+                      </div>
+
+                      <p className="mt-2 text-sm text-slate-600">
+                        <span className="font-medium text-slate-700">Focus:</span> {session.focus}
+                      </p>
+                      <p className="mt-1 text-sm text-slate-600">
+                        <span className="font-medium text-slate-700">Target set:</span>{" "}
+                        {session.targetSet}
+                      </p>
+
+                      <div className="mt-3 space-y-2">
+                        <label
+                          htmlFor={textareaId}
+                          className="text-xs font-semibold text-slate-700"
+                        >
+                          Session notes
+                        </label>
+                        <textarea
+                          id={textareaId}
+                          value={notes}
+                          onChange={(event) => {
+                            const timestamp = new Date().toISOString();
+                            const nextNotes = event.currentTarget.value.slice(0, MAX_NOTES_LENGTH);
+                            updateSessionProgress(session.id, (current) => ({
+                              completed: current.completed,
+                              notes: nextNotes,
+                              updatedAt: timestamp,
+                            }));
+                          }}
+                          rows={3}
+                          placeholder="Write what felt good, what to adjust next time, and pacing notes."
+                          className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-blue-500"
+                        />
+                        <div className="flex items-center justify-between gap-3 text-xs text-slate-500">
+                          <span>
+                            {notes.length}/{MAX_NOTES_LENGTH}
+                          </span>
+                          <span>{formatSessionUpdatedLabel(progress?.updatedAt)}</span>
+                        </div>
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/guides/GuidePdfDownloadButton.tsx
+++ b/components/guides/GuidePdfDownloadButton.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+
+type Props = {
+  apiPath: string;
+  fallbackFileName?: string;
+  className?: string;
+};
+
+const DEFAULT_ERROR_MESSAGE = "Could not download PDF right now. Please try again.";
+
+function toFileNameFromDisposition(disposition: string | null, fallback: string): string {
+  if (!disposition) return fallback;
+
+  const utf8Match = disposition.match(/filename\*=UTF-8''([^;]+)/i);
+  if (utf8Match?.[1]) {
+    try {
+      return decodeURIComponent(utf8Match[1]);
+    } catch {
+      return fallback;
+    }
+  }
+
+  const simpleMatch = disposition.match(/filename="?([^"]+)"?/i);
+  if (simpleMatch?.[1]) {
+    return simpleMatch[1];
+  }
+
+  return fallback;
+}
+
+export default function GuidePdfDownloadButton({
+  apiPath,
+  fallbackFileName = "guide.pdf",
+  className = "",
+}: Props) {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState("");
+
+  async function onClick() {
+    if (pending) return;
+    setPending(true);
+    setError("");
+
+    try {
+      const response = await fetch(apiPath, {
+        method: "GET",
+        cache: "no-store",
+        credentials: "same-origin",
+      });
+
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(payload?.error || DEFAULT_ERROR_MESSAGE);
+      }
+
+      const blob = await response.blob();
+      const filename = toFileNameFromDisposition(
+        response.headers.get("content-disposition"),
+        fallbackFileName
+      );
+
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = filename;
+      anchor.rel = "noopener";
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : DEFAULT_ERROR_MESSAGE;
+      setError(message);
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className={`space-y-2 ${className}`}>
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={pending}
+        className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {pending ? "Downloading PDF..." : "Download PDF"}
+      </button>
+      {error ? <p className="text-xs text-rose-700">{error}</p> : null}
+    </div>
+  );
+}

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -180,3 +180,33 @@ Failure:
 - `413`: too many rows in one request
 - `415`: unsupported content type
 - `500`: database failure
+
+## `GET /api/guides/0-1000m/pdf`
+
+### Request
+
+- Auth: signed-in user session required
+- Access: user must own `guide_0_1000m` entitlement
+
+### Response
+
+- Success:
+  - `200` with `application/pdf`
+  - `Content-Disposition: attachment; filename="freeswimming-0-1000m-guide.pdf"`
+
+- Failure:
+
+```json
+{
+  "ok": false,
+  "error": "Guide access required."
+}
+```
+
+### Status Codes
+
+- `200`: pdf download stream
+- `401`: unauthorized
+- `403`: user does not own guide entitlement
+- `500`: entitlement verification failure
+- `503`: PDF asset temporarily unavailable

--- a/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
+++ b/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
@@ -150,6 +150,17 @@ Users can start instantly in guest mode, buy optional paid products without acco
 - Paid-guide progress sync API baseline is implemented:
   - `/api/progress/guide` (authenticated read/write),
   - payload normalization + row caps aligned with course-progress API guardrails.
+- `0-1000m` interactive guide baseline is implemented:
+  - `/guides/0-1000m` authenticated + entitlement-gated route,
+  - 20-session (`S01-S20`) interactive tracker with per-session completion + notes,
+  - local-first persistence + background sync to `/api/progress/guide`,
+  - sync UX states include loading, offline, error, and retry.
+- `0-1000m` dual-action owned-item UX is implemented:
+  - owned-item detail now exposes both:
+    - `Open interactive plan`,
+    - `Download PDF`.
+  - PDF download is served through entitlement-gated API (`/api/guides/0-1000m/pdf`) with no public paid-file exposure.
+  - download UI includes explicit loading + failure state with retry option.
 - Guest progress-safety milestone prompt is implemented:
   - appears after 3 completed lessons in guest mode,
   - includes free-account CTA to preserve progress across devices,
@@ -163,16 +174,16 @@ Users can start instantly in guest mode, buy optional paid products without acco
 ### Outstanding (blocking move to `done`)
 
 - Missing routes from architecture contract:
-  - `/claim`,
-  - `/guides/0-1000m` interactive guide.
+  - `/claim`.
 - Missing API endpoints from architecture contract:
   - `/api/user/export`,
   - `/api/user/delete`.
 - `My Library` item detail is still placeholder text:
-  - preview/download/re-download behavior not implemented yet.
+  - dual-action flow is now implemented for `0-1000m`,
+  - preview/download/re-download behavior for remaining owned products is still pending.
 - Progress sync criteria is partially met:
   - free-course progress now supports signed-in server sync and local->account merge,
-  - paid-guide progress sync API is implemented, but interactive guide UX + client sync wiring is still pending.
+  - paid-guide interactive sync is implemented for `0-1000m`, but cross-device resume still needs manual QA confirmation.
 - Goals MVP UI/state flow is not implemented.
 - Analytics/KPI event pipeline is not implemented.
 - GDPR operational requirements are not complete:
@@ -188,7 +199,6 @@ Users can start instantly in guest mode, buy optional paid products without acco
 ## Next Delivery Order (Execution)
 
 1. Library/content slice:
-   - implement `/guides/0-1000m` interactive 20-session plan,
    - implement owned item preview/download/re-download in `/my-library/item/[slug]`,
    - expand claim/restore UX around owned content recovery.
 2. Trust/ops slice:
@@ -830,6 +840,31 @@ At each phase:
 
 ## Implementation Checkpoint Log (In Progress)
 
+- `2026-02-17` | `working tree` | `0-1000m` dual-action UX + protected PDF download complete:
+  - added secure entitlement-gated PDF endpoint: `GET /api/guides/0-1000m/pdf`,
+  - added private PDF asset path handling with safe path validation (`GUIDE_0_TO_1000M_PDF_ASSET_PATH` optional override),
+  - updated owned-item detail to show dual actions for `0-1000m`:
+    - `Open interactive plan`,
+    - `Download PDF`.
+  - updated `/guides/0-1000m` header actions with direct `Download PDF` and `Back to My Library`,
+  - added tests for:
+    - guide pdf asset path safety,
+    - download button success/error behavior.
+  - validation run completed:
+    - `npm run lint`,
+    - `npm run typecheck`,
+    - `npm run test:unit`.
+  - next step: implement preview/download/re-download behavior for remaining owned products in `/my-library/item/[slug]`.
+- `2026-02-17` | `working tree` | `/guides/0-1000m` interactive plan baseline complete:
+  - added authenticated + entitlement-gated `/guides/0-1000m` route,
+  - delivered 20-session interactive tracker (`S01-S20`) with per-session completion and notes,
+  - guide tracker now stores progress locally and syncs to `/api/progress/guide` with loading/offline/error/retry states,
+  - wired `My Library` item detail for `guide_0_1000m` to open the interactive plan.
+  - validation run completed:
+    - `npm run lint`,
+    - `npm run typecheck`,
+    - `npm run test:unit`.
+  - next step: implement owned item preview/download/re-download in `/my-library/item/[slug]`.
 - `2026-02-17` | `working tree` | `/api/progress/guide` baseline contract complete:
   - added `GET/POST /api/progress/guide` with auth guard, `no-store` responses, JSON/content-type validation, and explicit `401/415/413/500` handling,
   - added shared guide-progress normalization module with row de-duplication, identifier bounds, and stable sort behavior,

--- a/lib/guides/guide-0-1000m.ts
+++ b/lib/guides/guide-0-1000m.ts
@@ -1,0 +1,168 @@
+export type Guide0To1000Session = {
+  id: string;
+  weekNumber: number;
+  title: string;
+  focus: string;
+  targetSet: string;
+};
+
+export const GUIDE_0_TO_1000M_SLUG = "0-1000m";
+export const GUIDE_0_TO_1000M_PRODUCT_ID = "guide_0_1000m";
+export const GUIDE_0_TO_1000M_PDF_DOWNLOAD_FILENAME = "freeswimming-0-1000m-guide.pdf";
+
+const DEFAULT_GUIDE_0_TO_1000M_PDF_ASSET_PATH = "assets/guides/0-1000m-guide.pdf";
+const SAFE_PDF_PATH_REGEX = /^[A-Za-z0-9/_\-.]+\.pdf$/;
+
+export function getGuide0To1000PdfAssetPath(
+  env: Readonly<Record<string, string | undefined>> = process.env
+): string {
+  const candidate = env.GUIDE_0_TO_1000M_PDF_ASSET_PATH?.trim();
+  if (!candidate) return DEFAULT_GUIDE_0_TO_1000M_PDF_ASSET_PATH;
+  if (candidate.startsWith("/")) return DEFAULT_GUIDE_0_TO_1000M_PDF_ASSET_PATH;
+  if (candidate.includes("..")) return DEFAULT_GUIDE_0_TO_1000M_PDF_ASSET_PATH;
+  if (!SAFE_PDF_PATH_REGEX.test(candidate)) return DEFAULT_GUIDE_0_TO_1000M_PDF_ASSET_PATH;
+  return candidate;
+}
+
+export const GUIDE_0_TO_1000M_SESSIONS: Guide0To1000Session[] = [
+  {
+    id: "S01",
+    weekNumber: 1,
+    title: "Baseline and breathing rhythm",
+    focus: "Set calm breathing cadence and smooth exhale.",
+    targetSet: "6 x 50m easy + 4 x 25m drill focus",
+  },
+  {
+    id: "S02",
+    weekNumber: 1,
+    title: "Body line and head position",
+    focus: "Hold long shape with neutral head.",
+    targetSet: "8 x 50m with 20s rest",
+  },
+  {
+    id: "S03",
+    weekNumber: 2,
+    title: "Kick support without over-kicking",
+    focus: "Use small kick for balance, not speed.",
+    targetSet: "4 x 100m aerobic + 4 x 25m kick control",
+  },
+  {
+    id: "S04",
+    weekNumber: 2,
+    title: "Front quadrant timing",
+    focus: "Keep stroke patient and connected.",
+    targetSet: "10 x 50m negative split",
+  },
+  {
+    id: "S05",
+    weekNumber: 3,
+    title: "Catch setup and early pressure",
+    focus: "Build stable catch before pull-through.",
+    targetSet: "6 x 75m technique + 4 x 25m fist drill",
+  },
+  {
+    id: "S06",
+    weekNumber: 3,
+    title: "Rotation control",
+    focus: "Rotate from core without crossing line.",
+    targetSet: "5 x 100m with bilateral breathing",
+  },
+  {
+    id: "S07",
+    weekNumber: 4,
+    title: "Aerobic durability",
+    focus: "Stay relaxed while distance grows.",
+    targetSet: "3 x 200m steady + 4 x 50m easy",
+  },
+  {
+    id: "S08",
+    weekNumber: 4,
+    title: "Pace awareness",
+    focus: "Hold even pacing across reps.",
+    targetSet: "12 x 50m at controlled threshold",
+  },
+  {
+    id: "S09",
+    weekNumber: 5,
+    title: "Turns and push-off line",
+    focus: "Protect momentum out of wall.",
+    targetSet: "8 x 75m with turn focus",
+  },
+  {
+    id: "S10",
+    weekNumber: 5,
+    title: "Stroke length under fatigue",
+    focus: "Keep distance-per-stroke late in set.",
+    targetSet: "4 x 150m + 4 x 50m build",
+  },
+  {
+    id: "S11",
+    weekNumber: 6,
+    title: "Tempo and relaxation balance",
+    focus: "Increase tempo without losing form.",
+    targetSet: "16 x 25m tempo ladder + 4 x 100m easy",
+  },
+  {
+    id: "S12",
+    weekNumber: 6,
+    title: "Mid-plan check session",
+    focus: "Re-check breathing, body line, and catch.",
+    targetSet: "1 x 400m continuous + technique reset reps",
+  },
+  {
+    id: "S13",
+    weekNumber: 7,
+    title: "Endurance extension",
+    focus: "Stay efficient across longer repeats.",
+    targetSet: "3 x 250m with 30s rest",
+  },
+  {
+    id: "S14",
+    weekNumber: 7,
+    title: "Broken 500 prep",
+    focus: "Manage effort and stroke quality.",
+    targetSet: "5 x 100m + 1 x 50m at target effort",
+  },
+  {
+    id: "S15",
+    weekNumber: 8,
+    title: "Technique under threshold effort",
+    focus: "Protect form when heart rate rises.",
+    targetSet: "8 x 75m threshold + 4 x 25m reset",
+  },
+  {
+    id: "S16",
+    weekNumber: 8,
+    title: "Race-pace rhythm control",
+    focus: "Lock in repeatable target pace.",
+    targetSet: "10 x 50m at target 1000m pace",
+  },
+  {
+    id: "S17",
+    weekNumber: 9,
+    title: "Long aerobic confidence",
+    focus: "Build confidence for uninterrupted swim.",
+    targetSet: "2 x 300m + 4 x 50m easy",
+  },
+  {
+    id: "S18",
+    weekNumber: 9,
+    title: "Broken 800 rehearsal",
+    focus: "Practice fueling and pacing strategy.",
+    targetSet: "4 x 200m with stable split times",
+  },
+  {
+    id: "S19",
+    weekNumber: 10,
+    title: "Pre-test sharpening",
+    focus: "Stay crisp and relaxed before test day.",
+    targetSet: "6 x 50m build + 4 x 25m easy",
+  },
+  {
+    id: "S20",
+    weekNumber: 10,
+    title: "1000m completion session",
+    focus: "Swim controlled, confident, and continuous.",
+    targetSet: "1 x 1000m continuous + easy cooldown",
+  },
+];

--- a/tests/unit/guide-0-1000m-plan.test.ts
+++ b/tests/unit/guide-0-1000m-plan.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  GUIDE_0_TO_1000M_PRODUCT_ID,
+  GUIDE_0_TO_1000M_PDF_DOWNLOAD_FILENAME,
+  GUIDE_0_TO_1000M_SESSIONS,
+  GUIDE_0_TO_1000M_SLUG,
+  getGuide0To1000PdfAssetPath,
+} from "@/lib/guides/guide-0-1000m";
+
+describe("guide 0-1000m plan data", () => {
+  it("has stable identifiers", () => {
+    expect(GUIDE_0_TO_1000M_SLUG).toBe("0-1000m");
+    expect(GUIDE_0_TO_1000M_PRODUCT_ID).toBe("guide_0_1000m");
+    expect(GUIDE_0_TO_1000M_PDF_DOWNLOAD_FILENAME).toBe("freeswimming-0-1000m-guide.pdf");
+  });
+
+  it("contains exactly 20 sessions with unique ids", () => {
+    expect(GUIDE_0_TO_1000M_SESSIONS).toHaveLength(20);
+
+    const idSet = new Set(GUIDE_0_TO_1000M_SESSIONS.map((session) => session.id));
+    expect(idSet.size).toBe(20);
+  });
+
+  it("has 10 weeks with 2 sessions in each week", () => {
+    const weekCounts = GUIDE_0_TO_1000M_SESSIONS.reduce<Record<number, number>>((acc, session) => {
+      acc[session.weekNumber] = (acc[session.weekNumber] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    const weeks = Object.keys(weekCounts)
+      .map(Number)
+      .sort((a, b) => a - b);
+
+    expect(weeks).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+    for (const week of weeks) {
+      expect(weekCounts[week]).toBe(2);
+    }
+  });
+
+  it("uses safe PDF asset path with fallback on invalid values", () => {
+    expect(getGuide0To1000PdfAssetPath({})).toBe("assets/guides/0-1000m-guide.pdf");
+    expect(
+      getGuide0To1000PdfAssetPath({
+        GUIDE_0_TO_1000M_PDF_ASSET_PATH: "assets/guides/custom.pdf",
+      })
+    ).toBe("assets/guides/custom.pdf");
+    expect(
+      getGuide0To1000PdfAssetPath({
+        GUIDE_0_TO_1000M_PDF_ASSET_PATH: "../secret.pdf",
+      })
+    ).toBe("assets/guides/0-1000m-guide.pdf");
+    expect(
+      getGuide0To1000PdfAssetPath({
+        GUIDE_0_TO_1000M_PDF_ASSET_PATH: "/absolute/path.pdf",
+      })
+    ).toBe("assets/guides/0-1000m-guide.pdf");
+    expect(
+      getGuide0To1000PdfAssetPath({
+        GUIDE_0_TO_1000M_PDF_ASSET_PATH: "assets/guides/not-pdf.txt",
+      })
+    ).toBe("assets/guides/0-1000m-guide.pdf");
+  });
+});

--- a/tests/unit/guide-pdf-download-button.test.tsx
+++ b/tests/unit/guide-pdf-download-button.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import GuidePdfDownloadButton from "@/components/guides/GuidePdfDownloadButton";
+
+describe("GuidePdfDownloadButton", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("downloads PDF on successful response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === "content-disposition"
+            ? 'attachment; filename=\"freeswimming-0-1000m-guide.pdf\"'
+            : null,
+      },
+      blob: async () => new Blob(["%PDF-1.4"], { type: "application/pdf" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const createUrlSpy = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:http://127.0.0.1/mock-pdf");
+    const revokeUrlSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+
+    render(
+      <GuidePdfDownloadButton
+        apiPath="/api/guides/0-1000m/pdf"
+        fallbackFileName="freeswimming-0-1000m-guide.pdf"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Download PDF" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/guides/0-1000m/pdf", {
+        method: "GET",
+        cache: "no-store",
+        credentials: "same-origin",
+      });
+    });
+
+    await waitFor(() => {
+      expect(createUrlSpy).toHaveBeenCalledTimes(1);
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.queryByText("Could not download PDF right now. Please try again.")).toBeNull();
+    expect(revokeUrlSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("shows API error when download fails", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ ok: false, error: "PDF is temporarily unavailable." }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<GuidePdfDownloadButton apiPath="/api/guides/0-1000m/pdf" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Download PDF" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("PDF is temporarily unavailable.")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- adds `/guides/0-1000m` interactive 20-session tracker with local-first + synced progress
- adds dual-action owned UX for `0-1000m` (`Open interactive plan` + `Download PDF`)
- adds entitlement-gated PDF endpoint (`/api/guides/0-1000m/pdf`) with protected asset delivery
- adds unit tests for guide plan data, safe PDF path handling, and PDF download button behavior
- updates task brief + API contract docs for this slice

## Validation
- npm run lint
- npm run typecheck
- npm run test:unit

## Commit
- 9df0478 feat(guide): add 0-1000m dual-action UX with protected pdf download
