### PR TITLE
feat(analytics): add kpi event baseline for commerce and progress flows

### DIFF
--- a/app/api/analytics/event/route.ts
+++ b/app/api/analytics/event/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { isAnalyticsEventName, trackAnalyticsEvent } from "@/lib/analytics/events";
+
+type AnalyticsEventBody = {
+  eventName?: unknown;
+  payload?: unknown;
+};
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function jsonNoStore(body: unknown, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export async function POST(request: Request) {
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    return jsonNoStore({ ok: false, error: "Unsupported content type." }, 415);
+  }
+
+  let body: AnalyticsEventBody;
+  try {
+    body = (await request.json()) as AnalyticsEventBody;
+  } catch {
+    return jsonNoStore({ ok: false, error: "Invalid JSON." }, 400);
+  }
+
+  const eventName = String(body.eventName ?? "");
+  if (!isAnalyticsEventName(eventName)) {
+    return jsonNoStore({ ok: false, error: "Invalid event name." }, 400);
+  }
+
+  const payload =
+    body.payload && typeof body.payload === "object" && !Array.isArray(body.payload)
+      ? (body.payload as Record<string, unknown>)
+      : undefined;
+
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  trackAnalyticsEvent({
+    eventName,
+    channel: "client",
+    userId: user?.id ?? null,
+    payload,
+  });
+
+  return jsonNoStore({ ok: true });
+}

--- a/app/api/checkout/session/route.ts
+++ b/app/api/checkout/session/route.ts
@@ -5,6 +5,7 @@ import { createAdminSupabaseClient } from "@/lib/supabase/admin";
 import { getAppUrl } from "@/lib/supabase/env";
 import { getCatalogProductById, getCatalogProducts } from "@/lib/commerce/catalog";
 import { upsertCatalogProducts } from "@/lib/commerce/entitlements";
+import { trackAnalyticsEvent } from "@/lib/analytics/events";
 import { createStripeClient } from "@/lib/stripe/server";
 
 type CheckoutBody = {
@@ -80,6 +81,16 @@ export async function POST(request: Request) {
         { status: 500 }
       );
     }
+
+    trackAnalyticsEvent({
+      eventName: "checkout_started",
+      channel: "server",
+      userId: user?.id ?? null,
+      payload: {
+        productId: product.id,
+        sessionId: session.id,
+      },
+    });
 
     return NextResponse.json({ ok: true, url: session.url, sessionId: session.id });
   } catch (error) {

--- a/app/api/download/resend/route.ts
+++ b/app/api/download/resend/route.ts
@@ -10,6 +10,7 @@ import {
   RESEND_DOWNLOAD_GENERIC_MESSAGE,
   toDownloadResendSource,
 } from "@/lib/commerce/download-resend";
+import { trackAnalyticsEvent } from "@/lib/analytics/events";
 
 type ResendBody = {
   email?: string;
@@ -278,6 +279,16 @@ export async function POST(request: Request) {
     );
   }
 
+  if (source === "claim_entry") {
+    trackAnalyticsEvent({
+      eventName: "account_claim_started",
+      channel: "server",
+      payload: {
+        nextPath,
+      },
+    });
+  }
+
   try {
     const adminSupabase = createAdminSupabaseClient();
     const { data: entitlement, error: entitlementError } = await adminSupabase
@@ -342,6 +353,14 @@ export async function POST(request: Request) {
       source,
       emailHash,
       nextPath,
+    });
+    trackAnalyticsEvent({
+      eventName: "download_link_resent",
+      channel: "server",
+      payload: {
+        source,
+        nextPath,
+      },
     });
     return jsonNoStore(GENERIC_OK_BODY, { headers: rateHeaders });
   } catch (error) {

--- a/app/api/progress/course/route.ts
+++ b/app/api/progress/course/route.ts
@@ -4,6 +4,7 @@ import {
   normalizeCourseProgressRows,
   type CourseProgressRow,
 } from "@/lib/course/progress";
+import { trackAnalyticsEvent } from "@/lib/analytics/events";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 
 type ProgressBody = {
@@ -108,8 +109,27 @@ export async function POST(request: Request) {
 
   if (error) {
     console.error("[CourseProgressApi] Could not save progress", error);
+    trackAnalyticsEvent({
+      eventName: "sync_failed",
+      channel: "server",
+      userId,
+      payload: {
+        syncKind: "course",
+        rowCount: normalizedRows.length,
+      },
+    });
     return jsonNoStore({ ok: false, error: "Could not save course progress." }, 500);
   }
+
+  trackAnalyticsEvent({
+    eventName: "progress_synced",
+    channel: "server",
+    userId,
+    payload: {
+      syncKind: "course",
+      rowCount: normalizedRows.length,
+    },
+  });
 
   return jsonNoStore({ ok: true, upserted: normalizedRows.length });
 }

--- a/app/api/progress/guide/route.ts
+++ b/app/api/progress/guide/route.ts
@@ -4,6 +4,7 @@ import {
   normalizeGuideProgressRows,
   type GuideProgressRow,
 } from "@/lib/course/guide-progress";
+import { trackAnalyticsEvent } from "@/lib/analytics/events";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 
 type ProgressBody = {
@@ -109,8 +110,27 @@ export async function POST(request: Request) {
 
   if (error) {
     console.error("[GuideProgressApi] Could not save guide progress", error);
+    trackAnalyticsEvent({
+      eventName: "sync_failed",
+      channel: "server",
+      userId,
+      payload: {
+        syncKind: "guide",
+        rowCount: normalizedRows.length,
+      },
+    });
     return jsonNoStore({ ok: false, error: "Could not save guide progress." }, 500);
   }
+
+  trackAnalyticsEvent({
+    eventName: "progress_synced",
+    channel: "server",
+    userId,
+    payload: {
+      syncKind: "guide",
+      rowCount: normalizedRows.length,
+    },
+  });
 
   return jsonNoStore({ ok: true, upserted: normalizedRows.length });
 }

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -13,6 +13,7 @@ import {
   getCatalogProducts,
   type CatalogProduct,
 } from "@/lib/commerce/catalog";
+import { trackAnalyticsEvent } from "@/lib/analytics/events";
 import { createStripeClient, getStripeWebhookSecret } from "@/lib/stripe/server";
 
 const SUPPORTED_EVENTS = new Set([
@@ -91,6 +92,18 @@ async function fulfillCheckoutSession(stripe: Stripe, session: Stripe.Checkout.S
     stripeCheckoutSessionId: session.id,
   });
 
+  const grantedLatencyMs = Math.max(0, Date.now() - session.created * 1000);
+  trackAnalyticsEvent({
+    eventName: "entitlement_granted",
+    channel: "server",
+    userId,
+    payload: {
+      sessionId: session.id,
+      productId: product.id,
+      grantedLatencyMs,
+    },
+  });
+
   console.info("[StripeWebhook] Entitlement upserted", {
     sessionId: session.id,
     productId: product.id,
@@ -135,6 +148,17 @@ export async function POST(request: Request) {
       });
       return NextResponse.json({ ok: true, deferred: true });
     }
+
+    trackAnalyticsEvent({
+      eventName: "checkout_completed",
+      channel: "server",
+      userId: getValidUserId(session),
+      payload: {
+        sessionId: session.id,
+        productId: session.metadata?.fs_product_id ?? null,
+        eventType: event.type,
+      },
+    });
 
     await fulfillCheckoutSession(stripe, session);
     return NextResponse.json({ ok: true });

--- a/app/my-library/page.tsx
+++ b/app/my-library/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import SiteChrome from "@/components/SiteChrome";
+import TrackEventOnMount from "@/components/analytics/TrackEventOnMount";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { signOutFromLibrary } from "@/app/my-library/actions";
 import CheckoutButton from "@/components/my-library/CheckoutButton";
@@ -59,6 +60,13 @@ export default async function MyLibraryPage() {
   return (
     <SiteChrome>
       <section className="mx-auto min-h-screen w-full max-w-[980px] px-6 pb-20 pt-28">
+        <TrackEventOnMount
+          eventName="library_viewed"
+          payload={{
+            ownedCount: sections.owned.length + sections.unknownOwnedProductIds.length,
+            exploreCount: sections.explore.length,
+          }}
+        />
         <div className="rounded-3xl border border-blue-100 bg-white/95 p-8 shadow-[0_16px_60px_rgba(24,58,107,0.14)]">
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div>

--- a/app/plans/page.tsx
+++ b/app/plans/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import SiteChrome from "@/components/SiteChrome";
+import TrackEventOnMount from "@/components/analytics/TrackEventOnMount";
 import PageTemplate from "@/components/PageTemplate";
 import PageIntro from "@/components/PageIntro";
 import CheckoutButton from "@/components/my-library/CheckoutButton";
@@ -92,10 +93,18 @@ export default function PlansPage() {
   const products = getCatalogProductsWithAvailability();
   const hasAvailableProducts = products.some((product) => product.available);
   const hasUnavailableProducts = products.some((product) => !product.available);
+  const availableCount = products.filter((product) => product.available).length;
 
   return (
     <SiteChrome>
       <PageTemplate size="wide">
+        <TrackEventOnMount
+          eventName="plans_viewed"
+          payload={{
+            productCount: products.length,
+            availableCount,
+          }}
+        />
         <PageIntro
           title="Plans"
           subtitle="Paid guides and feedback to support your next step."

--- a/components/analytics/TrackEventOnMount.tsx
+++ b/components/analytics/TrackEventOnMount.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect } from "react";
+import { sendClientAnalyticsEvent } from "@/lib/analytics/client";
+import type { AnalyticsEventName } from "@/lib/analytics/events";
+
+type Props = {
+  eventName: AnalyticsEventName;
+  payload?: Record<string, unknown>;
+};
+
+export default function TrackEventOnMount({ eventName, payload }: Props) {
+  useEffect(() => {
+    void sendClientAnalyticsEvent(eventName, payload);
+  }, [eventName, payload]);
+
+  return null;
+}

--- a/components/guides/GuidePdfDownloadButton.tsx
+++ b/components/guides/GuidePdfDownloadButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { sendClientAnalyticsEvent } from "@/lib/analytics/client";
 
 type Props = {
   apiPath: string;
@@ -42,6 +43,10 @@ export default function GuidePdfDownloadButton({
     if (pending) return;
     setPending(true);
     setError("");
+
+    void sendClientAnalyticsEvent("item_download_started", {
+      apiPath,
+    });
 
     try {
       const response = await fetch(apiPath, {

--- a/components/my-library/ContinueCourseCard.tsx
+++ b/components/my-library/ContinueCourseCard.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { buildCourseContinueHref, COURSE_LAST_LESSON_STORAGE_KEY } from "@/lib/course/resume";
+import { sendClientAnalyticsEvent } from "@/lib/analytics/client";
 
 type ResumeState = {
   continueHref: string;
@@ -28,6 +29,13 @@ function getInitialResumeState(): ResumeState {
 export default function ContinueCourseCard() {
   const [{ continueHref, hasSavedProgress }] = useState<ResumeState>(getInitialResumeState);
 
+  function onResumeClick() {
+    void sendClientAnalyticsEvent("resume_clicked", {
+      hasSavedProgress,
+      destination: continueHref,
+    });
+  }
+
   return (
     <section className="rounded-2xl border border-blue-100 bg-blue-50/40 p-5">
       <h2 className="text-lg font-semibold text-slate-900">Continue Free Course</h2>
@@ -39,6 +47,7 @@ export default function ContinueCourseCard() {
       <div className="mt-4">
         <Link
           href={continueHref}
+          onClick={onResumeClick}
           className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-medium text-white transition hover:bg-blue-500 active:bg-blue-700"
         >
           {hasSavedProgress ? "Continue course" : "Start free course"}

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -206,6 +206,51 @@
 - `415`: unsupported content type
 - `500`: failed to delete user data
 
+## `POST /api/analytics/event`
+
+### Request
+
+- Headers:
+  - `Content-Type: application/json`
+- Auth: optional (event is accepted for signed-in and signed-out users)
+- `eventName` must match the allowed analytics event contract list (see My Library task brief section `Analytics and KPI Contract (V1)`).
+- Body:
+
+```json
+{
+  "eventName": "plans_viewed",
+  "payload": {
+    "productCount": 3,
+    "availableCount": 3
+  }
+}
+```
+
+### Response
+
+- Success:
+
+```json
+{
+  "ok": true
+}
+```
+
+- Failure:
+
+```json
+{
+  "ok": false,
+  "error": "Invalid event name."
+}
+```
+
+### Status Codes
+
+- `200`: event accepted
+- `400`: invalid JSON or invalid event name
+- `415`: unsupported content type
+
 ## `GET|POST /api/progress/guide`
 
 ### Request

--- a/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
+++ b/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
@@ -151,6 +151,22 @@ Users can start instantly in guest mode, buy optional paid products without acco
   - `/api/user/delete` authenticated endpoint with explicit confirmation contract (`confirm: "DELETE"`),
   - deletes auth user via server-only admin client (hard delete) to remove app-owned user data through DB constraints,
   - attempts sign-out/session clear after delete.
+- Analytics/KPI event baseline is implemented:
+  - centralized analytics event contract + server logger pipeline,
+  - client analytics ingestion endpoint (`POST /api/analytics/event`),
+  - core event instrumentation implemented for:
+    - `plans_viewed`,
+    - `library_viewed`,
+    - `checkout_started`,
+    - `checkout_completed`,
+    - `entitlement_granted`,
+    - `download_link_resent`,
+    - `account_claim_started`,
+    - `account_claim_completed`,
+    - `resume_clicked`,
+    - `item_download_started`,
+    - `progress_synced`,
+    - `sync_failed`.
 - Free-course account sync baseline is implemented:
   - `/api/progress/course` (authenticated read/write),
   - signed-in course clients hydrate from server and merge local progress on first sign-in,
@@ -188,7 +204,8 @@ Users can start instantly in guest mode, buy optional paid products without acco
   - free-course progress now supports signed-in server sync and local->account merge,
   - paid-guide interactive sync is implemented for `0-1000m`, but cross-device resume still needs manual QA confirmation.
 - Goals MVP UI/state flow is not implemented.
-- Analytics/KPI event pipeline is not implemented.
+- Analytics remaining scope:
+  - full event coverage for `library_tab_switched`, `item_preview_opened`, `support_clicked` and phase-2 upsell/discount events.
 - GDPR operational requirements are not complete:
   - rights workflow + privacy/cookie disclosure updates not completed in app docs/routes.
 - Library tab contract decision required:
@@ -228,7 +245,7 @@ Users can start instantly in guest mode, buy optional paid products without acco
      - `Visual view` fullscreen image mode (portrait + landscape support),
    - expand claim/restore UX around owned content recovery.
 2. Trust/ops slice:
-   - implement analytics event contract baseline,
+   - expand analytics coverage for remaining contract events (`library_tab_switched`, `item_preview_opened`, `support_clicked`, phase-2 upsell/discount events),
    - close GDPR/privacy/cookie documentation and operational runbook items.
 
 ## Manual QA Environments
@@ -880,6 +897,32 @@ At each phase:
 
 ## Implementation Checkpoint Log (In Progress)
 
+- `2026-02-17` | `working tree` | analytics/KPI baseline implemented:
+  - added central analytics event contract + sanitizing logger:
+    - `lib/analytics/events.ts`.
+  - added client analytics sender + mount tracker:
+    - `lib/analytics/client.ts`,
+    - `components/analytics/TrackEventOnMount.tsx`.
+  - added analytics ingestion endpoint:
+    - `POST /api/analytics/event` (`app/api/analytics/event/route.ts`).
+  - instrumented core flows:
+    - checkout/session + webhook:
+      - `checkout_started`,
+      - `checkout_completed`,
+      - `entitlement_granted`.
+    - resend/claim:
+      - `download_link_resent`,
+      - `account_claim_started`,
+      - `account_claim_completed` (on guest-entitlement attach).
+    - progress APIs:
+      - `progress_synced`,
+      - `sync_failed`.
+    - UI baseline signals:
+      - `plans_viewed`,
+      - `library_viewed`,
+      - `resume_clicked`,
+      - `item_download_started`.
+  - next step: close GDPR/privacy/cookie workflow docs + runbook scope.
 - `2026-02-17` | `working tree` | `/api/user/delete` endpoint implemented:
   - added authenticated delete route:
     - `app/api/user/delete/route.ts`.

--- a/lib/analytics/client.ts
+++ b/lib/analytics/client.ts
@@ -1,0 +1,25 @@
+import type { AnalyticsEventName } from "@/lib/analytics/events";
+
+type ClientPayload = Record<string, unknown> | undefined;
+
+export async function sendClientAnalyticsEvent(
+  eventName: AnalyticsEventName,
+  payload?: ClientPayload
+) {
+  try {
+    await fetch("/api/analytics/event", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        eventName,
+        payload,
+      }),
+      cache: "no-store",
+      keepalive: true,
+    });
+  } catch {
+    // Analytics failures should never block user actions.
+  }
+}

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -1,0 +1,98 @@
+export const ANALYTICS_EVENT_NAMES = [
+  "plans_viewed",
+  "checkout_started",
+  "checkout_completed",
+  "entitlement_granted",
+  "download_link_resent",
+  "account_claim_started",
+  "account_claim_completed",
+  "library_viewed",
+  "library_tab_switched",
+  "item_preview_opened",
+  "item_download_started",
+  "resume_clicked",
+  "progress_synced",
+  "sync_failed",
+  "support_clicked",
+  "upsell_presented",
+  "upsell_accepted",
+  "upsell_declined",
+  "discount_redeemed",
+] as const;
+
+export type AnalyticsEventName = (typeof ANALYTICS_EVENT_NAMES)[number];
+
+type AnalyticsEventPayloadScalar = string | number | boolean | null;
+
+export type AnalyticsEventRecord = {
+  type: "analytics_event";
+  eventName: AnalyticsEventName;
+  occurredAt: string;
+  channel: "server" | "client";
+  userId: string | null;
+  payload: Record<string, AnalyticsEventPayloadScalar>;
+};
+
+const EVENT_NAME_SET = new Set<string>(ANALYTICS_EVENT_NAMES);
+const SENSITIVE_KEY_PATTERN = /(email|token|secret|password|cookie|authorization)/i;
+const MAX_STRING_LENGTH = 200;
+
+function truncateString(value: string): string {
+  if (value.length <= MAX_STRING_LENGTH) return value;
+  return `${value.slice(0, MAX_STRING_LENGTH)}…`;
+}
+
+function toScalar(value: unknown): AnalyticsEventPayloadScalar | undefined {
+  if (value === null) return null;
+  if (typeof value === "string") return truncateString(value);
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "boolean") return value;
+  return undefined;
+}
+
+export function isAnalyticsEventName(value: string): value is AnalyticsEventName {
+  return EVENT_NAME_SET.has(value);
+}
+
+export function sanitizeAnalyticsPayload(
+  payload: Record<string, unknown> | null | undefined
+): Record<string, AnalyticsEventPayloadScalar> {
+  if (!payload) return {};
+
+  const sanitized: Record<string, AnalyticsEventPayloadScalar> = {};
+
+  for (const [key, value] of Object.entries(payload)) {
+    if (SENSITIVE_KEY_PATTERN.test(key)) {
+      sanitized[key] = "[redacted]";
+      continue;
+    }
+
+    const scalarValue = toScalar(value);
+    if (scalarValue !== undefined) {
+      sanitized[key] = scalarValue;
+    }
+  }
+
+  return sanitized;
+}
+
+type TrackAnalyticsEventInput = {
+  eventName: AnalyticsEventName;
+  channel: "server" | "client";
+  userId?: string | null;
+  payload?: Record<string, unknown> | null;
+};
+
+export function trackAnalyticsEvent(input: TrackAnalyticsEventInput): AnalyticsEventRecord {
+  const record: AnalyticsEventRecord = {
+    type: "analytics_event",
+    eventName: input.eventName,
+    occurredAt: new Date().toISOString(),
+    channel: input.channel,
+    userId: input.userId ?? null,
+    payload: sanitizeAnalyticsPayload(input.payload),
+  };
+
+  console.info("[AnalyticsEvent]", JSON.stringify(record));
+  return record;
+}

--- a/lib/commerce/entitlements.ts
+++ b/lib/commerce/entitlements.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/types/database";
 import type { CatalogProduct } from "@/lib/commerce/catalog";
+import { trackAnalyticsEvent } from "@/lib/analytics/events";
 
 type EntitlementUpsertInput = {
   userId: string | null;
@@ -84,15 +85,30 @@ export async function attachGuestEntitlementsByEmail(
   email: string
 ) {
   const normalizedEmail = normalizeEmail(email);
-  if (!normalizedEmail) return;
+  if (!normalizedEmail) return 0;
 
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from("entitlements")
     .update({ user_id: userId })
     .is("user_id", null)
-    .eq("purchaser_email", normalizedEmail);
+    .eq("purchaser_email", normalizedEmail)
+    .select("id");
 
   if (error) {
     throw new Error(`Could not attach guest entitlements: ${error.message}`);
   }
+
+  const attachedEntitlementCount = data?.length ?? 0;
+  if (attachedEntitlementCount > 0) {
+    trackAnalyticsEvent({
+      eventName: "account_claim_completed",
+      channel: "server",
+      userId,
+      payload: {
+        attachedEntitlementCount,
+      },
+    });
+  }
+
+  return attachedEntitlementCount;
 }

--- a/tests/unit/analytics-events.test.ts
+++ b/tests/unit/analytics-events.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  isAnalyticsEventName,
+  sanitizeAnalyticsPayload,
+  trackAnalyticsEvent,
+} from "@/lib/analytics/events";
+
+describe("analytics events", () => {
+  it("validates known event names", () => {
+    expect(isAnalyticsEventName("checkout_started")).toBe(true);
+    expect(isAnalyticsEventName("entitlement_granted")).toBe(true);
+    expect(isAnalyticsEventName("unknown_event")).toBe(false);
+  });
+
+  it("sanitizes payload and redacts sensitive keys", () => {
+    const payload = sanitizeAnalyticsPayload({
+      productId: "guide_0_1000m",
+      email: "swimmer@example.com",
+      rowCount: 4,
+      ok: true,
+      nested: { ignored: true },
+      tokenValue: "secret-token",
+      longText: "a".repeat(300),
+    });
+
+    expect(payload).toMatchObject({
+      productId: "guide_0_1000m",
+      email: "[redacted]",
+      rowCount: 4,
+      ok: true,
+      tokenValue: "[redacted]",
+    });
+    expect(typeof payload.longText).toBe("string");
+    expect(String(payload.longText).length).toBeLessThanOrEqual(201);
+    expect(payload.nested).toBeUndefined();
+  });
+
+  it("builds tracked event record with sanitized payload", () => {
+    const record = trackAnalyticsEvent({
+      eventName: "progress_synced",
+      channel: "server",
+      userId: "user-123",
+      payload: {
+        syncKind: "course",
+        email: "swimmer@example.com",
+      },
+    });
+
+    expect(record.eventName).toBe("progress_synced");
+    expect(record.userId).toBe("user-123");
+    expect(record.payload).toEqual({
+      syncKind: "course",
+      email: "[redacted]",
+    });
+    expect(record.occurredAt).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- What changed and why?

## Scope

- In scope:
- Out of scope:

## Risk

- Main risk:
- Rollback plan:

## Test Evidence

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
