### PR TITLE
fix(course): prevent hydrate race from reverting done sync

### DIFF
--- a/app/course/page.tsx
+++ b/app/course/page.tsx
@@ -30,12 +30,12 @@ import {
   shouldShowAutoInstallPrompt,
 } from "@/components/install/install-rules";
 import {
-  areCourseProgressRowsEqual,
   buildCourseProgressRowsFromLocal,
   buildLocalCourseProgressFromRows,
   mergeCourseProgressRows,
   normalizeCourseProgressRows,
   normalizeDoneLessonIds,
+  resolveCourseDirtyLessonIdsAfterHydrate,
   normalizeVideoProgressRecord,
   type CourseProgressRow,
 } from "@/lib/course/progress";
@@ -235,7 +235,9 @@ function CoursePageClient() {
   const courseSyncDirtyRef = useRef(false);
   const courseSyncDirtyLessonIdsRef = useRef<Set<string>>(new Set());
   const courseSyncInFlightRef = useRef(false);
+  const courseProgressMutationRef = useRef(0);
   const knownProgressLessonIdsRef = useRef<Set<string>>(new Set());
+  const doneLessonIdsRef = useRef<string[]>([]);
   const hydratedProgressUserIdRef = useRef<string | null>(null);
   const swipeTouchIdRef = useRef<number | null>(null);
   const swipeDirectionRef = useRef<SwipeDirection | null>(null);
@@ -297,6 +299,8 @@ function CoursePageClient() {
   }, []);
 
   const markCourseProgressDirty = useCallback((lessonId?: string) => {
+    courseProgressMutationRef.current += 1;
+
     if (lessonId) {
       knownProgressLessonIdsRef.current.add(lessonId);
       courseSyncDirtyLessonIdsRef.current.add(lessonId);
@@ -322,6 +326,7 @@ function CoursePageClient() {
       }
 
       playbackProgressRef.current = normalizedVideoProgress;
+      doneLessonIdsRef.current = normalizedDoneLessonIds;
       setDoneLessonIds(normalizedDoneLessonIds);
       setResumeAvailable(Math.floor(normalizedVideoProgress[activeLesson.id] ?? 0) >= 2);
 
@@ -333,21 +338,18 @@ function CoursePageClient() {
     [activeLesson.id]
   );
 
-  const buildSyncRows = useCallback(
-    (updatedAt?: string): CourseProgressRow[] => {
-      return buildCourseProgressRowsFromLocal(
-        {
-          doneLessonIds,
-          videoProgressByLessonId: playbackProgressRef.current,
-        },
-        {
-          knownLessonIds: knownProgressLessonIdsRef.current,
-          updatedAt,
-        }
-      );
-    },
-    [doneLessonIds]
-  );
+  const buildSyncRows = useCallback((updatedAt?: string): CourseProgressRow[] => {
+    return buildCourseProgressRowsFromLocal(
+      {
+        doneLessonIds: doneLessonIdsRef.current,
+        videoProgressByLessonId: playbackProgressRef.current,
+      },
+      {
+        knownLessonIds: knownProgressLessonIdsRef.current,
+        updatedAt,
+      }
+    );
+  }, []);
 
   const persistCourseProgressRows = useCallback(
     async (rows: CourseProgressRow[]) => {
@@ -449,6 +451,7 @@ function CoursePageClient() {
         for (const lessonId of normalizedDoneLessonIds) {
           knownProgressLessonIdsRef.current.add(lessonId);
         }
+        doneLessonIdsRef.current = normalizedDoneLessonIds;
         setDoneLessonIds(normalizedDoneLessonIds);
       }
     } catch {}
@@ -461,6 +464,10 @@ function CoursePageClient() {
       localStorage.setItem(DONE_STORAGE_KEY, JSON.stringify(doneLessonIds));
     } catch {}
   }, [doneLessonIds, doneLessonIdsLoaded]);
+
+  useEffect(() => {
+    doneLessonIdsRef.current = doneLessonIds;
+  }, [doneLessonIds]);
 
   useEffect(() => {
     try {
@@ -526,6 +533,7 @@ function CoursePageClient() {
 
     const hydrateFromServer = async () => {
       setCourseSyncStatus("syncing");
+      const hydrateStartedAtMutation = courseProgressMutationRef.current;
 
       try {
         const response = await fetch(COURSE_PROGRESS_SYNC_API_PATH, {
@@ -552,15 +560,30 @@ function CoursePageClient() {
           knownProgressLessonIdsRef.current.add(row.lessonId);
         }
 
-        applyLocalCourseProgress(buildLocalCourseProgressFromRows(mergedRows));
+        const hasLocalMutationDuringHydrate =
+          courseProgressMutationRef.current !== hydrateStartedAtMutation;
 
-        if (!areCourseProgressRowsEqual(mergedRows, remoteRows)) {
-          await persistCourseProgressRows(mergedRows);
+        if (!hasLocalMutationDuringHydrate) {
+          applyLocalCourseProgress(buildLocalCourseProgressFromRows(mergedRows));
         }
 
         if (cancelled) return;
-        courseSyncDirtyRef.current = false;
-        courseSyncDirtyLessonIdsRef.current.clear();
+
+        const dirtyLessonIds = resolveCourseDirtyLessonIdsAfterHydrate({
+          existingDirtyLessonIds: courseSyncDirtyLessonIdsRef.current,
+          mergedRows,
+          remoteRows,
+        });
+
+        courseSyncDirtyLessonIdsRef.current = new Set(dirtyLessonIds);
+        courseSyncDirtyRef.current = dirtyLessonIds.length > 0;
+
+        if (courseSyncDirtyRef.current) {
+          setCourseSyncStatus("syncing");
+          void syncCourseProgressNow({ force: true });
+          return;
+        }
+
         setCourseSyncStatus("synced");
         setLastCourseSyncAtMs(Date.now());
       } catch (error) {
@@ -580,8 +603,8 @@ function CoursePageClient() {
     authStateLoaded,
     buildSyncRows,
     localCourseProgressLoaded,
-    persistCourseProgressRows,
     signedInUserId,
+    syncCourseProgressNow,
   ]);
 
   useEffect(() => {
@@ -906,10 +929,13 @@ function CoursePageClient() {
     markCourseProgressDirty(activeLesson.id);
 
     setDoneLessonIds((prev) => {
-      if (prev.includes(activeLesson.id)) {
-        return prev.filter((id) => id !== activeLesson.id);
-      }
-      return [...prev, activeLesson.id];
+      const nextDoneLessonIds = prev.includes(activeLesson.id)
+        ? prev.filter((id) => id !== activeLesson.id)
+        : [...prev, activeLesson.id];
+
+      doneLessonIdsRef.current = nextDoneLessonIds;
+
+      return nextDoneLessonIds;
     });
     if (willMarkAsDone) {
       queueAutoInstallPrompt();
@@ -1833,6 +1859,7 @@ function CoursePageClient() {
                     tier="nav"
                     onClick={toggleLessonDone}
                     aria-pressed={isLessonDone}
+                    data-testid="course-mark-done-button"
                     className={cx(
                       "inline-flex min-h-[30px] shrink-0 items-center justify-center rounded-full px-3 py-1 text-[11px] font-semibold ring-1",
                       isLessonDone

--- a/lib/course/progress.ts
+++ b/lib/course/progress.ts
@@ -242,3 +242,22 @@ export function areCourseProgressRowsEqual(localRows: unknown, remoteRows: unkno
 
   return true;
 }
+
+export function resolveCourseDirtyLessonIdsAfterHydrate(options: {
+  existingDirtyLessonIds?: Iterable<string>;
+  mergedRows: unknown;
+  remoteRows: unknown;
+}): string[] {
+  const dirtyLessonIds = normalizeKnownLessonIds(options.existingDirtyLessonIds);
+  const mergedRows = normalizeCourseProgressRows(options.mergedRows, {
+    maxRows: MAX_COURSE_PROGRESS_ROWS,
+  });
+
+  if (!areCourseProgressRowsEqual(mergedRows, options.remoteRows)) {
+    for (const row of mergedRows) {
+      dirtyLessonIds.add(row.lessonId);
+    }
+  }
+
+  return Array.from(dirtyLessonIds).sort((a, b) => a.localeCompare(b));
+}

--- a/tests/e2e/course-progress-sync.spec.ts
+++ b/tests/e2e/course-progress-sync.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+
+test("signed-in mark-as-done syncs to account progress API", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "desktop-chromium", "Runs once on desktop Chromium.");
+
+  const lessonId = "mod1-l1";
+  await page.goto(`/dev/login?next=/course?lesson=${encodeURIComponent(lessonId)}`);
+
+  if (!page.url().includes("/course")) {
+    test.skip(true, "Dev auth bypass is not enabled in this environment.");
+  }
+
+  const markDoneButton = page.getByTestId("course-mark-done-button");
+  await expect(markDoneButton).toBeVisible();
+
+  await page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/progress/course") &&
+      response.request().method() === "GET" &&
+      response.status() === 200,
+    { timeout: 15_000 }
+  );
+  await page.waitForTimeout(1_200);
+
+  const initialPressed = (await markDoneButton.getAttribute("aria-pressed")) === "true";
+  const expectedAfterToggle = initialPressed ? "false" : "true";
+  const expectedAfterRestore = initialPressed ? "true" : "false";
+
+  await markDoneButton.click();
+  await expect(markDoneButton).toHaveAttribute("aria-pressed", expectedAfterToggle);
+
+  await expect
+    .poll(
+      async () => {
+        const response = await page.request.get("/api/progress/course");
+        if (response.status() !== 200) return `status:${response.status()}`;
+        const payload = (await response.json()) as {
+          rows?: Array<{ lessonId?: string; done?: boolean }>;
+        };
+        const row = payload.rows?.find((entry) => entry.lessonId === lessonId);
+        return row?.done ? "true" : "false";
+      },
+      { timeout: 20_000 }
+    )
+    .toBe(expectedAfterToggle);
+
+  await markDoneButton.click();
+  await expect(markDoneButton).toHaveAttribute("aria-pressed", expectedAfterRestore);
+
+  await expect
+    .poll(
+      async () => {
+        const response = await page.request.get("/api/progress/course");
+        if (response.status() !== 200) return `status:${response.status()}`;
+        const payload = (await response.json()) as {
+          rows?: Array<{ lessonId?: string; done?: boolean }>;
+        };
+        const row = payload.rows?.find((entry) => entry.lessonId === lessonId);
+        return row?.done ? "true" : "false";
+      },
+      { timeout: 20_000 }
+    )
+    .toBe(expectedAfterRestore);
+});

--- a/tests/e2e/course-progress-sync.spec.ts
+++ b/tests/e2e/course-progress-sync.spec.ts
@@ -4,9 +4,10 @@ test("signed-in mark-as-done syncs to account progress API", async ({ page }, te
   test.skip(testInfo.project.name !== "desktop-chromium", "Runs once on desktop Chromium.");
 
   const lessonId = "mod1-l1";
-  await page.goto(`/dev/login?next=/course?lesson=${encodeURIComponent(lessonId)}`);
+  const nextPath = `/course?lesson=${encodeURIComponent(lessonId)}`;
+  await page.goto(`/dev/login?next=${encodeURIComponent(nextPath)}`);
 
-  if (!page.url().includes("/course")) {
+  if (new URL(page.url()).pathname !== "/course") {
     test.skip(true, "Dev auth bypass is not enabled in this environment.");
   }
 

--- a/tests/unit/course-progress.test.ts
+++ b/tests/unit/course-progress.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeCourseProgressRows,
   normalizeDoneLessonIds,
   normalizeVideoProgressRecord,
+  resolveCourseDirtyLessonIdsAfterHydrate,
 } from "@/lib/course/progress";
 
 describe("course progress helpers", () => {
@@ -166,5 +167,59 @@ describe("course progress helpers", () => {
         "mod1-l1": 42,
       },
     });
+  });
+
+  it("keeps existing dirty lessons after hydrate even when merged equals remote", () => {
+    const dirty = resolveCourseDirtyLessonIdsAfterHydrate({
+      existingDirtyLessonIds: ["mod1-l1"],
+      mergedRows: [
+        {
+          lessonId: "mod1-l1",
+          done: false,
+          videoSeconds: 0,
+          updatedAt: "2026-02-17T10:00:00.000Z",
+        },
+      ],
+      remoteRows: [
+        {
+          lessonId: "mod1-l1",
+          done: false,
+          videoSeconds: 0,
+          updatedAt: "2026-02-17T10:01:00.000Z",
+        },
+      ],
+    });
+
+    expect(dirty).toEqual(["mod1-l1"]);
+  });
+
+  it("marks merged lesson ids dirty when hydrate reveals local/remote mismatch", () => {
+    const dirty = resolveCourseDirtyLessonIdsAfterHydrate({
+      existingDirtyLessonIds: [],
+      mergedRows: [
+        {
+          lessonId: "mod1-l1",
+          done: true,
+          videoSeconds: 0,
+          updatedAt: "2026-02-17T10:00:00.000Z",
+        },
+        {
+          lessonId: "mod1-l2",
+          done: false,
+          videoSeconds: 0,
+          updatedAt: "2026-02-17T10:00:00.000Z",
+        },
+      ],
+      remoteRows: [
+        {
+          lessonId: "mod1-l1",
+          done: false,
+          videoSeconds: 0,
+          updatedAt: "2026-02-17T10:01:00.000Z",
+        },
+      ],
+    });
+
+    expect(dirty).toEqual(["mod1-l1", "mod1-l2"]);
   });
 });


### PR DESCRIPTION
## Summary

- What changed and why?

## Scope

- In scope:
- Out of scope:

## Risk

- Main risk:
- Rollback plan:

## Test Evidence

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
