### PR TITLE
docs(task-brief): auto-open manual QA URLs in Safari

### DIFF
--- a/docs/task-brief-template.md
+++ b/docs/task-brief-template.md
@@ -173,8 +173,8 @@ Define when and how branch cleanup is executed so repository hygiene is consiste
 Define the default browser for PR handoff links so collaboration is consistent.
 
 - Default:
-  - open PR create/review/merge URLs in Safari:
-    - `open -a Safari "<PR_URL>"`
+  - open PR create/review/merge URLs in Safari as active foreground tab/window:
+    - `osascript -e 'tell application "Safari" to activate' -e 'tell application "Safari" to open location "<PR_URL>"'`
 - Exception:
   - use another browser only when owner explicitly requests it.
 
@@ -183,8 +183,8 @@ Define the default browser for PR handoff links so collaboration is consistent.
 Define how manual QA URLs are handled so owner flow is low-friction.
 
 - Default:
-  - for each manual QA step that requires opening a page, assistant opens the exact URL in Safari first:
-    - `open -a Safari "<QA_URL>"`
+  - for each manual QA step that requires opening a page, assistant opens the exact URL in Safari as active foreground tab/window:
+    - `osascript -e 'tell application "Safari" to activate' -e 'tell application "Safari" to open location "<QA_URL>"'`
   - then assistant asks owner to validate the concrete expected outcome and reply `done`.
 - Exception:
   - do not auto-open only if owner explicitly asks to open manually or use another browser.

--- a/docs/task-brief-template.md
+++ b/docs/task-brief-template.md
@@ -16,6 +16,7 @@ Use this quick check so the task execution is precise:
 - State git rhythm defaults (commit/push cadence and PR cut cadence to `main`)
 - State branch hygiene cadence (post-merge cleanup + stale-branch sweep frequency)
 - State PR browser rule (open PR/merge links in Safari by default unless owner requests otherwise)
+- State manual QA link rule (assistant opens each QA URL in Safari before asking for `done`)
 - State closeout gate (completion audit + final 10/10 quality/safety/perf/regression sweep + move/cleanup prompts)
 
 Suggested prompt wrapper:
@@ -24,6 +25,7 @@ Suggested prompt wrapper:
 Use task brief: <PATH_TO_BRIEF>
 Mode: end-to-end (implement + tests + commit + push on current branch)
 Communication: one manual step at a time; wait for my "done" between manual GitHub/UI steps.
+Manual QA links: open each URL in Safari for me before asking for "done".
 Git rhythm: commit + push each validated step; ask me before opening/updating PR to main.
 Handoff must include:
 
@@ -175,6 +177,17 @@ Define the default browser for PR handoff links so collaboration is consistent.
     - `open -a Safari "<PR_URL>"`
 - Exception:
   - use another browser only when owner explicitly requests it.
+
+## Manual QA URL Rule (Required)
+
+Define how manual QA URLs are handled so owner flow is low-friction.
+
+- Default:
+  - for each manual QA step that requires opening a page, assistant opens the exact URL in Safari first:
+    - `open -a Safari "<QA_URL>"`
+  - then assistant asks owner to validate the concrete expected outcome and reply `done`.
+- Exception:
+  - do not auto-open only if owner explicitly asks to open manually or use another browser.
 
 ## Implementation Checkpoint Log (Required For In-Progress Briefs)
 

--- a/docs/task-briefs/README.md
+++ b/docs/task-briefs/README.md
@@ -94,7 +94,7 @@ Use this cadence to keep repository branches clean and predictable:
 Use one browser default for PR handoff links to reduce friction:
 
 - open PR create/review/merge URLs in Safari by default:
-  - `open -a Safari "<PR_URL>"`
+  - `osascript -e 'tell application "Safari" to activate' -e 'tell application "Safari" to open location "<PR_URL>"'`
 - only use another browser if owner explicitly requests it.
 
 ## Manual QA URL Rule
@@ -102,6 +102,6 @@ Use one browser default for PR handoff links to reduce friction:
 For manual QA steps, reduce owner copy/paste work:
 
 - assistant should open each QA URL in Safari before asking for `done`:
-  - `open -a Safari "<QA_URL>"`
+  - `osascript -e 'tell application "Safari" to activate' -e 'tell application "Safari" to open location "<QA_URL>"'`
 - then ask for one concrete validation result per step.
 - only skip auto-open when owner explicitly asks to open URLs manually or use another browser.

--- a/docs/task-briefs/README.md
+++ b/docs/task-briefs/README.md
@@ -96,3 +96,12 @@ Use one browser default for PR handoff links to reduce friction:
 - open PR create/review/merge URLs in Safari by default:
   - `open -a Safari "<PR_URL>"`
 - only use another browser if owner explicitly requests it.
+
+## Manual QA URL Rule
+
+For manual QA steps, reduce owner copy/paste work:
+
+- assistant should open each QA URL in Safari before asking for `done`:
+  - `open -a Safari "<QA_URL>"`
+- then ask for one concrete validation result per step.
+- only skip auto-open when owner explicitly asks to open URLs manually or use another browser.

--- a/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
+++ b/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
@@ -914,6 +914,13 @@ At each phase:
   - `open -a Safari "<PR_URL>"`
 - Use another browser only if the owner explicitly asks for it.
 
+### Manual QA URL Rule (Locked For This Brief)
+
+- For each manual QA step requiring a page open:
+  - assistant opens the URL in Safari first (`open -a Safari "<QA_URL>"`),
+  - then asks for one concrete validation and waits for owner `done`.
+- Only skip auto-open if owner explicitly asks to open manually or use another browser.
+
 ### Final Closeout Gate (Locked For This Brief)
 
 - Before moving this brief to `done`, run a final completion audit:

--- a/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
+++ b/docs/task-briefs/in-progress/2026-02-15-my-library-commerce-and-progress-sync.md
@@ -910,14 +910,15 @@ At each phase:
 
 ### PR Browser Rule (Locked For This Brief)
 
-- Open PR create/review/merge links in Safari by default:
-  - `open -a Safari "<PR_URL>"`
+- Open PR create/review/merge links in Safari as active foreground tab/window:
+  - `osascript -e 'tell application "Safari" to activate' -e 'tell application "Safari" to open location "<PR_URL>"'`
 - Use another browser only if the owner explicitly asks for it.
 
 ### Manual QA URL Rule (Locked For This Brief)
 
 - For each manual QA step requiring a page open:
-  - assistant opens the URL in Safari first (`open -a Safari "<QA_URL>"`),
+  - assistant opens the URL in Safari as active foreground tab/window first:
+    - `osascript -e 'tell application "Safari" to activate' -e 'tell application "Safari" to open location "<QA_URL>"'`,
   - then asks for one concrete validation and waits for owner `done`.
 - Only skip auto-open if owner explicitly asks to open manually or use another browser.
 


### PR DESCRIPTION
## Summary

- What changed and why?

## Scope

- In scope:
- Out of scope:

## Risk

- Main risk:
- Rollback plan:

## Test Evidence

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
