### PR TITLE
fix(auth): persist dev bypass session cookies on redirects

### DIFF
--- a/app/api/dev-login/route.ts
+++ b/app/api/dev-login/route.ts
@@ -53,15 +53,17 @@ export async function POST(request: Request) {
 
   const result = await signInWithDevBypassAccount();
   if (!result.ok) {
-    return jsonNoStore({ ok: false, error: result.error }, 401);
+    return result.applySupabaseCookies(jsonNoStore({ ok: false, error: result.error }, 401));
   }
 
   const nextInput = typeof body.next === "string" ? body.next : "";
   const nextPath = getSafeNextPath(nextInput, "/my-library");
 
-  return jsonNoStore({
-    ok: true,
-    nextPath,
-    userEmail: result.userEmail,
-  });
+  return result.applySupabaseCookies(
+    jsonNoStore({
+      ok: true,
+      nextPath,
+      userEmail: result.userEmail,
+    })
+  );
 }

--- a/app/dev/login/route.ts
+++ b/app/dev/login/route.ts
@@ -48,8 +48,8 @@ export async function GET(request: Request) {
     const signInUrl = new URL("/auth/sign-in", requestUrl.origin);
     signInUrl.searchParams.set("next", nextPath);
     signInUrl.searchParams.set("error", result.error);
-    return redirectWithNoStore(signInUrl);
+    return result.applySupabaseCookies(redirectWithNoStore(signInUrl));
   }
 
-  return redirectWithNoStore(new URL(nextPath, requestUrl.origin));
+  return result.applySupabaseCookies(redirectWithNoStore(new URL(nextPath, requestUrl.origin)));
 }

--- a/lib/auth/dev-login.ts
+++ b/lib/auth/dev-login.ts
@@ -1,19 +1,22 @@
+import { NextResponse } from "next/server";
 import { getDevAuthBypassConfig } from "@/lib/auth/dev-auth-bypass";
-import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
 
 export type DevBypassSignInResult =
   | {
       ok: true;
       userEmail: string;
+      applySupabaseCookies: <T extends NextResponse>(response: T) => T;
     }
   | {
       ok: false;
       error: "Could not sign in.";
+      applySupabaseCookies: <T extends NextResponse>(response: T) => T;
     };
 
 export async function signInWithDevBypassAccount(): Promise<DevBypassSignInResult> {
   const config = getDevAuthBypassConfig();
-  const supabase = await createServerSupabaseClient();
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
 
   try {
     await supabase.auth.signOut();
@@ -29,11 +32,13 @@ export async function signInWithDevBypassAccount(): Promise<DevBypassSignInResul
     return {
       ok: false,
       error: "Could not sign in.",
+      applySupabaseCookies,
     };
   }
 
   return {
     ok: true,
     userEmail: config.email,
+    applySupabaseCookies,
   };
 }

--- a/lib/supabase/route-handler.ts
+++ b/lib/supabase/route-handler.ts
@@ -1,0 +1,44 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import type { Database } from "@/types/database";
+import { getSupabaseAnonKey, getSupabaseUrl } from "@/lib/supabase/env";
+
+type CookieStore = Awaited<ReturnType<typeof cookies>>;
+type CookieSetOptions = Parameters<CookieStore["set"]>[2];
+type PendingCookie = {
+  name: string;
+  value: string;
+  options?: CookieSetOptions;
+};
+
+export async function createRouteHandlerSupabaseClient() {
+  const cookieStore = await cookies();
+  const pendingCookies: PendingCookie[] = [];
+
+  const supabase = createServerClient<Database>(getSupabaseUrl(), getSupabaseAnonKey(), {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value, options }) => {
+          pendingCookies.push({ name, value, options });
+          try {
+            cookieStore.set(name, value, options);
+          } catch {}
+        });
+      },
+    },
+  });
+
+  const applySupabaseCookies = <T extends NextResponse>(response: T): T => {
+    pendingCookies.forEach(({ name, value, options }) => {
+      response.cookies.set(name, value, options);
+    });
+
+    return response;
+  };
+
+  return { supabase, applySupabaseCookies };
+}

--- a/tests/unit/dev-login-route.test.ts
+++ b/tests/unit/dev-login-route.test.ts
@@ -1,24 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { signOutMock, signInWithPasswordMock, createServerSupabaseClientMock } = vi.hoisted(() => {
-  const signOut = vi.fn();
-  const signInWithPassword = vi.fn();
-  const createServerSupabaseClient = vi.fn(async () => ({
-    auth: {
-      signOut,
-      signInWithPassword,
-    },
-  }));
+const { signInWithDevBypassAccountMock } = vi.hoisted(() => {
+  const signInWithDevBypassAccount = vi.fn();
 
   return {
-    signOutMock: signOut,
-    signInWithPasswordMock: signInWithPassword,
-    createServerSupabaseClientMock: createServerSupabaseClient,
+    signInWithDevBypassAccountMock: signInWithDevBypassAccount,
   };
 });
 
-vi.mock("@/lib/supabase/server", () => ({
-  createServerSupabaseClient: createServerSupabaseClientMock,
+vi.mock("@/lib/auth/dev-login", () => ({
+  signInWithDevBypassAccount: signInWithDevBypassAccountMock,
 }));
 
 import { POST } from "@/app/api/dev-login/route";
@@ -42,6 +33,10 @@ function buildRequest(input?: {
   });
 }
 
+function applyResponseCookiesIdentity<T>(response: T): T {
+  return response;
+}
+
 describe("/api/dev-login route", () => {
   beforeEach(() => {
     vi.stubEnv("NODE_ENV", "development");
@@ -50,8 +45,11 @@ describe("/api/dev-login route", () => {
     vi.stubEnv("DEV_AUTH_BYPASS_EMAIL", "dev@example.com");
     vi.stubEnv("DEV_AUTH_BYPASS_PASSWORD", "dev-password");
 
-    signOutMock.mockResolvedValue({ error: null });
-    signInWithPasswordMock.mockResolvedValue({ error: null });
+    signInWithDevBypassAccountMock.mockResolvedValue({
+      ok: true,
+      userEmail: "dev@example.com",
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
   });
 
   afterEach(() => {
@@ -65,7 +63,7 @@ describe("/api/dev-login route", () => {
 
     const response = await POST(buildRequest());
     expect(response.status).toBe(404);
-    expect(createServerSupabaseClientMock).not.toHaveBeenCalled();
+    expect(signInWithDevBypassAccountMock).not.toHaveBeenCalled();
   });
 
   it("returns 403 for non-local requests", async () => {
@@ -76,7 +74,7 @@ describe("/api/dev-login route", () => {
       })
     );
     expect(response.status).toBe(403);
-    expect(createServerSupabaseClientMock).not.toHaveBeenCalled();
+    expect(signInWithDevBypassAccountMock).not.toHaveBeenCalled();
   });
 
   it("returns 401 when token is invalid", async () => {
@@ -86,7 +84,7 @@ describe("/api/dev-login route", () => {
       })
     );
     expect(response.status).toBe(401);
-    expect(createServerSupabaseClientMock).not.toHaveBeenCalled();
+    expect(signInWithDevBypassAccountMock).not.toHaveBeenCalled();
   });
 
   it("signs in with configured dev credentials and returns safe next path", async () => {
@@ -107,12 +105,7 @@ describe("/api/dev-login route", () => {
       nextPath: "/guides/poolside",
       userEmail: "dev@example.com",
     });
-    expect(createServerSupabaseClientMock).toHaveBeenCalledTimes(1);
-    expect(signOutMock).toHaveBeenCalledTimes(1);
-    expect(signInWithPasswordMock).toHaveBeenCalledWith({
-      email: "dev@example.com",
-      password: "dev-password",
-    });
+    expect(signInWithDevBypassAccountMock).toHaveBeenCalledTimes(1);
   });
 
   it("sanitizes non-local next path and uses fallback", async () => {
@@ -129,8 +122,10 @@ describe("/api/dev-login route", () => {
 
   it("returns 401 when configured dev credentials cannot sign in", async () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    signInWithPasswordMock.mockResolvedValue({
-      error: { message: "Invalid login credentials" },
+    signInWithDevBypassAccountMock.mockResolvedValue({
+      ok: false,
+      error: "Could not sign in.",
+      applySupabaseCookies: applyResponseCookiesIdentity,
     });
 
     const response = await POST(buildRequest());
@@ -139,7 +134,7 @@ describe("/api/dev-login route", () => {
     expect(response.status).toBe(401);
     expect(payload.ok).toBe(false);
     expect(payload.error).toBe("Could not sign in.");
-    expect(consoleSpy).toHaveBeenCalled();
+    expect(consoleSpy).not.toHaveBeenCalled();
   });
 
   it("rejects unsupported content type", async () => {
@@ -149,6 +144,6 @@ describe("/api/dev-login route", () => {
       })
     );
     expect(response.status).toBe(415);
-    expect(createServerSupabaseClientMock).not.toHaveBeenCalled();
+    expect(signInWithDevBypassAccountMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/dev-login-shortcut-route.test.ts
+++ b/tests/unit/dev-login-shortcut-route.test.ts
@@ -10,6 +10,10 @@ vi.mock("@/lib/auth/dev-login", () => ({
 
 import { GET } from "@/app/dev/login/route";
 
+function applyResponseCookiesIdentity<T>(response: T): T {
+  return response;
+}
+
 function buildRequest(input?: { url?: string; origin?: string; forwardedHost?: string }) {
   return new Request(input?.url ?? "http://127.0.0.1:3000/dev/login?next=/my-library", {
     method: "GET",
@@ -27,6 +31,7 @@ describe("/dev/login shortcut route", () => {
     signInWithDevBypassAccountMock.mockResolvedValue({
       ok: true,
       userEmail: "dev@example.com",
+      applySupabaseCookies: applyResponseCookiesIdentity,
     });
   });
 
@@ -82,6 +87,7 @@ describe("/dev/login shortcut route", () => {
     signInWithDevBypassAccountMock.mockResolvedValue({
       ok: false,
       error: "Could not sign in.",
+      applySupabaseCookies: applyResponseCookiesIdentity,
     });
 
     const response = await GET(


### PR DESCRIPTION
## Summary

- What changed and why?

## Scope

- In scope:
- Out of scope:

## Risk

- Main risk:
- Rollback plan:

## Test Evidence

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
