### PR TITLE
feat(auth): add dev-only bypass login with strict guardrails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,16 @@ NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 
+# Local-only dev auth bypass (never enable in preview/production)
+# Guardrails:
+# - Route is hard-disabled unless NODE_ENV=development and DEV_AUTH_BYPASS_ENABLED=1
+# - Request must come from localhost/private network and include x-dev-auth-token
+# - Login always uses this seeded dev account (least privilege)
+DEV_AUTH_BYPASS_ENABLED=0
+DEV_AUTH_BYPASS_TOKEN=
+DEV_AUTH_BYPASS_EMAIL=
+DEV_AUTH_BYPASS_PASSWORD=
+
 # Stripe
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ npm run dev
 - `NEXT_PUBLIC_SUPABASE_URL`: Supabase project URL (public).
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`: Supabase browser key (public).
 - `SUPABASE_SERVICE_ROLE_KEY`: Supabase server key (secret, server-only).
+- `DEV_AUTH_BYPASS_ENABLED`: local dev-only auth bypass flag (`1` enables `/api/dev-login` in dev).
+- `DEV_AUTH_BYPASS_TOKEN`: required request header secret for `/api/dev-login`.
+- `DEV_AUTH_BYPASS_EMAIL`: seeded low-privilege test account email used by `/api/dev-login`.
+- `DEV_AUTH_BYPASS_PASSWORD`: seeded low-privilege test account password used by `/api/dev-login`.
 - `STRIPE_SECRET_KEY`: Stripe secret API key (secret, server-only).
 - `STRIPE_WEBHOOK_SECRET`: Stripe webhook signing secret (secret, server-only).
 - `STRIPE_PRICE_ID_0_1000M_GUIDE`: Stripe price ID for 0-1000m guide.
@@ -44,6 +48,24 @@ npm run dev
 - `STRIPE_PRICE_ID_ANALYSIS`: Stripe price ID for video analysis.
 
 If Upstash vars are missing, the contact API falls back to in-memory rate limiting.
+
+## Dev auth bypass (local only)
+
+Use this only in local development while testing flows that would otherwise require OTP email:
+
+```bash
+curl -i \
+  -X POST http://127.0.0.1:3000/api/dev-login \
+  -H "content-type: application/json" \
+  -H "x-dev-auth-token: $DEV_AUTH_BYPASS_TOKEN" \
+  -d '{"next":"/my-library"}'
+```
+
+Guardrails:
+
+- Route returns `404` unless `NODE_ENV=development` and `DEV_AUTH_BYPASS_ENABLED=1`.
+- Route rejects non-local host/origin/IP requests.
+- Route requires `x-dev-auth-token` and signs in only the configured seeded test account.
 
 ## Quality checks
 

--- a/app/api/dev-login/route.ts
+++ b/app/api/dev-login/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+import { getSafeNextPath } from "@/lib/auth/next-path";
+import {
+  getDevAuthBypassConfig,
+  isDevAuthBypassEnabled,
+  isDevAuthTokenValid,
+  isLocalDevelopmentRequest,
+} from "@/lib/auth/dev-auth-bypass";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+type DevLoginBody = {
+  next?: unknown;
+};
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function jsonNoStore(body: unknown, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export async function POST(request: Request) {
+  if (!isDevAuthBypassEnabled()) {
+    return jsonNoStore({ ok: false, error: "Not found." }, 404);
+  }
+
+  if (!isLocalDevelopmentRequest(request)) {
+    return jsonNoStore({ ok: false, error: "Forbidden." }, 403);
+  }
+
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    return jsonNoStore({ ok: false, error: "Unsupported content type." }, 415);
+  }
+
+  let body: DevLoginBody;
+  try {
+    body = (await request.json()) as DevLoginBody;
+  } catch {
+    return jsonNoStore({ ok: false, error: "Invalid JSON." }, 400);
+  }
+
+  const config = getDevAuthBypassConfig();
+  const token = request.headers.get("x-dev-auth-token");
+  if (!isDevAuthTokenValid(token, config.token)) {
+    return jsonNoStore({ ok: false, error: "Unauthorized." }, 401);
+  }
+
+  const supabase = await createServerSupabaseClient();
+
+  try {
+    await supabase.auth.signOut();
+  } catch {}
+
+  const { error } = await supabase.auth.signInWithPassword({
+    email: config.email,
+    password: config.password,
+  });
+
+  if (error) {
+    console.error("[DevLoginApi] Could not sign in with configured dev account", error);
+    return jsonNoStore({ ok: false, error: "Could not sign in." }, 401);
+  }
+
+  const nextInput = typeof body.next === "string" ? body.next : "";
+  const nextPath = getSafeNextPath(nextInput, "/my-library");
+
+  return jsonNoStore({
+    ok: true,
+    nextPath,
+    userEmail: config.email,
+  });
+}

--- a/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
+++ b/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
@@ -216,6 +216,10 @@ Users can start instantly in guest mode, buy optional paid products without acco
   - request/verify rate limits,
   - cooldown messaging,
   - Upstash support with in-memory fallback.
+- Local QA auth bypass (dev-only) is implemented:
+  - `POST /api/dev-login` is hard-disabled outside `NODE_ENV=development`,
+  - guarded by explicit feature flag + token header + localhost/private-network request checks,
+  - signs in only configured seeded dev account (no dynamic account selection).
 - Soft-launch public UX exists with under-construction banner.
 
 ### Outstanding (blocking move to `done`)

--- a/lib/auth/dev-auth-bypass.ts
+++ b/lib/auth/dev-auth-bypass.ts
@@ -1,0 +1,134 @@
+import { timingSafeEqual } from "node:crypto";
+
+type EnvLike = Record<string, string | undefined>;
+
+export type DevAuthBypassConfig = {
+  token: string;
+  email: string;
+  password: string;
+};
+
+function requireEnvValue(value: string | undefined, name: string): string {
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+
+  return value;
+}
+
+function splitHeaderValue(value: string | null): string[] {
+  return (value ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function normalizeHostCandidate(value: string): string {
+  const candidate = value.trim();
+  if (!candidate) return "";
+
+  try {
+    return new URL(candidate).hostname.toLowerCase();
+  } catch {}
+
+  if (candidate.startsWith("[")) {
+    const bracketIndex = candidate.indexOf("]");
+    if (bracketIndex > 1) {
+      return candidate.slice(1, bracketIndex).toLowerCase();
+    }
+  }
+
+  const maybeHostWithPort = candidate.toLowerCase();
+  const splitByColon = maybeHostWithPort.split(":");
+  if (splitByColon.length === 2 && /^\d+$/.test(splitByColon[1])) {
+    return splitByColon[0];
+  }
+
+  return maybeHostWithPort;
+}
+
+function isPrivateOrLoopbackIpv4(hostname: string): boolean {
+  if (!/^\d{1,3}(?:\.\d{1,3}){3}$/.test(hostname)) return false;
+
+  const octets = hostname.split(".").map((part) => Number(part));
+  if (octets.some((octet) => !Number.isFinite(octet) || octet < 0 || octet > 255)) return false;
+
+  const [a, b] = octets;
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  return false;
+}
+
+function isPrivateOrLoopbackIpv6(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  if (normalized === "::1" || normalized === "0:0:0:0:0:0:0:1") return true;
+  if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true; // Unique local
+  if (normalized.startsWith("fe80:")) return true; // Link-local
+  return false;
+}
+
+export function isLocalHostOrIp(value: string): boolean {
+  const hostname = normalizeHostCandidate(value);
+  if (!hostname) return false;
+
+  if (hostname === "localhost" || hostname.endsWith(".localhost")) return true;
+  if (isPrivateOrLoopbackIpv4(hostname)) return true;
+  if (isPrivateOrLoopbackIpv6(hostname)) return true;
+  return false;
+}
+
+export function isLocalDevelopmentRequest(request: Request): boolean {
+  const hostHeader = splitHeaderValue(request.headers.get("x-forwarded-host"))[0]
+    ? splitHeaderValue(request.headers.get("x-forwarded-host"))[0]
+    : splitHeaderValue(request.headers.get("host"))[0];
+
+  if (!hostHeader || !isLocalHostOrIp(hostHeader)) {
+    return false;
+  }
+
+  const originHeader = request.headers.get("origin");
+  if (originHeader) {
+    try {
+      const originHost = new URL(originHeader).hostname;
+      if (!isLocalHostOrIp(originHost)) return false;
+    } catch {
+      return false;
+    }
+  }
+
+  const forwardedIp = splitHeaderValue(request.headers.get("x-forwarded-for"))[0];
+  if (forwardedIp && !isLocalHostOrIp(forwardedIp)) {
+    return false;
+  }
+
+  const realIp = request.headers.get("x-real-ip");
+  if (realIp && !isLocalHostOrIp(realIp)) {
+    return false;
+  }
+
+  return true;
+}
+
+export function isDevAuthBypassEnabled(env: EnvLike = process.env): boolean {
+  return env.NODE_ENV === "development" && env.DEV_AUTH_BYPASS_ENABLED === "1";
+}
+
+export function getDevAuthBypassConfig(env: EnvLike = process.env): DevAuthBypassConfig {
+  return {
+    token: requireEnvValue(env.DEV_AUTH_BYPASS_TOKEN, "DEV_AUTH_BYPASS_TOKEN"),
+    email: requireEnvValue(env.DEV_AUTH_BYPASS_EMAIL, "DEV_AUTH_BYPASS_EMAIL").trim().toLowerCase(),
+    password: requireEnvValue(env.DEV_AUTH_BYPASS_PASSWORD, "DEV_AUTH_BYPASS_PASSWORD"),
+  };
+}
+
+export function isDevAuthTokenValid(inputToken: string | null, expectedToken: string): boolean {
+  if (!inputToken || !expectedToken) return false;
+
+  const inputBuffer = Buffer.from(inputToken);
+  const expectedBuffer = Buffer.from(expectedToken);
+  if (inputBuffer.length !== expectedBuffer.length) return false;
+
+  return timingSafeEqual(inputBuffer, expectedBuffer);
+}

--- a/tests/unit/dev-auth-bypass.test.ts
+++ b/tests/unit/dev-auth-bypass.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getDevAuthBypassConfig,
+  isDevAuthBypassEnabled,
+  isDevAuthTokenValid,
+  isLocalDevelopmentRequest,
+  isLocalHostOrIp,
+} from "@/lib/auth/dev-auth-bypass";
+
+function buildRequest(headers: Record<string, string>) {
+  return new Request("http://127.0.0.1:3000/api/dev-login", {
+    method: "POST",
+    headers,
+    body: "{}",
+  });
+}
+
+describe("dev auth bypass helpers", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("enables bypass only for development mode with explicit flag", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("DEV_AUTH_BYPASS_ENABLED", "1");
+    expect(isDevAuthBypassEnabled()).toBe(true);
+
+    vi.stubEnv("DEV_AUTH_BYPASS_ENABLED", "0");
+    expect(isDevAuthBypassEnabled()).toBe(false);
+
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("DEV_AUTH_BYPASS_ENABLED", "1");
+    expect(isDevAuthBypassEnabled()).toBe(false);
+  });
+
+  it("loads required bypass config values from env", () => {
+    vi.stubEnv("DEV_AUTH_BYPASS_TOKEN", "token-value");
+    vi.stubEnv("DEV_AUTH_BYPASS_EMAIL", " Dev.User@Example.com ");
+    vi.stubEnv("DEV_AUTH_BYPASS_PASSWORD", "password-value");
+
+    expect(getDevAuthBypassConfig()).toEqual({
+      token: "token-value",
+      email: "dev.user@example.com",
+      password: "password-value",
+    });
+  });
+
+  it("throws if bypass config env is missing", () => {
+    vi.stubEnv("DEV_AUTH_BYPASS_TOKEN", "");
+    vi.stubEnv("DEV_AUTH_BYPASS_EMAIL", "");
+    vi.stubEnv("DEV_AUTH_BYPASS_PASSWORD", "");
+
+    expect(() => getDevAuthBypassConfig()).toThrowError(
+      "Missing required environment variable: DEV_AUTH_BYPASS_TOKEN"
+    );
+  });
+
+  it("validates token equality safely", () => {
+    expect(isDevAuthTokenValid("same-token", "same-token")).toBe(true);
+    expect(isDevAuthTokenValid("bad-token", "same-token")).toBe(false);
+    expect(isDevAuthTokenValid(null, "same-token")).toBe(false);
+  });
+
+  it("recognizes localhost, loopback, and private hosts", () => {
+    expect(isLocalHostOrIp("localhost")).toBe(true);
+    expect(isLocalHostOrIp("127.0.0.1")).toBe(true);
+    expect(isLocalHostOrIp("192.168.1.42")).toBe(true);
+    expect(isLocalHostOrIp("10.1.2.3")).toBe(true);
+    expect(isLocalHostOrIp("172.16.0.9")).toBe(true);
+    expect(isLocalHostOrIp("172.31.255.10")).toBe(true);
+    expect(isLocalHostOrIp("172.32.0.1")).toBe(false);
+    expect(isLocalHostOrIp("freeswimming.org")).toBe(false);
+  });
+
+  it("allows only local development requests", () => {
+    const okLocal = buildRequest({
+      "content-type": "application/json",
+      origin: "http://127.0.0.1:3000",
+      "x-forwarded-host": "127.0.0.1:3000",
+      "x-forwarded-for": "127.0.0.1",
+    });
+    expect(isLocalDevelopmentRequest(okLocal)).toBe(true);
+
+    const badHost = buildRequest({
+      "content-type": "application/json",
+      origin: "http://127.0.0.1:3000",
+      "x-forwarded-host": "freeswimming.org",
+    });
+    expect(isLocalDevelopmentRequest(badHost)).toBe(false);
+
+    const badOrigin = buildRequest({
+      "content-type": "application/json",
+      origin: "https://freeswimming.org",
+      "x-forwarded-host": "127.0.0.1:3000",
+    });
+    expect(isLocalDevelopmentRequest(badOrigin)).toBe(false);
+
+    const badForwardedIp = buildRequest({
+      "content-type": "application/json",
+      origin: "http://127.0.0.1:3000",
+      "x-forwarded-host": "127.0.0.1:3000",
+      "x-forwarded-for": "203.0.113.18",
+    });
+    expect(isLocalDevelopmentRequest(badForwardedIp)).toBe(false);
+  });
+});

--- a/tests/unit/dev-login-route.test.ts
+++ b/tests/unit/dev-login-route.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { signOutMock, signInWithPasswordMock, createServerSupabaseClientMock } = vi.hoisted(() => {
+  const signOut = vi.fn();
+  const signInWithPassword = vi.fn();
+  const createServerSupabaseClient = vi.fn(async () => ({
+    auth: {
+      signOut,
+      signInWithPassword,
+    },
+  }));
+
+  return {
+    signOutMock: signOut,
+    signInWithPasswordMock: signInWithPassword,
+    createServerSupabaseClientMock: createServerSupabaseClient,
+  };
+});
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerSupabaseClient: createServerSupabaseClientMock,
+}));
+
+import { POST } from "@/app/api/dev-login/route";
+
+function buildRequest(input?: {
+  token?: string;
+  origin?: string;
+  forwardedHost?: string;
+  contentType?: string;
+  body?: Record<string, unknown>;
+}) {
+  return new Request("http://127.0.0.1:3000/api/dev-login", {
+    method: "POST",
+    headers: {
+      "content-type": input?.contentType ?? "application/json",
+      origin: input?.origin ?? "http://127.0.0.1:3000",
+      "x-forwarded-host": input?.forwardedHost ?? "127.0.0.1:3000",
+      "x-dev-auth-token": input?.token ?? "dev-token",
+    },
+    body: JSON.stringify(input?.body ?? { next: "/my-library" }),
+  });
+}
+
+describe("/api/dev-login route", () => {
+  beforeEach(() => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("DEV_AUTH_BYPASS_ENABLED", "1");
+    vi.stubEnv("DEV_AUTH_BYPASS_TOKEN", "dev-token");
+    vi.stubEnv("DEV_AUTH_BYPASS_EMAIL", "dev@example.com");
+    vi.stubEnv("DEV_AUTH_BYPASS_PASSWORD", "dev-password");
+
+    signOutMock.mockResolvedValue({ error: null });
+    signInWithPasswordMock.mockResolvedValue({ error: null });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it("returns 404 when bypass is disabled or outside development mode", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("DEV_AUTH_BYPASS_ENABLED", "1");
+
+    const response = await POST(buildRequest());
+    expect(response.status).toBe(404);
+    expect(createServerSupabaseClientMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for non-local requests", async () => {
+    const response = await POST(
+      buildRequest({
+        origin: "https://freeswimming.org",
+        forwardedHost: "freeswimming.org",
+      })
+    );
+    expect(response.status).toBe(403);
+    expect(createServerSupabaseClientMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when token is invalid", async () => {
+    const response = await POST(
+      buildRequest({
+        token: "wrong-token",
+      })
+    );
+    expect(response.status).toBe(401);
+    expect(createServerSupabaseClientMock).not.toHaveBeenCalled();
+  });
+
+  it("signs in with configured dev credentials and returns safe next path", async () => {
+    const response = await POST(
+      buildRequest({
+        body: { next: "/guides/poolside" },
+      })
+    );
+    const payload = (await response.json()) as {
+      ok?: boolean;
+      nextPath?: string;
+      userEmail?: string;
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({
+      ok: true,
+      nextPath: "/guides/poolside",
+      userEmail: "dev@example.com",
+    });
+    expect(createServerSupabaseClientMock).toHaveBeenCalledTimes(1);
+    expect(signOutMock).toHaveBeenCalledTimes(1);
+    expect(signInWithPasswordMock).toHaveBeenCalledWith({
+      email: "dev@example.com",
+      password: "dev-password",
+    });
+  });
+
+  it("sanitizes non-local next path and uses fallback", async () => {
+    const response = await POST(
+      buildRequest({
+        body: { next: "https://evil.example/redirect" },
+      })
+    );
+    const payload = (await response.json()) as { nextPath?: string };
+
+    expect(response.status).toBe(200);
+    expect(payload.nextPath).toBe("/my-library");
+  });
+
+  it("returns 401 when configured dev credentials cannot sign in", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    signInWithPasswordMock.mockResolvedValue({
+      error: { message: "Invalid login credentials" },
+    });
+
+    const response = await POST(buildRequest());
+    const payload = (await response.json()) as { ok?: boolean; error?: string };
+
+    expect(response.status).toBe(401);
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toBe("Could not sign in.");
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it("rejects unsupported content type", async () => {
+    const response = await POST(
+      buildRequest({
+        contentType: "text/plain",
+      })
+    );
+    expect(response.status).toBe(415);
+    expect(createServerSupabaseClientMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- What changed and why?

## Scope

- In scope:
- Out of scope:

## Risk

- Main risk:
- Rollback plan:

## Test Evidence

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
