### PR TITLE
feat(admin): persist profile roles and use db-backed gate

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
 import SiteChrome from "@/components/SiteChrome";
-import { resolveAdminRoleForUser } from "@/lib/admin/access";
+import { isAdminRoleColumnMissingError, resolveAdminRoleForUser } from "@/lib/admin/access";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 
 type AdminLayoutProps = {
@@ -21,7 +21,23 @@ export default async function AdminLayout({ children }: AdminLayoutProps) {
     redirect("/auth/sign-in?next=%2Fadmin");
   }
 
+  let profileRole: string | null = null;
+  const profileRoleResult = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (profileRoleResult.error) {
+    if (!isAdminRoleColumnMissingError(profileRoleResult.error)) {
+      console.error("[Admin] Could not load admin role from profile", profileRoleResult.error);
+    }
+  } else {
+    profileRole = profileRoleResult.data?.role ?? null;
+  }
+
   const role = resolveAdminRoleForUser(user, {
+    profileRole,
     allowlistedEmailsRaw: process.env.ADMIN_EMAIL_ALLOWLIST,
   });
 

--- a/docs/task-briefs/in-progress/2026-02-18-admin-foundation-content-commerce-ops.md
+++ b/docs/task-briefs/in-progress/2026-02-18-admin-foundation-content-commerce-ops.md
@@ -171,6 +171,22 @@ Owner should be able to manage lessons, guides, products, and operational states
   - added env docs for bootstrap allowlist:
     - `.env.example` (`ADMIN_EMAIL_ALLOWLIST`).
   - next step: validate this slice (`lint`, `typecheck`, targeted unit), then implement role persistence model in DB (`profiles` role column + RLS-safe usage).
+- `2026-02-18` | `working tree` | admin foundation slice 2 implemented (role persistence model):
+  - added migration for persisted profile roles:
+    - `supabase/migrations/20260218230000_admin_profiles_role.sql`:
+      - `public.admin_role` enum (`admin`, `editor`, `viewer`),
+      - `public.profiles.role` column with default `viewer`,
+      - index on `profiles.role`.
+  - updated typed DB contract:
+    - `types/database.ts` (`profiles.role` + `Enums.admin_role`).
+  - admin gate now reads role from `profiles.role` (RLS-safe own-row read) with fallback to metadata/allowlist:
+    - `app/admin/layout.tsx`,
+    - `lib/admin/access.ts`.
+  - added resilience for schema-cache lag during rollout:
+    - `isAdminRoleColumnMissingError` fallback path.
+  - expanded unit coverage:
+    - `tests/unit/admin-access.test.ts` (profile-role precedence + missing-column detection).
+  - next step: validate slice 2 and implement first admin content model table + CRUD API scaffold.
 
 ## Completion Record (fill when done)
 

--- a/lib/admin/access.ts
+++ b/lib/admin/access.ts
@@ -4,6 +4,13 @@ export const ADMIN_ROLE_VALUES = ["admin", "editor", "viewer"] as const;
 
 export type AdminRole = (typeof ADMIN_ROLE_VALUES)[number];
 
+type RoleLookupError = {
+  code?: string;
+  message?: string;
+  details?: string;
+  hint?: string;
+} | null;
+
 function normalizeRole(value: unknown): AdminRole | null {
   if (typeof value !== "string") return null;
   const normalized = value.trim().toLowerCase();
@@ -31,9 +38,13 @@ export function isAdminEmailAllowlisted(email: string | null | undefined, raw: s
 export function resolveAdminRoleForUser(
   user: Pick<User, "email" | "app_metadata">,
   options?: {
+    profileRole?: unknown;
     allowlistedEmailsRaw?: string | undefined;
   }
 ): AdminRole | null {
+  const profileRole = normalizeRole(options?.profileRole);
+  if (profileRole) return profileRole;
+
   const claimRole = normalizeRole(user.app_metadata?.admin_role ?? user.app_metadata?.role);
   if (claimRole) return claimRole;
 
@@ -42,4 +53,12 @@ export function resolveAdminRoleForUser(
   }
 
   return null;
+}
+
+export function isAdminRoleColumnMissingError(error: RoleLookupError): boolean {
+  if (!error) return false;
+  if (error.code === "PGRST204") return true;
+  const combined =
+    `${error.message ?? ""} ${error.details ?? ""} ${error.hint ?? ""}`.toLowerCase();
+  return combined.includes("role") && combined.includes("profiles");
 }

--- a/supabase/migrations/20260218230000_admin_profiles_role.sql
+++ b/supabase/migrations/20260218230000_admin_profiles_role.sql
@@ -1,0 +1,20 @@
+-- Admin foundation: persist profile role for server-side authorization.
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_type t
+    join pg_namespace n on n.oid = t.typnamespace
+    where t.typname = 'admin_role' and n.nspname = 'public'
+  ) then
+    create type public.admin_role as enum ('admin', 'editor', 'viewer');
+  end if;
+end
+$$;
+
+alter table public.profiles
+  add column if not exists role public.admin_role not null default 'viewer';
+
+create index if not exists profiles_role_idx
+  on public.profiles (role);

--- a/tests/unit/admin-access.test.ts
+++ b/tests/unit/admin-access.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   isAdminEmailAllowlisted,
+  isAdminRoleColumnMissingError,
   parseAdminEmailAllowlist,
   resolveAdminRoleForUser,
 } from "@/lib/admin/access";
@@ -18,6 +19,17 @@ describe("admin access helpers", () => {
       app_metadata: { admin_role: "editor" },
     } as never);
     expect(role).toBe("editor");
+  });
+
+  it("prefers profile role over metadata claim", () => {
+    const role = resolveAdminRoleForUser(
+      {
+        email: "user@freeswimming.org",
+        app_metadata: { admin_role: "viewer" },
+      } as never,
+      { profileRole: "admin" }
+    );
+    expect(role).toBe("admin");
   });
 
   it("falls back to allowlist email as admin", () => {
@@ -48,6 +60,15 @@ describe("admin access helpers", () => {
         "Owner@FreeSwimming.org",
         "owner@freeswimming.org,ops@freeswimming.org"
       )
+    ).toBe(true);
+  });
+
+  it("detects missing role-column errors from postgrest", () => {
+    expect(
+      isAdminRoleColumnMissingError({
+        code: "PGRST204",
+        message: "Could not find the 'role' column of 'profiles' in the schema cache",
+      })
     ).toBe(true);
   });
 });

--- a/types/database.ts
+++ b/types/database.ts
@@ -296,18 +296,21 @@ export type Database = {
           created_at: string;
           email: string;
           id: string;
+          role: Database["public"]["Enums"]["admin_role"];
           updated_at: string;
         };
         Insert: {
           created_at?: string;
           email: string;
           id: string;
+          role?: Database["public"]["Enums"]["admin_role"];
           updated_at?: string;
         };
         Update: {
           created_at?: string;
           email?: string;
           id?: string;
+          role?: Database["public"]["Enums"]["admin_role"];
           updated_at?: string;
         };
         Relationships: [];
@@ -323,7 +326,7 @@ export type Database = {
       };
     };
     Enums: {
-      [_ in never]: never;
+      admin_role: "admin" | "editor" | "viewer";
     };
     CompositeTypes: {
       [_ in never]: never;


### PR DESCRIPTION
## Summary

- What changed and why?

## Scope

- In scope:
- Out of scope:

## Risk

- Main risk:
- Rollback plan:

## Test Evidence

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
