### PR TITLE
fix(admin): degrade setup/policy failures to schema-ready warnings

### DIFF
--- a/app/api/admin/products/[id]/route.ts
+++ b/app/api/admin/products/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { parseUpdateAdminProductPayload } from "@/lib/admin/products";
+import { getAdminSchemaSetupMessage, isAdminCommerceSchemaMissing } from "@/lib/admin/schema";
 import { requireAdminRoleFromSupabase } from "@/lib/admin/server";
 import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
 
@@ -72,6 +73,19 @@ export async function PATCH(request: Request, context: RouteContext) {
     .maybeSingle();
 
   if (updateResult.error) {
+    if (isAdminCommerceSchemaMissing(updateResult.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: getAdminSchemaSetupMessage("commerce"),
+            code: "ADMIN_SCHEMA_NOT_READY",
+          },
+          { status: 503 }
+        )
+      );
+    }
+
     console.error("[AdminProducts] Could not update product", updateResult.error);
     return applySupabaseCookies(
       noStoreJson({ ok: false, error: "Could not update product right now." }, { status: 500 })

--- a/app/api/admin/products/route.ts
+++ b/app/api/admin/products/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { getAdminSchemaSetupMessage, isAdminCommerceSchemaMissing } from "@/lib/admin/schema";
 import { requireAdminRoleFromSupabase } from "@/lib/admin/server";
 import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
 
@@ -35,6 +36,17 @@ export async function GET() {
     .order("created_at", { ascending: true });
 
   if (result.error) {
+    if (isAdminCommerceSchemaMissing(result.error)) {
+      return applySupabaseCookies(
+        noStoreJson({
+          ok: true,
+          items: [],
+          schemaReady: false,
+          warning: getAdminSchemaSetupMessage("commerce"),
+        })
+      );
+    }
+
     console.error("[AdminProducts] Could not load products", result.error);
     return applySupabaseCookies(
       noStoreJson({ ok: false, error: "Could not load products right now." }, { status: 500 })
@@ -45,6 +57,8 @@ export async function GET() {
     noStoreJson({
       ok: true,
       items: result.data ?? [],
+      schemaReady: true,
+      warning: null,
     })
   );
 }

--- a/components/admin/AdminCommerceManager.tsx
+++ b/components/admin/AdminCommerceManager.tsx
@@ -9,6 +9,8 @@ type AdminProductsResponse =
   | {
       ok: true;
       items: AdminProductRow[];
+      schemaReady?: boolean;
+      warning?: string | null;
     }
   | {
       ok: false;
@@ -35,6 +37,8 @@ export default function AdminCommerceManager() {
   const [draftById, setDraftById] = useState<Record<string, ProductDraft>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
+  const [schemaReady, setSchemaReady] = useState(true);
   const [actionError, setActionError] = useState<string | null>(null);
   const [savingId, setSavingId] = useState<string | null>(null);
   const [savedId, setSavedId] = useState<string | null>(null);
@@ -42,6 +46,7 @@ export default function AdminCommerceManager() {
   async function loadProducts() {
     setLoading(true);
     setError(null);
+    setWarning(null);
     try {
       const response = await fetch("/api/admin/products", {
         method: "GET",
@@ -51,15 +56,16 @@ export default function AdminCommerceManager() {
       const payload = (await response.json()) as AdminProductsResponse;
       if (!response.ok || !payload.ok) {
         setError(
-          payload.ok
-            ? "Could not load products."
-            : (payload.error ?? "Could not load products.")
+          payload.ok ? "Could not load products." : (payload.error ?? "Could not load products.")
         );
         setItems([]);
         setDraftById({});
+        setSchemaReady(true);
         return;
       }
       setItems(payload.items);
+      setSchemaReady(payload.schemaReady !== false);
+      setWarning(payload.warning ?? null);
       setDraftById(
         Object.fromEntries(
           payload.items.map((item) => [
@@ -75,6 +81,7 @@ export default function AdminCommerceManager() {
       setError("Could not load products.");
       setItems([]);
       setDraftById({});
+      setSchemaReady(true);
     } finally {
       setLoading(false);
     }
@@ -132,14 +139,14 @@ export default function AdminCommerceManager() {
       const payload = (await response.json()) as AdminProductUpdateResponse;
       if (!response.ok || !payload.ok) {
         setActionError(
-          payload.ok
-            ? "Could not update product."
-            : (payload.error ?? "Could not update product.")
+          payload.ok ? "Could not update product." : (payload.error ?? "Could not update product.")
         );
         return;
       }
 
-      setItems((prev) => prev.map((entry) => (entry.id === payload.item.id ? payload.item : entry)));
+      setItems((prev) =>
+        prev.map((entry) => (entry.id === payload.item.id ? payload.item : entry))
+      );
       setDraftById((prev) => ({
         ...prev,
         [payload.item.id]: {
@@ -190,6 +197,12 @@ export default function AdminCommerceManager() {
         </div>
       ) : null}
 
+      {!schemaReady && warning ? (
+        <p className="mt-5 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          {warning}
+        </p>
+      ) : null}
+
       {!loading && !error && items.length === 0 ? (
         <p className="mt-5 rounded-xl border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-600">
           Product catalog is empty. Checkout flows depend on seeded products.
@@ -234,12 +247,16 @@ export default function AdminCommerceManager() {
                   </label>
 
                   <div>
-                    <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Slug</p>
+                    <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                      Slug
+                    </p>
                     <p className="mt-1 text-sm text-slate-700">/{item.slug}</p>
                   </div>
 
                   <div>
-                    <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Kind</p>
+                    <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                      Kind
+                    </p>
                     <p className="mt-1 text-sm text-slate-700">{item.kind}</p>
                   </div>
 
@@ -261,7 +278,9 @@ export default function AdminCommerceManager() {
                       }
                       className="h-4 w-4 rounded border-slate-300 text-blue-600"
                     />
-                    <span>{draft.active ? "Active in plans/library" : "Hidden from new sales"}</span>
+                    <span>
+                      {draft.active ? "Active in plans/library" : "Hidden from new sales"}
+                    </span>
                   </label>
 
                   <div className="sm:col-span-2">

--- a/docs/task-briefs/in-progress/2026-02-19-admin-content-source-of-truth-and-dashboard-10-10.md
+++ b/docs/task-briefs/in-progress/2026-02-19-admin-content-source-of-truth-and-dashboard-10-10.md
@@ -3,10 +3,10 @@
 ## Metadata
 
 - `id`: `2026-02-19-admin-content-source-of-truth-and-dashboard-10-10`
-- `status`: `planned`
+- `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-02-19`
-- `updated`: `2026-02-19`
+- `updated`: `2026-02-20`
 
 ## Goal
 
@@ -196,7 +196,13 @@ State scope or `N/A` for each category during implementation and closeout:
 - Recovery:
   1. `git status -sb`
   2. `git log --oneline -n 10`
-  3. reopen this brief and continue from latest checkpoint.
+
+3. reopen this brief and continue from latest checkpoint.
+
+## Implementation Checkpoint Log
+
+- `2026-02-20 | working tree | moved brief to in-progress and started admin API hardening for schema/policy readiness handling | patch schema helpers + admin routes and validate with tests`
+- `2026-02-20 | working tree | hardened admin schema helpers + products APIs/UI for setup-not-ready fallback (no red 500 for missing grants/RLS) | commit checkpoint + push + PR`
 
 ## Final Closeout Gate
 

--- a/lib/admin/schema.ts
+++ b/lib/admin/schema.ts
@@ -6,6 +6,13 @@ type PostgrestLikeError = {
 };
 
 const MISSING_SCHEMA_CODES = new Set(["42P01", "42703", "PGRST204", "PGRST205"]);
+const SETUP_BLOCKED_CODES = new Set(["42501"]);
+const SETUP_BLOCKED_MARKERS = [
+  "permission denied",
+  "row-level security",
+  "violates row-level security",
+  "insufficient privilege",
+];
 
 function buildErrorBlob(error: PostgrestLikeError): string {
   return `${error.message ?? ""} ${error.details ?? ""} ${error.hint ?? ""}`.toLowerCase();
@@ -13,6 +20,10 @@ function buildErrorBlob(error: PostgrestLikeError): string {
 
 function hasMissingSchemaCode(error: PostgrestLikeError): boolean {
   return Boolean(error.code && MISSING_SCHEMA_CODES.has(error.code));
+}
+
+function hasSetupBlockedCode(error: PostgrestLikeError): boolean {
+  return Boolean(error.code && SETUP_BLOCKED_CODES.has(error.code));
 }
 
 function includesAnyMarker(blob: string, markers: string[]): boolean {
@@ -24,6 +35,8 @@ export function isAdminContentSchemaMissing(error: PostgrestLikeError | null | u
   if (hasMissingSchemaCode(error)) return true;
 
   const blob = buildErrorBlob(error);
+  if (hasSetupBlockedCode(error) || includesAnyMarker(blob, SETUP_BLOCKED_MARKERS)) return true;
+
   return includesAnyMarker(blob, [
     "admin_content_items",
     "admin_content_type",
@@ -38,6 +51,8 @@ export function isAdminRuntimeFlagsSchemaMissing(
   if (hasMissingSchemaCode(error)) return true;
 
   const blob = buildErrorBlob(error);
+  if (hasSetupBlockedCode(error) || includesAnyMarker(blob, SETUP_BLOCKED_MARKERS)) return true;
+
   return includesAnyMarker(blob, ["admin_runtime_flags"]);
 }
 
@@ -46,16 +61,34 @@ export function isAdminNotesSchemaMissing(error: PostgrestLikeError | null | und
   if (hasMissingSchemaCode(error)) return true;
 
   const blob = buildErrorBlob(error);
+  if (hasSetupBlockedCode(error) || includesAnyMarker(blob, SETUP_BLOCKED_MARKERS)) return true;
+
   return includesAnyMarker(blob, ["admin_notes"]);
 }
 
-export function getAdminSchemaSetupMessage(section: "content" | "operations" | "notes"): string {
+export function isAdminCommerceSchemaMissing(
+  error: PostgrestLikeError | null | undefined
+): boolean {
+  if (!error) return false;
+  if (hasMissingSchemaCode(error)) return true;
+
+  const blob = buildErrorBlob(error);
+  if (hasSetupBlockedCode(error) || includesAnyMarker(blob, SETUP_BLOCKED_MARKERS)) return true;
+
+  return includesAnyMarker(blob, ["products", "profiles", "role"]);
+}
+
+export function getAdminSchemaSetupMessage(
+  section: "content" | "operations" | "notes" | "commerce"
+): string {
   const area =
     section === "content"
       ? "Admin content"
       : section === "operations"
         ? "Admin operations"
-        : "Admin notes";
+        : section === "notes"
+          ? "Admin notes"
+          : "Admin commerce";
 
-  return `${area} setup is not ready in this environment yet. Apply latest Supabase migrations and refresh.`;
+  return `${area} setup is not ready in this environment yet. Apply latest Supabase migrations (tables + grants + RLS policies), then refresh.`;
 }

--- a/tests/unit/admin-schema.test.ts
+++ b/tests/unit/admin-schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  isAdminCommerceSchemaMissing,
   getAdminSchemaSetupMessage,
   isAdminContentSchemaMissing,
   isAdminNotesSchemaMissing,
@@ -28,9 +29,30 @@ describe("admin schema helpers", () => {
     expect(isAdminNotesSchemaMissing({ code: "PGRST205" })).toBe(true);
   });
 
+  it("detects setup blocked by missing grants or policies", () => {
+    expect(
+      isAdminContentSchemaMissing({
+        code: "42501",
+        message: "permission denied for table admin_content_items",
+      })
+    ).toBe(true);
+    expect(
+      isAdminRuntimeFlagsSchemaMissing({
+        message: "new row violates row-level security policy for table admin_runtime_flags",
+      })
+    ).toBe(true);
+    expect(
+      isAdminCommerceSchemaMissing({
+        code: "42501",
+        message: "permission denied for table products",
+      })
+    ).toBe(true);
+  });
+
   it("returns setup message per section", () => {
     expect(getAdminSchemaSetupMessage("content")).toContain("Admin content");
     expect(getAdminSchemaSetupMessage("operations")).toContain("Admin operations");
     expect(getAdminSchemaSetupMessage("notes")).toContain("Admin notes");
+    expect(getAdminSchemaSetupMessage("commerce")).toContain("Admin commerce");
   });
 });


### PR DESCRIPTION
## Summary

- What changed and why?

## Scope

- In scope:
- Out of scope:

## Risk

- Main risk:
- Rollback plan:

## Test Evidence

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (or explain why private-gate step is not required)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
