### PR TITLE
fix(auth): scope cooldown to resend session and preserve sign-in flow

### DIFF
--- a/app/auth/sign-in/actions.ts
+++ b/app/auth/sign-in/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
-import { createHash } from "node:crypto";
-import { headers } from "next/headers";
+import { createHash, randomBytes } from "node:crypto";
+import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 import {
   formatLoginCodeCooldownMessage,
@@ -10,6 +10,7 @@ import {
   toRetrySeconds,
 } from "@/lib/auth/magic-link-cooldown";
 import { getSafeNextPath } from "@/lib/auth/next-path";
+import { isResendRequestFlag, shouldApplyMagicLinkCooldown } from "@/lib/auth/sign-in-request";
 import { getAppUrl } from "@/lib/supabase/env";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 
@@ -27,6 +28,9 @@ const SIGN_IN_CODE_IP_WINDOW_MS = 5 * 60_000;
 const SIGN_IN_CODE_IP_MAX = 12;
 const SIGN_IN_CODE_EMAIL_WINDOW_MS = 10 * 60_000;
 const SIGN_IN_CODE_EMAIL_MAX = 8;
+const MAGIC_LINK_SESSION_COOKIE_NAME = "fs_auth_magic_link_session";
+const MAGIC_LINK_SESSION_MAX_AGE_SECONDS = 7 * 24 * 60 * 60;
+const MAGIC_LINK_SESSION_ID_PATTERN = /^[a-f0-9]{32}$/i;
 
 type RateLimitResult =
   | {
@@ -84,6 +88,28 @@ function getClientIp(headerStore: Headers): string {
 
 function getEmailHash(email: string): string {
   return createHash("sha256").update(email).digest("hex").slice(0, 32);
+}
+
+async function getMagicLinkSessionId(): Promise<string> {
+  const cookieStore = await cookies();
+  const existing = cookieStore.get(MAGIC_LINK_SESSION_COOKIE_NAME)?.value ?? "";
+
+  if (MAGIC_LINK_SESSION_ID_PATTERN.test(existing)) {
+    return existing.toLowerCase();
+  }
+
+  const generated = randomBytes(16).toString("hex");
+  cookieStore.set({
+    name: MAGIC_LINK_SESSION_COOKIE_NAME,
+    value: generated,
+    httpOnly: true,
+    secure: process.env.NODE_ENV !== "development",
+    sameSite: "lax",
+    path: "/",
+    maxAge: MAGIC_LINK_SESSION_MAX_AGE_SECONDS,
+  });
+
+  return generated;
 }
 
 function shouldUseUpstash(): boolean {
@@ -291,6 +317,7 @@ async function enforceRateLimitSet(rules: RateLimitRule[]) {
 export async function requestMagicLink(formData: FormData) {
   const email = getNormalizedEmail(formData);
   const nextPath = getNextPath(formData);
+  const isResendRequest = isResendRequestFlag(formData.get("resend"));
 
   if (!email || !EMAIL_REGEX.test(email)) {
     redirect(buildSignInPath(nextPath, { error: "Enter a valid email address." }));
@@ -299,13 +326,16 @@ export async function requestMagicLink(formData: FormData) {
   const headerStore = await headers();
   const clientIp = getClientIp(headerStore);
   const emailHash = getEmailHash(email);
-  const cooldownLockKey = `rate:auth:magic-link:cooldown:${emailHash}`;
+  const magicLinkSessionId = await getMagicLinkSessionId();
+  const sessionScopedEmailHash = `${emailHash}:${magicLinkSessionId}`;
+  const cooldownLockKey = `rate:auth:magic-link:cooldown:${sessionScopedEmailHash}`;
   const activeCooldownMs = await getCooldownTtlMs(cooldownLockKey);
-  if (activeCooldownMs > 0) {
+  if (shouldApplyMagicLinkCooldown(activeCooldownMs, isResendRequest)) {
     redirect(
       buildSignInPath(nextPath, {
         error: formatLoginCodeCooldownMessage(activeCooldownMs),
         cooldownUntil: String(Date.now() + activeCooldownMs),
+        sent: "1",
         email,
       })
     );
@@ -325,13 +355,16 @@ export async function requestMagicLink(formData: FormData) {
   ]);
 
   if (!limitResult.ok) {
-    redirect(
-      buildSignInPath(nextPath, {
-        error: formatLoginCodeCooldownMessage(limitResult.retryAfterMs),
-        cooldownUntil: String(Date.now() + limitResult.retryAfterMs),
-        email,
-      })
-    );
+    const params: Record<string, string> = {
+      error: formatLoginCodeCooldownMessage(limitResult.retryAfterMs),
+      cooldownUntil: String(Date.now() + limitResult.retryAfterMs),
+      email,
+    };
+    if (isResendRequest) {
+      params.sent = "1";
+    }
+
+    redirect(buildSignInPath(nextPath, params));
   }
 
   const origin = headerStore.get("origin") ?? getAppUrl();
@@ -347,13 +380,16 @@ export async function requestMagicLink(formData: FormData) {
 
   if (error) {
     if (error.message.toLowerCase().includes("rate limit")) {
-      redirect(
-        buildSignInPath(nextPath, {
-          error: "Please wait about a minute before requesting a new login code.",
-          cooldownUntil: String(Date.now() + 60_000),
-          email,
-        })
-      );
+      const params: Record<string, string> = {
+        error: "Please wait about a minute before requesting a new login code.",
+        cooldownUntil: String(Date.now() + 60_000),
+        email,
+      };
+      if (isResendRequest) {
+        params.sent = "1";
+      }
+
+      redirect(buildSignInPath(nextPath, params));
     }
 
     console.error("[Auth] Could not request sign-in email.", {
@@ -361,15 +397,18 @@ export async function requestMagicLink(formData: FormData) {
       status: error.status,
       code: error.code,
     });
-    redirect(
-      buildSignInPath(nextPath, {
-        error: "Could not send sign-in email right now. Please try again.",
-        email,
-      })
-    );
+    const params: Record<string, string> = {
+      error: "Could not send sign-in email right now. Please try again.",
+      email,
+    };
+    if (isResendRequest) {
+      params.sent = "1";
+    }
+
+    redirect(buildSignInPath(nextPath, params));
   }
 
-  const cadenceCounterKey = `rate:auth:magic-link:cadence:${emailHash}`;
+  const cadenceCounterKey = `rate:auth:magic-link:cadence:${sessionScopedEmailHash}`;
   const cadenceCount = await incrementCooldownCounter(
     cadenceCounterKey,
     MAGIC_LINK_CADENCE_WINDOW_MS

--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -105,6 +105,7 @@ export default async function SignInPage({ searchParams }: Props) {
               <form action={requestMagicLink}>
                 <input type="hidden" name="next" value={nextPath} />
                 <input type="hidden" name="email" value={email} />
+                <input type="hidden" name="resend" value="1" />
                 <button
                   type="submit"
                   className="inline-flex h-11 items-center justify-center rounded-xl border border-slate-200 bg-white px-5 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"

--- a/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
+++ b/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
@@ -6,7 +6,7 @@
 - `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-02-15`
-- `updated`: `2026-02-17`
+- `updated`: `2026-02-18`
 
 ## Goal
 
@@ -223,6 +223,14 @@ Users can start instantly in guest mode, buy optional paid products without acco
   - local browser shortcut route exists for fast session bootstrap:
     - `GET /dev/login?next=/my-library`.
 - Soft-launch public UX exists with under-construction banner.
+
+### Active Workstream Split (2026-02-18)
+
+- Auth reliability/cooldown UX is now tracked in dedicated AW-003 brief:
+  - `docs/task-briefs/in-progress/2026-02-18-aw-003-sign-in-cooldown-reliability.md`.
+- Private site lock and owner bypass is tracked separately:
+  - `docs/task-briefs/in-progress/2026-02-18-private-access-gate-and-owner-bypass.md`.
+- This core brief keeps ownership of commerce/library/progress completion criteria.
 
 ### Outstanding (blocking move to `done`)
 

--- a/docs/task-briefs/in-progress/2026-02-17-additional-work-backlog.md
+++ b/docs/task-briefs/in-progress/2026-02-17-additional-work-backlog.md
@@ -6,7 +6,7 @@
 - `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-02-17`
-- `updated`: `2026-02-17`
+- `updated`: `2026-02-18`
 
 ## Purpose
 
@@ -14,10 +14,10 @@ Capture good ideas that should be implemented later without blocking the active 
 
 ## Queue
 
-| ID       | Title                                                                      | Priority | Status    |
-| -------- | -------------------------------------------------------------------------- | -------- | --------- |
-| `AW-002` | Email one-time-code UX hardening (magic link first + OTP fallback clarity) | `medium` | `triaged` |
-| `AW-003` | Sign-in code request reliability + cooldown UX redesign (10/10)            | `high`   | `triaged` |
+| ID       | Title                                                                      | Priority | Status        |
+| -------- | -------------------------------------------------------------------------- | -------- | ------------- |
+| `AW-002` | Email one-time-code UX hardening (magic link first + OTP fallback clarity) | `medium` | `triaged`     |
+| `AW-003` | Sign-in code request reliability + cooldown UX redesign (10/10)            | `high`   | `in-progress` |
 
 ## AW-002: Email one-time-code UX hardening
 
@@ -54,5 +54,7 @@ Capture good ideas that should be implemented later without blocking the active 
 
 - Backlog items here are intentionally deferred.
 - When an item starts implementation, cut a dedicated feature branch and a focused task brief/checkpoint log entry.
+  - active now:
+    - `AW-003` -> `docs/task-briefs/in-progress/2026-02-18-aw-003-sign-in-cooldown-reliability.md`
 - PR create/review/merge links should be opened in Safari by default:
   - `open -a Safari "<PR_URL>"`

--- a/docs/task-briefs/in-progress/2026-02-18-aw-003-sign-in-cooldown-reliability.md
+++ b/docs/task-briefs/in-progress/2026-02-18-aw-003-sign-in-cooldown-reliability.md
@@ -1,0 +1,60 @@
+# Task Brief: AW-003 Sign-In Cooldown Reliability UX
+
+## Metadata
+
+- `id`: `2026-02-18-aw-003-sign-in-cooldown-reliability`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-02-18`
+- `updated`: `2026-02-18`
+
+## Goal
+
+Make sign-in code request behavior predictable and trustworthy: first request confirms code sent, then resend applies clear progressive cooldown messaging without dead ends.
+
+## Scope
+
+- Harden `/auth/sign-in` resend/request UX flow.
+- Adjust cooldown logic so first request in a new browser session does not immediately show 30s cooldown due prior requests elsewhere.
+- Keep progressive resend cadence (`30s`, `60s`, `5m`) on repeated resend attempts in same sign-in session.
+- Preserve code-entry state when resend fails.
+- Improve user-facing error classification for resend outcomes.
+- Add/update tests for cooldown and resend behavior.
+- Update task briefs and checkpoint logs.
+
+## Out Of Scope
+
+- No auth provider migration.
+- No redesign outside sign-in scope.
+- No new analytics vendor.
+
+## Acceptance Criteria
+
+- First request shows success (`sent`) if send succeeds.
+- Second immediate resend shows `wait 30s`; next immediate resend shows `wait 60s`; then `5m`.
+- Resend failures keep code-entry mode active (no jarring reset).
+- Cooldown copy is explicit and actionable.
+- Unit tests cover cooldown sequencing and session-scoped behavior.
+
+## Validation
+
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test:unit`
+- `npm run build`
+
+## Implementation Checkpoint Log
+
+- `2026-02-18` | `working tree` | brief created and branch started (`feat/auth-aw003-cooldown-ux`) | next: implement session-scoped cooldown + resend state hardening in auth actions/page.
+- `2026-02-18` | `working tree` | AW-003 implementation slice completed:
+  - cooldown lock/cadence keys are now scoped by email + sign-in session cookie,
+  - cooldown pre-check applies only to explicit resend requests,
+  - resend failures keep token entry mode (`sent=1`) instead of resetting flow,
+  - resend form now sends `resend=1` marker,
+  - added helper + unit tests for resend/cooldown decision rules.
+  - validation:
+    - `npm run lint`,
+    - `npm run typecheck` (after clearing stale `.next` from previous branch context),
+    - `npm run test:unit`,
+    - `npm run build`.
+  - next step: checkpoint commit + push, then open PR.

--- a/lib/auth/sign-in-request.ts
+++ b/lib/auth/sign-in-request.ts
@@ -1,0 +1,10 @@
+export function isResendRequestFlag(value: unknown): boolean {
+  return typeof value === "string" && value === "1";
+}
+
+export function shouldApplyMagicLinkCooldown(
+  activeCooldownMs: number,
+  isResendRequest: boolean
+): boolean {
+  return isResendRequest && activeCooldownMs > 0;
+}

--- a/tests/unit/sign-in-request.test.ts
+++ b/tests/unit/sign-in-request.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { isResendRequestFlag, shouldApplyMagicLinkCooldown } from "@/lib/auth/sign-in-request";
+
+describe("sign-in request flow helpers", () => {
+  it("treats resend as explicit opt-in flag", () => {
+    expect(isResendRequestFlag("1")).toBe(true);
+    expect(isResendRequestFlag("0")).toBe(false);
+    expect(isResendRequestFlag(undefined)).toBe(false);
+    expect(isResendRequestFlag(null)).toBe(false);
+  });
+
+  it("applies cooldown only for resend requests", () => {
+    expect(shouldApplyMagicLinkCooldown(30_000, true)).toBe(true);
+    expect(shouldApplyMagicLinkCooldown(30_000, false)).toBe(false);
+    expect(shouldApplyMagicLinkCooldown(0, true)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- What changed and why?

## Scope

- In scope:
- Out of scope:

## Risk

- Main risk:
- Rollback plan:

## Test Evidence

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
