### PR TITLE
feat(claim): add dedicated claim route and recovery source tracking

### DIFF
--- a/app/checkout/success/page.tsx
+++ b/app/checkout/success/page.tsx
@@ -21,6 +21,7 @@ export default async function CheckoutSuccessPage({ searchParams }: Props) {
   } = await supabase.auth.getUser();
   const libraryHref = user ? "/my-library" : "/auth/sign-in?next=%2Fmy-library";
   const libraryCta = user ? "Download from My Library" : "Sign in to My Library";
+  const claimHref = "/claim?next=%2Fmy-library";
 
   return (
     <SiteChrome>
@@ -65,6 +66,15 @@ export default async function CheckoutSuccessPage({ searchParams }: Props) {
               source="checkout_success"
               className="mt-3"
             />
+            {!user ? (
+              <p className="mt-3 text-xs text-slate-600">
+                Prefer a dedicated flow?{" "}
+                <Link href={claimHref} className="font-semibold text-blue-700 hover:text-blue-600">
+                  Open claim page
+                </Link>
+                .
+              </p>
+            ) : null}
           </div>
         </div>
       </section>

--- a/app/claim/page.tsx
+++ b/app/claim/page.tsx
@@ -1,0 +1,89 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import SiteChrome from "@/components/SiteChrome";
+import DownloadResendForm from "@/components/commerce/DownloadResendForm";
+import { getSafeNextPath } from "@/lib/auth/next-path";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+type Props = {
+  searchParams: SearchParams;
+};
+
+export const metadata: Metadata = {
+  title: "Claim Access",
+  description:
+    "Claim your purchases and progress by requesting a secure sign-in link to My Library.",
+};
+
+function getOptionalQueryString(value: string | string[] | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed;
+}
+
+export default async function ClaimPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const nextPath = getSafeNextPath(getOptionalQueryString(params.next));
+  const prefilledEmail = getOptionalQueryString(params.email) ?? "";
+
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (user) {
+    redirect(nextPath);
+  }
+
+  const signInQuery = new URLSearchParams({ next: nextPath });
+  if (prefilledEmail) {
+    signInQuery.set("email", prefilledEmail);
+  }
+  const signInHref = `/auth/sign-in?${signInQuery.toString()}`;
+
+  return (
+    <SiteChrome>
+      <section className="mx-auto flex min-h-screen w-full max-w-[760px] items-center px-6 pb-16 pt-28">
+        <div className="w-full rounded-3xl border border-blue-100 bg-white/95 p-8 shadow-[0_16px_60px_rgba(24,58,107,0.16)]">
+          <h1 className="text-3xl font-bold text-slate-900">Claim your purchases and progress</h1>
+          <p className="mt-3 text-sm leading-relaxed text-slate-600">
+            Use the same email you used at checkout. If purchases exist for that email, we send a
+            secure access link so you can open My Library.
+          </p>
+
+          <div className="mt-6 rounded-2xl border border-slate-200 bg-slate-50/60 p-4">
+            <h2 className="text-sm font-semibold text-slate-900">Send secure access link</h2>
+            <p className="mt-2 text-xs leading-relaxed text-slate-600">
+              To protect privacy, we always return the same response copy.
+            </p>
+            <DownloadResendForm
+              initialEmail={prefilledEmail}
+              nextPath={nextPath}
+              source="claim_entry"
+              className="mt-3"
+            />
+          </div>
+
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Link
+              href={signInHref}
+              className="inline-flex h-11 items-center justify-center rounded-xl border border-slate-200 bg-white px-5 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+            >
+              I already have a sign-in code
+            </Link>
+            <Link
+              href="/programs"
+              className="inline-flex h-11 items-center justify-center rounded-xl border border-slate-200 bg-white px-5 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+            >
+              Back to Programs
+            </Link>
+          </div>
+        </div>
+      </section>
+    </SiteChrome>
+  );
+}

--- a/components/commerce/DownloadResendForm.tsx
+++ b/components/commerce/DownloadResendForm.tsx
@@ -10,7 +10,7 @@ import {
 type Props = {
   initialEmail?: string;
   nextPath?: string;
-  source?: "checkout_success" | "library_recovery";
+  source?: "checkout_success" | "library_recovery" | "claim_entry";
   className?: string;
 };
 

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -71,6 +71,12 @@
 }
 ```
 
+- Allowed `source` values:
+  - `checkout_success`
+  - `library_recovery`
+  - `claim_entry`
+  - unknown values normalize to `unknown`
+
 ### Response
 
 - Success (non-enumerating):

--- a/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
+++ b/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
@@ -141,7 +141,8 @@ Users can start instantly in guest mode, buy optional paid products without acco
 - Checkout/library recovery UX baseline is implemented:
   - `/checkout/success` now includes immediate `Download from My Library` CTA,
   - `/checkout/success` includes purchase-email resend form for secure access link recovery,
-  - `My Library` empty-owned state includes `already bought?` recovery resend entry.
+  - `My Library` empty-owned state includes `already bought?` recovery resend entry,
+  - `/claim` route is implemented as dedicated magic-link claim entry for guest purchasers.
 - Guest purchase attach-by-email on sign-in is implemented.
 - Free-course account sync baseline is implemented:
   - `/api/progress/course` (authenticated read/write),
@@ -173,8 +174,6 @@ Users can start instantly in guest mode, buy optional paid products without acco
 
 ### Outstanding (blocking move to `done`)
 
-- Missing routes from architecture contract:
-  - `/claim`.
 - Missing API endpoints from architecture contract:
   - `/api/user/export`,
   - `/api/user/delete`.
@@ -879,6 +878,16 @@ At each phase:
 
 ## Implementation Checkpoint Log (In Progress)
 
+- `2026-02-17` | `working tree` | `/claim` recovery route implemented:
+  - added dedicated claim entry route:
+    - `app/claim/page.tsx`,
+    - supports safe `next` handling and optional email prefill.
+  - integrated existing secure resend flow on claim page:
+    - `DownloadResendForm` now supports `source: "claim_entry"`,
+    - resend source normalization supports `claim_entry`.
+  - checkout success page now links to dedicated claim flow for signed-out users.
+  - updated unit tests for resend source normalization and claim source form submit payload.
+  - next step: implement `/api/user/export` endpoint contract.
 - `2026-02-17` | `working tree` | repository branch hygiene cleanup completed:
   - deleted remote merged branches:
     - `origin/feat/poolside-interactive-guide`,

--- a/lib/commerce/download-resend.ts
+++ b/lib/commerce/download-resend.ts
@@ -8,7 +8,11 @@ export const RESEND_DOWNLOAD_FALLBACK_ERROR =
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
 
-export type DownloadResendSource = "checkout_success" | "library_recovery" | "unknown";
+export type DownloadResendSource =
+  | "checkout_success"
+  | "library_recovery"
+  | "claim_entry"
+  | "unknown";
 
 export function normalizeResendEmail(value: string): string {
   return value.trim().toLowerCase();
@@ -25,5 +29,6 @@ export function getSafeDownloadResendNextPath(input: string | undefined): string
 export function toDownloadResendSource(input: string | undefined): DownloadResendSource {
   if (input === "checkout_success") return input;
   if (input === "library_recovery") return input;
+  if (input === "claim_entry") return input;
   return "unknown";
 }

--- a/tests/unit/download-resend-form.test.tsx
+++ b/tests/unit/download-resend-form.test.tsx
@@ -64,4 +64,37 @@ describe("DownloadResendForm", () => {
       expect(screen.getByText("Too many requests. Please try again shortly.")).toBeInTheDocument();
     });
   });
+
+  it("sends claim source from claim entry flow", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        message: RESEND_DOWNLOAD_GENERIC_MESSAGE,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <DownloadResendForm
+        initialEmail="buyer@example.com"
+        nextPath="/my-library"
+        source="claim_entry"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Email me access link" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/download/resend", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: "buyer@example.com",
+          nextPath: "/my-library",
+          source: "claim_entry",
+        }),
+      });
+    });
+  });
 });

--- a/tests/unit/download-resend-utils.test.ts
+++ b/tests/unit/download-resend-utils.test.ts
@@ -29,6 +29,7 @@ describe("download resend helpers", () => {
   it("normalizes source values into allowed source enum", () => {
     expect(toDownloadResendSource("checkout_success")).toBe("checkout_success");
     expect(toDownloadResendSource("library_recovery")).toBe("library_recovery");
+    expect(toDownloadResendSource("claim_entry")).toBe("claim_entry");
     expect(toDownloadResendSource("anything-else")).toBe("unknown");
     expect(toDownloadResendSource(undefined)).toBe("unknown");
   });


### PR DESCRIPTION
## Summary

- What changed and why?

## Scope

- In scope:
- Out of scope:

## Risk

- Main risk:
- Rollback plan:

## Test Evidence

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
