### PR TITLE
fix(auth): allow ipv6-mapped loopback in dev bypass checks

### DIFF
--- a/lib/auth/dev-auth-bypass.ts
+++ b/lib/auth/dev-auth-bypass.ts
@@ -41,7 +41,22 @@ function normalizeHostCandidate(value: string): string {
   const maybeHostWithPort = candidate.toLowerCase();
   const splitByColon = maybeHostWithPort.split(":");
   if (splitByColon.length === 2 && /^\d+$/.test(splitByColon[1])) {
-    return splitByColon[0];
+    const bareHost = splitByColon[0];
+    if (bareHost.startsWith("::ffff:")) {
+      const mappedV4 = bareHost.slice("::ffff:".length);
+      if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(mappedV4)) {
+        return mappedV4;
+      }
+    }
+    return bareHost;
+  }
+
+  if (maybeHostWithPort.startsWith("::ffff:")) {
+    const mappedV4 = maybeHostWithPort.slice("::ffff:".length);
+    const normalizedMappedV4 = mappedV4.replace(/:\d+$/, "");
+    if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(normalizedMappedV4)) {
+      return normalizedMappedV4;
+    }
   }
 
   return maybeHostWithPort;

--- a/tests/unit/dev-auth-bypass.test.ts
+++ b/tests/unit/dev-auth-bypass.test.ts
@@ -64,6 +64,8 @@ describe("dev auth bypass helpers", () => {
   it("recognizes localhost, loopback, and private hosts", () => {
     expect(isLocalHostOrIp("localhost")).toBe(true);
     expect(isLocalHostOrIp("127.0.0.1")).toBe(true);
+    expect(isLocalHostOrIp("::ffff:127.0.0.1")).toBe(true);
+    expect(isLocalHostOrIp("::ffff:127.0.0.1:3000")).toBe(true);
     expect(isLocalHostOrIp("192.168.1.42")).toBe(true);
     expect(isLocalHostOrIp("10.1.2.3")).toBe(true);
     expect(isLocalHostOrIp("172.16.0.9")).toBe(true);


### PR DESCRIPTION
## Summary

- What changed and why?

## Scope

- In scope:
- Out of scope:

## Risk

- Main risk:
- Rollback plan:

## Test Evidence

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
