### PR TITLE
feat(ops): add one-click site-lock workflow foundation

### DIFF
--- a/.github/workflows/site-lock-operations.yml
+++ b/.github/workflows/site-lock-operations.yml
@@ -1,0 +1,251 @@
+name: Site Lock Operations
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Operation to run"
+        required: true
+        type: choice
+        options:
+          - lock_on
+          - lock_off
+      target_environment:
+        description: "Target Vercel environment"
+        required: true
+        type: choice
+        options:
+          - preview
+          - production
+      reason:
+        description: "Reason for operation (audit trail)"
+        required: true
+        default: "Manual site-lock operation"
+        type: string
+      confirm:
+        description: "Type APPLY to confirm"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: site-lock-ops-${{ inputs.target_environment }}
+  cancel-in-progress: false
+
+jobs:
+  operate-site-lock:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: ${{ inputs.target_environment == 'production' && 'site-lock-production' || 'site-lock-preview' }}
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      OPERATION: ${{ inputs.action }}
+      TARGET_ENVIRONMENT: ${{ inputs.target_environment }}
+      OPERATION_REASON: ${{ inputs.reason }}
+      OPERATION_CONFIRM: ${{ inputs.confirm }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Validate operation request
+        id: validate
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/site-lock-ops
+
+          if [ "$OPERATION_CONFIRM" != "APPLY" ]; then
+            echo "::error::Input 'confirm' must be exactly APPLY."
+            exit 1
+          fi
+
+          case "$OPERATION" in
+            lock_on)
+              desired="1"
+              rollback="lock_off"
+              ;;
+            lock_off)
+              desired="0"
+              rollback="lock_on"
+              ;;
+            *)
+              echo "::error::Unsupported operation: $OPERATION"
+              exit 1
+              ;;
+          esac
+
+          case "$TARGET_ENVIRONMENT" in
+            preview|production) ;;
+            *)
+              echo "::error::Unsupported target environment: $TARGET_ENVIRONMENT"
+              exit 1
+              ;;
+          esac
+
+          echo "desired=$desired" >> "$GITHUB_OUTPUT"
+          echo "rollback=$rollback" >> "$GITHUB_OUTPUT"
+
+      - name: Check required Vercel secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=""
+          for key in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+            if [ -z "${!key:-}" ]; then
+              if [ -n "$missing" ]; then
+                missing="$missing, "
+              fi
+              missing="${missing}${key}"
+            fi
+          done
+
+          if [ -n "$missing" ]; then
+            echo "::error::Missing required Vercel secrets: $missing"
+            exit 1
+          fi
+
+      - name: Install Vercel CLI
+        run: npm i -g vercel@latest
+
+      - name: Pull Vercel project settings
+        shell: bash
+        run: |
+          set -euo pipefail
+          vercel pull --yes --environment="$TARGET_ENVIRONMENT" --token="$VERCEL_TOKEN"
+
+      - name: Validate lock prerequisites for lock_on
+        if: inputs.action == 'lock_on'
+        shell: bash
+        run: |
+          set -euo pipefail
+          env_list="$(vercel env ls "$TARGET_ENVIRONMENT" --token="$VERCEL_TOKEN")"
+
+          missing=""
+          for key in SITE_LOCK_PASSWORD_HASH SITE_LOCK_BYPASS_TOKEN; do
+            if ! printf '%s\n' "$env_list" | grep -q "$key"; then
+              if [ -n "$missing" ]; then
+                missing="$missing, "
+              fi
+              missing="${missing}${key}"
+            fi
+          done
+
+          if [ -n "$missing" ]; then
+            echo "::error::Cannot run lock_on. Missing required site-lock vars in Vercel $TARGET_ENVIRONMENT: $missing"
+            exit 1
+          fi
+
+      - name: Apply SITE_LOCK_ENABLED in Vercel environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          desired="${{ steps.validate.outputs.desired }}"
+
+          env_list="$(vercel env ls "$TARGET_ENVIRONMENT" --token="$VERCEL_TOKEN" || true)"
+          if printf '%s\n' "$env_list" | grep -q "SITE_LOCK_ENABLED"; then
+            vercel env rm SITE_LOCK_ENABLED "$TARGET_ENVIRONMENT" --yes --token="$VERCEL_TOKEN"
+          fi
+
+          printf '%s\n' "$desired" | vercel env add SITE_LOCK_ENABLED "$TARGET_ENVIRONMENT" --token="$VERCEL_TOKEN"
+
+      - name: Deploy updated environment
+        id: deploy
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/site-lock-ops
+          deploy_output_file="artifacts/site-lock-ops/deploy-output.log"
+
+          if [ "$TARGET_ENVIRONMENT" = "preview" ]; then
+            vercel deploy --target=preview --yes --token="$VERCEL_TOKEN" >"$deploy_output_file" 2>&1
+          else
+            vercel deploy --prod --yes --token="$VERCEL_TOKEN" >"$deploy_output_file" 2>&1
+          fi
+
+          deploy_url="$(grep -Eo 'https://[^ ]+' "$deploy_output_file" | tail -n 1 || true)"
+          if [ -z "$deploy_url" ]; then
+            echo "::error::Could not extract deployment URL from Vercel output."
+            cat "$deploy_output_file"
+            exit 1
+          fi
+
+          echo "deploy_url=$deploy_url" >> "$GITHUB_OUTPUT"
+          echo "Deploy URL: $deploy_url"
+
+      - name: Smoke verify lock behavior
+        id: smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/site-lock-ops
+          headers_file="artifacts/site-lock-ops/smoke-headers.txt"
+          deploy_url="${{ steps.deploy.outputs.deploy_url }}"
+
+          curl -sS -I --max-time 20 "$deploy_url" > "$headers_file"
+
+          status_code="$(awk 'NR==1 {print $2}' "$headers_file")"
+          location_header="$(awk 'tolower($1)=="location:" {print $2}' "$headers_file" | tr -d '\r' | tail -n 1)"
+
+          if [ "$OPERATION" = "lock_on" ]; then
+            if [[ "$location_header" != *"/preview-access"* ]]; then
+              echo "::error::lock_on smoke check failed. Expected redirect to /preview-access."
+              cat "$headers_file"
+              exit 1
+            fi
+          else
+            if [[ "$location_header" == *"/preview-access"* ]]; then
+              echo "::error::lock_off smoke check failed. Unexpected redirect to /preview-access."
+              cat "$headers_file"
+              exit 1
+            fi
+          fi
+
+          echo "status_code=$status_code" >> "$GITHUB_OUTPUT"
+          echo "location_header=$location_header" >> "$GITHUB_OUTPUT"
+
+      - name: Write operation summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/site-lock-ops
+          summary_file="artifacts/site-lock-ops/summary.md"
+          run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          cat > "$summary_file" <<EOF
+          # Site lock operation summary
+
+          - actor: \`${{ github.actor }}\`
+          - operation: \`$OPERATION\`
+          - target environment: \`$TARGET_ENVIRONMENT\`
+          - desired SITE_LOCK_ENABLED: \`${{ steps.validate.outputs.desired }}\`
+          - rollback action: \`${{ steps.validate.outputs.rollback }}\`
+          - reason: $OPERATION_REASON
+          - deployment URL: ${{ steps.deploy.outputs.deploy_url }}
+          - smoke status code: \`${{ steps.smoke.outputs.status_code }}\`
+          - smoke location header: \`${{ steps.smoke.outputs.location_header }}\`
+          - run URL: $run_url
+          EOF
+
+          cat "$summary_file" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload site-lock operation artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-lock-operation-${{ inputs.target_environment }}-${{ inputs.action }}
+          path: |
+            artifacts/site-lock-ops/summary.md
+            artifacts/site-lock-ops/smoke-headers.txt
+            artifacts/site-lock-ops/deploy-output.log
+          if-no-files-found: ignore
+          retention-days: 14

--- a/components/admin/AdminHelpCenter.tsx
+++ b/components/admin/AdminHelpCenter.tsx
@@ -16,7 +16,7 @@ type ActionGroup = {
   actions: Array<{ label: string; meaning: string }>;
 };
 
-const LAST_UPDATED = "2026-03-08";
+const LAST_UPDATED = "2026-03-10";
 
 const QUICK_ACTIONS = [
   { id: "overview", label: "Start here" },
@@ -256,6 +256,11 @@ const BUTTON_GUIDE: ActionGroup[] = [
     section: "Operations tab",
     actions: [
       {
+        label: "Open lock operations workflow",
+        meaning:
+          "Opens GitHub Actions dispatch for lock_on/lock_off with audited deploy + smoke verification.",
+      },
+      {
         label: "Open password page",
         meaning: "Opens private-access page for gate behavior testing.",
       },
@@ -417,6 +422,8 @@ const DAILY_PLAYBOOKS: Playbook[] = [
 
 const RUNBOOK_LINKS = [
   "docs/runbooks/qr-redirect-operations.md",
+  "docs/runbooks/site-lock-operations.md",
+  "docs/runbooks/private-access-gate.md",
   "docs/runbooks/post-merge-local-sync.md",
   "docs/runbooks/ci-unblock.md",
 ];

--- a/components/admin/AdminOperationsManager.tsx
+++ b/components/admin/AdminOperationsManager.tsx
@@ -34,6 +34,11 @@ type AdminRuntimeFlagUpdateResponse =
       error?: string;
     };
 
+const SITE_LOCK_WORKFLOW_URL =
+  "https://github.com/stianvikra/freeswimming/actions/workflows/site-lock-operations.yml";
+const SITE_LOCK_RUNBOOK_URL =
+  "https://github.com/stianvikra/freeswimming/blob/main/docs/runbooks/site-lock-operations.md";
+
 function runtimeFlagLabel(key: string): string {
   return key;
 }
@@ -217,6 +222,14 @@ export default function AdminOperationsManager() {
           </div>
           <div className="mt-3 flex flex-wrap gap-2">
             <a
+              href={SITE_LOCK_WORKFLOW_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex h-9 items-center justify-center rounded-lg border border-indigo-200 bg-indigo-50 px-3 text-xs font-medium text-indigo-800 transition hover:bg-indigo-100"
+            >
+              Open lock operations workflow
+            </a>
+            <a
               href="/preview-access?next=%2Fadmin"
               className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50"
             >
@@ -229,6 +242,17 @@ export default function AdminOperationsManager() {
               Sign out this browser
             </a>
           </div>
+          <p className="mt-3 text-xs text-slate-500">
+            Operator runbook:{" "}
+            <a
+              href={SITE_LOCK_RUNBOOK_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="font-medium text-slate-700 underline underline-offset-2"
+            >
+              docs/runbooks/site-lock-operations.md
+            </a>
+          </p>
           <p className="mt-3 text-xs text-slate-500">
             To turn this off: set <code>SITE_LOCK_ENABLED=0</code> in hosting environment settings
             and redeploy.

--- a/docs/runbooks/private-access-gate.md
+++ b/docs/runbooks/private-access-gate.md
@@ -43,6 +43,11 @@ Preview cookie clear URL:
 /preview-access/clear?next=/
 ```
 
+Ops alternative:
+
+- For hosted preview/production, prefer the one-click workflow runbook:
+  - `docs/runbooks/site-lock-operations.md`
+
 ## Disable Lock
 
 1. Set `SITE_LOCK_ENABLED=0`.

--- a/docs/runbooks/site-lock-operations.md
+++ b/docs/runbooks/site-lock-operations.md
@@ -1,0 +1,63 @@
+# Site-Lock Operations Workflow Runbook
+
+## Purpose
+
+Run safe, auditable lock/unlock operations without manual Vercel env editing.
+
+## Workflow
+
+- GitHub Actions workflow: `.github/workflows/site-lock-operations.yml`
+- Trigger path: `Actions -> Site Lock Operations -> Run workflow`
+
+## Required Setup
+
+1. Repository secrets:
+   - `VERCEL_TOKEN`
+   - `VERCEL_ORG_ID`
+   - `VERCEL_PROJECT_ID`
+2. GitHub environments:
+   - `site-lock-preview`
+   - `site-lock-production`
+3. Environment protection:
+   - `site-lock-production` should require manual reviewer approval.
+4. Vercel target env requirements for `lock_on`:
+   - `SITE_LOCK_PASSWORD_HASH` exists
+   - `SITE_LOCK_BYPASS_TOKEN` exists
+
+## Run An Operation
+
+1. Open the workflow dispatch form.
+2. Set inputs:
+   - `action`: `lock_on` or `lock_off`
+   - `target_environment`: `preview` or `production`
+   - `reason`: short human-readable reason
+   - `confirm`: `APPLY`
+3. Run workflow.
+
+## What The Workflow Does
+
+1. Validates allowlisted action/environment inputs.
+2. Validates required Vercel secrets.
+3. For `lock_on`: checks lock prerequisites in target Vercel environment.
+4. Applies `SITE_LOCK_ENABLED` in target environment.
+5. Deploys the target environment.
+6. Runs smoke check:
+   - `lock_on`: expects redirect to `/preview-access`
+   - `lock_off`: expects no redirect to `/preview-access`
+7. Uploads operation artifact with summary + smoke headers + deploy output.
+
+## Rollback
+
+- If last operation was `lock_on`, run `lock_off` on the same environment.
+- If last operation was `lock_off`, run `lock_on` on the same environment.
+- Verify smoke expectations again after rollback.
+
+## Audit Trail
+
+- Use workflow run summary + uploaded artifact:
+  - actor
+  - action
+  - target environment
+  - deployment URL
+  - smoke result
+  - rollback action

--- a/docs/task-briefs/in-progress/2026-02-17-additional-work-backlog.md
+++ b/docs/task-briefs/in-progress/2026-02-17-additional-work-backlog.md
@@ -22,7 +22,7 @@ Capture good ideas that should be implemented later without blocking the active 
 | `AW-005` | Contextual admin notes on lesson/drill/product pages                       | `high`   | `done`        |
 | `AW-006` | Full cross-platform visual/UX/readability hardening pass                   | `high`   | `planned`     |
 | `AW-007` | Login flow UX/state-machine stabilization (success + cooldown continuity)  | `high`   | `done`        |
-| `AW-008` | One-click site-lock operations (safe lock on/off workflow)                 | `high`   | `planned`     |
+| `AW-008` | One-click site-lock operations (safe lock on/off workflow)                 | `high`   | `in-progress` |
 | `AW-009` | Admin email templates and message governance                               | `high`   | `planned`     |
 | `AW-010` | PageSpeed/Lighthouse governance for password-gated environments            | `high`   | `planned`     |
 | `AW-011` | Terms/Privacy compliance lifecycle and policy ops                          | `high`   | `planned`     |
@@ -179,8 +179,8 @@ Capture good ideas that should be implemented later without blocking the active 
   - production lock toggle always requires human approval and leaves audit trail,
   - smoke checks pass for both actions in preview,
   - negative-path tests cover unauthorized/invalid action inputs.
-- Planned follow-up brief:
-  - `docs/task-briefs/planned/2026-03-10-aw-008-one-click-site-lock-operations-10-10.md`
+- Active brief:
+  - `docs/task-briefs/in-progress/2026-03-10-aw-008-one-click-site-lock-operations-10-10.md`
 
 ## AW-009: Admin email templates and message governance
 
@@ -346,6 +346,7 @@ Apply these when backlog items graduate to dedicated implementation briefs:
 
 ## Checkpoint Log
 
+- `2026-03-10 | feat/aw-008-site-lock-ops-workflow-slice-1 | moved AW-008 from planned to in-progress and started implementation slice-1 (workflow-dispatch foundation + runbook/UI/help alignment) | next: run lint:briefs + verify:pre-pr, then open PR`
 - `2026-03-10 | working tree | synced AW-003/AW-007 done-evidence in backlog sections (added explicit AW-003 done briefs and corrected AW-007 merged PR reference from #95 to #96) | next: run lint:briefs + verify:pre-pr, then open PR`
 - `2026-03-10 | working tree | created dedicated planned implementation brief for AW-002 email OTP fallback UX hardening (`docs/task-briefs/planned/2026-03-10-aw-002-email-one-time-code-ux-hardening-10-10.md`) and linked backlog AW-002 entry to canonical brief path | next: run lint:briefs + verify:pre-pr, then open PR`
 - `2026-03-10 | working tree | created dedicated planned implementation brief for AW-006 cross-platform UX hardening (`docs/task-briefs/planned/2026-03-10-aw-006-cross-platform-ux-design-hardening-10-10.md`) and linked backlog AW-006 entry to canonical brief path | next: run lint:briefs + verify:pre-pr, then open PR`
@@ -353,7 +354,7 @@ Apply these when backlog items graduate to dedicated implementation briefs:
 - `2026-03-10 | working tree | created dedicated planned implementation brief for AW-011 terms/privacy compliance lifecycle (`docs/task-briefs/planned/2026-03-10-aw-011-terms-privacy-compliance-lifecycle-10-10.md`) and linked backlog AW-011 entry to canonical brief path | next: run lint:briefs + verify:pre-pr, then open PR`
 - `2026-03-10 | working tree | created dedicated planned implementation brief for AW-010 gated/public performance governance (`docs/task-briefs/planned/2026-03-10-aw-010-pagespeed-lighthouse-governance-gated-environments-10-10.md`) and linked backlog AW-010 entry to canonical brief path | next: run lint:briefs + verify:pre-pr, then open PR`
 - `2026-03-10 | working tree | created dedicated planned implementation brief for AW-009 admin email templates governance (`docs/task-briefs/planned/2026-03-10-aw-009-admin-email-templates-and-governance-10-10.md`) and linked backlog AW-009 entry to canonical brief path | next: run lint:briefs + verify:pre-pr, then open PR`
-- `2026-03-10 | working tree | created dedicated planned implementation brief for AW-008 one-click site-lock operations (`docs/task-briefs/planned/2026-03-10-aw-008-one-click-site-lock-operations-10-10.md`) and linked backlog AW-008 entry to canonical brief path | next: run lint:briefs + verify:pre-pr, then open PR`
+- `2026-03-10 | working tree | created dedicated planned implementation brief for AW-008 one-click site-lock operations (`docs/task-briefs/in-progress/2026-03-10-aw-008-one-click-site-lock-operations-10-10.md`) and linked backlog AW-008 entry to canonical brief path | next: run lint:briefs + verify:pre-pr, then open PR`
 - `2026-03-09 | working tree | backlog status-sync slice: marked AW-007 as done with merged evidence, updated AW-013 active brief path, and refreshed execution order for currently open work | next: run lint:briefs + verify:pre-pr, then open PR`
 - `2026-03-09 | working tree | closeout sync slice: marked AW-004 as done and linked both merged Help/Guide briefs (initial delivery + pedagogy/governance hardening) | next: run verify:pre-pr, open PR, run gate:pre-merge`
 - `2026-03-09 | working tree | docs link-parity maintenance: replaced missing planned path for AW-008 follow-up brief with explicit TBD note until the brief is created | next: run verify:pre-pr and open PR`

--- a/docs/task-briefs/in-progress/2026-03-10-aw-008-one-click-site-lock-operations-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-10-aw-008-one-click-site-lock-operations-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-03-10-aw-008-one-click-site-lock-operations-10-10`
-- `status`: `planned`
+- `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-03-10`
 - `updated`: `2026-03-10`
@@ -14,7 +14,7 @@ Enable safe, auditable, one-click site lock/unlock operations (`preview` and `pr
 
 ## Why This Brief Exists
 
-- AW-008 is currently `planned` in backlog but had no dedicated implementation brief.
+- AW-008 needed a dedicated implementation brief before execution.
 - Current env-controlled lock model is correct for security, but operators need deterministic ergonomics.
 - This brief defines measurable 10/10 thresholds before implementation starts.
 
@@ -114,4 +114,5 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 
 ## Checkpoint Log
 
+- `2026-03-10 | feat/aw-008-site-lock-ops-workflow-slice-1 | started implementation slice-1: added workflow-dispatch foundation (`.github/workflows/site-lock-operations.yml`) with allowlisted inputs, audited summary artifact, deploy + smoke checks, and updated operator docs/UI pointers | next: run verify:pre-pr, open PR, run gate:pre-merge`
 - `2026-03-10 | working tree | created AW-008 planned implementation brief with scorecard-complete thresholds and deterministic ops/rollback contract | next: link this brief in backlog and use it as canonical scope when implementation starts`

--- a/tests/e2e/admin-help-center.spec.ts
+++ b/tests/e2e/admin-help-center.spec.ts
@@ -66,6 +66,7 @@ test.describe("admin help center", () => {
     await expect(
       page.getByText("Use P0 template / Use P1 template / Use P2 template:")
     ).toBeVisible();
+    await expect(page.getByText("Open lock operations workflow:")).toBeVisible();
     await expect(page.getByText("Open password page:")).toBeVisible();
     await expect(
       page.getByText(
@@ -73,5 +74,6 @@ test.describe("admin help center", () => {
       )
     ).toBeVisible();
     await expect(page.getByText("docs/runbooks/qr-redirect-operations.md")).toBeVisible();
+    await expect(page.getByText("docs/runbooks/site-lock-operations.md")).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-03-10T14:22:46.201Z for branch `feat/aw-008-site-lock-ops-workflow-slice-1` (base ref `origin/main`).
- Latest commit: `5caf62e` - feat(ops): add one-click site-lock workflow foundation.
- User-visible changes: Admin-facing behavior/guardrails may change in touched admin routes or APIs.
- Technical changes: Updated 8 file(s): `.github/workflows/site-lock-operations.yml`, `components/admin/AdminHelpCenter.tsx`, `components/admin/AdminOperationsManager.tsx`, `docs/runbooks/private-access-gate.md`, `docs/runbooks/site-lock-operations.md`, `... and 3 more file(s)`.
- Brief link(s): `docs/task-briefs/in-progress/2026-02-17-additional-work-backlog.md`
- Scorecard target outcomes: 4 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (4); tests (1); CI/workflow config (1); runtime UI/routes/components (2).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (8):
  - `.github/workflows/site-lock-operations.yml`
  - `components/admin/AdminHelpCenter.tsx`
  - `components/admin/AdminOperationsManager.tsx`
  - `docs/runbooks/private-access-gate.md`
  - `docs/runbooks/site-lock-operations.md`
  - `docs/task-briefs/in-progress/2026-02-17-additional-work-backlog.md`
  - `docs/task-briefs/in-progress/2026-03-10-aw-008-one-click-site-lock-operations-10-10.md`
  - `tests/e2e/admin-help-center.spec.ts`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `5caf62e` (`git revert 5caf62e`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **NOT RUN** (run locally before pushing PR updates).
- `npm run verify:pre-merge`: **PASS** for `5caf62e` (2026-03-10T14:22:45Z, mode: skipped).
- Key verify summary:
  - No local verify log found in `artifacts/test-runs/latest`.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
