### PR TITLE
fix(library): resolve continue-card hydration mismatch

### DIFF
--- a/components/my-library/ContinueCourseCard.tsx
+++ b/components/my-library/ContinueCourseCard.tsx
@@ -1,33 +1,25 @@
 "use client";
 
-import { useState } from "react";
+import { useSyncExternalStore } from "react";
 import Link from "next/link";
 import { buildCourseContinueHref, COURSE_LAST_LESSON_STORAGE_KEY } from "@/lib/course/resume";
 import { sendClientAnalyticsEvent } from "@/lib/analytics/client";
 
-type ResumeState = {
-  continueHref: string;
-  hasSavedProgress: boolean;
-};
+const EMPTY_SUBSCRIBE = () => () => {};
 
-function getInitialResumeState(): ResumeState {
-  if (typeof window === "undefined") {
-    return { continueHref: "/course", hasSavedProgress: false };
-  }
-
+function getLastLessonSnapshot(): string {
   try {
     const lastLessonId = localStorage.getItem(COURSE_LAST_LESSON_STORAGE_KEY);
-    return {
-      continueHref: buildCourseContinueHref(lastLessonId),
-      hasSavedProgress: Boolean(lastLessonId && lastLessonId.trim().length > 0),
-    };
+    return lastLessonId?.trim() ?? "";
   } catch {
-    return { continueHref: "/course", hasSavedProgress: false };
+    return "";
   }
 }
 
 export default function ContinueCourseCard() {
-  const [{ continueHref, hasSavedProgress }] = useState<ResumeState>(getInitialResumeState);
+  const lastLessonId = useSyncExternalStore(EMPTY_SUBSCRIBE, getLastLessonSnapshot, () => "");
+  const hasSavedProgress = lastLessonId.length > 0;
+  const continueHref = buildCourseContinueHref(lastLessonId);
 
   function onResumeClick() {
     void sendClientAnalyticsEvent("resume_clicked", {

--- a/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
+++ b/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
@@ -929,6 +929,16 @@ At each phase:
 
 ## Implementation Checkpoint Log (In Progress)
 
+- `2026-02-18` | `working tree` | QA regression fix for `My Library` hydration + desktop install-entry test stability:
+  - fixed hydration mismatch in `Continue Free Course` card by using SSR-safe external-store snapshot for local lesson resume state:
+    - `components/my-library/ContinueCourseCard.tsx`.
+  - added unit coverage for default vs saved-resume rendering and analytics payload:
+    - `tests/unit/continue-course-card.test.tsx`.
+  - hardened desktop/tablet install-entry E2E locator against course suspense fallback/header overlap:
+    - `tests/e2e/install-entry-desktop-tablet.spec.ts`.
+  - validation run completed:
+    - `npm run verify`.
+  - next step: continue manual QA checklist (cross-device resume + owned-item preview/download/re-download + trust/ops checks).
 - `2026-02-18` | `working tree` | owned-item detail fallback + recovery UX completed:
   - removed placeholder-only fallback in owned-item action mapping:
     - `lib/commerce/library-item-actions.ts`.

--- a/tests/e2e/install-entry-desktop-tablet.spec.ts
+++ b/tests/e2e/install-entry-desktop-tablet.spec.ts
@@ -11,7 +11,9 @@ test("main menu exposes install action on desktop and tablet layouts", async ({
 
   await page.goto("/course?lesson=mod3-l1");
 
-  const menuToggle = page.getByTestId("header-menu-toggle");
+  // Course route can briefly render suspense fallback header before the final course header.
+  // Target the course-specific toggle label to avoid strict-mode locator collisions.
+  const menuToggle = page.getByRole("button", { name: "Toggle lessons", exact: true });
   await expect(menuToggle).toBeVisible();
   await menuToggle.click();
 

--- a/tests/unit/continue-course-card.test.tsx
+++ b/tests/unit/continue-course-card.test.tsx
@@ -1,0 +1,81 @@
+import type React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ContinueCourseCard from "@/components/my-library/ContinueCourseCard";
+import { sendClientAnalyticsEvent } from "@/lib/analytics/client";
+import { COURSE_LAST_LESSON_STORAGE_KEY } from "@/lib/course/resume";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/lib/analytics/client", () => ({
+  sendClientAnalyticsEvent: vi.fn(),
+}));
+
+describe("ContinueCourseCard", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("shows start state when no saved lesson exists", () => {
+    render(<ContinueCourseCard />);
+
+    expect(
+      screen.getByText(
+        "Start the free course and your lesson progress will be saved on this device."
+      )
+    ).toBeInTheDocument();
+
+    const link = screen.getByRole("link", { name: "Start free course" });
+    expect(link).toHaveAttribute("href", "/course");
+
+    fireEvent.click(link);
+
+    expect(sendClientAnalyticsEvent).toHaveBeenCalledWith("resume_clicked", {
+      hasSavedProgress: false,
+      destination: "/course",
+    });
+  });
+
+  it("hydrates saved lesson state from localStorage after mount", async () => {
+    localStorage.setItem(COURSE_LAST_LESSON_STORAGE_KEY, "mod1-l2");
+
+    render(<ContinueCourseCard />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: "Continue course" })).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("We saved your latest lesson on this device. Continue where you left off.")
+    ).toBeInTheDocument();
+
+    const link = screen.getByRole("link", { name: "Continue course" });
+    expect(link).toHaveAttribute("href", "/course?lesson=mod1-l2");
+
+    fireEvent.click(link);
+
+    expect(sendClientAnalyticsEvent).toHaveBeenCalledWith("resume_clicked", {
+      hasSavedProgress: true,
+      destination: "/course?lesson=mod1-l2",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- What changed and why?

## Scope

- In scope:
- Out of scope:

## Risk

- Main risk:
- Rollback plan:

## Test Evidence

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
