### PR TITLE
feat(auth): add local /dev/login shortcut for browser bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ If Upstash vars are missing, the contact API falls back to in-memory rate limiti
 
 Use this only in local development while testing flows that would otherwise require OTP email:
 
+Browser shortcut (recommended for manual QA):
+
+```text
+http://127.0.0.1:3000/dev/login?next=/my-library
+```
+
+API shortcut (useful for scripts/automation):
+
 ```bash
 curl -i \
   -X POST http://127.0.0.1:3000/api/dev-login \
@@ -66,6 +74,7 @@ Guardrails:
 - Route returns `404` unless `NODE_ENV=development` and `DEV_AUTH_BYPASS_ENABLED=1`.
 - Route rejects non-local host/origin/IP requests.
 - Route requires `x-dev-auth-token` and signs in only the configured seeded test account.
+- Browser shortcut `/dev/login` is local-only and signs in the same seeded test account before redirect.
 
 ## Quality checks
 

--- a/app/api/dev-login/route.ts
+++ b/app/api/dev-login/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from "next/server";
 import { getSafeNextPath } from "@/lib/auth/next-path";
 import {
-  getDevAuthBypassConfig,
   isDevAuthBypassEnabled,
   isDevAuthTokenValid,
   isLocalDevelopmentRequest,
 } from "@/lib/auth/dev-auth-bypass";
-import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { signInWithDevBypassAccount } from "@/lib/auth/dev-login";
+import { getDevAuthBypassConfig } from "@/lib/auth/dev-auth-bypass";
 
 type DevLoginBody = {
   next?: unknown;
@@ -51,20 +51,9 @@ export async function POST(request: Request) {
     return jsonNoStore({ ok: false, error: "Unauthorized." }, 401);
   }
 
-  const supabase = await createServerSupabaseClient();
-
-  try {
-    await supabase.auth.signOut();
-  } catch {}
-
-  const { error } = await supabase.auth.signInWithPassword({
-    email: config.email,
-    password: config.password,
-  });
-
-  if (error) {
-    console.error("[DevLoginApi] Could not sign in with configured dev account", error);
-    return jsonNoStore({ ok: false, error: "Could not sign in." }, 401);
+  const result = await signInWithDevBypassAccount();
+  if (!result.ok) {
+    return jsonNoStore({ ok: false, error: result.error }, 401);
   }
 
   const nextInput = typeof body.next === "string" ? body.next : "";
@@ -73,6 +62,6 @@ export async function POST(request: Request) {
   return jsonNoStore({
     ok: true,
     nextPath,
-    userEmail: config.email,
+    userEmail: result.userEmail,
   });
 }

--- a/app/dev/login/route.ts
+++ b/app/dev/login/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { getSafeNextPath } from "@/lib/auth/next-path";
+import { isDevAuthBypassEnabled, isLocalDevelopmentRequest } from "@/lib/auth/dev-auth-bypass";
+import { signInWithDevBypassAccount } from "@/lib/auth/dev-login";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function redirectWithNoStore(url: URL, status: 302 | 307 = 302) {
+  return NextResponse.redirect(url, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export async function GET(request: Request) {
+  if (!isDevAuthBypassEnabled()) {
+    return NextResponse.json(
+      { ok: false, error: "Not found." },
+      {
+        status: 404,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      }
+    );
+  }
+
+  if (!isLocalDevelopmentRequest(request)) {
+    return NextResponse.json(
+      { ok: false, error: "Forbidden." },
+      {
+        status: 403,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      }
+    );
+  }
+
+  const requestUrl = new URL(request.url);
+  const nextPath = getSafeNextPath(requestUrl.searchParams.get("next"), "/my-library");
+
+  const result = await signInWithDevBypassAccount();
+  if (!result.ok) {
+    const signInUrl = new URL("/auth/sign-in", requestUrl.origin);
+    signInUrl.searchParams.set("next", nextPath);
+    signInUrl.searchParams.set("error", result.error);
+    return redirectWithNoStore(signInUrl);
+  }
+
+  return redirectWithNoStore(new URL(nextPath, requestUrl.origin));
+}

--- a/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
+++ b/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
@@ -220,6 +220,8 @@ Users can start instantly in guest mode, buy optional paid products without acco
   - `POST /api/dev-login` is hard-disabled outside `NODE_ENV=development`,
   - guarded by explicit feature flag + token header + localhost/private-network request checks,
   - signs in only configured seeded dev account (no dynamic account selection).
+  - local browser shortcut route exists for fast session bootstrap:
+    - `GET /dev/login?next=/my-library`.
 - Soft-launch public UX exists with under-construction banner.
 
 ### Outstanding (blocking move to `done`)

--- a/lib/auth/dev-login.ts
+++ b/lib/auth/dev-login.ts
@@ -1,0 +1,39 @@
+import { getDevAuthBypassConfig } from "@/lib/auth/dev-auth-bypass";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+export type DevBypassSignInResult =
+  | {
+      ok: true;
+      userEmail: string;
+    }
+  | {
+      ok: false;
+      error: "Could not sign in.";
+    };
+
+export async function signInWithDevBypassAccount(): Promise<DevBypassSignInResult> {
+  const config = getDevAuthBypassConfig();
+  const supabase = await createServerSupabaseClient();
+
+  try {
+    await supabase.auth.signOut();
+  } catch {}
+
+  const { error } = await supabase.auth.signInWithPassword({
+    email: config.email,
+    password: config.password,
+  });
+
+  if (error) {
+    console.error("[DevLogin] Could not sign in with configured dev account", error);
+    return {
+      ok: false,
+      error: "Could not sign in.",
+    };
+  }
+
+  return {
+    ok: true,
+    userEmail: config.email,
+  };
+}

--- a/tests/unit/dev-login-shortcut-route.test.ts
+++ b/tests/unit/dev-login-shortcut-route.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { signInWithDevBypassAccountMock } = vi.hoisted(() => ({
+  signInWithDevBypassAccountMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/dev-login", () => ({
+  signInWithDevBypassAccount: signInWithDevBypassAccountMock,
+}));
+
+import { GET } from "@/app/dev/login/route";
+
+function buildRequest(input?: { url?: string; origin?: string; forwardedHost?: string }) {
+  return new Request(input?.url ?? "http://127.0.0.1:3000/dev/login?next=/my-library", {
+    method: "GET",
+    headers: {
+      origin: input?.origin ?? "http://127.0.0.1:3000",
+      "x-forwarded-host": input?.forwardedHost ?? "127.0.0.1:3000",
+    },
+  });
+}
+
+describe("/dev/login shortcut route", () => {
+  beforeEach(() => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("DEV_AUTH_BYPASS_ENABLED", "1");
+    signInWithDevBypassAccountMock.mockResolvedValue({
+      ok: true,
+      userEmail: "dev@example.com",
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it("returns 404 when bypass is disabled", async () => {
+    vi.stubEnv("DEV_AUTH_BYPASS_ENABLED", "0");
+
+    const response = await GET(buildRequest());
+    expect(response.status).toBe(404);
+    expect(signInWithDevBypassAccountMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for non-local requests", async () => {
+    const response = await GET(
+      buildRequest({
+        origin: "https://freeswimming.org",
+        forwardedHost: "freeswimming.org",
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expect(signInWithDevBypassAccountMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects to next path on successful sign-in", async () => {
+    const response = await GET(
+      buildRequest({
+        url: "http://127.0.0.1:3000/dev/login?next=/guides/poolside",
+      })
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("http://127.0.0.1:3000/guides/poolside");
+    expect(signInWithDevBypassAccountMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("sanitizes unsafe next param and redirects to my-library fallback", async () => {
+    const response = await GET(
+      buildRequest({
+        url: "http://127.0.0.1:3000/dev/login?next=https://evil.example/phish",
+      })
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("http://127.0.0.1:3000/my-library");
+  });
+
+  it("redirects to sign-in with error when dev bypass sign-in fails", async () => {
+    signInWithDevBypassAccountMock.mockResolvedValue({
+      ok: false,
+      error: "Could not sign in.",
+    });
+
+    const response = await GET(
+      buildRequest({
+        url: "http://127.0.0.1:3000/dev/login?next=/my-library",
+      })
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "http://127.0.0.1:3000/auth/sign-in?next=%2Fmy-library&error=Could+not+sign+in."
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- What changed and why?

## Scope

- In scope:
- Out of scope:

## Risk

- Main risk:
- Rollback plan:

## Test Evidence

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
