### PR TITLE
feat(admin): add preview mode and open lesson preview

### DIFF
--- a/app/api/course/content/route.ts
+++ b/app/api/course/content/route.ts
@@ -1,6 +1,12 @@
 import { NextResponse } from "next/server";
 import { COURSE_MODULES } from "@/app/course/courseData";
-import { loadPublishedCourseModules } from "@/lib/admin/content-course";
+import { loadCourseModulesByStatus } from "@/lib/admin/content-course";
+import { requireAdminRoleFromSupabase } from "@/lib/admin/server";
+import {
+  resolveCourseContentStatusesForPreviewMode,
+  resolveCoursePreviewRequest,
+} from "@/lib/course/preview";
+import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
 
 export const dynamic = "force-dynamic";
 
@@ -8,28 +14,115 @@ function noStoreJson(
   body: Record<string, unknown>,
   init?: {
     status?: number;
+    noindex?: boolean;
   }
 ) {
+  const headers: HeadersInit = {
+    "Cache-Control": "no-store",
+  };
+  if (init?.noindex) {
+    headers["X-Robots-Tag"] = "noindex, nofollow, noarchive";
+  }
+
   return NextResponse.json(body, {
     status: init?.status ?? 200,
-    headers: {
-      "Cache-Control": "no-store",
-    },
+    headers,
   });
 }
 
-export async function GET() {
+export async function GET(request: Request) {
+  const requestUrl = new URL(request.url);
+  const previewResolution = resolveCoursePreviewRequest({
+    previewParam: requestUrl.searchParams.get("preview"),
+    previewModeParam: requestUrl.searchParams.get("previewMode"),
+  });
+
+  if (!previewResolution.ok) {
+    return noStoreJson(
+      {
+        ok: false,
+        error: previewResolution.error,
+      },
+      { status: 400 }
+    );
+  }
+
   try {
-    const modules = await loadPublishedCourseModules();
+    if (previewResolution.enabled) {
+      const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+      const gate = await requireAdminRoleFromSupabase(supabase, {
+        allowlistedEmailsRaw: process.env.ADMIN_EMAIL_ALLOWLIST,
+        minimumRole: "viewer",
+      });
+
+      if (!gate.ok) {
+        return applySupabaseCookies(
+          noStoreJson(
+            {
+              ok: false,
+              error: gate.error,
+            },
+            { status: gate.status, noindex: true }
+          )
+        );
+      }
+
+      const previewStatuses = resolveCourseContentStatusesForPreviewMode(previewResolution.mode);
+      const modules = await loadCourseModulesByStatus({
+        statuses: previewStatuses,
+        fallback: [],
+        autoSeedWhenEmpty: false,
+      });
+
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: true,
+            modules,
+            preview: {
+              enabled: true,
+              mode: previewResolution.mode,
+              statuses: previewStatuses,
+            },
+          },
+          { noindex: true }
+        )
+      );
+    }
+
+    const modules = await loadCourseModulesByStatus({
+      statuses: ["published"],
+      fallback: COURSE_MODULES,
+      autoSeedWhenEmpty: true,
+    });
     return noStoreJson({
       ok: true,
       modules: modules.length > 0 ? modules : COURSE_MODULES,
+      preview: {
+        enabled: false,
+        mode: "published",
+      },
     });
   } catch (error) {
-    console.error("[CourseContent] Could not load published course modules", error);
+    console.error("[CourseContent] Could not load course modules", error);
+
+    if (previewResolution.enabled) {
+      return noStoreJson(
+        {
+          ok: false,
+          error: "Could not load preview content.",
+        },
+        { status: 500, noindex: true }
+      );
+    }
+
     return noStoreJson({
       ok: true,
       modules: COURSE_MODULES,
+      preview: {
+        enabled: false,
+        mode: "published",
+      },
     });
   }
 }

--- a/app/course/page.tsx
+++ b/app/course/page.tsx
@@ -41,7 +41,11 @@ import {
   normalizeVideoProgressRecord,
   type CourseProgressRow,
 } from "@/lib/course/progress";
-import { COURSE_LAST_LESSON_STORAGE_KEY } from "@/lib/course/resume";
+import {
+  getCourseProgressStorageKeys,
+  parseCoursePreviewMode,
+  type CoursePreviewMode,
+} from "@/lib/course/preview";
 import { createBrowserSupabaseClient } from "@/lib/supabase/browser";
 
 import {
@@ -53,11 +57,7 @@ import {
   type CourseLesson,
 } from "./courseData";
 
-const STORAGE_KEY = COURSE_LAST_LESSON_STORAGE_KEY;
 const OVERVIEW_STORAGE_KEY = "fs_course_overview_expanded";
-const DONE_STORAGE_KEY = "fs_course_done_lessons";
-const DONE_CONFIRMATION_STORAGE_KEY = "fs_course_done_confirmations";
-const VIDEO_PROGRESS_STORAGE_KEY = "fs_course_video_progress";
 const SWIPE_NUX_STORAGE_KEY = "fs_course_swipe_nux_seen";
 const SWIPE_ZONE_INSET_PX = 12;
 const SWIPE_SIDE_ZONE_RATIO = 0.31;
@@ -118,6 +118,13 @@ const FALLBACK_LESSON: CourseLesson = COURSE_LESSONS_FLAT[0] ?? {
     steps: ["Swim easy and keep your body line calm and controlled."],
   },
   nextStep: "Continue to the next lesson.",
+};
+
+const PREVIEW_MODE_COPY: Record<CoursePreviewMode, string> = {
+  published: "Published only",
+  review: "Review only",
+  draft: "Draft only",
+  all: "All statuses",
 };
 
 type SwipeDirection = "prev" | "next";
@@ -219,7 +226,38 @@ function CoursePageClient() {
   const install = useInstallContext();
 
   const lessonParam = searchParams.get("lesson");
+  const previewEnabled = searchParams.get("preview") === "1";
+  const previewModeParam = searchParams.get("previewMode");
+  const parsedPreviewMode = parseCoursePreviewMode(previewModeParam);
+  const previewMode = parsedPreviewMode ?? "published";
+  const previewType = searchParams.get("previewType");
+  const previewRefRaw = searchParams.get("previewRef");
+  const previewRef = previewRefRaw?.trim() ?? "";
+  const previewStorageKeys = useMemo(
+    () =>
+      getCourseProgressStorageKeys({
+        previewEnabled,
+        previewMode,
+      }),
+    [previewEnabled, previewMode]
+  );
+  const courseProgressSyncEnabled = !previewEnabled;
+  const previewContextLabel = useMemo(() => {
+    if (!previewEnabled) return null;
+    if (previewType === "module") {
+      return previewRef ? `Module: ${previewRef}` : "Module preview";
+    }
+    if (previewType === "lesson") {
+      return previewRef ? `Lesson: ${previewRef}` : "Lesson preview";
+    }
+    return previewRef ? `Context: ${previewRef}` : null;
+  }, [previewEnabled, previewRef, previewType]);
+
   const [courseModules, setCourseModules] = useState<CourseModule[]>(COURSE_MODULES);
+  const [courseContentLoadState, setCourseContentLoadState] = useState<
+    "idle" | "loading" | "success" | "error"
+  >("idle");
+  const [courseContentError, setCourseContentError] = useState<string | null>(null);
   const courseLessonsFlat = useMemo(
     () => courseModules.flatMap((module) => module.lessons),
     [courseModules]
@@ -414,15 +452,26 @@ function CoursePageClient() {
       setResumeAvailable(Math.floor(normalizedVideoProgress[activeLesson.id] ?? 0) >= 2);
 
       try {
-        localStorage.setItem(DONE_STORAGE_KEY, JSON.stringify(normalizedDoneLessonIds));
         localStorage.setItem(
-          DONE_CONFIRMATION_STORAGE_KEY,
+          previewStorageKeys.doneLessons,
+          JSON.stringify(normalizedDoneLessonIds)
+        );
+        localStorage.setItem(
+          previewStorageKeys.doneConfirmations,
           JSON.stringify(normalizedDoneConfirmationByLessonId)
         );
-        localStorage.setItem(VIDEO_PROGRESS_STORAGE_KEY, JSON.stringify(normalizedVideoProgress));
+        localStorage.setItem(
+          previewStorageKeys.videoProgress,
+          JSON.stringify(normalizedVideoProgress)
+        );
       } catch {}
     },
-    [activeLesson.id]
+    [
+      activeLesson.id,
+      previewStorageKeys.doneConfirmations,
+      previewStorageKeys.doneLessons,
+      previewStorageKeys.videoProgress,
+    ]
   );
 
   const buildSyncRows = useCallback((updatedAt?: string): CourseProgressRow[] => {
@@ -441,7 +490,7 @@ function CoursePageClient() {
 
   const persistCourseProgressRows = useCallback(
     async (rows: CourseProgressRow[]) => {
-      if (!signedInUserId) return;
+      if (!signedInUserId || !courseProgressSyncEnabled) return;
 
       const response = await fetch(COURSE_PROGRESS_SYNC_API_PATH, {
         method: "POST",
@@ -457,12 +506,12 @@ function CoursePageClient() {
         throw new Error(`Course progress sync failed (${response.status})`);
       }
     },
-    [signedInUserId]
+    [courseProgressSyncEnabled, signedInUserId]
   );
 
   const syncCourseProgressNow = useCallback(
     async (options?: { force?: boolean }) => {
-      if (!signedInUserId || !localCourseProgressLoaded) return;
+      if (!courseProgressSyncEnabled || !signedInUserId || !localCourseProgressLoaded) return;
       if (!options?.force && !courseSyncDirtyRef.current) return;
       if (courseSyncInFlightRef.current) return;
 
@@ -500,34 +549,55 @@ function CoursePageClient() {
         courseSyncInFlightRef.current = false;
       }
     },
-    [buildSyncRows, localCourseProgressLoaded, persistCourseProgressRows, signedInUserId]
+    [
+      buildSyncRows,
+      courseProgressSyncEnabled,
+      localCourseProgressLoaded,
+      persistCourseProgressRows,
+      signedInUserId,
+    ]
   );
 
   useEffect(() => {
     try {
-      localStorage.setItem(STORAGE_KEY, activeLesson.id);
+      localStorage.setItem(previewStorageKeys.lastLesson, activeLesson.id);
     } catch {}
-  }, [activeLesson.id]);
+  }, [activeLesson.id, previewStorageKeys.lastLesson]);
 
   useEffect(() => {
     if (lessonParam) return;
 
     try {
-      const last = localStorage.getItem(STORAGE_KEY);
+      const last = localStorage.getItem(previewStorageKeys.lastLesson);
       const next = last || defaultLessonId;
       router.replace(`${pathname}?lesson=${encodeURIComponent(next)}`);
     } catch {
       router.replace(`${pathname}?lesson=${encodeURIComponent(defaultLessonId)}`);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [defaultLessonId, pathname, previewStorageKeys.lastLesson, router]);
 
   useEffect(() => {
     let cancelled = false;
 
-    const loadPublishedCourseContent = async () => {
+    const loadCourseContent = async () => {
+      setCourseContentLoadState("loading");
+      setCourseContentError(null);
+
+      const params = new URLSearchParams();
+      if (previewEnabled) {
+        params.set("preview", "1");
+        if (previewModeParam) {
+          params.set("previewMode", previewModeParam);
+        } else {
+          params.set("previewMode", "published");
+        }
+      }
+      const requestPath =
+        params.size > 0 ? `/api/course/content?${params.toString()}` : "/api/course/content";
+
       try {
-        const response = await fetch("/api/course/content", {
+        const response = await fetch(requestPath, {
           method: "GET",
           credentials: "same-origin",
           cache: "no-store",
@@ -536,29 +606,45 @@ function CoursePageClient() {
         const payload = (await response.json()) as {
           ok?: boolean;
           modules?: CourseModule[];
+          error?: string;
         };
 
-        if (
-          cancelled ||
-          !response.ok ||
-          !payload.ok ||
-          !Array.isArray(payload.modules) ||
-          payload.modules.length === 0
-        ) {
+        if (cancelled) {
           return;
         }
 
-        setCourseModules(payload.modules);
+        if (!response.ok || !payload.ok || !Array.isArray(payload.modules)) {
+          const fallbackError = previewEnabled
+            ? "Could not load preview content."
+            : "Could not load course content.";
+          setCourseContentError(payload.error ?? fallbackError);
+          setCourseContentLoadState(previewEnabled ? "error" : "success");
+          if (!previewEnabled) {
+            setCourseModules(COURSE_MODULES);
+          }
+          return;
+        }
+
+        setCourseModules(
+          payload.modules.length > 0 ? payload.modules : previewEnabled ? [] : COURSE_MODULES
+        );
+        setCourseContentLoadState("success");
       } catch {
-        // keep safe default
+        if (cancelled) return;
+        setCourseContentError(previewEnabled ? "Could not load preview content." : null);
+        setCourseContentLoadState(previewEnabled ? "error" : "success");
+        if (!previewEnabled) {
+          // keep safe default
+          setCourseModules(COURSE_MODULES);
+        }
       }
     };
 
-    void loadPublishedCourseContent();
+    void loadCourseContent();
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [previewEnabled, previewMode, previewModeParam]);
 
   useEffect(() => {
     let cancelled = false;
@@ -607,7 +693,7 @@ function CoursePageClient() {
 
   useEffect(() => {
     try {
-      const raw = localStorage.getItem(DONE_STORAGE_KEY);
+      const raw = localStorage.getItem(previewStorageKeys.doneLessons);
       if (raw) {
         const parsed = JSON.parse(raw);
         const normalizedDoneLessonIds = normalizeDoneLessonIds(parsed);
@@ -619,11 +705,11 @@ function CoursePageClient() {
       }
     } catch {}
     setDoneLessonIdsLoaded(true);
-  }, []);
+  }, [previewStorageKeys.doneLessons]);
 
   useEffect(() => {
     try {
-      const raw = localStorage.getItem(DONE_CONFIRMATION_STORAGE_KEY);
+      const raw = localStorage.getItem(previewStorageKeys.doneConfirmations);
       if (raw) {
         const parsed = JSON.parse(raw);
         const normalizedDoneConfirmationByLessonId = normalizeDoneConfirmationRecord(parsed);
@@ -632,24 +718,24 @@ function CoursePageClient() {
       }
     } catch {}
     setDoneConfirmationLoaded(true);
-  }, []);
+  }, [previewStorageKeys.doneConfirmations]);
 
   useEffect(() => {
     if (!doneLessonIdsLoaded) return;
     try {
-      localStorage.setItem(DONE_STORAGE_KEY, JSON.stringify(doneLessonIds));
+      localStorage.setItem(previewStorageKeys.doneLessons, JSON.stringify(doneLessonIds));
     } catch {}
-  }, [doneLessonIds, doneLessonIdsLoaded]);
+  }, [doneLessonIds, doneLessonIdsLoaded, previewStorageKeys.doneLessons]);
 
   useEffect(() => {
     if (!doneConfirmationLoaded) return;
     try {
       localStorage.setItem(
-        DONE_CONFIRMATION_STORAGE_KEY,
+        previewStorageKeys.doneConfirmations,
         JSON.stringify(doneConfirmationByLessonId)
       );
     } catch {}
-  }, [doneConfirmationByLessonId, doneConfirmationLoaded]);
+  }, [doneConfirmationByLessonId, doneConfirmationLoaded, previewStorageKeys.doneConfirmations]);
 
   useEffect(() => {
     doneLessonIdsRef.current = doneLessonIds;
@@ -661,7 +747,7 @@ function CoursePageClient() {
 
   useEffect(() => {
     try {
-      const raw = localStorage.getItem(VIDEO_PROGRESS_STORAGE_KEY);
+      const raw = localStorage.getItem(previewStorageKeys.videoProgress);
       if (raw) {
         const parsed = JSON.parse(raw);
         const normalized = normalizeVideoProgressRecord(parsed);
@@ -672,7 +758,7 @@ function CoursePageClient() {
       }
     } catch {}
     setPlaybackProgressLoaded(true);
-  }, []);
+  }, [previewStorageKeys.videoProgress]);
 
   useEffect(() => {
     let mounted = true;
@@ -704,7 +790,7 @@ function CoursePageClient() {
   }, []);
 
   useEffect(() => {
-    if (signedInUserId) return;
+    if (courseProgressSyncEnabled && signedInUserId) return;
     clearCourseSyncTimer();
     hydratedProgressUserIdRef.current = null;
     courseSyncDirtyRef.current = false;
@@ -712,10 +798,16 @@ function CoursePageClient() {
     courseSyncInFlightRef.current = false;
     setCourseSyncStatus("idle");
     setLastCourseSyncAtMs(null);
-  }, [clearCourseSyncTimer, signedInUserId]);
+  }, [clearCourseSyncTimer, courseProgressSyncEnabled, signedInUserId]);
 
   useEffect(() => {
-    if (!authStateLoaded || !localCourseProgressLoaded || !signedInUserId) return;
+    if (
+      !courseProgressSyncEnabled ||
+      !authStateLoaded ||
+      !localCourseProgressLoaded ||
+      !signedInUserId
+    )
+      return;
     if (hydratedProgressUserIdRef.current === signedInUserId) return;
 
     hydratedProgressUserIdRef.current = signedInUserId;
@@ -792,13 +884,14 @@ function CoursePageClient() {
     applyLocalCourseProgress,
     authStateLoaded,
     buildSyncRows,
+    courseProgressSyncEnabled,
     localCourseProgressLoaded,
     signedInUserId,
     syncCourseProgressNow,
   ]);
 
   useEffect(() => {
-    if (!signedInUserId || !localCourseProgressLoaded) return;
+    if (!courseProgressSyncEnabled || !signedInUserId || !localCourseProgressLoaded) return;
     clearCourseSyncTimer();
     courseSyncTimerRef.current = window.setInterval(() => {
       void syncCourseProgressNow();
@@ -807,10 +900,16 @@ function CoursePageClient() {
     return () => {
       clearCourseSyncTimer();
     };
-  }, [clearCourseSyncTimer, localCourseProgressLoaded, signedInUserId, syncCourseProgressNow]);
+  }, [
+    clearCourseSyncTimer,
+    courseProgressSyncEnabled,
+    localCourseProgressLoaded,
+    signedInUserId,
+    syncCourseProgressNow,
+  ]);
 
   useEffect(() => {
-    if (!signedInUserId) return;
+    if (!courseProgressSyncEnabled || !signedInUserId) return;
 
     const flushWhenBackgrounded = () => {
       if (document.visibilityState !== "hidden") return;
@@ -828,13 +927,19 @@ function CoursePageClient() {
       document.removeEventListener("visibilitychange", flushWhenBackgrounded);
       window.removeEventListener("pagehide", flushOnPageHide);
     };
-  }, [signedInUserId, syncCourseProgressNow]);
+  }, [courseProgressSyncEnabled, signedInUserId, syncCourseProgressNow]);
 
   useEffect(() => {
-    if (!signedInUserId || !doneLessonIdsLoaded) return;
+    if (!courseProgressSyncEnabled || !signedInUserId || !doneLessonIdsLoaded) return;
     if (!courseSyncDirtyRef.current) return;
     void syncCourseProgressNow({ force: true });
-  }, [doneLessonIds, doneLessonIdsLoaded, signedInUserId, syncCourseProgressNow]);
+  }, [
+    courseProgressSyncEnabled,
+    doneLessonIds,
+    doneLessonIdsLoaded,
+    signedInUserId,
+    syncCourseProgressNow,
+  ]);
 
   useEffect(() => {
     if (!playbackProgressLoaded) return;
@@ -863,9 +968,12 @@ function CoursePageClient() {
 
   const persistPlaybackProgress = useCallback(() => {
     try {
-      localStorage.setItem(VIDEO_PROGRESS_STORAGE_KEY, JSON.stringify(playbackProgressRef.current));
+      localStorage.setItem(
+        previewStorageKeys.videoProgress,
+        JSON.stringify(playbackProgressRef.current)
+      );
     } catch {}
-  }, []);
+  }, [previewStorageKeys.videoProgress]);
 
   const stopProgressSaveTimer = useCallback(() => {
     if (progressSaveTimerRef.current == null) return;
@@ -1402,24 +1510,26 @@ function CoursePageClient() {
   const showVideoOverlay = !videoStarted || videoPaused;
   const showResumeState = videoStarted && videoPaused;
   const showResumeCta = showResumeState || (!videoStarted && resumeAvailable);
-  const isSignedIn = Boolean(signedInUserId);
-  const isGuest = authStateLoaded && !signedInUserId;
+  const isSignedIn = courseProgressSyncEnabled && Boolean(signedInUserId);
+  const isGuest = courseProgressSyncEnabled && authStateLoaded && !signedInUserId;
   const backupSignInHref = `/auth/sign-in?next=${encodeURIComponent(
     `${pathname}?lesson=${encodeURIComponent(activeLesson.id)}`
   )}`;
-  const courseProgressStatusCopy = isSignedIn
-    ? courseSyncStatus === "error"
-      ? "Sync paused right now. We'll retry automatically."
-      : courseSyncStatus === "syncing"
-        ? "Syncing lesson progress to your account..."
-        : formatSyncStatusAgeLabel(lastCourseSyncAtMs)
-    : "Lesson and playback progress saved on this device.";
+  const courseProgressStatusCopy = previewEnabled
+    ? "Preview progress is local only and isolated from learner progress."
+    : isSignedIn
+      ? courseSyncStatus === "error"
+        ? "Sync paused right now. We'll retry automatically."
+        : courseSyncStatus === "syncing"
+          ? "Syncing lesson progress to your account..."
+          : formatSyncStatusAgeLabel(lastCourseSyncAtMs)
+      : "Lesson and playback progress saved on this device.";
 
   const supportCardClass =
     "rounded-2xl border border-slate-200/70 bg-[linear-gradient(180deg,rgba(255,255,255,0.92),rgba(248,250,252,0.92))] shadow-[0_10px_24px_rgba(15,23,42,0.065)] lg:border-slate-300/70 lg:bg-white/96 lg:shadow-[0_14px_34px_rgba(15,23,42,0.08)]";
 
   useEffect(() => {
-    if (!isGuest) {
+    if (previewEnabled || !isGuest) {
       setShowBackupPrompt(false);
       return;
     }
@@ -1435,7 +1545,7 @@ function CoursePageClient() {
     } catch {}
 
     setShowBackupPrompt(true);
-  }, [doneLessonsCount, isGuest]);
+  }, [doneLessonsCount, isGuest, previewEnabled]);
 
   useEffect(() => {
     setCommonMistakesExpanded(false);
@@ -2081,6 +2191,110 @@ function CoursePageClient() {
     [safePreviewLessonIndex, setOverviewDragging, totalLessons]
   );
 
+  const previewBanner = previewEnabled ? (
+    <section
+      className="mt-2 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3"
+      data-testid="course-preview-mode-banner"
+      aria-live="polite"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <p className="text-sm font-semibold text-amber-900">
+          Preview mode - not visible to learners
+        </p>
+        <span className="rounded-full border border-amber-300 bg-white px-2.5 py-1 text-xs font-semibold text-amber-800">
+          {PREVIEW_MODE_COPY[previewMode]}
+        </span>
+        {previewContextLabel ? (
+          <span className="rounded-full border border-amber-300 bg-white px-2.5 py-1 text-xs font-medium text-amber-800">
+            {previewContextLabel}
+          </span>
+        ) : null}
+      </div>
+      <p className="mt-1 text-xs text-amber-800">
+        Preview state is isolated to this browser and does not change learner progress.
+      </p>
+    </section>
+  ) : null;
+
+  const previewSurfaceState = previewEnabled
+    ? courseContentLoadState === "loading" || courseContentLoadState === "idle"
+      ? "loading"
+      : courseContentLoadState === "error"
+        ? "error"
+        : courseModules.length === 0
+          ? "empty"
+          : "ready"
+    : "ready";
+
+  if (previewEnabled && previewSurfaceState !== "ready") {
+    return (
+      <SiteChrome
+        menu={{
+          mode: "custom",
+          isOpen: drawerOpen,
+          onOpen: () => {
+            setDrawerView("course");
+            setDrawerOpen(true);
+          },
+          onClose: () => setDrawerOpen(false),
+          ariaLabel: "Toggle lessons",
+        }}
+        bottomBar={bottomBar}
+      >
+        <PageTemplate size="wide" showBack={false}>
+          <PageIntro
+            title="Free Course"
+            subtitle="Learn. Drill. Swim."
+            variant="compact"
+            belowDivider={
+              <div className="flex items-baseline gap-1 text-[12px] font-medium sm:text-[13px]">
+                <span className="shrink-0 text-slate-500">Current lesson:</span>
+                <span className="min-w-0 truncate text-slate-800">{activeLesson.title}</span>
+              </div>
+            }
+          />
+          {previewBanner}
+          <section className="mt-3 rounded-2xl border border-slate-200 bg-white px-4 py-4">
+            {previewSurfaceState === "loading" ? (
+              <p className="text-sm text-slate-700">Loading preview content...</p>
+            ) : null}
+            {previewSurfaceState === "empty" ? (
+              <p className="text-sm text-slate-700">
+                No lessons available for this preview mode yet. Publish or reclassify content and
+                try again.
+              </p>
+            ) : null}
+            {previewSurfaceState === "error" ? (
+              <div className="space-y-3">
+                <p className="text-sm font-medium text-rose-700">
+                  {courseContentError ?? "Could not load preview content."}
+                </p>
+                <div className="flex flex-wrap items-center gap-2">
+                  <PressButton
+                    tier="nav"
+                    onClick={() => router.refresh()}
+                    className="inline-flex min-h-[36px] items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-semibold text-slate-700"
+                  >
+                    Retry
+                  </PressButton>
+                  <PressLink
+                    tier="nav"
+                    href={
+                      lessonParam ? `/course?lesson=${encodeURIComponent(lessonParam)}` : "/course"
+                    }
+                    className="inline-flex min-h-[36px] items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-semibold text-slate-700"
+                  >
+                    Open learner view
+                  </PressLink>
+                </div>
+              </div>
+            ) : null}
+          </section>
+        </PageTemplate>
+      </SiteChrome>
+    );
+  }
+
   return (
     <SiteChrome
       menu={{
@@ -2127,6 +2341,7 @@ function CoursePageClient() {
               </CourseNavButton>
             }
           />
+          {previewBanner}
 
           <section className="lg:bg-white/96 mt-2 rounded-[20px] border border-slate-200/65 bg-white/90 p-3 shadow-[0_5px_14px_rgba(15,23,42,0.045)] lg:border-slate-300/70 lg:shadow-[0_10px_26px_rgba(15,23,42,0.08)]">
             <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">

--- a/components/admin/AdminContentManager.tsx
+++ b/components/admin/AdminContentManager.tsx
@@ -7,6 +7,7 @@ import type {
   AdminContentType,
 } from "@/lib/admin/content";
 import type { AdminCategoryRow } from "@/lib/admin/categories";
+import { buildCoursePreviewHref, resolveCoursePreviewModeFromStatus } from "@/lib/course/preview";
 
 const CONTENT_TYPE_OPTIONS: Array<{ value: AdminContentType; label: string }> = [
   { value: "course_module", label: "Course module" },
@@ -231,6 +232,7 @@ type CourseLessonWorkspaceItem = {
   id: string;
   title: string;
   slug: string;
+  status: AdminContentStatus;
   sortOrder: number;
   parentId: string | null;
   moduleLabel: string | null;
@@ -505,6 +507,25 @@ function lessonOpenHref(item: AdminContentItemRow): string {
   return `/course?lesson=${encodeURIComponent(lessonId)}`;
 }
 
+function lessonPreviewHref(item: AdminContentItemRow): string {
+  const lessonId = parseBodyString(item.body, "lessonId") ?? inferLessonIdFromSlug(item.slug);
+  return buildCoursePreviewHref({
+    lessonId,
+    mode: resolveCoursePreviewModeFromStatus(item.status),
+    previewType: "lesson",
+    previewRef: item.slug,
+  });
+}
+
+function modulePreviewHref(item: AdminContentItemRow, lessonId: string): string {
+  return buildCoursePreviewHref({
+    lessonId,
+    mode: resolveCoursePreviewModeFromStatus(item.status),
+    previewType: "module",
+    previewRef: item.slug,
+  });
+}
+
 function toEditFormState(item: AdminContentItemRow): EditFormState {
   return {
     title: item.title,
@@ -585,6 +606,7 @@ export default function AdminContentManager() {
           id: item.id,
           title: item.title,
           slug: item.slug,
+          status: item.status,
           sortOrder: item.sort_order,
           parentId: item.parent_id,
           moduleLabel: item.parent_id ? (moduleLabelById.get(item.parent_id) ?? null) : null,
@@ -593,6 +615,27 @@ export default function AdminContentManager() {
         })),
     [items, moduleLabelById]
   );
+
+  const firstRuntimeLessonIdByModuleId = useMemo(() => {
+    const byModuleId = new Map<string, string>();
+
+    const sortedLessons = [...courseLessonWorkspaceItems]
+      .filter((item) => item.parentId && moduleIdSet.has(item.parentId))
+      .sort((left, right) => {
+        const parentCompare = (left.parentId ?? "").localeCompare(right.parentId ?? "");
+        if (parentCompare !== 0) return parentCompare;
+        if (left.sortOrder !== right.sortOrder) return left.sortOrder - right.sortOrder;
+        return left.title.localeCompare(right.title);
+      });
+
+    for (const lesson of sortedLessons) {
+      if (!lesson.parentId) continue;
+      if (byModuleId.has(lesson.parentId)) continue;
+      byModuleId.set(lesson.parentId, lesson.runtimeLessonId);
+    }
+
+    return byModuleId;
+  }, [courseLessonWorkspaceItems, moduleIdSet]);
 
   const unlinkedLessonCount = useMemo(
     () =>
@@ -1641,7 +1684,7 @@ export default function AdminContentManager() {
             </div>
             <p className="mt-2 text-xs text-slate-600">
               Pick a module scope to sync workspace and list view, then jump straight to row edit or
-              open the public lesson page.
+              open preview/public lesson pages.
             </p>
             <div className="mt-3 flex flex-wrap items-end gap-2">
               <label className="space-y-1 text-xs font-medium text-slate-700">
@@ -1703,6 +1746,19 @@ export default function AdminContentManager() {
                         Edit lesson
                       </button>
                       <a
+                        href={buildCoursePreviewHref({
+                          lessonId: lesson.runtimeLessonId,
+                          mode: resolveCoursePreviewModeFromStatus(lesson.status),
+                          previewType: "lesson",
+                          previewRef: lesson.slug,
+                        })}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex h-8 items-center justify-center rounded-lg border border-amber-200 bg-amber-50 px-3 text-xs font-medium text-amber-800 transition hover:bg-amber-100"
+                      >
+                        Open preview
+                      </a>
+                      <a
                         href={`/course?lesson=${encodeURIComponent(lesson.runtimeLessonId)}`}
                         target="_blank"
                         rel="noreferrer"
@@ -1760,6 +1816,16 @@ export default function AdminContentManager() {
             {sortedItems.map((item) => {
               const isEditingRow = editingItemId === item.id;
               const isInlineEditable = canEditInline(item);
+              const rowPreviewHref =
+                item.content_type === "course_lesson"
+                  ? lessonPreviewHref(item)
+                  : item.content_type === "course_module"
+                    ? (() => {
+                        const firstLessonId = firstRuntimeLessonIdByModuleId.get(item.id);
+                        if (!firstLessonId) return null;
+                        return modulePreviewHref(item, firstLessonId);
+                      })()
+                    : null;
               const rowBusy = Boolean(
                 updatingId || deletingId || restoringRevisionId || savingEditId
               );
@@ -2495,6 +2561,23 @@ export default function AdminContentManager() {
                       </button>
                       {!isEditingRow ? (
                         <>
+                          {item.content_type === "course_lesson" ||
+                          item.content_type === "course_module" ? (
+                            rowPreviewHref ? (
+                              <a
+                                href={rowPreviewHref}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="inline-flex h-8 items-center justify-center rounded-lg border border-amber-200 bg-amber-50 px-3 text-xs font-medium text-amber-800 transition hover:bg-amber-100"
+                              >
+                                Open preview
+                              </a>
+                            ) : (
+                              <span className="inline-flex h-8 items-center justify-center rounded-lg border border-slate-200 bg-slate-100 px-3 text-xs font-medium text-slate-500">
+                                Open preview (no lessons)
+                              </span>
+                            )
+                          ) : null}
                           {item.content_type === "course_lesson" ? (
                             <a
                               href={lessonOpenHref(item)}

--- a/components/admin/AdminHelpCenter.tsx
+++ b/components/admin/AdminHelpCenter.tsx
@@ -159,6 +159,11 @@ const BUTTON_GUIDE = [
           "Opens edit mode for that lesson row and jumps to it in the content list. Use this for lesson body updates.",
       },
       {
+        label: "Open preview",
+        meaning:
+          "Opens admin preview mode in a new tab using the row status (draft/review/published/all) with a clear preview banner.",
+      },
+      {
         label: "Open lesson",
         meaning:
           "Opens the real lesson page in a new tab so you can verify exactly what users will see.",

--- a/docs/task-briefs/in-progress/2026-02-25-content-production-v1-admin-editorial-run.md
+++ b/docs/task-briefs/in-progress/2026-02-25-content-production-v1-admin-editorial-run.md
@@ -145,6 +145,7 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 
 ## Checkpoint Log
 
+- `2026-03-03 | c87c5b4 | admin preview mode slice delivered | shipped admin preview links for module/lesson rows, server-gated preview mode content reads, explicit /course preview banner + loading/error/empty states, preview-local progress key isolation, and non-index headers; added unit + e2e coverage and passed npm run verify:pre-pr | next: open/update PR in Safari; after merge continue with my-library new-content notice slice`
 - `2026-03-03 | planning gate for library notice + admin preview mode | verified branch/main parity and no half-finished local diff for these features; created dedicated planned briefs: docs/task-briefs/planned/2026-03-03-my-library-new-content-notice-10-10.md and docs/task-briefs/planned/2026-03-03-admin-preview-mode-and-open-lesson-preview-10-10.md | next: execute preview-mode brief first, then library notice brief`
 - `2026-02-25 | kickoff | content production v1 track opened after AW-013 phase8 merge; no hard blockers found in active briefs for starting editorial production | next: run Slice 1 production session and capture first friction batch`
 - `2026-02-25 | desktop visual calibration slice | tuned large-screen readability/contrast and widened PageTemplate (wide layout) for course/admin surfaces to reduce washed-out look on large monitors; npm run verify:pre-pr passed (second run after one transient Playwright goto timeout) | next: verify on 49" monitor and capture any residual contrast/layout friction`

--- a/docs/task-briefs/in-progress/2026-03-03-admin-preview-mode-and-open-lesson-preview-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-03-admin-preview-mode-and-open-lesson-preview-10-10.md
@@ -138,4 +138,4 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 
 ## Checkpoint Log
 
-- `2026-03-03 | implementation started | moved brief from planned->in-progress; implemented preview-mode core on admin links + /api/course/content gate + /course banner/state + preview-local progress isolation + noindex headers + new unit/e2e coverage | next: run validation gates, then commit/push/PR`
+- `2026-03-03 | c87c5b4 | implementation complete for slice scope | moved brief from planned->in-progress; implemented preview-mode core on admin links + /api/course/content gate + /course banner/state + preview-local progress isolation + noindex headers + new unit/e2e coverage; verification gate npm run verify:pre-pr passed | next: push branch and open/update PR in Safari`

--- a/docs/task-briefs/in-progress/2026-03-03-admin-preview-mode-and-open-lesson-preview-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-03-admin-preview-mode-and-open-lesson-preview-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-03-03-admin-preview-mode-and-open-lesson-preview-10-10`
-- `status`: `planned`
+- `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-03-03`
 - `updated`: `2026-03-03`
@@ -135,3 +135,7 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 1. `git status -sb`
 2. `git log --oneline -n 10`
 3. reopen this brief and continue from latest checkpoint.
+
+## Checkpoint Log
+
+- `2026-03-03 | implementation started | moved brief from planned->in-progress; implemented preview-mode core on admin links + /api/course/content gate + /course banner/state + preview-local progress isolation + noindex headers + new unit/e2e coverage | next: run validation gates, then commit/push/PR`

--- a/lib/admin/content-course.ts
+++ b/lib/admin/content-course.ts
@@ -6,16 +6,17 @@ import {
 } from "@/app/course/courseData";
 import { ensurePlatformContentSeeded } from "@/lib/admin/content-import-apply";
 import { isAdminContentSchemaMissing } from "@/lib/admin/schema";
+import type { CourseContentReadStatus } from "@/lib/course/preview";
 import { createAdminSupabaseClient } from "@/lib/supabase/admin";
 import type { Database, Json } from "@/types/database";
 
 type AdminContentRow = Database["public"]["Tables"]["admin_content_items"]["Row"];
 
-type PublishedCourseModuleRow = Pick<
+type CourseModuleContentRow = Pick<
   AdminContentRow,
   "id" | "slug" | "title" | "summary" | "sort_order" | "body"
 >;
-type PublishedCourseLessonRow = Pick<
+type CourseLessonContentRow = Pick<
   AdminContentRow,
   "id" | "parent_id" | "slug" | "title" | "summary" | "sort_order" | "body"
 >;
@@ -177,8 +178,8 @@ function normalizeSupportCard(value: unknown): CourseLesson["supportCard"] | und
 }
 
 export function toPublishedCourseModules(
-  moduleRows: PublishedCourseModuleRow[],
-  lessonRows: PublishedCourseLessonRow[],
+  moduleRows: CourseModuleContentRow[],
+  lessonRows: CourseLessonContentRow[],
   fallback: CourseModule[] = COURSE_MODULES
 ): CourseModule[] {
   if (moduleRows.length === 0 || lessonRows.length === 0) {
@@ -263,49 +264,91 @@ export function toPublishedCourseModules(
   return normalizedModules;
 }
 
-export async function loadPublishedCourseModules(): Promise<CourseModule[]> {
+type LoadCourseModulesByStatusInput = {
+  statuses: CourseContentReadStatus[];
+  fallback: CourseModule[];
+  autoSeedWhenEmpty: boolean;
+};
+
+function normalizeReadStatuses(
+  statuses: readonly CourseContentReadStatus[]
+): CourseContentReadStatus[] {
+  const unique = new Set<CourseContentReadStatus>();
+  for (const status of statuses) {
+    if (
+      status === "draft" ||
+      status === "review" ||
+      status === "published" ||
+      status === "archived"
+    ) {
+      unique.add(status);
+    }
+  }
+
+  if (unique.size === 0) {
+    return ["published"];
+  }
+
+  return Array.from(unique);
+}
+
+export async function loadCourseModulesByStatus(
+  input: LoadCourseModulesByStatusInput
+): Promise<CourseModule[]> {
+  const statuses = normalizeReadStatuses(input.statuses);
+
   try {
     const supabase = createAdminSupabaseClient();
 
     const readRows = async () => {
-      const modulesResult = await supabase
+      const modulesQuery = supabase
         .from("admin_content_items")
         .select("id, slug, title, summary, sort_order, body, created_at")
         .eq("content_type", "course_module")
-        .eq("status", "published")
         .order("sort_order", { ascending: true })
         .order("created_at", { ascending: true });
+      if (statuses.length === 1) {
+        modulesQuery.eq("status", statuses[0]);
+      } else {
+        modulesQuery.in("status", statuses);
+      }
+      const modulesResult = await modulesQuery;
 
       if (modulesResult.error) {
         return {
           ok: false as const,
           error: modulesResult.error,
-          modules: [] as PublishedCourseModuleRow[],
-          lessons: [] as PublishedCourseLessonRow[],
+          modules: [] as CourseModuleContentRow[],
+          lessons: [] as CourseLessonContentRow[],
         };
       }
 
-      const lessonsResult = await supabase
+      const lessonsQuery = supabase
         .from("admin_content_items")
         .select("id, parent_id, slug, title, summary, sort_order, body, created_at")
         .eq("content_type", "course_lesson")
-        .eq("status", "published")
         .order("sort_order", { ascending: true })
         .order("created_at", { ascending: true });
+      if (statuses.length === 1) {
+        lessonsQuery.eq("status", statuses[0]);
+      } else {
+        lessonsQuery.in("status", statuses);
+      }
+      const lessonsResult = await lessonsQuery;
 
       if (lessonsResult.error) {
         return {
           ok: false as const,
           error: lessonsResult.error,
-          modules: [] as PublishedCourseModuleRow[],
-          lessons: [] as PublishedCourseLessonRow[],
+          modules: [] as CourseModuleContentRow[],
+          lessons: [] as CourseLessonContentRow[],
         };
       }
 
       return {
         ok: true as const,
-        modules: (modulesResult.data ?? []) as PublishedCourseModuleRow[],
-        lessons: (lessonsResult.data ?? []) as PublishedCourseLessonRow[],
+        modules: (modulesResult.data ?? []) as CourseModuleContentRow[],
+        lessons: (lessonsResult.data ?? []) as CourseLessonContentRow[],
       };
     };
 
@@ -317,10 +360,13 @@ export async function loadPublishedCourseModules(): Promise<CourseModule[]> {
           readResult.error
         );
       }
-      return COURSE_MODULES;
+      return input.fallback;
     }
 
-    if (readResult.modules.length === 0 || readResult.lessons.length === 0) {
+    if (
+      input.autoSeedWhenEmpty &&
+      (readResult.modules.length === 0 || readResult.lessons.length === 0)
+    ) {
       const ensureResult = await ensurePlatformContentSeeded({ supabase });
       if (!ensureResult.ok) {
         if (ensureResult.schemaReady) {
@@ -329,7 +375,7 @@ export async function loadPublishedCourseModules(): Promise<CourseModule[]> {
             ensureResult.error
           );
         }
-        return COURSE_MODULES;
+        return input.fallback;
       }
       if (ensureResult.seeded) {
         readResult = await readRows();
@@ -340,15 +386,23 @@ export async function loadPublishedCourseModules(): Promise<CourseModule[]> {
               readResult.error
             );
           }
-          return COURSE_MODULES;
+          return input.fallback;
         }
       }
     }
 
     const publishedModules = toPublishedCourseModules(readResult.modules, readResult.lessons, []);
-    return publishedModules.length > 0 ? publishedModules : COURSE_MODULES;
+    return publishedModules.length > 0 ? publishedModules : input.fallback;
   } catch (error) {
     console.error("[PublishedContent] Could not query published course content", error);
-    return COURSE_MODULES;
+    return input.fallback;
   }
+}
+
+export async function loadPublishedCourseModules(): Promise<CourseModule[]> {
+  return loadCourseModulesByStatus({
+    statuses: ["published"],
+    fallback: COURSE_MODULES,
+    autoSeedWhenEmpty: true,
+  });
 }

--- a/lib/course/preview.ts
+++ b/lib/course/preview.ts
@@ -1,0 +1,133 @@
+export const COURSE_PREVIEW_MODES = ["published", "review", "draft", "all"] as const;
+export type CoursePreviewMode = (typeof COURSE_PREVIEW_MODES)[number];
+
+export const COURSE_CONTENT_READ_STATUSES = ["draft", "review", "published", "archived"] as const;
+export type CourseContentReadStatus = (typeof COURSE_CONTENT_READ_STATUSES)[number];
+
+export type CoursePreviewType = "lesson" | "module";
+
+export type CoursePreviewRequestResolution =
+  | {
+      ok: true;
+      enabled: false;
+      mode: "published";
+    }
+  | {
+      ok: true;
+      enabled: true;
+      mode: CoursePreviewMode;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export type CourseProgressStorageKeys = {
+  lastLesson: string;
+  doneLessons: string;
+  doneConfirmations: string;
+  videoProgress: string;
+};
+
+export const LEARNER_COURSE_PROGRESS_STORAGE_KEYS: CourseProgressStorageKeys = {
+  lastLesson: "fs_course_last_lesson",
+  doneLessons: "fs_course_done_lessons",
+  doneConfirmations: "fs_course_done_confirmations",
+  videoProgress: "fs_course_video_progress",
+};
+
+export function parseCoursePreviewMode(value: string | null | undefined): CoursePreviewMode | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return null;
+  return COURSE_PREVIEW_MODES.includes(normalized as CoursePreviewMode)
+    ? (normalized as CoursePreviewMode)
+    : null;
+}
+
+export function resolveCoursePreviewRequest(input: {
+  previewParam?: string | null;
+  previewModeParam?: string | null;
+}): CoursePreviewRequestResolution {
+  const previewEnabled = input.previewParam === "1";
+  const hasPreviewModeParam = typeof input.previewModeParam === "string";
+
+  if (!previewEnabled && hasPreviewModeParam) {
+    return {
+      ok: false,
+      error: "previewMode requires preview=1.",
+    };
+  }
+
+  if (!previewEnabled) {
+    return {
+      ok: true,
+      enabled: false,
+      mode: "published",
+    };
+  }
+
+  const mode = parseCoursePreviewMode(input.previewModeParam ?? "published");
+  if (!mode) {
+    return {
+      ok: false,
+      error: "Invalid preview mode.",
+    };
+  }
+
+  return {
+    ok: true,
+    enabled: true,
+    mode,
+  };
+}
+
+export function resolveCourseContentStatusesForPreviewMode(
+  mode: CoursePreviewMode
+): CourseContentReadStatus[] {
+  if (mode === "draft") return ["draft"];
+  if (mode === "review") return ["review"];
+  if (mode === "all") return ["draft", "review", "published", "archived"];
+  return ["published"];
+}
+
+export function resolveCoursePreviewModeFromStatus(
+  status: CourseContentReadStatus
+): CoursePreviewMode {
+  if (status === "draft") return "draft";
+  if (status === "review") return "review";
+  if (status === "archived") return "all";
+  return "published";
+}
+
+export function getCourseProgressStorageKeys(input: {
+  previewEnabled: boolean;
+  previewMode: CoursePreviewMode;
+}): CourseProgressStorageKeys {
+  if (!input.previewEnabled) {
+    return LEARNER_COURSE_PROGRESS_STORAGE_KEYS;
+  }
+
+  const prefix = `fs_course_preview_${input.previewMode}`;
+  return {
+    lastLesson: `${prefix}_last_lesson`,
+    doneLessons: `${prefix}_done_lessons`,
+    doneConfirmations: `${prefix}_done_confirmations`,
+    videoProgress: `${prefix}_video_progress`,
+  };
+}
+
+export function buildCoursePreviewHref(input: {
+  lessonId: string;
+  mode: CoursePreviewMode;
+  previewType: CoursePreviewType;
+  previewRef: string;
+}) {
+  const params = new URLSearchParams();
+  params.set("lesson", input.lessonId);
+  params.set("preview", "1");
+  params.set("previewMode", input.mode);
+  params.set("previewType", input.previewType);
+  params.set("previewRef", input.previewRef);
+  return `/course?${params.toString()}`;
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -18,13 +18,13 @@ export async function proxy(request: NextRequest) {
   }
 
   if (!config.enabled || isSiteLockPathBypassed(request.nextUrl.pathname)) {
-    return updateSupabaseSession(request);
+    return withCoursePreviewHeadersIfNeeded(await updateSupabaseSession(request), request);
   }
 
   if (
     isSiteLockBypassTokenValid(request.headers.get("x-site-lock-bypass-token"), config.bypassToken)
   ) {
-    return updateSupabaseSession(request);
+    return withCoursePreviewHeadersIfNeeded(await updateSupabaseSession(request), request);
   }
 
   const siteLockCookie = request.cookies.get(config.cookieName)?.value;
@@ -35,7 +35,7 @@ export async function proxy(request: NextRequest) {
       maxAgeSeconds: config.sessionMaxAgeSeconds,
     })
   ) {
-    return updateSupabaseSession(request);
+    return withCoursePreviewHeadersIfNeeded(await updateSupabaseSession(request), request);
   }
 
   if (request.nextUrl.pathname.startsWith("/api/")) {
@@ -46,6 +46,25 @@ export async function proxy(request: NextRequest) {
 }
 
 function withNoStoreHeaders(response: NextResponse): NextResponse {
+  response.headers.set("Cache-Control", "no-store");
+  response.headers.set("X-Robots-Tag", "noindex, nofollow, noarchive");
+  return response;
+}
+
+function isCoursePreviewRequest(request: NextRequest): boolean {
+  return (
+    request.nextUrl.pathname === "/course" && request.nextUrl.searchParams.get("preview") === "1"
+  );
+}
+
+function withCoursePreviewHeadersIfNeeded(
+  response: NextResponse,
+  request: NextRequest
+): NextResponse {
+  if (!isCoursePreviewRequest(request)) {
+    return response;
+  }
+
   response.headers.set("Cache-Control", "no-store");
   response.headers.set("X-Robots-Tag", "noindex, nofollow, noarchive");
   return response;

--- a/tests/e2e/admin-foundation.spec.ts
+++ b/tests/e2e/admin-foundation.spec.ts
@@ -226,6 +226,10 @@ test.describe("admin foundation", () => {
       .filter({ hasText: "Welcome & Course Structure" })
       .first();
     await expect(workspaceLessonRow).toBeVisible();
+    await expect(workspaceLessonRow.getByRole("link", { name: "Open preview" })).toHaveAttribute(
+      "href",
+      /\/course\?lesson=mod1-l1&preview=1&previewMode=published&previewType=lesson&previewRef=course-lesson-mod1-l1/
+    );
     await expect(workspaceLessonRow.getByRole("link", { name: "Open lesson" })).toHaveAttribute(
       "href",
       /\/course\?lesson=mod1-l1/

--- a/tests/e2e/admin-help-center.spec.ts
+++ b/tests/e2e/admin-help-center.spec.ts
@@ -51,6 +51,7 @@ test.describe("admin help center", () => {
     await expect(page.getByText("Mirror snapshot cards:")).toBeVisible();
     await expect(page.getByText("Module workspace:")).toBeVisible();
     await expect(page.getByText("Edit lesson:")).toBeVisible();
+    await expect(page.getByText("Open preview:")).toBeVisible();
     await expect(page.getByText("Open lesson:")).toBeVisible();
     await expect(page.getByText("All statuses filter:")).toBeVisible();
     await expect(page.getByText("Sort content list:")).toBeVisible();

--- a/tests/e2e/admin-preview-mode.spec.ts
+++ b/tests/e2e/admin-preview-mode.spec.ts
@@ -1,0 +1,87 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+const isSiteLockEnabled = process.env.SITE_LOCK_ENABLED === "1";
+const unauthenticatedDeniedStatuses = new Set([401, 403, 423]);
+
+function runOnceOnDesktopChromium(projectName: string) {
+  test.skip(!projectName.startsWith("desktop-"), "Admin preview e2e is desktop-only.");
+  test.skip(projectName !== "desktop-chromium", "Runs once on desktop Chromium.");
+  test.skip(isSiteLockEnabled, "Skipped while private access gate is enabled.");
+}
+
+async function loginAsAdminViaDevBypass(page: Page) {
+  await page.goto(`/dev/login?next=${encodeURIComponent("/admin")}`);
+  const pathAfterDevLogin = new URL(page.url()).pathname;
+
+  if (pathAfterDevLogin !== "/admin") {
+    test.skip(true, "Dev auth bypass is not enabled in this environment.");
+  }
+
+  const noAccessHeading = page.getByRole("heading", { name: "You don't have access" });
+  if (await noAccessHeading.isVisible().catch(() => false)) {
+    test.skip(true, "Dev bypass account is signed in but not allowlisted/admin.");
+  }
+
+  await expect(page.getByRole("heading", { name: "Admin console" })).toBeVisible();
+}
+
+test.describe("admin preview mode", () => {
+  test("denies unauthenticated preview API access", async ({ request }, testInfo) => {
+    runOnceOnDesktopChromium(testInfo.project.name);
+
+    const response = await request.get("/api/course/content?preview=1&previewMode=draft");
+    expect(
+      unauthenticatedDeniedStatuses.has(response.status()),
+      `Unexpected status ${response.status()} for unauthenticated preview request`
+    ).toBeTruthy();
+  });
+
+  test("opens module/lesson preview links and renders preview banner with noindex headers", async ({
+    page,
+    request,
+  }, testInfo) => {
+    runOnceOnDesktopChromium(testInfo.project.name);
+    await loginAsAdminViaDevBypass(page);
+
+    const lessonWorkspace = page.getByTestId("admin-course-lesson-workspace");
+    await expect(lessonWorkspace).toBeVisible();
+
+    const workspaceLessonRow = lessonWorkspace
+      .getByTestId("admin-workspace-lesson-row")
+      .filter({ hasText: "Welcome & Course Structure" })
+      .first();
+    await expect(workspaceLessonRow).toBeVisible();
+
+    const lessonPreviewLink = workspaceLessonRow.getByRole("link", { name: "Open preview" });
+    await expect(lessonPreviewLink).toHaveAttribute(
+      "href",
+      /preview=1&previewMode=published&previewType=lesson/
+    );
+
+    const moduleRow = page
+      .getByTestId("admin-content-item")
+      .filter({ hasText: "Introduction to the Course" })
+      .first();
+    await expect(moduleRow).toBeVisible();
+    await expect(moduleRow.getByRole("link", { name: "Open preview" })).toHaveAttribute(
+      "href",
+      /preview=1&previewMode=published&previewType=module/
+    );
+
+    const [previewPage] = await Promise.all([
+      page.context().waitForEvent("page"),
+      lessonPreviewLink.click(),
+    ]);
+    await previewPage.waitForLoadState("domcontentloaded");
+
+    const previewBanner = previewPage.getByTestId("course-preview-mode-banner");
+    await expect(previewBanner).toBeVisible();
+    await expect(previewBanner).toContainText("Preview mode");
+    await expect(previewBanner).toContainText("not visible to learners");
+
+    const previewPath = new URL(previewPage.url());
+    const previewResponse = await request.get(`${previewPath.pathname}${previewPath.search}`);
+    expect(previewResponse.headers()["x-robots-tag"]).toBe("noindex, nofollow, noarchive");
+  });
+});

--- a/tests/unit/course-content-route.test.ts
+++ b/tests/unit/course-content-route.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  loadCourseModulesByStatusMock,
+  requireAdminRoleFromSupabaseMock,
+  createRouteHandlerSupabaseClientMock,
+} = vi.hoisted(() => {
+  return {
+    loadCourseModulesByStatusMock: vi.fn(),
+    requireAdminRoleFromSupabaseMock: vi.fn(),
+    createRouteHandlerSupabaseClientMock: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/admin/content-course", () => ({
+  loadCourseModulesByStatus: loadCourseModulesByStatusMock,
+}));
+
+vi.mock("@/lib/admin/server", () => ({
+  requireAdminRoleFromSupabase: requireAdminRoleFromSupabaseMock,
+}));
+
+vi.mock("@/lib/supabase/route-handler", () => ({
+  createRouteHandlerSupabaseClient: createRouteHandlerSupabaseClientMock,
+}));
+
+import { GET } from "@/app/api/course/content/route";
+
+function buildRequest(path: string): Request {
+  return new Request(`http://127.0.0.1:3000${path}`);
+}
+
+describe("/api/course/content route", () => {
+  beforeEach(() => {
+    loadCourseModulesByStatusMock.mockResolvedValue([
+      {
+        id: "mod1",
+        title: "Intro",
+        lessons: [
+          {
+            id: "mod1-l1",
+            title: "Lesson",
+            youtubeId: "abc123",
+            goal: "Goal",
+            cues: ["Cue"],
+            drill: {
+              title: "Drill",
+              steps: ["Step"],
+            },
+            nextStep: "Next",
+          },
+        ],
+      },
+    ]);
+
+    requireAdminRoleFromSupabaseMock.mockResolvedValue({
+      ok: true,
+      user: { id: "user-1" },
+      role: "admin",
+    });
+
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {},
+      applySupabaseCookies: <T>(response: T) => response,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns published learner content by default", async () => {
+    const response = await GET(buildRequest("/api/course/content"));
+    const payload = (await response.json()) as {
+      ok?: boolean;
+      preview?: { enabled?: boolean; mode?: string };
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(payload.preview).toEqual({
+      enabled: false,
+      mode: "published",
+    });
+    expect(loadCourseModulesByStatusMock).toHaveBeenCalledWith({
+      statuses: ["published"],
+      fallback: expect.any(Array),
+      autoSeedWhenEmpty: true,
+    });
+    expect(requireAdminRoleFromSupabaseMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects previewMode without explicit preview flag", async () => {
+    const response = await GET(buildRequest("/api/course/content?previewMode=draft"));
+    const payload = (await response.json()) as { ok?: boolean; error?: string };
+
+    expect(response.status).toBe(400);
+    expect(payload).toMatchObject({
+      ok: false,
+      error: "previewMode requires preview=1.",
+    });
+  });
+
+  it("returns forbidden for unauthorized preview requests", async () => {
+    requireAdminRoleFromSupabaseMock.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: "Forbidden.",
+    });
+
+    const response = await GET(buildRequest("/api/course/content?preview=1&previewMode=draft"));
+    const payload = (await response.json()) as { ok?: boolean; error?: string };
+
+    expect(response.status).toBe(403);
+    expect(payload).toMatchObject({
+      ok: false,
+      error: "Forbidden.",
+    });
+    expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow, noarchive");
+  });
+
+  it("returns admin preview content with noindex headers", async () => {
+    const response = await GET(buildRequest("/api/course/content?preview=1&previewMode=review"));
+    const payload = (await response.json()) as {
+      ok?: boolean;
+      preview?: { enabled?: boolean; mode?: string; statuses?: string[] };
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(payload.preview).toEqual({
+      enabled: true,
+      mode: "review",
+      statuses: ["review"],
+    });
+    expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow, noarchive");
+    expect(loadCourseModulesByStatusMock).toHaveBeenCalledWith({
+      statuses: ["review"],
+      fallback: [],
+      autoSeedWhenEmpty: false,
+    });
+  });
+});

--- a/tests/unit/course-preview.test.ts
+++ b/tests/unit/course-preview.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  LEARNER_COURSE_PROGRESS_STORAGE_KEYS,
+  buildCoursePreviewHref,
+  getCourseProgressStorageKeys,
+  resolveCourseContentStatusesForPreviewMode,
+  resolveCoursePreviewModeFromStatus,
+  resolveCoursePreviewRequest,
+} from "@/lib/course/preview";
+
+describe("course preview helpers", () => {
+  it("keeps learner defaults when preview is disabled", () => {
+    expect(
+      getCourseProgressStorageKeys({
+        previewEnabled: false,
+        previewMode: "published",
+      })
+    ).toEqual(LEARNER_COURSE_PROGRESS_STORAGE_KEYS);
+  });
+
+  it("uses isolated storage keys when preview is enabled", () => {
+    expect(
+      getCourseProgressStorageKeys({
+        previewEnabled: true,
+        previewMode: "draft",
+      })
+    ).toEqual({
+      lastLesson: "fs_course_preview_draft_last_lesson",
+      doneLessons: "fs_course_preview_draft_done_lessons",
+      doneConfirmations: "fs_course_preview_draft_done_confirmations",
+      videoProgress: "fs_course_preview_draft_video_progress",
+    });
+  });
+
+  it("rejects previewMode without explicit preview flag", () => {
+    expect(
+      resolveCoursePreviewRequest({
+        previewParam: null,
+        previewModeParam: "draft",
+      })
+    ).toEqual({
+      ok: false,
+      error: "previewMode requires preview=1.",
+    });
+  });
+
+  it("normalizes preview request to published mode by default", () => {
+    expect(
+      resolveCoursePreviewRequest({
+        previewParam: "1",
+        previewModeParam: null,
+      })
+    ).toEqual({
+      ok: true,
+      enabled: true,
+      mode: "published",
+    });
+  });
+
+  it("maps preview modes to deterministic status filters", () => {
+    expect(resolveCourseContentStatusesForPreviewMode("draft")).toEqual(["draft"]);
+    expect(resolveCourseContentStatusesForPreviewMode("review")).toEqual(["review"]);
+    expect(resolveCourseContentStatusesForPreviewMode("published")).toEqual(["published"]);
+    expect(resolveCourseContentStatusesForPreviewMode("all")).toEqual([
+      "draft",
+      "review",
+      "published",
+      "archived",
+    ]);
+  });
+
+  it("maps content status to preview mode for admin links", () => {
+    expect(resolveCoursePreviewModeFromStatus("draft")).toBe("draft");
+    expect(resolveCoursePreviewModeFromStatus("review")).toBe("review");
+    expect(resolveCoursePreviewModeFromStatus("published")).toBe("published");
+    expect(resolveCoursePreviewModeFromStatus("archived")).toBe("all");
+  });
+
+  it("builds explicit preview links with context", () => {
+    expect(
+      buildCoursePreviewHref({
+        lessonId: "mod1-l1",
+        mode: "review",
+        previewType: "lesson",
+        previewRef: "course-lesson-mod1-l1",
+      })
+    ).toBe(
+      "/course?lesson=mod1-l1&preview=1&previewMode=review&previewType=lesson&previewRef=course-lesson-mod1-l1"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds explicit admin preview mode flow for `/course` with status-aware content reads: `published`, `review`, `draft`, `all`.
- Adds `Open preview` actions in admin lesson/module rows (including workspace), opening `_blank` with explicit preview context in URL.
- Adds clear preview banner on course page and explicit loading/error/empty states for preview fetch.
- Isolates preview progress from learner progress via dedicated localStorage namespaces and disables account sync during preview.
- Enforces fail-closed preview access in `/api/course/content` using admin role checks and explicit invalid-mode handling.
- Marks preview responses as non-indexable (`X-Robots-Tag: noindex, nofollow, noarchive`) and applies same header on `/course?preview=1` via `proxy.ts`.

## Validation
- `npm run test:unit -- tests/unit/course-preview.test.ts tests/unit/course-content-route.test.ts tests/unit/admin-content-course.test.ts` ✅
- `npx playwright test tests/e2e/admin-preview-mode.spec.ts tests/e2e/admin-foundation.spec.ts tests/e2e/admin-help-center.spec.ts --project=desktop-chromium` ✅
- `npx playwright test tests/e2e/admin-preview-mode.spec.ts --project=desktop-chromium` (post-fix rerun) ✅
- `npm run verify:pre-pr` ✅

## Risk / Regression Notes
- Course preview now has an explicit blocking state if preview fetch fails, to avoid silent fallback from requested preview mode.
- Existing learner flow remains default (`published` only) and still falls back to static course data if content API fails.
- CI `verify` check on this PR is currently running; merge readiness depends on required checks turning green.

## Brief / Continuity
- Moved brief to in-progress:
  - `docs/task-briefs/in-progress/2026-03-03-admin-preview-mode-and-open-lesson-preview-10-10.md`
- Updated parent checkpoint log:
  - `docs/task-briefs/in-progress/2026-02-25-content-production-v1-admin-editorial-run.md`
