### PR TITLE
fix(auth): preserve request host in dev login redirects

### DIFF
--- a/app/dev/login/route.ts
+++ b/app/dev/login/route.ts
@@ -15,6 +15,24 @@ function redirectWithNoStore(url: URL, status: 302 | 307 = 302) {
   });
 }
 
+function splitHeaderValue(value: string | null): string[] {
+  return (value ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function resolveRequestOrigin(request: Request): string {
+  const requestUrl = new URL(request.url);
+  const forwardedHost = splitHeaderValue(request.headers.get("x-forwarded-host"))[0];
+  const host = forwardedHost || splitHeaderValue(request.headers.get("host"))[0] || requestUrl.host;
+
+  const forwardedProto = splitHeaderValue(request.headers.get("x-forwarded-proto"))[0];
+  const protocol = forwardedProto || requestUrl.protocol.replace(":", "") || "http";
+
+  return `${protocol}://${host}`;
+}
+
 export async function GET(request: Request) {
   if (!isDevAuthBypassEnabled()) {
     return NextResponse.json(
@@ -41,15 +59,16 @@ export async function GET(request: Request) {
   }
 
   const requestUrl = new URL(request.url);
+  const requestOrigin = resolveRequestOrigin(request);
   const nextPath = getSafeNextPath(requestUrl.searchParams.get("next"), "/my-library");
 
   const result = await signInWithDevBypassAccount();
   if (!result.ok) {
-    const signInUrl = new URL("/auth/sign-in", requestUrl.origin);
+    const signInUrl = new URL("/auth/sign-in", requestOrigin);
     signInUrl.searchParams.set("next", nextPath);
     signInUrl.searchParams.set("error", result.error);
     return result.applySupabaseCookies(redirectWithNoStore(signInUrl));
   }
 
-  return result.applySupabaseCookies(redirectWithNoStore(new URL(nextPath, requestUrl.origin)));
+  return result.applySupabaseCookies(redirectWithNoStore(new URL(nextPath, requestOrigin)));
 }

--- a/tests/unit/dev-login-shortcut-route.test.ts
+++ b/tests/unit/dev-login-shortcut-route.test.ts
@@ -72,6 +72,19 @@ describe("/dev/login shortcut route", () => {
     expect(signInWithDevBypassAccountMock).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps incoming host for redirects to avoid localhost/127 cookie split", async () => {
+    const response = await GET(
+      buildRequest({
+        url: "http://localhost:3000/dev/login?next=/my-library",
+        origin: "http://127.0.0.1:3000",
+        forwardedHost: "127.0.0.1:3000",
+      })
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("http://127.0.0.1:3000/my-library");
+  });
+
   it("sanitizes unsafe next param and redirects to my-library fallback", async () => {
     const response = await GET(
       buildRequest({


### PR DESCRIPTION
## Summary

- What changed and why?

## Scope

- In scope:
- Out of scope:

## Risk

- Main risk:
- Rollback plan:

## Test Evidence

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
