### PR TITLE
feat(admin): add email template governance data foundation

### DIFF
--- a/app/api/admin/email-templates/[id]/route.ts
+++ b/app/api/admin/email-templates/[id]/route.ts
@@ -1,0 +1,225 @@
+import { NextResponse } from "next/server";
+import {
+  canTransitionAdminEmailTemplateStatus,
+  parseUpdateAdminEmailTemplatePayload,
+  validateAdminEmailTemplatePlaceholders,
+} from "@/lib/admin/email-templates";
+import { getAdminSchemaSetupMessage, isAdminEmailTemplatesSchemaMissing } from "@/lib/admin/schema";
+import { requireAdminRoleFromSupabase } from "@/lib/admin/server";
+import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
+
+const TEMPLATE_SELECT =
+  "id,template_key,locale,status,version,subject,body,required_placeholders,optional_placeholders,last_published_at,last_published_by,created_by,updated_by,created_at,updated_at" as const;
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+function noStoreJson(
+  body: Record<string, unknown>,
+  init?: {
+    status?: number;
+  }
+) {
+  return NextResponse.json(body, {
+    status: init?.status ?? 200,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  const params = await context.params;
+  const templateId = params.id;
+  if (!templateId.trim()) {
+    return noStoreJson({ ok: false, error: "Invalid template id." }, { status: 400 });
+  }
+
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+  const gate = await requireAdminRoleFromSupabase(supabase, {
+    allowlistedEmailsRaw: process.env.ADMIN_EMAIL_ALLOWLIST,
+    minimumRole: "editor",
+  });
+
+  if (!gate.ok) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: gate.error }, { status: gate.status })
+    );
+  }
+
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Unsupported content type." }, { status: 415 })
+    );
+  }
+
+  let payload: unknown = null;
+  try {
+    payload = await request.json();
+  } catch {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Invalid JSON." }, { status: 400 })
+    );
+  }
+
+  const parsed = parseUpdateAdminEmailTemplatePayload((payload ?? {}) as Record<string, unknown>);
+  if (!parsed.ok) {
+    return applySupabaseCookies(noStoreJson({ ok: false, error: parsed.error }, { status: 400 }));
+  }
+
+  const existingResult = await supabase
+    .from("admin_email_templates")
+    .select(TEMPLATE_SELECT)
+    .eq("id", templateId)
+    .maybeSingle();
+
+  if (existingResult.error) {
+    if (isAdminEmailTemplatesSchemaMissing(existingResult.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: getAdminSchemaSetupMessage("emailTemplates"),
+            code: "ADMIN_SCHEMA_NOT_READY",
+          },
+          { status: 503 }
+        )
+      );
+    }
+
+    console.error("[AdminEmailTemplates] Could not load existing template", existingResult.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not load template right now." }, { status: 500 })
+    );
+  }
+
+  if (!existingResult.data) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Template not found." }, { status: 404 })
+    );
+  }
+
+  const existing = existingResult.data;
+  if (parsed.value.expectedUpdatedAt && parsed.value.expectedUpdatedAt !== existing.updated_at) {
+    return applySupabaseCookies(
+      noStoreJson(
+        {
+          ok: false,
+          error: "Template was updated by another user. Reload before retry.",
+        },
+        { status: 409 }
+      )
+    );
+  }
+
+  const nextStatus = parsed.value.patch.status ?? existing.status;
+  if (!canTransitionAdminEmailTemplateStatus(existing.status, nextStatus)) {
+    return applySupabaseCookies(
+      noStoreJson(
+        {
+          ok: false,
+          error: `Invalid status transition (${existing.status} -> ${nextStatus}).`,
+        },
+        { status: 400 }
+      )
+    );
+  }
+
+  const nextSubject = parsed.value.patch.subject ?? existing.subject;
+  const nextBody = parsed.value.patch.body ?? existing.body;
+  const nextRequired =
+    parsed.value.patch.requiredPlaceholders ?? existing.required_placeholders ?? [];
+  const nextOptional =
+    parsed.value.patch.optionalPlaceholders ?? existing.optional_placeholders ?? [];
+
+  const placeholderValidation = validateAdminEmailTemplatePlaceholders({
+    subject: nextSubject,
+    body: nextBody,
+    requiredPlaceholders: nextRequired,
+    optionalPlaceholders: nextOptional,
+  });
+  if (!placeholderValidation.ok) {
+    return applySupabaseCookies(
+      noStoreJson(
+        {
+          ok: false,
+          error: placeholderValidation.error,
+          details: placeholderValidation.details,
+        },
+        { status: 400 }
+      )
+    );
+  }
+
+  const isPublishing = existing.status !== "published" && nextStatus === "published";
+  const now = new Date().toISOString();
+
+  const updatePayload = {
+    template_key: parsed.value.patch.templateKey ?? existing.template_key,
+    locale: parsed.value.patch.locale ?? existing.locale,
+    status: nextStatus,
+    subject: nextSubject,
+    body: nextBody,
+    required_placeholders: nextRequired,
+    optional_placeholders: nextOptional,
+    version: isPublishing ? existing.version + 1 : existing.version,
+    last_published_at: isPublishing ? now : existing.last_published_at,
+    last_published_by: isPublishing ? gate.user.id : existing.last_published_by,
+    updated_by: gate.user.id,
+  };
+
+  const updateResult = await supabase
+    .from("admin_email_templates")
+    .update(updatePayload)
+    .eq("id", templateId)
+    .eq("updated_at", existing.updated_at)
+    .select(TEMPLATE_SELECT)
+    .maybeSingle();
+
+  if (updateResult.error) {
+    if (isAdminEmailTemplatesSchemaMissing(updateResult.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: getAdminSchemaSetupMessage("emailTemplates"),
+            code: "ADMIN_SCHEMA_NOT_READY",
+          },
+          { status: 503 }
+        )
+      );
+    }
+
+    if (updateResult.error.code === "23505") {
+      return applySupabaseCookies(
+        noStoreJson({ ok: false, error: "Template key+locale already exists." }, { status: 409 })
+      );
+    }
+
+    console.error("[AdminEmailTemplates] Could not update template", updateResult.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not update template right now." }, { status: 500 })
+    );
+  }
+
+  if (!updateResult.data) {
+    return applySupabaseCookies(
+      noStoreJson(
+        {
+          ok: false,
+          error: "Template was updated by another user. Reload before retry.",
+        },
+        { status: 409 }
+      )
+    );
+  }
+
+  return applySupabaseCookies(
+    noStoreJson({
+      ok: true,
+      item: updateResult.data,
+    })
+  );
+}

--- a/app/api/admin/email-templates/route.ts
+++ b/app/api/admin/email-templates/route.ts
@@ -1,0 +1,196 @@
+import { NextResponse } from "next/server";
+import {
+  parseCreateAdminEmailTemplatePayload,
+  validateAdminEmailTemplatePlaceholders,
+} from "@/lib/admin/email-templates";
+import { getAdminSchemaSetupMessage, isAdminEmailTemplatesSchemaMissing } from "@/lib/admin/schema";
+import { requireAdminRoleFromSupabase } from "@/lib/admin/server";
+import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
+
+const TEMPLATE_SELECT =
+  "id,template_key,locale,status,version,subject,body,required_placeholders,optional_placeholders,last_published_at,last_published_by,created_by,updated_by,created_at,updated_at" as const;
+
+function noStoreJson(
+  body: Record<string, unknown>,
+  init?: {
+    status?: number;
+  }
+) {
+  return NextResponse.json(body, {
+    status: init?.status ?? 200,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export async function GET() {
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+  const gate = await requireAdminRoleFromSupabase(supabase, {
+    allowlistedEmailsRaw: process.env.ADMIN_EMAIL_ALLOWLIST,
+    minimumRole: "viewer",
+  });
+
+  if (!gate.ok) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: gate.error }, { status: gate.status })
+    );
+  }
+
+  const result = await supabase
+    .from("admin_email_templates")
+    .select(TEMPLATE_SELECT)
+    .order("template_key", { ascending: true })
+    .order("locale", { ascending: true });
+
+  if (result.error) {
+    if (isAdminEmailTemplatesSchemaMissing(result.error)) {
+      return applySupabaseCookies(
+        noStoreJson({
+          ok: true,
+          items: [],
+          schemaReady: false,
+          warning: getAdminSchemaSetupMessage("emailTemplates"),
+        })
+      );
+    }
+
+    console.error("[AdminEmailTemplates] Could not load templates", result.error);
+    return applySupabaseCookies(
+      noStoreJson({
+        ok: true,
+        items: [],
+        schemaReady: false,
+        warning: getAdminSchemaSetupMessage("emailTemplates"),
+      })
+    );
+  }
+
+  return applySupabaseCookies(
+    noStoreJson({
+      ok: true,
+      items: result.data ?? [],
+      schemaReady: true,
+      warning: null,
+    })
+  );
+}
+
+export async function POST(request: Request) {
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+  const gate = await requireAdminRoleFromSupabase(supabase, {
+    allowlistedEmailsRaw: process.env.ADMIN_EMAIL_ALLOWLIST,
+    minimumRole: "editor",
+  });
+
+  if (!gate.ok) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: gate.error }, { status: gate.status })
+    );
+  }
+
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Unsupported content type." }, { status: 415 })
+    );
+  }
+
+  let payload: unknown = null;
+  try {
+    payload = await request.json();
+  } catch {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Invalid JSON." }, { status: 400 })
+    );
+  }
+
+  const parsed = parseCreateAdminEmailTemplatePayload((payload ?? {}) as Record<string, unknown>);
+  if (!parsed.ok) {
+    return applySupabaseCookies(noStoreJson({ ok: false, error: parsed.error }, { status: 400 }));
+  }
+
+  if (parsed.value.status === "published") {
+    return applySupabaseCookies(
+      noStoreJson(
+        {
+          ok: false,
+          error: "New templates must start in draft/review before publish.",
+        },
+        { status: 400 }
+      )
+    );
+  }
+
+  const placeholderValidation = validateAdminEmailTemplatePlaceholders({
+    subject: parsed.value.subject,
+    body: parsed.value.body,
+    requiredPlaceholders: parsed.value.requiredPlaceholders,
+    optionalPlaceholders: parsed.value.optionalPlaceholders,
+  });
+  if (!placeholderValidation.ok) {
+    return applySupabaseCookies(
+      noStoreJson(
+        {
+          ok: false,
+          error: placeholderValidation.error,
+          details: placeholderValidation.details,
+        },
+        { status: 400 }
+      )
+    );
+  }
+
+  const insertResult = await supabase
+    .from("admin_email_templates")
+    .insert({
+      template_key: parsed.value.templateKey,
+      locale: parsed.value.locale,
+      status: parsed.value.status,
+      subject: parsed.value.subject,
+      body: parsed.value.body,
+      required_placeholders: parsed.value.requiredPlaceholders,
+      optional_placeholders: parsed.value.optionalPlaceholders,
+      version: 1,
+      created_by: gate.user.id,
+      updated_by: gate.user.id,
+    })
+    .select(TEMPLATE_SELECT)
+    .single();
+
+  if (insertResult.error || !insertResult.data) {
+    if (isAdminEmailTemplatesSchemaMissing(insertResult.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: getAdminSchemaSetupMessage("emailTemplates"),
+            code: "ADMIN_SCHEMA_NOT_READY",
+          },
+          { status: 503 }
+        )
+      );
+    }
+
+    if (insertResult.error?.code === "23505") {
+      return applySupabaseCookies(
+        noStoreJson({ ok: false, error: "Template key+locale already exists." }, { status: 409 })
+      );
+    }
+
+    console.error("[AdminEmailTemplates] Could not create template", insertResult.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not create template right now." }, { status: 500 })
+    );
+  }
+
+  return applySupabaseCookies(
+    noStoreJson(
+      {
+        ok: true,
+        item: insertResult.data,
+      },
+      { status: 201 }
+    )
+  );
+}

--- a/docs/task-briefs/in-progress/2026-02-17-additional-work-backlog.md
+++ b/docs/task-briefs/in-progress/2026-02-17-additional-work-backlog.md
@@ -345,6 +345,7 @@ Apply these when backlog items graduate to dedicated implementation briefs:
 
 ## Checkpoint Log
 
+- `2026-03-11 | feat/aw-009-email-template-data-contract-slice-2 | completed AW-009 slice-2 foundation: added canonical email-template schema + revisions, fail-closed admin API routes, placeholder/status transition validation, and unauthorized negative-path coverage for new endpoints | next: run lint:briefs + verify:pre-pr, then open PR`
 - `2026-03-11 | feat/aw-009-email-template-governance-slice-1 | started AW-009 slice-1: set backlog status to in-progress, moved AW-009 brief to in-progress, and added template governance runbook baseline (`docs/runbooks/admin-email-template-governance.md`) | next: run lint:briefs + verify:pre-pr, then open PR`
 - `2026-03-10 | feat/aw-008-preview-lock-smoke-fix-slice-3@0e1e70e | AW-008 closeout evidence captured: preview workflow run 22928386773 (`lock_on` PASS) + 22928440585 (`lock_off` PASS); updated workflow/runbook smoke contract to protected API route and marked AW-008 done | next: move AW-008 brief to done and continue with next low-risk backlog slice (AW-009 or AW-012)`
 - `2026-03-10 | feat/aw-008-production-approval-enforcement-slice-2 | started AW-008 slice-2 to enforce production required-reviewer gate directly in workflow and operator runbook | next: run lint:briefs + verify:pre-pr, then open PR`

--- a/docs/task-briefs/in-progress/2026-03-10-aw-009-admin-email-templates-and-governance-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-10-aw-009-admin-email-templates-and-governance-10-10.md
@@ -109,5 +109,6 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 
 ## Checkpoint Log
 
+- `2026-03-11 | feat/aw-009-email-template-data-contract-slice-2 | completed AW-009 slice-2 server-canonical foundation: added admin_email_templates + revision migration, fail-closed admin API routes (GET/POST/PATCH), placeholder/status transition validation, and unauthorized negative-path coverage for new endpoints | next: run lint:briefs + verify:pre-pr, then open PR`
 - `2026-03-11 | feat/aw-009-email-template-governance-slice-1 | started AW-009 slice-1: moved brief to in-progress, aligned backlog lifecycle state, and added operator runbook baseline for draft/review/publish/revert governance (`docs/runbooks/admin-email-template-governance.md`) | next: run lint:briefs + verify:pre-pr, then open PR`
 - `2026-03-10 | working tree | created AW-009 planned implementation brief with scorecard-complete governance thresholds and deterministic draft/review/publish contract | next: link this brief in backlog and use it as canonical scope when implementation starts`

--- a/lib/admin/email-templates.ts
+++ b/lib/admin/email-templates.ts
@@ -1,0 +1,390 @@
+import type { Database } from "@/types/database";
+
+export const ADMIN_EMAIL_TEMPLATE_STATUS_VALUES = [
+  "draft",
+  "review",
+  "published",
+  "archived",
+] as const;
+
+export type AdminEmailTemplateStatus = (typeof ADMIN_EMAIL_TEMPLATE_STATUS_VALUES)[number];
+
+export type CreateAdminEmailTemplatePayload = {
+  templateKey?: unknown;
+  locale?: unknown;
+  subject?: unknown;
+  body?: unknown;
+  status?: unknown;
+  requiredPlaceholders?: unknown;
+  optionalPlaceholders?: unknown;
+};
+
+export type UpdateAdminEmailTemplatePayload = {
+  templateKey?: unknown;
+  locale?: unknown;
+  subject?: unknown;
+  body?: unknown;
+  status?: unknown;
+  requiredPlaceholders?: unknown;
+  optionalPlaceholders?: unknown;
+  expectedUpdatedAt?: unknown;
+};
+
+export type AdminEmailTemplateRow = Database["public"]["Tables"]["admin_email_templates"]["Row"];
+
+export type PlaceholderValidationResult =
+  | {
+      ok: true;
+      placeholders: string[];
+    }
+  | {
+      ok: false;
+      error: string;
+      details: string[];
+      placeholders: string[];
+    };
+
+type ParsedCreateAdminEmailTemplatePayload = {
+  templateKey: string;
+  locale: string;
+  subject: string;
+  body: string;
+  status: AdminEmailTemplateStatus;
+  requiredPlaceholders: string[];
+  optionalPlaceholders: string[];
+};
+
+type ParseCreateAdminEmailTemplateResult =
+  | {
+      ok: true;
+      value: ParsedCreateAdminEmailTemplatePayload;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+type ParsedUpdateAdminEmailTemplatePayload = {
+  patch: {
+    templateKey?: string;
+    locale?: string;
+    subject?: string;
+    body?: string;
+    status?: AdminEmailTemplateStatus;
+    requiredPlaceholders?: string[];
+    optionalPlaceholders?: string[];
+  };
+  expectedUpdatedAt?: string;
+};
+
+type ParseUpdateAdminEmailTemplateResult =
+  | {
+      ok: true;
+      value: ParsedUpdateAdminEmailTemplatePayload;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+function normalizeString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function hasOwn(payload: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(payload, key);
+}
+
+function parseTemplateKey(value: unknown): string | null {
+  const templateKey = normalizeString(value).toLowerCase();
+  if (templateKey.length < 3 || templateKey.length > 120) return null;
+  if (!/^[a-z0-9]+(?:_[a-z0-9]+)*$/.test(templateKey)) return null;
+  return templateKey;
+}
+
+function parseLocale(value: unknown): string | null {
+  const locale = normalizeString(value);
+  if (locale.length < 2 || locale.length > 16) return null;
+  if (!/^[a-z]{2}(?:-[A-Z]{2})?$/.test(locale)) return null;
+  return locale;
+}
+
+function parseSubject(value: unknown): string | null {
+  const subject = normalizeString(value);
+  if (subject.length < 1 || subject.length > 240) return null;
+  return subject;
+}
+
+function parseBody(value: unknown): string | null {
+  const body = normalizeString(value);
+  if (body.length < 1 || body.length > 20000) return null;
+  return body;
+}
+
+function normalizePlaceholderName(value: unknown): string | null {
+  const token = normalizeString(value).toLowerCase();
+  if (token.length < 2 || token.length > 64) return null;
+  if (!/^[a-z0-9_]+$/.test(token)) return null;
+  return token;
+}
+
+function parsePlaceholderList(
+  value: unknown,
+  fieldName: "requiredPlaceholders" | "optionalPlaceholders"
+): { ok: true; value: string[] } | { ok: false; error: string } {
+  if (value === undefined) return { ok: true, value: [] };
+  if (!Array.isArray(value)) {
+    return { ok: false, error: `${fieldName} must be an array of placeholder keys.` };
+  }
+
+  const unique = new Set<string>();
+  for (const entry of value) {
+    const token = normalizePlaceholderName(entry);
+    if (!token) {
+      return {
+        ok: false,
+        error: `${fieldName} entries must use lowercase letters, numbers, or underscores (2-64 chars).`,
+      };
+    }
+    unique.add(token);
+  }
+
+  if (unique.size > 50) {
+    return { ok: false, error: `${fieldName} supports max 50 placeholders.` };
+  }
+
+  return { ok: true, value: [...unique].sort() };
+}
+
+function parseStatus(value: unknown): AdminEmailTemplateStatus | null {
+  const status = normalizeString(value);
+  if (!ADMIN_EMAIL_TEMPLATE_STATUS_VALUES.includes(status as AdminEmailTemplateStatus)) {
+    return null;
+  }
+  return status as AdminEmailTemplateStatus;
+}
+
+export function extractAdminEmailTemplatePlaceholders(input: string): string[] {
+  const found = new Set<string>();
+  const pattern = /{{\s*([a-z0-9_]+)\s*}}/gi;
+  for (const match of input.matchAll(pattern)) {
+    const raw = match[1];
+    if (!raw) continue;
+    const token = normalizePlaceholderName(raw);
+    if (token) found.add(token);
+  }
+  return [...found].sort();
+}
+
+export function validateAdminEmailTemplatePlaceholders(input: {
+  subject: string;
+  body: string;
+  requiredPlaceholders: readonly string[];
+  optionalPlaceholders: readonly string[];
+}): PlaceholderValidationResult {
+  const contentPlaceholders = new Set<string>([
+    ...extractAdminEmailTemplatePlaceholders(input.subject),
+    ...extractAdminEmailTemplatePlaceholders(input.body),
+  ]);
+  const required = new Set(input.requiredPlaceholders);
+  const optional = new Set(input.optionalPlaceholders);
+  const declared = new Set<string>([...required, ...optional]);
+  const details: string[] = [];
+
+  for (const token of required) {
+    if (optional.has(token)) {
+      details.push(`Placeholder "${token}" cannot be both required and optional.`);
+    }
+  }
+
+  const usedPlaceholders = [...contentPlaceholders].sort();
+  if (usedPlaceholders.length > 0 && declared.size === 0) {
+    details.push("Template uses placeholders but required/optional placeholder lists are empty.");
+  }
+
+  for (const token of required) {
+    if (!contentPlaceholders.has(token)) {
+      details.push(`Required placeholder "{{${token}}}" is missing from subject/body.`);
+    }
+  }
+
+  if (declared.size > 0) {
+    for (const token of contentPlaceholders) {
+      if (!declared.has(token)) {
+        details.push(`Placeholder "{{${token}}}" is not declared as required/optional.`);
+      }
+    }
+  }
+
+  if (details.length > 0) {
+    return {
+      ok: false,
+      error: "Invalid template placeholders.",
+      details,
+      placeholders: usedPlaceholders,
+    };
+  }
+
+  return {
+    ok: true,
+    placeholders: usedPlaceholders,
+  };
+}
+
+export function canTransitionAdminEmailTemplateStatus(
+  from: AdminEmailTemplateStatus,
+  to: AdminEmailTemplateStatus
+): boolean {
+  const allowed: Record<AdminEmailTemplateStatus, readonly AdminEmailTemplateStatus[]> = {
+    draft: ["draft", "review", "archived"],
+    review: ["draft", "review", "published", "archived"],
+    published: ["review", "published", "archived"],
+    archived: ["draft", "archived"],
+  };
+  return allowed[from].includes(to);
+}
+
+export function parseCreateAdminEmailTemplatePayload(
+  payload: CreateAdminEmailTemplatePayload
+): ParseCreateAdminEmailTemplateResult {
+  const templateKey = parseTemplateKey(payload.templateKey);
+  if (!templateKey) {
+    return { ok: false, error: "templateKey must use snake_case (3-120 chars)." };
+  }
+
+  const locale = parseLocale(payload.locale ?? "nb-NO");
+  if (!locale) {
+    return { ok: false, error: "locale must be `xx` or `xx-YY` format." };
+  }
+
+  const subject = parseSubject(payload.subject);
+  if (!subject) {
+    return { ok: false, error: "subject must be between 1 and 240 characters." };
+  }
+
+  const body = parseBody(payload.body);
+  if (!body) {
+    return { ok: false, error: "body must be between 1 and 20000 characters." };
+  }
+
+  const parsedRequired = parsePlaceholderList(payload.requiredPlaceholders, "requiredPlaceholders");
+  if (!parsedRequired.ok) return parsedRequired;
+
+  const parsedOptional = parsePlaceholderList(payload.optionalPlaceholders, "optionalPlaceholders");
+  if (!parsedOptional.ok) return parsedOptional;
+
+  const status = payload.status === undefined ? "draft" : parseStatus(payload.status);
+  if (!status) {
+    return { ok: false, error: "Invalid lifecycle status." };
+  }
+
+  return {
+    ok: true,
+    value: {
+      templateKey,
+      locale,
+      subject,
+      body,
+      status,
+      requiredPlaceholders: parsedRequired.value,
+      optionalPlaceholders: parsedOptional.value,
+    },
+  };
+}
+
+function parseExpectedUpdatedAt(value: unknown): string | null {
+  if (value === undefined) return null;
+  const normalized = normalizeString(value);
+  if (!normalized) return null;
+  return Number.isNaN(Date.parse(normalized)) ? null : normalized;
+}
+
+export function parseUpdateAdminEmailTemplatePayload(
+  payload: UpdateAdminEmailTemplatePayload
+): ParseUpdateAdminEmailTemplateResult {
+  const source = payload as Record<string, unknown>;
+  const patch: ParsedUpdateAdminEmailTemplatePayload["patch"] = {};
+  let changes = 0;
+
+  if (hasOwn(source, "templateKey")) {
+    const templateKey = parseTemplateKey(payload.templateKey);
+    if (!templateKey) {
+      return { ok: false, error: "templateKey must use snake_case (3-120 chars)." };
+    }
+    patch.templateKey = templateKey;
+    changes += 1;
+  }
+
+  if (hasOwn(source, "locale")) {
+    const locale = parseLocale(payload.locale);
+    if (!locale) {
+      return { ok: false, error: "locale must be `xx` or `xx-YY` format." };
+    }
+    patch.locale = locale;
+    changes += 1;
+  }
+
+  if (hasOwn(source, "subject")) {
+    const subject = parseSubject(payload.subject);
+    if (!subject) {
+      return { ok: false, error: "subject must be between 1 and 240 characters." };
+    }
+    patch.subject = subject;
+    changes += 1;
+  }
+
+  if (hasOwn(source, "body")) {
+    const body = parseBody(payload.body);
+    if (!body) {
+      return { ok: false, error: "body must be between 1 and 20000 characters." };
+    }
+    patch.body = body;
+    changes += 1;
+  }
+
+  if (hasOwn(source, "status")) {
+    const status = parseStatus(payload.status);
+    if (!status) {
+      return { ok: false, error: "Invalid lifecycle status." };
+    }
+    patch.status = status;
+    changes += 1;
+  }
+
+  if (hasOwn(source, "requiredPlaceholders")) {
+    const parsedRequired = parsePlaceholderList(
+      payload.requiredPlaceholders,
+      "requiredPlaceholders"
+    );
+    if (!parsedRequired.ok) return parsedRequired;
+    patch.requiredPlaceholders = parsedRequired.value;
+    changes += 1;
+  }
+
+  if (hasOwn(source, "optionalPlaceholders")) {
+    const parsedOptional = parsePlaceholderList(
+      payload.optionalPlaceholders,
+      "optionalPlaceholders"
+    );
+    if (!parsedOptional.ok) return parsedOptional;
+    patch.optionalPlaceholders = parsedOptional.value;
+    changes += 1;
+  }
+
+  if (changes === 0) {
+    return { ok: false, error: "No updatable fields were provided." };
+  }
+
+  const expectedUpdatedAt = parseExpectedUpdatedAt(payload.expectedUpdatedAt);
+  if (hasOwn(source, "expectedUpdatedAt") && !expectedUpdatedAt) {
+    return { ok: false, error: "expectedUpdatedAt must be a valid ISO date string." };
+  }
+
+  return {
+    ok: true,
+    value: {
+      patch,
+      expectedUpdatedAt: expectedUpdatedAt ?? undefined,
+    },
+  };
+}

--- a/lib/admin/schema.ts
+++ b/lib/admin/schema.ts
@@ -100,8 +100,21 @@ export function isAdminCategoriesSchemaMissing(
   return includesAnyMarker(blob, ["admin_categories"]);
 }
 
+export function isAdminEmailTemplatesSchemaMissing(
+  error: PostgrestLikeError | null | undefined
+): boolean {
+  if (!error) return false;
+  if (hasMissingSchemaCode(error)) return true;
+  if (hasLikelySetupCode(error)) return true;
+
+  const blob = buildErrorBlob(error);
+  if (hasSetupBlockedCode(error) || includesAnyMarker(blob, SETUP_BLOCKED_MARKERS)) return true;
+
+  return includesAnyMarker(blob, ["admin_email_templates", "admin_email_template_revisions"]);
+}
+
 export function getAdminSchemaSetupMessage(
-  section: "content" | "operations" | "notes" | "commerce" | "categories"
+  section: "content" | "operations" | "notes" | "commerce" | "categories" | "emailTemplates"
 ): string {
   const area =
     section === "content"
@@ -112,7 +125,9 @@ export function getAdminSchemaSetupMessage(
           ? "Admin notes"
           : section === "commerce"
             ? "Admin commerce"
-            : "Admin categories";
+            : section === "categories"
+              ? "Admin categories"
+              : "Admin email templates";
 
   return `${area} setup is not ready in this environment yet. Apply latest Supabase migrations (tables + grants + RLS policies), then refresh.`;
 }

--- a/supabase/migrations/20260311100000_admin_email_templates_foundation.sql
+++ b/supabase/migrations/20260311100000_admin_email_templates_foundation.sql
@@ -1,0 +1,256 @@
+-- AW-009 slice-2 foundation:
+-- canonical admin email template storage + revision/audit trail.
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_type t
+    join pg_namespace n on n.oid = t.typnamespace
+    where t.typname = 'admin_email_template_status' and n.nspname = 'public'
+  ) then
+    create type public.admin_email_template_status as enum ('draft', 'review', 'published', 'archived');
+  end if;
+end
+$$;
+
+create table if not exists public.admin_email_templates (
+  id uuid primary key default gen_random_uuid(),
+  template_key text not null,
+  locale text not null default 'nb-NO',
+  status public.admin_email_template_status not null default 'draft',
+  version integer not null default 1 check (version > 0),
+  subject text not null default '',
+  body text not null default '',
+  required_placeholders text[] not null default '{}',
+  optional_placeholders text[] not null default '{}',
+  last_published_at timestamptz,
+  last_published_by uuid references auth.users (id) on delete set null,
+  created_by uuid references auth.users (id) on delete set null,
+  updated_by uuid references auth.users (id) on delete set null,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint admin_email_templates_key_locale_unique
+    unique (template_key, locale),
+  constraint admin_email_templates_template_key_format
+    check (template_key ~ '^[a-z0-9]+(?:_[a-z0-9]+)*$'),
+  constraint admin_email_templates_template_key_length
+    check (char_length(template_key) >= 3 and char_length(template_key) <= 120),
+  constraint admin_email_templates_locale_length
+    check (char_length(locale) >= 2 and char_length(locale) <= 16),
+  constraint admin_email_templates_subject_length
+    check (char_length(subject) <= 240),
+  constraint admin_email_templates_body_length
+    check (char_length(body) <= 20000),
+  constraint admin_email_templates_required_placeholders_cardinality
+    check (coalesce(cardinality(required_placeholders), 0) <= 50),
+  constraint admin_email_templates_optional_placeholders_cardinality
+    check (coalesce(cardinality(optional_placeholders), 0) <= 50)
+);
+
+create index if not exists admin_email_templates_status_key_idx
+  on public.admin_email_templates (status, template_key, locale);
+
+create index if not exists admin_email_templates_updated_idx
+  on public.admin_email_templates (updated_at desc);
+
+drop trigger if exists admin_email_templates_set_updated_at on public.admin_email_templates;
+create trigger admin_email_templates_set_updated_at
+before update on public.admin_email_templates
+for each row execute function public.set_updated_at();
+
+grant select, insert, update, delete on public.admin_email_templates to authenticated;
+
+alter table public.admin_email_templates enable row level security;
+
+drop policy if exists admin_email_templates_select_roles on public.admin_email_templates;
+create policy admin_email_templates_select_roles
+on public.admin_email_templates
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.id = auth.uid()
+      and profile.role in ('admin', 'editor', 'viewer')
+  )
+);
+
+drop policy if exists admin_email_templates_insert_roles on public.admin_email_templates;
+create policy admin_email_templates_insert_roles
+on public.admin_email_templates
+for insert
+to authenticated
+with check (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.id = auth.uid()
+      and profile.role in ('admin', 'editor')
+  )
+);
+
+drop policy if exists admin_email_templates_update_roles on public.admin_email_templates;
+create policy admin_email_templates_update_roles
+on public.admin_email_templates
+for update
+to authenticated
+using (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.id = auth.uid()
+      and profile.role in ('admin', 'editor')
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.id = auth.uid()
+      and profile.role in ('admin', 'editor')
+  )
+);
+
+drop policy if exists admin_email_templates_delete_admin_only on public.admin_email_templates;
+create policy admin_email_templates_delete_admin_only
+on public.admin_email_templates
+for delete
+to authenticated
+using (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.id = auth.uid()
+      and profile.role = 'admin'
+  )
+);
+
+create table if not exists public.admin_email_template_revisions (
+  id uuid primary key default gen_random_uuid(),
+  template_id uuid not null references public.admin_email_templates (id) on delete cascade,
+  template_key text not null,
+  locale text not null,
+  revision_number integer not null check (revision_number > 0),
+  action text not null check (action in ('insert', 'update', 'delete')),
+  snapshot jsonb not null,
+  changed_by uuid references auth.users (id) on delete set null,
+  changed_by_email text,
+  created_at timestamptz not null default timezone('utc', now()),
+  unique (template_id, revision_number)
+);
+
+create index if not exists admin_email_template_revisions_template_idx
+  on public.admin_email_template_revisions (template_id, created_at desc);
+
+create index if not exists admin_email_template_revisions_key_locale_idx
+  on public.admin_email_template_revisions (template_key, locale, created_at desc);
+
+grant select, insert on public.admin_email_template_revisions to authenticated;
+
+alter table public.admin_email_template_revisions enable row level security;
+
+drop policy if exists admin_email_template_revisions_select_roles on public.admin_email_template_revisions;
+create policy admin_email_template_revisions_select_roles
+on public.admin_email_template_revisions
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.id = auth.uid()
+      and profile.role in ('admin', 'editor', 'viewer')
+  )
+);
+
+drop policy if exists admin_email_template_revisions_insert_roles on public.admin_email_template_revisions;
+create policy admin_email_template_revisions_insert_roles
+on public.admin_email_template_revisions
+for insert
+to authenticated
+with check (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.id = auth.uid()
+      and profile.role in ('admin', 'editor')
+  )
+);
+
+create or replace function public.log_admin_email_template_revision()
+returns trigger
+language plpgsql
+as $$
+declare
+  actor_email text;
+  target_id uuid;
+  target_key text;
+  target_locale text;
+  snapshot jsonb;
+  next_revision integer;
+begin
+  actor_email := nullif(auth.jwt() ->> 'email', '');
+
+  if tg_op = 'INSERT' then
+    target_id := new.id;
+    target_key := new.template_key;
+    target_locale := new.locale;
+    snapshot := to_jsonb(new);
+  elsif tg_op = 'UPDATE' then
+    target_id := new.id;
+    target_key := new.template_key;
+    target_locale := new.locale;
+    snapshot := to_jsonb(new);
+  elsif tg_op = 'DELETE' then
+    target_id := old.id;
+    target_key := old.template_key;
+    target_locale := old.locale;
+    snapshot := to_jsonb(old);
+  else
+    return null;
+  end if;
+
+  select coalesce(max(revision_number), 0) + 1
+  into next_revision
+  from public.admin_email_template_revisions
+  where template_id = target_id;
+
+  insert into public.admin_email_template_revisions (
+    template_id,
+    template_key,
+    locale,
+    revision_number,
+    action,
+    snapshot,
+    changed_by,
+    changed_by_email
+  ) values (
+    target_id,
+    target_key,
+    target_locale,
+    next_revision,
+    lower(tg_op),
+    snapshot,
+    auth.uid(),
+    actor_email
+  );
+
+  if tg_op = 'DELETE' then
+    return old;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists admin_email_templates_revision_log on public.admin_email_templates;
+create trigger admin_email_templates_revision_log
+after insert or update or delete on public.admin_email_templates
+for each row execute function public.log_admin_email_template_revision();
+
+drop trigger if exists admin_email_templates_audit_log on public.admin_email_templates;
+create trigger admin_email_templates_audit_log
+after insert or update or delete on public.admin_email_templates
+for each row execute function public.log_admin_content_item_audit();

--- a/tests/e2e/api-security-negative-paths.spec.ts
+++ b/tests/e2e/api-security-negative-paths.spec.ts
@@ -261,6 +261,33 @@ test.describe("api security negative paths", () => {
         }),
       })
     );
+    await expectUnauthorizedNoLeakWithTransientRetry(() =>
+      request.get("/api/admin/email-templates")
+    );
+    await expectUnauthorizedNoLeakWithTransientRetry(() =>
+      request.post("/api/admin/email-templates", {
+        headers: {
+          "content-type": "application/json",
+        },
+        data: JSON.stringify({
+          templateKey: "auth_login_code",
+          locale: "nb-NO",
+          subject: "Login code {{code}}",
+          body: "Use {{code}} to sign in.",
+          requiredPlaceholders: ["code"],
+        }),
+      })
+    );
+    await expectUnauthorizedNoLeakWithTransientRetry(() =>
+      request.patch(`/api/admin/email-templates/${dummyUuid}`, {
+        headers: {
+          "content-type": "application/json",
+        },
+        data: JSON.stringify({
+          subject: "Unauthorized email template update probe",
+        }),
+      })
+    );
 
     await expectUnauthorizedNoLeakWithTransientRetry(() =>
       request.get("/api/admin/operations/flags")

--- a/tests/unit/admin-email-templates.test.ts
+++ b/tests/unit/admin-email-templates.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  canTransitionAdminEmailTemplateStatus,
+  extractAdminEmailTemplatePlaceholders,
+  parseCreateAdminEmailTemplatePayload,
+  parseUpdateAdminEmailTemplatePayload,
+  validateAdminEmailTemplatePlaceholders,
+} from "@/lib/admin/email-templates";
+
+describe("parseCreateAdminEmailTemplatePayload", () => {
+  it("accepts valid payload with placeholder declarations", () => {
+    const parsed = parseCreateAdminEmailTemplatePayload({
+      templateKey: "auth_login_code",
+      locale: "nb-NO",
+      subject: "Din kode er {{code}}",
+      body: "Bruk {{code}} innen {{expires_minutes}} minutter.",
+      requiredPlaceholders: ["code"],
+      optionalPlaceholders: ["expires_minutes"],
+    });
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+
+    expect(parsed.value.templateKey).toBe("auth_login_code");
+    expect(parsed.value.status).toBe("draft");
+    expect(parsed.value.requiredPlaceholders).toEqual(["code"]);
+    expect(parsed.value.optionalPlaceholders).toEqual(["expires_minutes"]);
+  });
+
+  it("rejects invalid template key format", () => {
+    const parsed = parseCreateAdminEmailTemplatePayload({
+      templateKey: "Auth Login Code",
+      locale: "nb-NO",
+      subject: "Hei",
+      body: "Body",
+    });
+    expect(parsed.ok).toBe(false);
+  });
+});
+
+describe("extractAdminEmailTemplatePlaceholders", () => {
+  it("extracts unique normalized placeholders from subject/body text", () => {
+    const placeholders = extractAdminEmailTemplatePlaceholders(
+      "Use {{ CODE }} and {{expires_minutes}}; code={{code}}"
+    );
+    expect(placeholders).toEqual(["code", "expires_minutes"]);
+  });
+});
+
+describe("validateAdminEmailTemplatePlaceholders", () => {
+  it("rejects undeclared placeholders and missing required placeholders", () => {
+    const validation = validateAdminEmailTemplatePlaceholders({
+      subject: "Kode: {{code}}",
+      body: "Link: {{magic_link}}",
+      requiredPlaceholders: ["code", "expires_minutes"],
+      optionalPlaceholders: [],
+    });
+
+    expect(validation.ok).toBe(false);
+    if (validation.ok) return;
+    expect(validation.details.join(" ")).toContain("expires_minutes");
+    expect(validation.details.join(" ")).toContain("magic_link");
+  });
+
+  it("passes when required/optional declarations match usage", () => {
+    const validation = validateAdminEmailTemplatePlaceholders({
+      subject: "Kode: {{code}}",
+      body: "Bruk innen {{expires_minutes}} min.",
+      requiredPlaceholders: ["code"],
+      optionalPlaceholders: ["expires_minutes"],
+    });
+    expect(validation.ok).toBe(true);
+  });
+});
+
+describe("parseUpdateAdminEmailTemplatePayload", () => {
+  it("accepts patch fields with expectedUpdatedAt", () => {
+    const parsed = parseUpdateAdminEmailTemplatePayload({
+      subject: "Ny subject {{code}}",
+      status: "review",
+      expectedUpdatedAt: "2026-03-11T10:00:00.000Z",
+    });
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.value.patch.subject).toBe("Ny subject {{code}}");
+    expect(parsed.value.patch.status).toBe("review");
+    expect(parsed.value.expectedUpdatedAt).toBe("2026-03-11T10:00:00.000Z");
+  });
+
+  it("rejects payload without updatable fields", () => {
+    const parsed = parseUpdateAdminEmailTemplatePayload({});
+    expect(parsed.ok).toBe(false);
+  });
+});
+
+describe("canTransitionAdminEmailTemplateStatus", () => {
+  it("allows review -> published and blocks draft -> published", () => {
+    expect(canTransitionAdminEmailTemplateStatus("review", "published")).toBe(true);
+    expect(canTransitionAdminEmailTemplateStatus("draft", "published")).toBe(false);
+  });
+});

--- a/types/database.ts
+++ b/types/database.ts
@@ -562,6 +562,107 @@ export type Database = {
         };
         Relationships: [];
       };
+      admin_email_templates: {
+        Row: {
+          body: string;
+          created_at: string;
+          created_by: string | null;
+          id: string;
+          last_published_at: string | null;
+          last_published_by: string | null;
+          locale: string;
+          optional_placeholders: string[];
+          required_placeholders: string[];
+          status: Database["public"]["Enums"]["admin_email_template_status"];
+          subject: string;
+          template_key: string;
+          updated_at: string;
+          updated_by: string | null;
+          version: number;
+        };
+        Insert: {
+          body?: string;
+          created_at?: string;
+          created_by?: string | null;
+          id?: string;
+          last_published_at?: string | null;
+          last_published_by?: string | null;
+          locale?: string;
+          optional_placeholders?: string[];
+          required_placeholders?: string[];
+          status?: Database["public"]["Enums"]["admin_email_template_status"];
+          subject?: string;
+          template_key: string;
+          updated_at?: string;
+          updated_by?: string | null;
+          version?: number;
+        };
+        Update: {
+          body?: string;
+          created_at?: string;
+          created_by?: string | null;
+          id?: string;
+          last_published_at?: string | null;
+          last_published_by?: string | null;
+          locale?: string;
+          optional_placeholders?: string[];
+          required_placeholders?: string[];
+          status?: Database["public"]["Enums"]["admin_email_template_status"];
+          subject?: string;
+          template_key?: string;
+          updated_at?: string;
+          updated_by?: string | null;
+          version?: number;
+        };
+        Relationships: [];
+      };
+      admin_email_template_revisions: {
+        Row: {
+          action: string;
+          changed_by: string | null;
+          changed_by_email: string | null;
+          created_at: string;
+          id: string;
+          locale: string;
+          revision_number: number;
+          snapshot: Json;
+          template_id: string;
+          template_key: string;
+        };
+        Insert: {
+          action: string;
+          changed_by?: string | null;
+          changed_by_email?: string | null;
+          created_at?: string;
+          id?: string;
+          locale: string;
+          revision_number: number;
+          snapshot: Json;
+          template_id: string;
+          template_key: string;
+        };
+        Update: {
+          action?: string;
+          changed_by?: string | null;
+          changed_by_email?: string | null;
+          created_at?: string;
+          id?: string;
+          locale?: string;
+          revision_number?: number;
+          snapshot?: Json;
+          template_id?: string;
+          template_key?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "admin_email_template_revisions_template_id_fkey";
+            columns: ["template_id"];
+            isOneToOne: false;
+            referencedRelation: "admin_email_templates";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       products: {
         Row: {
           active: boolean;
@@ -631,6 +732,7 @@ export type Database = {
     };
     Enums: {
       admin_role: "admin" | "editor" | "viewer";
+      admin_email_template_status: "draft" | "review" | "published" | "archived";
       admin_content_status: "draft" | "review" | "published" | "archived";
       admin_content_type:
         | "course_module"


### PR DESCRIPTION
## Summary

- Implements AW-009 slice-2 server-canonical foundation for admin email template governance.
- Adds Supabase migration for `admin_email_templates` + `admin_email_template_revisions` with RLS policies, revision logging trigger, and audit trigger.
- Adds fail-closed admin API routes:
  - `GET /api/admin/email-templates`
  - `POST /api/admin/email-templates`
  - `PATCH /api/admin/email-templates/:id`
- Adds lifecycle/business-rule validation (placeholder contract, status transitions, optimistic concurrency guard via `expectedUpdatedAt`).
- Adds security/contract test coverage for unauthorized access and unit coverage for payload + validation logic.
- Updates AW-009 checkpoint entries in active briefs.

- Brief link(s): `docs/task-briefs/in-progress/2026-03-10-aw-009-admin-email-templates-and-governance-10-10.md`
- Scorecard target outcomes: 4 target scorecard categories are defined in the linked brief.

## Scope

- In scope:
  - New migration: `supabase/migrations/20260311100000_admin_email_templates_foundation.sql`
  - New API handlers: `app/api/admin/email-templates/route.ts`, `app/api/admin/email-templates/[id]/route.ts`
  - New domain validation lib: `lib/admin/email-templates.ts`
  - Schema readiness helper update: `lib/admin/schema.ts`
  - DB contract type update: `types/database.ts`
  - Tests: `tests/unit/admin-email-templates.test.ts`, `tests/e2e/api-security-negative-paths.spec.ts`
  - Brief checkpoints: AW-009 + backlog logs
- Out of scope:
  - Admin UI editor screens for managing templates
  - Send-time integration with transactional email providers

## Risk

- Main risk: incorrect lifecycle/placeholder rules could block legitimate admin edits.
- Data risk: new migration introduces tables/triggers/RLS; must be applied consistently across environments.
- Rollback plan:
  - Code rollback: `git revert d8098a9`
  - If migration is applied and rollback is needed, follow with explicit SQL rollback migration (do not hot-edit tables manually).

## Test Evidence

- `npm run verify:pre-pr`: **PASS** on `d8098a9` (local run on 2026-03-11).
  - Includes: `npm run lint:briefs`, `npm run lint`, `npm run typecheck`, `npm run test:unit`, `npm run build`, `npm run test:perf:budgets`, `npm run test:e2e`.
  - E2E summary from run: `76 passed`, `200 skipped`.
- `npm run verify:pre-merge`: **PASS** for `d8098a9` (2026-03-11T10:48:12Z, mode: `skipped` private-gate segment because `SITE_LOCK_ENABLED!=1`).
- CI checks (PR #182): all required checks are green.
- Manual QA: **NOT RUN** (no UI scope in this slice).
- CI links: PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [x] `npm run lint:briefs`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- N/A: no UI changes in this slice.
- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [x] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [x] PR is <= 500 changed lines, or intentionally split/explained
  - Intentionally split: this is AW-009 slice-2 foundation; line count mainly from migration + generated DB types.
- [x] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [x] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
