### PR TITLE
docs(video): add 60s intro production pack with per-video workspace

### DIFF
--- a/docs/task-briefs/in-progress/2026-02-25-content-production-v1-admin-editorial-run.md
+++ b/docs/task-briefs/in-progress/2026-02-25-content-production-v1-admin-editorial-run.md
@@ -6,7 +6,7 @@
 - `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-02-25`
-- `updated`: `2026-02-25`
+- `updated`: `2026-02-27`
 
 ## Goal
 
@@ -147,3 +147,4 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 
 - `2026-02-25 | kickoff | content production v1 track opened after AW-013 phase8 merge; no hard blockers found in active briefs for starting editorial production | next: run Slice 1 production session and capture first friction batch`
 - `2026-02-25 | desktop visual calibration slice | tuned large-screen readability/contrast and widened PageTemplate (wide layout) for course/admin surfaces to reduce washed-out look on large monitors; npm run verify:pre-pr passed (second run after one transient Playwright goto timeout) | next: verify on 49" monitor and capture any residual contrast/layout friction`
+- `2026-02-27 | intro-video production pack | added complete 60s course intro video production package (timing, script, shot types, Camtasia specs, subtitles, YouTube metadata) in docs/video-production/intro-course-60s/production-pack.md + docs/video-production/intro-course-60s/subtitles.en.srt | next: produce first export cut in Camtasia and review against acceptance checklist`

--- a/docs/video-production/README.md
+++ b/docs/video-production/README.md
@@ -1,0 +1,14 @@
+# Video Production Workspace
+
+Use one folder per video under `docs/video-production/`.
+
+Recommended per-video structure:
+
+- `production-pack.md` (script, shotlist, style, edit settings)
+- `subtitles.en.srt`
+- `youtube-metadata.md` (optional)
+- `assets-notes.md` (optional)
+
+Current videos:
+
+- `intro-course-60s/`

--- a/docs/video-production/intro-course-60s/production-pack.md
+++ b/docs/video-production/intro-course-60s/production-pack.md
@@ -1,0 +1,219 @@
+# Course Intro Video 60s Production Pack
+
+## Purpose
+
+Ship one production-ready 60s intro video for the free freestyle course, optimized for:
+
+- adult beginners (`18-99`),
+- coaching tone,
+- strong watch retention in first 3-5 seconds,
+- clear CTA: `Start the free course now`.
+
+## What This Pack Solves
+
+This pack gives you a complete blueprint so you can build in Camtasia without re-planning:
+
+- exact 60s timeline,
+- voiceover script,
+- scene-by-scene shot type (`app click video`, `still`, `swim footage`),
+- on-screen text specs,
+- color/visual system matched to freeswimming UI,
+- subtitle file (`.srt`) and YouTube publish copy.
+
+## Source Visual Tokens (from app)
+
+Use these tokens so video looks native to the platform.
+
+- Header gradient: `#4F8FE5 -> #62A8FF`
+- Primary CTA blue: `#3B82F6 -> #2563EB`
+- Page background light gradient family:
+  - `#EAF3FF`
+  - `#F7FBFF`
+  - `#FFFFFF`
+- Text primary: `#0F172A`
+- Text secondary: `#334155`
+- Success accent: `#10B981`
+- Border/light panel: `#E2E8F0`
+
+## Typography
+
+Keep typography simple and consistent:
+
+- Headline: `SF Pro Display` (or `Inter` fallback), `Semibold`
+- Body: `SF Pro Text` (or `Inter` fallback), `Regular`
+- Numbers/badges: same family, `Medium`
+
+Sizes for 1080p canvas:
+
+- H1: `72-84px`
+- H2: `44-56px`
+- Body: `30-36px`
+- Caption/chip: `24-28px`
+
+## Camtasia Project Settings
+
+- Canvas: `1920x1080` (16:9)
+- FPS: `30`
+- Audio sample rate: `48kHz`
+- Color profile: `Rec.709`
+- Max transition length: `180-260ms`
+- Motion easing: `Ease out` (avoid bouncy effects)
+
+## 60s Master Timeline (Locked)
+
+### [0:00-0:03] Hook (swim footage + headline)
+
+- Shot type: `swim footage` (tight shot, clean freestyle glide).
+- On-screen text:
+  - Line 1: `Learn freestyle as an adult`
+  - Line 2: `Without confusion`
+- Voiceover:
+  - `Learning freestyle as an adult should feel simple.`
+
+### [0:03-0:09] Problem framing (still + subtle UI movement)
+
+- Shot type: `still` (soft background gradient + 2-3 quick phrases).
+- Text sequence (stagger 0.8s):
+  - `Too many random tips`
+  - `No clear order`
+  - `Hard to know when you're actually ready`
+- Voiceover:
+  - `Most people get too many random tips and no clear progression.`
+
+### [0:09-0:19] Product reveal (app click footage)
+
+- Shot type: `app click video` (home -> course entry).
+- Focus:
+  - logo/header,
+  - course card,
+  - clear progress context.
+- Voiceover:
+  - `Freeswimming gives you one step-by-step system with short lessons, clear drills, and simple checkpoints.`
+
+### [0:19-0:31] How lesson works (app click footage)
+
+- Shot type: `app click video`.
+- Show:
+  - lesson title,
+  - goal section,
+  - drill section,
+  - pass criteria,
+  - done action.
+- Voiceover:
+  - `Every lesson tells you what to focus on, what to practice, and exactly what “done” looks like before you move on.`
+
+### [0:31-0:41] Trust + support (mixed still/app)
+
+- Shot type: `app click video` for support card + `still` for emphasis words.
+- Show:
+  - Need extra help card,
+  - optional support options.
+- Voiceover:
+  - `If you need help, support options are there. If not, keep progressing in order.`
+
+### [0:41-0:52] Outcome framing (swim footage + app progress)
+
+- Shot type: split sequence:
+  - 2s swim footage,
+  - 2s app progress,
+  - 2s swim footage.
+- Voiceover:
+  - `The goal is relaxed, repeatable freestyle you can trust, one small win at a time.`
+
+### [0:52-1:00] CTA close (app + founder face optional)
+
+- Shot type:
+  - primary: `app CTA screen` + animated button highlight.
+  - optional last 2s: founder face shot for credibility.
+- Text:
+  - `Start the free course now`
+  - `freeswimming.org`
+- Voiceover:
+  - `Start the free course now at freeswimming.org.`
+
+## Shot-Type Rules (10/10 UX)
+
+- Use `app click video` when teaching flow/actions.
+- Use `still` when framing concept quickly (faster readability).
+- Use `swim footage` for emotion, aspiration, and rhythm breaks.
+- Do not stay on one shot type longer than ~8-10 seconds.
+
+## Overlay Design System
+
+Use consistent overlay chips/cards:
+
+- Chip background: `rgba(255,255,255,0.90)`
+- Chip border: `1px #E2E8F0`
+- Chip radius: `14px`
+- Text color: `#0F172A`
+- Shadow: `0 8px 24px rgba(15,23,42,0.12)`
+
+For dark swim shots:
+
+- Text plate background: `rgba(15,23,42,0.58)`
+- Text color: `#FFFFFF`
+- Plate radius: `12px`
+- Padding: `16px vertical`, `22px horizontal`
+
+## Motion and Transitions
+
+- Default cut cadence: every `1.8-3.5s` depending on spoken phrase.
+- Use 2 transition types only:
+  - `Fade` (`120-180ms`)
+  - `Position slide` (`180-240ms`, max 24px movement)
+- Avoid zoom-heavy style and complex wipes.
+
+## Audio Mix (Target)
+
+- Voiceover LUFS: `-16` (integrated)
+- Music bed LUFS: `-27` to `-24`
+- Peak limiter: `-1.0 dB`
+- Duck music under voice by `-8 dB`
+
+## Founder Shot Guidance
+
+Use founder shot if available and natural:
+
+- Keep to `1.5-2.5s` near ending.
+- One short line max, no long monologue.
+- If not strong on camera yet, skip founder and keep app CTA ending.
+
+## Final Voiceover Script (exact)
+
+Learning freestyle as an adult should feel simple.  
+Most people get too many random tips and no clear progression.  
+Freeswimming gives you one step-by-step system with short lessons, clear drills, and simple checkpoints.  
+Every lesson tells you what to focus on, what to practice, and exactly what done looks like before you move on.  
+If you need help, support options are there. If not, keep progressing in order.  
+The goal is relaxed, repeatable freestyle you can trust, one small win at a time.  
+Start the free course now at freeswimming.org.
+
+## YouTube Publish Pack
+
+- Title:
+  - `Learn Freestyle as an Adult (Step-by-Step Free Course)`
+- Description first lines:
+  - `Start free: https://freeswimming.org`
+  - `A step-by-step freestyle course for adult learners who want calm, repeatable progress.`
+- Tags:
+  - `freestyle swimming, adult learn to swim, swim drills, swimming technique, beginner freestyle`
+- Thumbnail:
+  - one strong swim frame + one clean app frame + short text:
+    - `Adult Freestyle Made Simple`
+
+## Export Settings
+
+- Format: `MP4`
+- Resolution: `1920x1080`
+- FPS: `30`
+- Bitrate target: `12-16 Mbps`
+- Audio: `AAC 320 kbps`
+
+## Acceptance Checklist
+
+- Runtime is `59-61s`
+- First hook visible within `0.5s`
+- CTA appears clearly in last `8s`
+- No text overlap with mobile-safe zones in source captures
+- Subtitles included and synced
+- Brand colors match app tokens

--- a/docs/video-production/intro-course-60s/subtitles.en.srt
+++ b/docs/video-production/intro-course-60s/subtitles.en.srt
@@ -1,0 +1,28 @@
+1
+00:00:00,000 --> 00:00:03,000
+Learning freestyle as an adult should feel simple.
+
+2
+00:00:03,000 --> 00:00:09,000
+Most people get too many random tips and no clear progression.
+
+3
+00:00:09,000 --> 00:00:19,000
+Freeswimming gives you one step-by-step system with short lessons, clear drills, and simple checkpoints.
+
+4
+00:00:19,000 --> 00:00:31,000
+Every lesson tells you what to focus on, what to practice, and exactly what done looks like before you move on.
+
+5
+00:00:31,000 --> 00:00:41,000
+If you need help, support options are there. If not, keep progressing in order.
+
+6
+00:00:41,000 --> 00:00:52,000
+The goal is relaxed, repeatable freestyle you can trust, one small win at a time.
+
+7
+00:00:52,000 --> 00:01:00,000
+Start the free course now at freeswimming.org.
+


### PR DESCRIPTION
## Summary

- What changed and why?

## Scope

- In scope:
- Out of scope:

## Risk

- Main risk:
- Rollback plan:

## Test Evidence

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (or explain why private-gate step is not required)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
