### PR TITLE
docs(briefs): add branch hygiene cadence and cleanup protocol

### DIFF
--- a/docs/task-brief-template.md
+++ b/docs/task-brief-template.md
@@ -14,6 +14,7 @@ Use this quick check so the task execution is precise:
 - State non-negotiables (no secrets in repo, UX quality bar, performance guardrails)
 - State continuity rules (commit cadence + resume protocol if chat/session is interrupted)
 - State git rhythm defaults (commit/push cadence and PR cut cadence to `main`)
+- State branch hygiene cadence (post-merge cleanup + stale-branch sweep frequency)
 
 Suggested prompt wrapper:
 
@@ -147,6 +148,22 @@ Define concrete git execution defaults so quality does not depend on memory.
   - after each validated step, assistant must explicitly ask whether to commit+push now,
   - after every `2` pushed checkpoints (or one completed slice), assistant must explicitly ask whether to open/refresh PR to `main`.
 
+## Branch Hygiene Defaults (Required)
+
+Define when and how branch cleanup is executed so repository hygiene is consistent.
+
+- Post-merge cleanup (same working session):
+  - `git checkout main`
+  - `git pull --ff-only origin main`
+  - `git branch -d <merged-branch>`
+  - if remote branch still exists: `git push origin --delete <merged-branch>`
+  - `git fetch --prune origin`
+- Ongoing cleanup cadence:
+  - run `git branch -vv` at least once per active day,
+  - remove stale local branches with upstream marked `: gone` after owner confirmation.
+- Safety rule:
+  - avoid `git branch -D` unless owner explicitly confirms, or a dated backup/tag has been created.
+
 ## Implementation Checkpoint Log (Required For In-Progress Briefs)
 
 Add a running log section in each in-progress brief so status survives chat loss.
@@ -181,8 +198,10 @@ Add a running log section in each in-progress brief so status survives chat loss
     - `git checkout main`
     - `git pull --ff-only origin main`
     - `git branch -d <merged-branch>`
-  - optional cleanup:
     - `git fetch --prune`
+  - if remote branch still exists:
+    - `git push origin --delete <merged-branch>`
+  - optional verification:
     - `git branch -vv` (confirm no stale branch tracking)
   - runbook: `docs/runbooks/post-merge-local-sync.md`
 

--- a/docs/task-briefs/README.md
+++ b/docs/task-briefs/README.md
@@ -52,3 +52,19 @@ After merge confirmation, agent handoff should include local sync commands:
 `git checkout main`
 `git pull --ff-only origin main`
 `git branch -d <merged-branch>`
+
+## Branch Hygiene Best Practice
+
+Use this cadence to keep repository branches clean and predictable:
+
+1. After each merged PR (same session):
+   - `git checkout main`
+   - `git pull --ff-only origin main`
+   - `git branch -d <merged-branch>`
+   - if remote branch remains: `git push origin --delete <merged-branch>`
+   - `git fetch --prune origin`
+2. At least once per active day:
+   - `git branch -vv`
+   - clean stale local branches that show upstream `: gone` (with owner confirmation).
+3. Safety:
+   - do not force-delete (`git branch -D`) unless explicitly confirmed by owner or after creating a dated backup/tag.

--- a/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
+++ b/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
@@ -864,8 +864,36 @@ At each phase:
     - `Open/update PR to main now?`
   - this prompt contract is mandatory even if owner does not explicitly request it each time.
 
+### Branch Hygiene (Locked For This Brief)
+
+- Post-merge cleanup (same session):
+  - `git checkout main`
+  - `git pull --ff-only origin main`
+  - `git branch -d <merged-branch>`
+  - if remote branch remains: `git push origin --delete <merged-branch>`
+  - `git fetch --prune origin`
+- Daily hygiene while this brief is active:
+  - run `git branch -vv` and clean stale local branches with upstream `: gone` after owner confirmation.
+- Safety:
+  - avoid `git branch -D` unless owner explicitly confirms, or a dated backup/tag has been created first.
+
 ## Implementation Checkpoint Log (In Progress)
 
+- `2026-02-17` | `working tree` | repository branch hygiene cleanup completed:
+  - deleted remote merged branches:
+    - `origin/feat/poolside-interactive-guide`,
+    - `origin/feat/my-library-core-split`,
+    - `origin/feat/my-library-guides-pdf-split`.
+  - deleted stale local branches:
+    - `docs/runbooks-and-task-briefs`,
+    - `chore/vercel-connect-trigger`,
+    - `chore/vercel-prod-env-redeploy`,
+    - `backup/main-pre-sync-2026-02-14`.
+  - updated task-brief standards to include explicit branch hygiene cadence in:
+    - `docs/task-brief-template.md`,
+    - `docs/task-briefs/README.md`,
+    - this in-progress brief.
+  - next step: continue remaining My Library scope from latest `main`.
 - `2026-02-17` | `working tree` | cross-guide UX polish bundle (items `1-5`) implemented:
   - `0-1000m`:
     - added `Continue where you left off` CTA tied to persisted last opened session,


### PR DESCRIPTION
## Summary

- What changed and why?

## Scope

- In scope:
- Out of scope:

## Risk

- Main risk:
- Rollback plan:

## Test Evidence

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
