### PR TITLE
feat(admin): add content CRUD scaffold with role-gated API

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
 import SiteChrome from "@/components/SiteChrome";
-import { isAdminRoleColumnMissingError, resolveAdminRoleForUser } from "@/lib/admin/access";
+import { requireAdminRoleFromSupabase } from "@/lib/admin/server";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 
 type AdminLayoutProps = {
@@ -13,35 +13,16 @@ export const dynamic = "force-dynamic";
 
 export default async function AdminLayout({ children }: AdminLayoutProps) {
   const supabase = await createServerSupabaseClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const gate = await requireAdminRoleFromSupabase(supabase, {
+    allowlistedEmailsRaw: process.env.ADMIN_EMAIL_ALLOWLIST,
+    minimumRole: "viewer",
+  });
 
-  if (!user) {
+  if (!gate.ok && gate.status === 401) {
     redirect("/auth/sign-in?next=%2Fadmin");
   }
 
-  let profileRole: string | null = null;
-  const profileRoleResult = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .maybeSingle();
-
-  if (profileRoleResult.error) {
-    if (!isAdminRoleColumnMissingError(profileRoleResult.error)) {
-      console.error("[Admin] Could not load admin role from profile", profileRoleResult.error);
-    }
-  } else {
-    profileRole = profileRoleResult.data?.role ?? null;
-  }
-
-  const role = resolveAdminRoleForUser(user, {
-    profileRole,
-    allowlistedEmailsRaw: process.env.ADMIN_EMAIL_ALLOWLIST,
-  });
-
-  if (!role) {
+  if (!gate.ok) {
     return (
       <SiteChrome>
         <section className="mx-auto min-h-screen w-full max-w-[980px] px-6 pb-20 pt-28">
@@ -67,6 +48,8 @@ export default async function AdminLayout({ children }: AdminLayoutProps) {
       </SiteChrome>
     );
   }
+
+  const { role } = gate;
 
   return (
     <SiteChrome>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,25 +1,5 @@
+import AdminContentManager from "@/components/admin/AdminContentManager";
+
 export default function AdminPage() {
-  return (
-    <section className="rounded-2xl border border-slate-200 bg-white p-6">
-      <h2 className="text-lg font-semibold text-slate-900">Foundation ready</h2>
-      <p className="mt-2 max-w-[64ch] text-sm text-slate-700">
-        Next slices will add content and commerce modules with draft/publish workflows, validation,
-        and audit logging.
-      </p>
-      <div className="mt-5 grid gap-3 sm:grid-cols-3">
-        <article className="rounded-xl border border-slate-200 bg-slate-50/70 p-4">
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-700">Content</p>
-          <p className="mt-2 text-sm text-slate-700">Modules, lessons, guides, publish state.</p>
-        </article>
-        <article className="rounded-xl border border-slate-200 bg-slate-50/70 p-4">
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-700">Commerce</p>
-          <p className="mt-2 text-sm text-slate-700">Product metadata and active/inactive state.</p>
-        </article>
-        <article className="rounded-xl border border-slate-200 bg-slate-50/70 p-4">
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-700">Operations</p>
-          <p className="mt-2 text-sm text-slate-700">Site lock and runtime support controls.</p>
-        </article>
-      </div>
-    </section>
-  );
+  return <AdminContentManager />;
 }

--- a/app/api/admin/content/route.ts
+++ b/app/api/admin/content/route.ts
@@ -1,0 +1,189 @@
+import { NextResponse } from "next/server";
+import { parseCreateAdminContentPayload } from "@/lib/admin/content";
+import { requireAdminRoleFromSupabase } from "@/lib/admin/server";
+import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
+import type { Database } from "@/types/database";
+
+function noStoreJson(
+  body: Record<string, unknown>,
+  init?: {
+    status?: number;
+  }
+) {
+  return NextResponse.json(body, {
+    status: init?.status ?? 200,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export async function GET() {
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+  const gate = await requireAdminRoleFromSupabase(supabase, {
+    allowlistedEmailsRaw: process.env.ADMIN_EMAIL_ALLOWLIST,
+    minimumRole: "viewer",
+  });
+
+  if (!gate.ok) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: gate.error }, { status: gate.status })
+    );
+  }
+
+  const result = await supabase
+    .from("admin_content_items")
+    .select(
+      `
+      id,
+      content_type,
+      parent_id,
+      slug,
+      title,
+      summary,
+      body,
+      sort_order,
+      status,
+      published_at,
+      created_by,
+      updated_by,
+      created_at,
+      updated_at
+    `
+    )
+    .order("sort_order", { ascending: true })
+    .order("created_at", { ascending: true })
+    .limit(250);
+
+  if (result.error) {
+    console.error("[AdminContent] Could not load content items", result.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not load admin content right now." }, { status: 500 })
+    );
+  }
+
+  return applySupabaseCookies(
+    noStoreJson({
+      ok: true,
+      items: result.data ?? [],
+    })
+  );
+}
+
+export async function POST(request: Request) {
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+  const gate = await requireAdminRoleFromSupabase(supabase, {
+    allowlistedEmailsRaw: process.env.ADMIN_EMAIL_ALLOWLIST,
+    minimumRole: "editor",
+  });
+
+  if (!gate.ok) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: gate.error }, { status: gate.status })
+    );
+  }
+
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Unsupported content type." }, { status: 415 })
+    );
+  }
+
+  let payload: unknown = null;
+  try {
+    payload = await request.json();
+  } catch {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Invalid JSON." }, { status: 400 })
+    );
+  }
+
+  const parsed = parseCreateAdminContentPayload((payload ?? {}) as Record<string, unknown>);
+  if (!parsed.ok) {
+    return applySupabaseCookies(noStoreJson({ ok: false, error: parsed.error }, { status: 400 }));
+  }
+
+  if (parsed.value.parentId) {
+    const parentResult = await supabase
+      .from("admin_content_items")
+      .select("id")
+      .eq("id", parsed.value.parentId)
+      .maybeSingle();
+
+    if (parentResult.error) {
+      console.error("[AdminContent] Could not validate parent item", parentResult.error);
+      return applySupabaseCookies(
+        noStoreJson({ ok: false, error: "Could not validate parent content." }, { status: 500 })
+      );
+    }
+
+    if (!parentResult.data) {
+      return applySupabaseCookies(
+        noStoreJson({ ok: false, error: "Parent content item not found." }, { status: 400 })
+      );
+    }
+  }
+
+  const insertResult = await supabase
+    .from("admin_content_items")
+    .insert({
+      content_type: parsed.value.contentType,
+      parent_id: parsed.value.parentId,
+      slug: parsed.value.slug,
+      title: parsed.value.title,
+      summary: parsed.value.summary,
+      body: parsed.value
+        .body as Database["public"]["Tables"]["admin_content_items"]["Insert"]["body"],
+      sort_order: parsed.value.sortOrder,
+      status: parsed.value.status,
+      published_at: parsed.value.status === "published" ? new Date().toISOString() : null,
+      created_by: gate.user.id,
+      updated_by: gate.user.id,
+    })
+    .select(
+      `
+      id,
+      content_type,
+      parent_id,
+      slug,
+      title,
+      summary,
+      body,
+      sort_order,
+      status,
+      published_at,
+      created_by,
+      updated_by,
+      created_at,
+      updated_at
+    `
+    )
+    .single();
+
+  if (insertResult.error || !insertResult.data) {
+    if (insertResult.error?.code === "23505") {
+      return applySupabaseCookies(
+        noStoreJson(
+          { ok: false, error: "Slug already exists. Choose a unique slug." },
+          { status: 409 }
+        )
+      );
+    }
+
+    console.error("[AdminContent] Could not create content item", insertResult.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not create content item right now." }, { status: 500 })
+    );
+  }
+
+  return applySupabaseCookies(
+    noStoreJson(
+      {
+        ok: true,
+        item: insertResult.data,
+      },
+      { status: 201 }
+    )
+  );
+}

--- a/components/admin/AdminContentManager.tsx
+++ b/components/admin/AdminContentManager.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { AdminContentItemRow, AdminContentType } from "@/lib/admin/content";
+
+const CONTENT_TYPE_OPTIONS: Array<{ value: AdminContentType; label: string }> = [
+  { value: "course_module", label: "Course module" },
+  { value: "course_lesson", label: "Course lesson" },
+  { value: "guide_session", label: "Guide session" },
+  { value: "guide_drill", label: "Guide drill" },
+];
+
+type AdminContentListResponse =
+  | {
+      ok: true;
+      items: AdminContentItemRow[];
+    }
+  | {
+      ok: false;
+      error?: string;
+    };
+
+type AdminContentCreateResponse =
+  | {
+      ok: true;
+      item: AdminContentItemRow;
+    }
+  | {
+      ok: false;
+      error?: string;
+    };
+
+type FormState = {
+  contentType: AdminContentType;
+  title: string;
+  slug: string;
+  summary: string;
+  status: "draft" | "published";
+};
+
+const INITIAL_FORM: FormState = {
+  contentType: "course_module",
+  title: "",
+  slug: "",
+  summary: "",
+  status: "draft",
+};
+
+export default function AdminContentManager() {
+  const [items, setItems] = useState<AdminContentItemRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [formState, setFormState] = useState<FormState>(INITIAL_FORM);
+  const [submitting, setSubmitting] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  async function loadItems() {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/admin/content", {
+        method: "GET",
+        credentials: "same-origin",
+        cache: "no-store",
+      });
+      const payload = (await response.json()) as AdminContentListResponse;
+      if (!response.ok || !payload.ok) {
+        setError(
+          payload.ok
+            ? "Could not load content list."
+            : (payload.error ?? "Could not load content list.")
+        );
+        setItems([]);
+        return;
+      }
+      setItems(payload.items);
+    } catch {
+      setError("Could not load content list.");
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadItems();
+  }, []);
+
+  const groupedCountLabel = useMemo(() => {
+    if (items.length === 0) return "No content items yet.";
+    return `${items.length} content item${items.length === 1 ? "" : "s"} in admin catalog.`;
+  }, [items]);
+
+  async function handleCreate(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
+    setActionError(null);
+
+    try {
+      const response = await fetch("/api/admin/content", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        credentials: "same-origin",
+        body: JSON.stringify({
+          contentType: formState.contentType,
+          title: formState.title,
+          slug: formState.slug,
+          summary: formState.summary,
+          status: formState.status,
+        }),
+      });
+
+      const payload = (await response.json()) as AdminContentCreateResponse;
+      if (!response.ok || !payload.ok) {
+        setActionError(
+          payload.ok
+            ? "Could not create content item."
+            : (payload.error ?? "Could not create content item.")
+        );
+        return;
+      }
+
+      setItems((prev) => [payload.item, ...prev]);
+      setFormState(INITIAL_FORM);
+    } catch {
+      setActionError("Could not create content item.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-2xl border border-slate-200 bg-white p-6">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Content items</h2>
+            <p className="mt-2 text-sm text-slate-600">{groupedCountLabel}</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void loadItems()}
+            className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+          >
+            Refresh
+          </button>
+        </div>
+
+        {loading ? (
+          <p className="mt-5 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+            Loading content list…
+          </p>
+        ) : null}
+
+        {!loading && error ? (
+          <div className="mt-5 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3">
+            <p className="text-sm font-medium text-rose-700">{error}</p>
+            <button
+              type="button"
+              onClick={() => void loadItems()}
+              className="mt-3 inline-flex h-9 items-center justify-center rounded-lg border border-rose-200 bg-white px-3 text-sm font-medium text-rose-700 transition hover:bg-rose-50"
+            >
+              Retry
+            </button>
+          </div>
+        ) : null}
+
+        {!loading && !error && items.length === 0 ? (
+          <p className="mt-5 rounded-xl border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+            No content items created yet. Use the form below to create your first draft.
+          </p>
+        ) : null}
+
+        {!loading && !error && items.length > 0 ? (
+          <ul className="mt-5 space-y-2">
+            {items.map((item) => (
+              <li
+                key={item.id}
+                className="rounded-xl border border-slate-200 bg-slate-50/70 px-4 py-3 text-sm text-slate-700"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="font-semibold text-slate-900">{item.title}</p>
+                    <p className="mt-1 text-xs text-slate-500">
+                      {item.content_type} · {item.status} · /{item.slug}
+                    </p>
+                  </div>
+                  <span className="text-xs text-slate-500">Order: {item.sort_order}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-6">
+        <h2 className="text-lg font-semibold text-slate-900">Create content item</h2>
+        <p className="mt-2 text-sm text-slate-600">
+          This scaffold creates draft/published content records for future lesson and guide editors.
+        </p>
+        <form className="mt-5 grid gap-4 sm:grid-cols-2" onSubmit={handleCreate}>
+          <label className="space-y-1 text-sm font-medium text-slate-700">
+            <span>Type</span>
+            <select
+              value={formState.contentType}
+              onChange={(e) =>
+                setFormState((prev) => ({
+                  ...prev,
+                  contentType: e.target.value as AdminContentType,
+                }))
+              }
+              className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+            >
+              {CONTENT_TYPE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="space-y-1 text-sm font-medium text-slate-700">
+            <span>Status</span>
+            <select
+              value={formState.status}
+              onChange={(e) =>
+                setFormState((prev) => ({
+                  ...prev,
+                  status: e.target.value as "draft" | "published",
+                }))
+              }
+              className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+            >
+              <option value="draft">Draft</option>
+              <option value="published">Published</option>
+            </select>
+          </label>
+
+          <label className="space-y-1 text-sm font-medium text-slate-700 sm:col-span-2">
+            <span>Title</span>
+            <input
+              type="text"
+              required
+              value={formState.title}
+              onChange={(e) =>
+                setFormState((prev) => ({
+                  ...prev,
+                  title: e.target.value,
+                }))
+              }
+              className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+              placeholder="Module 1 foundations"
+            />
+          </label>
+
+          <label className="space-y-1 text-sm font-medium text-slate-700 sm:col-span-2">
+            <span>Slug (optional)</span>
+            <input
+              type="text"
+              value={formState.slug}
+              onChange={(e) =>
+                setFormState((prev) => ({
+                  ...prev,
+                  slug: e.target.value,
+                }))
+              }
+              className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+              placeholder="module-1-foundations"
+            />
+          </label>
+
+          <label className="space-y-1 text-sm font-medium text-slate-700 sm:col-span-2">
+            <span>Summary</span>
+            <textarea
+              rows={3}
+              value={formState.summary}
+              onChange={(e) =>
+                setFormState((prev) => ({
+                  ...prev,
+                  summary: e.target.value,
+                }))
+              }
+              className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
+              placeholder="Short purpose or editor note."
+            />
+          </label>
+
+          {actionError ? (
+            <p className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700 sm:col-span-2">
+              {actionError}
+            </p>
+          ) : null}
+
+          <div className="sm:col-span-2">
+            <button
+              type="submit"
+              disabled={submitting}
+              className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+            >
+              {submitting ? "Saving…" : "Save content item"}
+            </button>
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/docs/task-briefs/in-progress/2026-02-18-admin-foundation-content-commerce-ops.md
+++ b/docs/task-briefs/in-progress/2026-02-18-admin-foundation-content-commerce-ops.md
@@ -207,6 +207,12 @@ Owner should be able to manage lessons, guides, products, and operational states
   - added unit coverage:
     - `tests/unit/admin-content.test.ts`.
   - next step: run validation and ship this slice, then add `PATCH/DELETE` endpoints + audit log table.
+- `2026-02-18` | `working tree` | CodeQL security hotfix for slice 3:
+  - removed regex-based slug sanitizer flagged by `js/polynomial-redos`:
+    - `lib/admin/content.ts` now uses linear char-by-char slug normalization.
+  - expanded unit coverage for slug normalization behavior:
+    - `tests/unit/admin-content.test.ts`.
+  - next step: push fix and re-run CI/CodeQL on PR `feat/admin-content-crud-scaffold`.
 
 ## Completion Record (fill when done)
 

--- a/docs/task-briefs/in-progress/2026-02-18-admin-foundation-content-commerce-ops.md
+++ b/docs/task-briefs/in-progress/2026-02-18-admin-foundation-content-commerce-ops.md
@@ -207,12 +207,12 @@ Owner should be able to manage lessons, guides, products, and operational states
   - added unit coverage:
     - `tests/unit/admin-content.test.ts`.
   - next step: run validation and ship this slice, then add `PATCH/DELETE` endpoints + audit log table.
-- `2026-02-18` | `working tree` | CodeQL security hotfix for slice 3:
+- `2026-02-18` | `e46c6ce` | CodeQL security hotfix for slice 3:
   - removed regex-based slug sanitizer flagged by `js/polynomial-redos`:
     - `lib/admin/content.ts` now uses linear char-by-char slug normalization.
   - expanded unit coverage for slug normalization behavior:
     - `tests/unit/admin-content.test.ts`.
-  - next step: push fix and re-run CI/CodeQL on PR `feat/admin-content-crud-scaffold`.
+  - next step: re-run CI/CodeQL on PR `feat/admin-content-crud-scaffold` and merge if green.
 
 ## Completion Record (fill when done)
 

--- a/docs/task-briefs/in-progress/2026-02-18-admin-foundation-content-commerce-ops.md
+++ b/docs/task-briefs/in-progress/2026-02-18-admin-foundation-content-commerce-ops.md
@@ -187,6 +187,26 @@ Owner should be able to manage lessons, guides, products, and operational states
   - expanded unit coverage:
     - `tests/unit/admin-access.test.ts` (profile-role precedence + missing-column detection).
   - next step: validate slice 2 and implement first admin content model table + CRUD API scaffold.
+- `2026-02-18` | `working tree` | admin foundation slice 3 implemented (content CRUD scaffold):
+  - added admin content data model + RLS scaffold:
+    - `supabase/migrations/20260218234500_admin_content_items_scaffold.sql`
+      - enums: `admin_content_type`, `admin_content_status`
+      - table: `admin_content_items` with `draft/published`, ordering, parent linkage, metadata
+      - RLS policies: `viewer+` read, `editor+` create/update, `admin` delete.
+  - updated typed DB contract:
+    - `types/database.ts` (`admin_content_items` + related enums).
+  - added reusable admin server gate helper:
+    - `lib/admin/server.ts` (`requireAdminRoleFromSupabase`).
+  - added admin content payload validation + normalization:
+    - `lib/admin/content.ts`.
+  - added secured API scaffold:
+    - `app/api/admin/content/route.ts` (`GET` list + `POST` create with validation, parent check, slug conflict handling).
+  - replaced admin page placeholder with working manager UI:
+    - `app/admin/page.tsx`,
+    - `components/admin/AdminContentManager.tsx`.
+  - added unit coverage:
+    - `tests/unit/admin-content.test.ts`.
+  - next step: run validation and ship this slice, then add `PATCH/DELETE` endpoints + audit log table.
 
 ## Completion Record (fill when done)
 

--- a/lib/admin/access.ts
+++ b/lib/admin/access.ts
@@ -3,6 +3,7 @@ import type { User } from "@supabase/supabase-js";
 export const ADMIN_ROLE_VALUES = ["admin", "editor", "viewer"] as const;
 
 export type AdminRole = (typeof ADMIN_ROLE_VALUES)[number];
+export type MinimumAdminRole = "admin" | "editor" | "viewer";
 
 type RoleLookupError = {
   code?: string;
@@ -61,4 +62,14 @@ export function isAdminRoleColumnMissingError(error: RoleLookupError): boolean {
   const combined =
     `${error.message ?? ""} ${error.details ?? ""} ${error.hint ?? ""}`.toLowerCase();
   return combined.includes("role") && combined.includes("profiles");
+}
+
+const ADMIN_ROLE_RANK: Record<AdminRole, number> = {
+  viewer: 1,
+  editor: 2,
+  admin: 3,
+};
+
+export function hasRequiredAdminRole(role: AdminRole, minimumRole: MinimumAdminRole): boolean {
+  return ADMIN_ROLE_RANK[role] >= ADMIN_ROLE_RANK[minimumRole];
 }

--- a/lib/admin/content.ts
+++ b/lib/admin/content.ts
@@ -1,0 +1,125 @@
+import type { Database } from "@/types/database";
+
+export const ADMIN_CONTENT_TYPE_VALUES = [
+  "course_module",
+  "course_lesson",
+  "guide_session",
+  "guide_drill",
+] as const;
+
+export const ADMIN_CONTENT_STATUS_VALUES = ["draft", "published"] as const;
+
+export type AdminContentType = (typeof ADMIN_CONTENT_TYPE_VALUES)[number];
+export type AdminContentStatus = (typeof ADMIN_CONTENT_STATUS_VALUES)[number];
+export type AdminContentItemRow = Database["public"]["Tables"]["admin_content_items"]["Row"];
+
+export type CreateAdminContentPayload = {
+  contentType?: unknown;
+  slug?: unknown;
+  title?: unknown;
+  summary?: unknown;
+  body?: unknown;
+  sortOrder?: unknown;
+  status?: unknown;
+  parentId?: unknown;
+};
+
+type CreateAdminContentNormalized = {
+  contentType: AdminContentType;
+  slug: string;
+  title: string;
+  summary: string;
+  body: Record<string, unknown>;
+  sortOrder: number;
+  status: AdminContentStatus;
+  parentId: string | null;
+};
+
+type ParseCreateAdminContentResult =
+  | {
+      ok: true;
+      value: CreateAdminContentNormalized;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function sanitizeSlug(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 120);
+}
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+export function parseCreateAdminContentPayload(
+  payload: CreateAdminContentPayload
+): ParseCreateAdminContentResult {
+  const contentTypeRaw = normalizeString(payload.contentType);
+  if (!ADMIN_CONTENT_TYPE_VALUES.includes(contentTypeRaw as AdminContentType)) {
+    return { ok: false, error: "Invalid content type." };
+  }
+
+  const title = normalizeString(payload.title);
+  if (title.length < 2 || title.length > 120) {
+    return { ok: false, error: "Title must be between 2 and 120 characters." };
+  }
+
+  const slugInput = normalizeString(payload.slug) || title;
+  const slug = sanitizeSlug(slugInput);
+  if (slug.length < 2) {
+    return { ok: false, error: "Slug is too short after normalization." };
+  }
+
+  const summary = normalizeString(payload.summary).slice(0, 500);
+  const body = payload.body;
+  if (body !== undefined && !isPlainObject(body)) {
+    return { ok: false, error: "Body must be a JSON object." };
+  }
+
+  const sortOrderRaw =
+    typeof payload.sortOrder === "number"
+      ? payload.sortOrder
+      : Number.parseInt(String(payload.sortOrder ?? "0"), 10);
+  if (!Number.isFinite(sortOrderRaw) || sortOrderRaw < -10000 || sortOrderRaw > 10000) {
+    return { ok: false, error: "Sort order must be between -10000 and 10000." };
+  }
+  const sortOrder = Math.trunc(sortOrderRaw);
+
+  const statusRaw = normalizeString(payload.status) || "draft";
+  if (!ADMIN_CONTENT_STATUS_VALUES.includes(statusRaw as AdminContentStatus)) {
+    return { ok: false, error: "Invalid publish status." };
+  }
+
+  const parentIdRaw = normalizeString(payload.parentId);
+  if (parentIdRaw && !isUuid(parentIdRaw)) {
+    return { ok: false, error: "parentId must be a valid UUID." };
+  }
+
+  return {
+    ok: true,
+    value: {
+      contentType: contentTypeRaw as AdminContentType,
+      slug,
+      title,
+      summary,
+      body: isPlainObject(body) ? body : {},
+      sortOrder,
+      status: statusRaw as AdminContentStatus,
+      parentId: parentIdRaw || null,
+    },
+  };
+}

--- a/lib/admin/content.ts
+++ b/lib/admin/content.ts
@@ -54,11 +54,31 @@ function normalizeString(value: unknown): string {
 }
 
 function sanitizeSlug(input: string): string {
-  return input
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 120);
+  const lower = input.toLowerCase();
+  const chars: string[] = [];
+  let wroteSeparator = false;
+
+  for (let index = 0; index < lower.length; index += 1) {
+    const code = lower.charCodeAt(index);
+    const isDigit = code >= 48 && code <= 57;
+    const isLetter = code >= 97 && code <= 122;
+    if (isDigit || isLetter) {
+      chars.push(lower[index] ?? "");
+      wroteSeparator = false;
+      continue;
+    }
+
+    if (chars.length > 0 && !wroteSeparator) {
+      chars.push("-");
+      wroteSeparator = true;
+    }
+  }
+
+  while (chars[chars.length - 1] === "-") {
+    chars.pop();
+  }
+
+  return chars.join("").slice(0, 120);
 }
 
 function isUuid(value: string): boolean {

--- a/lib/admin/server.ts
+++ b/lib/admin/server.ts
@@ -1,0 +1,126 @@
+import type { SupabaseClient, User } from "@supabase/supabase-js";
+import {
+  hasRequiredAdminRole,
+  isAdminRoleColumnMissingError,
+  resolveAdminRoleForUser,
+  type AdminRole,
+  type MinimumAdminRole,
+} from "@/lib/admin/access";
+import { createAdminSupabaseClient } from "@/lib/supabase/admin";
+import type { Database } from "@/types/database";
+
+type ResolveAdminRoleOptions = {
+  allowlistedEmailsRaw?: string | undefined;
+};
+
+type RequireAdminRoleOptions = ResolveAdminRoleOptions & {
+  minimumRole: MinimumAdminRole;
+};
+
+type RequireAdminRoleResult =
+  | {
+      ok: true;
+      user: User;
+      role: AdminRole;
+    }
+  | {
+      ok: false;
+      status: 401 | 403 | 500;
+      error: string;
+    };
+
+async function loadProfileRole(
+  supabase: SupabaseClient<Database>,
+  userId: string
+): Promise<{ role: string | null; error: null | { code?: string; message?: string } }> {
+  const result = await supabase.from("profiles").select("role").eq("id", userId).maybeSingle();
+  if (result.error) {
+    return {
+      role: null,
+      error: {
+        code: result.error.code,
+        message: result.error.message,
+      },
+    };
+  }
+
+  return {
+    role: result.data?.role ?? null,
+    error: null,
+  };
+}
+
+async function ensureAllowlistedAdminProfile(user: User) {
+  if (!user.email) return;
+
+  const adminSupabase = createAdminSupabaseClient();
+  const { error } = await adminSupabase.from("profiles").upsert(
+    {
+      id: user.id,
+      email: user.email.toLowerCase(),
+      role: "admin",
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "id" }
+  );
+
+  if (error) {
+    console.error("[Admin] Could not bootstrap allowlisted admin profile", error);
+  }
+}
+
+export async function resolveAdminRoleFromSupabase(
+  supabase: SupabaseClient<Database>,
+  user: User,
+  options: ResolveAdminRoleOptions
+): Promise<AdminRole | null> {
+  const { role: profileRole, error: profileRoleError } = await loadProfileRole(supabase, user.id);
+
+  if (profileRoleError && !isAdminRoleColumnMissingError(profileRoleError)) {
+    console.error("[Admin] Could not load admin role from profile", profileRoleError);
+  }
+
+  const resolvedRole = resolveAdminRoleForUser(user, {
+    profileRole,
+    allowlistedEmailsRaw: options.allowlistedEmailsRaw,
+  });
+
+  if (resolvedRole === "admin" && !profileRole && user.email) {
+    await ensureAllowlistedAdminProfile(user);
+  }
+
+  return resolvedRole;
+}
+
+export async function requireAdminRoleFromSupabase(
+  supabase: SupabaseClient<Database>,
+  options: RequireAdminRoleOptions
+): Promise<RequireAdminRoleResult> {
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError) {
+    console.error("[Admin] Could not load auth user", userError);
+    return { ok: false, status: 500, error: "Could not verify admin session." };
+  }
+
+  if (!user) {
+    return { ok: false, status: 401, error: "Unauthorized." };
+  }
+
+  const role = await resolveAdminRoleFromSupabase(supabase, user, {
+    allowlistedEmailsRaw: options.allowlistedEmailsRaw,
+  });
+
+  if (!role || !hasRequiredAdminRole(role, options.minimumRole)) {
+    return { ok: false, status: 403, error: "Forbidden." };
+  }
+
+  return {
+    ok: true,
+    user,
+    role,
+  };
+}

--- a/supabase/migrations/20260218234500_admin_content_items_scaffold.sql
+++ b/supabase/migrations/20260218234500_admin_content_items_scaffold.sql
@@ -1,0 +1,131 @@
+-- Admin foundation: content CRUD scaffold table + RLS.
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_type t
+    join pg_namespace n on n.oid = t.typnamespace
+    where t.typname = 'admin_content_type' and n.nspname = 'public'
+  ) then
+    create type public.admin_content_type as enum (
+      'course_module',
+      'course_lesson',
+      'guide_session',
+      'guide_drill'
+    );
+  end if;
+end
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_type t
+    join pg_namespace n on n.oid = t.typnamespace
+    where t.typname = 'admin_content_status' and n.nspname = 'public'
+  ) then
+    create type public.admin_content_status as enum ('draft', 'published');
+  end if;
+end
+$$;
+
+create table if not exists public.admin_content_items (
+  id uuid primary key default gen_random_uuid(),
+  content_type public.admin_content_type not null,
+  parent_id uuid references public.admin_content_items (id) on delete set null,
+  slug text not null unique,
+  title text not null,
+  summary text not null default '',
+  body jsonb not null default '{}'::jsonb,
+  sort_order integer not null default 0,
+  status public.admin_content_status not null default 'draft',
+  published_at timestamptz,
+  created_by uuid references auth.users (id) on delete set null,
+  updated_by uuid references auth.users (id) on delete set null,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists admin_content_items_type_status_idx
+  on public.admin_content_items (content_type, status);
+
+create index if not exists admin_content_items_parent_sort_idx
+  on public.admin_content_items (parent_id, sort_order, created_at);
+
+create index if not exists admin_content_items_slug_idx
+  on public.admin_content_items (slug);
+
+drop trigger if exists admin_content_items_set_updated_at on public.admin_content_items;
+create trigger admin_content_items_set_updated_at
+before update on public.admin_content_items
+for each row execute function public.set_updated_at();
+
+grant select, insert, update, delete on public.admin_content_items to authenticated;
+
+alter table public.admin_content_items enable row level security;
+
+drop policy if exists admin_content_items_select_roles on public.admin_content_items;
+create policy admin_content_items_select_roles
+on public.admin_content_items
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.id = auth.uid()
+      and profile.role in ('admin', 'editor', 'viewer')
+  )
+);
+
+drop policy if exists admin_content_items_insert_roles on public.admin_content_items;
+create policy admin_content_items_insert_roles
+on public.admin_content_items
+for insert
+to authenticated
+with check (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.id = auth.uid()
+      and profile.role in ('admin', 'editor')
+  )
+);
+
+drop policy if exists admin_content_items_update_roles on public.admin_content_items;
+create policy admin_content_items_update_roles
+on public.admin_content_items
+for update
+to authenticated
+using (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.id = auth.uid()
+      and profile.role in ('admin', 'editor')
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.id = auth.uid()
+      and profile.role in ('admin', 'editor')
+  )
+);
+
+drop policy if exists admin_content_items_delete_roles on public.admin_content_items;
+create policy admin_content_items_delete_roles
+on public.admin_content_items
+for delete
+to authenticated
+using (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.id = auth.uid()
+      and profile.role = 'admin'
+  )
+);

--- a/tests/unit/admin-content.test.ts
+++ b/tests/unit/admin-content.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { parseCreateAdminContentPayload } from "@/lib/admin/content";
+
+describe("parseCreateAdminContentPayload", () => {
+  it("normalizes slug from title when slug not provided", () => {
+    const parsed = parseCreateAdminContentPayload({
+      contentType: "course_module",
+      title: " Module 1 Foundations ",
+      status: "draft",
+    });
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+
+    expect(parsed.value.slug).toBe("module-1-foundations");
+    expect(parsed.value.status).toBe("draft");
+  });
+
+  it("accepts valid payload with explicit slug and body object", () => {
+    const parsed = parseCreateAdminContentPayload({
+      contentType: "guide_session",
+      title: "Session 2",
+      slug: "session-2",
+      summary: "A short summary",
+      sortOrder: 4,
+      status: "published",
+      body: { markdown: "## Hello" },
+    });
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+
+    expect(parsed.value.contentType).toBe("guide_session");
+    expect(parsed.value.status).toBe("published");
+    expect(parsed.value.sortOrder).toBe(4);
+  });
+
+  it("rejects invalid content type", () => {
+    const parsed = parseCreateAdminContentPayload({
+      contentType: "unknown",
+      title: "Any title",
+    });
+
+    expect(parsed.ok).toBe(false);
+  });
+
+  it("rejects non-object body", () => {
+    const parsed = parseCreateAdminContentPayload({
+      contentType: "course_lesson",
+      title: "Lesson",
+      body: ["invalid"],
+    });
+
+    expect(parsed.ok).toBe(false);
+  });
+
+  it("rejects invalid parent uuid", () => {
+    const parsed = parseCreateAdminContentPayload({
+      contentType: "guide_drill",
+      title: "Drill",
+      parentId: "not-a-uuid",
+    });
+
+    expect(parsed.ok).toBe(false);
+  });
+});

--- a/tests/unit/admin-content.test.ts
+++ b/tests/unit/admin-content.test.ts
@@ -35,6 +35,19 @@ describe("parseCreateAdminContentPayload", () => {
     expect(parsed.value.sortOrder).toBe(4);
   });
 
+  it("collapses invalid slug separators and trims slug edges", () => {
+    const parsed = parseCreateAdminContentPayload({
+      contentType: "guide_session",
+      title: "Session 2",
+      slug: "___Session---2+++",
+    });
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+
+    expect(parsed.value.slug).toBe("session-2");
+  });
+
   it("rejects invalid content type", () => {
     const parsed = parseCreateAdminContentPayload({
       contentType: "unknown",

--- a/types/database.ts
+++ b/types/database.ts
@@ -258,6 +258,65 @@ export type Database = {
         };
         Relationships: [];
       };
+      admin_content_items: {
+        Row: {
+          body: Json;
+          content_type: Database["public"]["Enums"]["admin_content_type"];
+          created_at: string;
+          created_by: string | null;
+          id: string;
+          parent_id: string | null;
+          published_at: string | null;
+          slug: string;
+          sort_order: number;
+          status: Database["public"]["Enums"]["admin_content_status"];
+          summary: string;
+          title: string;
+          updated_at: string;
+          updated_by: string | null;
+        };
+        Insert: {
+          body?: Json;
+          content_type: Database["public"]["Enums"]["admin_content_type"];
+          created_at?: string;
+          created_by?: string | null;
+          id?: string;
+          parent_id?: string | null;
+          published_at?: string | null;
+          slug: string;
+          sort_order?: number;
+          status?: Database["public"]["Enums"]["admin_content_status"];
+          summary?: string;
+          title: string;
+          updated_at?: string;
+          updated_by?: string | null;
+        };
+        Update: {
+          body?: Json;
+          content_type?: Database["public"]["Enums"]["admin_content_type"];
+          created_at?: string;
+          created_by?: string | null;
+          id?: string;
+          parent_id?: string | null;
+          published_at?: string | null;
+          slug?: string;
+          sort_order?: number;
+          status?: Database["public"]["Enums"]["admin_content_status"];
+          summary?: string;
+          title?: string;
+          updated_at?: string;
+          updated_by?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "admin_content_items_parent_id_fkey";
+            columns: ["parent_id"];
+            isOneToOne: false;
+            referencedRelation: "admin_content_items";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       products: {
         Row: {
           active: boolean;
@@ -327,6 +386,8 @@ export type Database = {
     };
     Enums: {
       admin_role: "admin" | "editor" | "viewer";
+      admin_content_status: "draft" | "published";
+      admin_content_type: "course_module" | "course_lesson" | "guide_session" | "guide_drill";
     };
     CompositeTypes: {
       [_ in never]: never;


### PR DESCRIPTION
## Summary

- What changed and why?

## Scope

- In scope:
- Out of scope:

## Risk

- Main risk:
- Rollback plan:

## Test Evidence

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
