### PR TITLE
feat(admin): add AW-009 email template manager UI

### DIFF
--- a/components/admin/AdminEmailTemplatesManager.tsx
+++ b/components/admin/AdminEmailTemplatesManager.tsx
@@ -1,0 +1,822 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ADMIN_EMAIL_TEMPLATE_STATUS_VALUES,
+  canTransitionAdminEmailTemplateStatus,
+  extractAdminEmailTemplatePlaceholders,
+  type AdminEmailTemplateRow,
+  type AdminEmailTemplateStatus,
+} from "@/lib/admin/email-templates";
+
+type AdminEmailTemplatesResponse =
+  | {
+      ok: true;
+      items: AdminEmailTemplateRow[];
+      schemaReady?: boolean;
+      warning?: string | null;
+    }
+  | {
+      ok: false;
+      error?: string;
+    };
+
+type AdminEmailTemplateCreateResponse =
+  | {
+      ok: true;
+      item: AdminEmailTemplateRow;
+    }
+  | {
+      ok: false;
+      error?: string;
+      details?: string[];
+    };
+
+type AdminEmailTemplateUpdateResponse =
+  | {
+      ok: true;
+      item: AdminEmailTemplateRow;
+    }
+  | {
+      ok: false;
+      error?: string;
+      details?: string[];
+    };
+
+type CreateFormState = {
+  templateKey: string;
+  locale: string;
+  subject: string;
+  body: string;
+  requiredPlaceholders: string;
+  optionalPlaceholders: string;
+  status: "draft" | "review";
+};
+
+type EditFormState = {
+  templateKey: string;
+  locale: string;
+  subject: string;
+  body: string;
+  requiredPlaceholders: string;
+  optionalPlaceholders: string;
+  status: AdminEmailTemplateStatus;
+};
+
+const CREATE_FORM_INITIAL: CreateFormState = {
+  templateKey: "",
+  locale: "nb-NO",
+  subject: "",
+  body: "",
+  requiredPlaceholders: "",
+  optionalPlaceholders: "",
+  status: "draft",
+};
+
+function formatDateTime(value: string | null): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat("nb-NO", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function toStatusLabel(status: AdminEmailTemplateStatus): string {
+  switch (status) {
+    case "draft":
+      return "Draft";
+    case "review":
+      return "Review";
+    case "published":
+      return "Published";
+    case "archived":
+      return "Archived";
+    default:
+      return status;
+  }
+}
+
+function toStatusChipClasses(status: AdminEmailTemplateStatus): string {
+  switch (status) {
+    case "draft":
+      return "border border-slate-200 bg-slate-100 text-slate-700";
+    case "review":
+      return "border border-amber-200 bg-amber-50 text-amber-800";
+    case "published":
+      return "border border-emerald-200 bg-emerald-50 text-emerald-800";
+    case "archived":
+      return "border border-rose-200 bg-rose-50 text-rose-800";
+    default:
+      return "border border-slate-200 bg-slate-100 text-slate-700";
+  }
+}
+
+function normalizeListInput(value: string): string[] {
+  if (!value.trim()) return [];
+  const unique = new Set<string>();
+  for (const entry of value.split(/[\s,]+/)) {
+    const token = entry.trim().toLowerCase();
+    if (!token) continue;
+    unique.add(token);
+  }
+  return [...unique].sort();
+}
+
+function toListInput(values: readonly string[] | null | undefined): string {
+  if (!values || values.length === 0) return "";
+  return [...values].sort().join(", ");
+}
+
+function arraysEqual(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) return false;
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) return false;
+  }
+  return true;
+}
+
+function toEditFormState(item: AdminEmailTemplateRow): EditFormState {
+  return {
+    templateKey: item.template_key,
+    locale: item.locale,
+    subject: item.subject,
+    body: item.body,
+    requiredPlaceholders: toListInput(item.required_placeholders),
+    optionalPlaceholders: toListInput(item.optional_placeholders),
+    status: item.status,
+  };
+}
+
+function sortTemplates(rows: AdminEmailTemplateRow[]): AdminEmailTemplateRow[] {
+  return [...rows].sort((left, right) => {
+    if (left.template_key !== right.template_key) {
+      return left.template_key.localeCompare(right.template_key, "nb-NO");
+    }
+    return left.locale.localeCompare(right.locale, "nb-NO");
+  });
+}
+
+function normalizeInput(value: string): string {
+  return value.trim();
+}
+
+function nextQuickStatusOptions(current: AdminEmailTemplateStatus): AdminEmailTemplateStatus[] {
+  if (current === "draft") return ["review", "archived"];
+  if (current === "review") return ["published", "draft", "archived"];
+  if (current === "published") return ["review", "archived"];
+  return ["draft"];
+}
+
+export default function AdminEmailTemplatesManager() {
+  const [items, setItems] = useState<AdminEmailTemplateRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
+  const [schemaReady, setSchemaReady] = useState(true);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [actionNotice, setActionNotice] = useState<string | null>(null);
+  const [submittingCreate, setSubmittingCreate] = useState(false);
+  const [createState, setCreateState] = useState<CreateFormState>(CREATE_FORM_INITIAL);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editState, setEditState] = useState<EditFormState | null>(null);
+  const [savingId, setSavingId] = useState<string | null>(null);
+  const [quickStatusId, setQuickStatusId] = useState<string | null>(null);
+
+  const loadTemplates = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setWarning(null);
+    try {
+      const response = await fetch("/api/admin/email-templates", {
+        method: "GET",
+        credentials: "same-origin",
+        cache: "no-store",
+      });
+      const payload = (await response.json()) as AdminEmailTemplatesResponse;
+      if (!response.ok || !payload.ok) {
+        setError(
+          payload.ok
+            ? "Could not load email templates."
+            : (payload.error ?? "Could not load email templates.")
+        );
+        setItems([]);
+        setSchemaReady(true);
+        return;
+      }
+
+      setItems(sortTemplates(payload.items));
+      setSchemaReady(payload.schemaReady !== false);
+      setWarning(payload.warning ?? null);
+    } catch {
+      setError("Could not load email templates.");
+      setItems([]);
+      setSchemaReady(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadTemplates();
+  }, [loadTemplates]);
+
+  const summary = useMemo(() => {
+    if (items.length === 0) return "No templates configured yet.";
+    const published = items.filter((item) => item.status === "published").length;
+    const review = items.filter((item) => item.status === "review").length;
+    const draft = items.filter((item) => item.status === "draft").length;
+    const archived = items.filter((item) => item.status === "archived").length;
+    return `${items.length} total · ${published} published · ${review} review · ${draft} draft · ${archived} archived`;
+  }, [items]);
+
+  const activeEditItem = useMemo(
+    () => (editingId ? (items.find((item) => item.id === editingId) ?? null) : null),
+    [editingId, items]
+  );
+
+  const placeholderPreview = useMemo(() => {
+    if (!editState) return [];
+    return extractAdminEmailTemplatePlaceholders(`${editState.subject}\n${editState.body}`);
+  }, [editState]);
+
+  function startEdit(item: AdminEmailTemplateRow) {
+    if (savingId || quickStatusId) return;
+    setActionError(null);
+    setActionNotice(null);
+    setEditingId(item.id);
+    setEditState(toEditFormState(item));
+  }
+
+  function clearEdit() {
+    setEditingId(null);
+    setEditState(null);
+  }
+
+  async function handleCreate(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (submittingCreate || savingId || quickStatusId) return;
+
+    setSubmittingCreate(true);
+    setActionError(null);
+    setActionNotice(null);
+    try {
+      const response = await fetch("/api/admin/email-templates", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        credentials: "same-origin",
+        body: JSON.stringify({
+          templateKey: normalizeInput(createState.templateKey),
+          locale: normalizeInput(createState.locale),
+          subject: createState.subject,
+          body: createState.body,
+          status: createState.status,
+          requiredPlaceholders: normalizeListInput(createState.requiredPlaceholders),
+          optionalPlaceholders: normalizeListInput(createState.optionalPlaceholders),
+        }),
+      });
+      const payload = (await response.json()) as AdminEmailTemplateCreateResponse;
+      if (!response.ok || !payload.ok) {
+        const details =
+          payload.ok || !payload.details?.length ? "" : ` ${payload.details.join(" ")}`;
+        setActionError(
+          payload.ok
+            ? "Could not create email template."
+            : `${payload.error ?? "Could not create email template."}${details}`
+        );
+        return;
+      }
+
+      setItems((prev) => sortTemplates([...prev, payload.item]));
+      setCreateState(CREATE_FORM_INITIAL);
+      setActionNotice(`Template ${payload.item.template_key} (${payload.item.locale}) created.`);
+      startEdit(payload.item);
+    } catch {
+      setActionError("Could not create email template.");
+    } finally {
+      setSubmittingCreate(false);
+    }
+  }
+
+  async function saveEdit() {
+    if (!activeEditItem || !editState || savingId || quickStatusId) return;
+    setSavingId(activeEditItem.id);
+    setActionError(null);
+    setActionNotice(null);
+
+    const requiredPlaceholders = normalizeListInput(editState.requiredPlaceholders);
+    const optionalPlaceholders = normalizeListInput(editState.optionalPlaceholders);
+    const nextTemplateKey = normalizeInput(editState.templateKey).toLowerCase();
+    const nextLocale = normalizeInput(editState.locale);
+
+    const patch: Record<string, unknown> = {};
+    if (activeEditItem.template_key !== nextTemplateKey) patch.templateKey = nextTemplateKey;
+    if (activeEditItem.locale !== nextLocale) patch.locale = nextLocale;
+    if (activeEditItem.subject !== editState.subject) patch.subject = editState.subject;
+    if (activeEditItem.body !== editState.body) patch.body = editState.body;
+    if (!arraysEqual(activeEditItem.required_placeholders ?? [], requiredPlaceholders)) {
+      patch.requiredPlaceholders = requiredPlaceholders;
+    }
+    if (!arraysEqual(activeEditItem.optional_placeholders ?? [], optionalPlaceholders)) {
+      patch.optionalPlaceholders = optionalPlaceholders;
+    }
+    if (activeEditItem.status !== editState.status) patch.status = editState.status;
+
+    if (Object.keys(patch).length === 0) {
+      setSavingId(null);
+      setActionNotice("No template changes to save.");
+      return;
+    }
+
+    patch.expectedUpdatedAt = activeEditItem.updated_at;
+
+    try {
+      const response = await fetch(`/api/admin/email-templates/${activeEditItem.id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        credentials: "same-origin",
+        body: JSON.stringify(patch),
+      });
+      const payload = (await response.json()) as AdminEmailTemplateUpdateResponse;
+      if (!response.ok || !payload.ok) {
+        const details =
+          payload.ok || !payload.details?.length ? "" : ` ${payload.details.join(" ")}`;
+        setActionError(
+          payload.ok
+            ? "Could not update email template."
+            : `${payload.error ?? "Could not update email template."}${details}`
+        );
+        return;
+      }
+
+      setItems((prev) =>
+        sortTemplates(prev.map((entry) => (entry.id === payload.item.id ? payload.item : entry)))
+      );
+      setEditState(toEditFormState(payload.item));
+      setActionNotice(`Template ${payload.item.template_key} saved.`);
+    } catch {
+      setActionError("Could not update email template.");
+    } finally {
+      setSavingId(null);
+    }
+  }
+
+  async function updateTemplateStatus(
+    item: AdminEmailTemplateRow,
+    nextStatus: AdminEmailTemplateStatus
+  ) {
+    if (quickStatusId || savingId) return;
+    if (!canTransitionAdminEmailTemplateStatus(item.status, nextStatus)) return;
+
+    setQuickStatusId(item.id);
+    setActionError(null);
+    setActionNotice(null);
+    try {
+      const response = await fetch(`/api/admin/email-templates/${item.id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        credentials: "same-origin",
+        body: JSON.stringify({
+          status: nextStatus,
+          expectedUpdatedAt: item.updated_at,
+        }),
+      });
+      const payload = (await response.json()) as AdminEmailTemplateUpdateResponse;
+      if (!response.ok || !payload.ok) {
+        const details =
+          payload.ok || !payload.details?.length ? "" : ` ${payload.details.join(" ")}`;
+        setActionError(
+          payload.ok
+            ? "Could not update template status."
+            : `${payload.error ?? "Could not update template status."}${details}`
+        );
+        return;
+      }
+      setItems((prev) =>
+        sortTemplates(prev.map((entry) => (entry.id === payload.item.id ? payload.item : entry)))
+      );
+      if (editingId === payload.item.id) {
+        setEditState(toEditFormState(payload.item));
+      }
+      setActionNotice(
+        `Template ${payload.item.template_key} moved to ${toStatusLabel(payload.item.status)}.`
+      );
+    } catch {
+      setActionError("Could not update template status.");
+    } finally {
+      setQuickStatusId(null);
+    }
+  }
+
+  return (
+    <section
+      className="rounded-2xl border border-slate-200 bg-white p-6"
+      data-testid="admin-email-templates-manager"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Email templates</h2>
+          <p className="mt-2 text-sm text-slate-600">{summary}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void loadTemplates()}
+          className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {!schemaReady && warning ? (
+        <p className="mt-5 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          {warning}
+        </p>
+      ) : null}
+
+      {loading ? (
+        <p className="mt-5 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+          Loading email templates…
+        </p>
+      ) : null}
+
+      {!loading && error ? (
+        <div className="mt-5 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3">
+          <p className="text-sm font-medium text-rose-700">{error}</p>
+          <button
+            type="button"
+            onClick={() => void loadTemplates()}
+            className="mt-3 inline-flex h-9 items-center justify-center rounded-lg border border-rose-200 bg-white px-3 text-sm font-medium text-rose-700 transition hover:bg-rose-50"
+          >
+            Retry
+          </button>
+        </div>
+      ) : null}
+
+      {actionError ? (
+        <p className="mt-5 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+          {actionError}
+        </p>
+      ) : null}
+
+      {actionNotice ? (
+        <p className="mt-5 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+          {actionNotice}
+        </p>
+      ) : null}
+
+      <form
+        className="mt-5 rounded-xl border border-slate-200 bg-slate-50/70 p-4"
+        data-testid="admin-email-templates-create-form"
+        onSubmit={(event) => void handleCreate(event)}
+      >
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="text-sm font-semibold text-slate-900">Create template</h3>
+          <p className="text-xs text-slate-500">Create as draft/review, then publish from list.</p>
+        </div>
+        <div className="mt-3 grid gap-3 md:grid-cols-3">
+          <label className="space-y-1 text-sm font-medium text-slate-700">
+            <span>Template key</span>
+            <input
+              type="text"
+              value={createState.templateKey}
+              onChange={(event) =>
+                setCreateState((prev) => ({ ...prev, templateKey: event.target.value }))
+              }
+              placeholder="auth_login_code"
+              className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+              required
+            />
+          </label>
+
+          <label className="space-y-1 text-sm font-medium text-slate-700">
+            <span>Locale</span>
+            <input
+              type="text"
+              value={createState.locale}
+              onChange={(event) =>
+                setCreateState((prev) => ({ ...prev, locale: event.target.value }))
+              }
+              placeholder="nb-NO"
+              className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+              required
+            />
+          </label>
+
+          <label className="space-y-1 text-sm font-medium text-slate-700">
+            <span>Status</span>
+            <select
+              value={createState.status}
+              onChange={(event) =>
+                setCreateState((prev) => ({
+                  ...prev,
+                  status: event.target.value as CreateFormState["status"],
+                }))
+              }
+              className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+            >
+              <option value="draft">Draft</option>
+              <option value="review">Review</option>
+            </select>
+          </label>
+        </div>
+
+        <div className="mt-3 space-y-3">
+          <label className="space-y-1 text-sm font-medium text-slate-700">
+            <span>Subject</span>
+            <input
+              type="text"
+              value={createState.subject}
+              onChange={(event) =>
+                setCreateState((prev) => ({ ...prev, subject: event.target.value }))
+              }
+              placeholder="Din kode er {{code}}"
+              className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+              required
+            />
+          </label>
+          <label className="space-y-1 text-sm font-medium text-slate-700">
+            <span>Body</span>
+            <textarea
+              value={createState.body}
+              onChange={(event) =>
+                setCreateState((prev) => ({ ...prev, body: event.target.value }))
+              }
+              rows={4}
+              placeholder="Bruk {{code}} innen {{expires_minutes}} minutter."
+              className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
+              required
+            />
+          </label>
+          <div className="grid gap-3 md:grid-cols-2">
+            <label className="space-y-1 text-sm font-medium text-slate-700">
+              <span>Required placeholders</span>
+              <input
+                type="text"
+                value={createState.requiredPlaceholders}
+                onChange={(event) =>
+                  setCreateState((prev) => ({
+                    ...prev,
+                    requiredPlaceholders: event.target.value,
+                  }))
+                }
+                placeholder="code"
+                className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+              />
+            </label>
+            <label className="space-y-1 text-sm font-medium text-slate-700">
+              <span>Optional placeholders</span>
+              <input
+                type="text"
+                value={createState.optionalPlaceholders}
+                onChange={(event) =>
+                  setCreateState((prev) => ({
+                    ...prev,
+                    optionalPlaceholders: event.target.value,
+                  }))
+                }
+                placeholder="expires_minutes"
+                className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+              />
+            </label>
+          </div>
+        </div>
+
+        <button
+          type="submit"
+          disabled={submittingCreate || Boolean(savingId) || Boolean(quickStatusId)}
+          className="mt-4 inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+        >
+          {submittingCreate ? "Creating…" : "Create template"}
+        </button>
+      </form>
+
+      {!loading && !error && items.length === 0 ? (
+        <p className="mt-5 rounded-xl border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+          No templates created yet.
+        </p>
+      ) : null}
+
+      {!loading && !error && items.length > 0 ? (
+        <ul className="mt-5 space-y-3">
+          {items.map((item) => {
+            const isEditing = editingId === item.id;
+            const nextStatusOptions = nextQuickStatusOptions(item.status).filter((nextStatus) =>
+              canTransitionAdminEmailTemplateStatus(item.status, nextStatus)
+            );
+            const disableRowActions = Boolean(savingId || quickStatusId || submittingCreate);
+
+            return (
+              <li
+                key={item.id}
+                className="rounded-xl border border-slate-200 bg-slate-50/70 p-4"
+                data-testid="admin-email-template-item"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <p className="text-sm font-semibold text-slate-900">
+                      {item.template_key} · {item.locale}
+                    </p>
+                    <p className="mt-1 text-xs text-slate-500">
+                      v{item.version} · updated {formatDateTime(item.updated_at)} · last published{" "}
+                      {formatDateTime(item.last_published_at)}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span
+                      className={[
+                        "inline-flex rounded-full px-2 py-1 text-xs font-semibold",
+                        toStatusChipClasses(item.status),
+                      ].join(" ")}
+                    >
+                      {toStatusLabel(item.status)}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => (isEditing ? clearEdit() : startEdit(item))}
+                      disabled={disableRowActions}
+                      className="inline-flex h-8 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {isEditing ? "Close editor" : "Edit"}
+                    </button>
+                  </div>
+                </div>
+
+                {nextStatusOptions.length > 0 ? (
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {nextStatusOptions.map((nextStatus) => (
+                      <button
+                        key={`${item.id}-${nextStatus}`}
+                        type="button"
+                        disabled={disableRowActions}
+                        onClick={() => void updateTemplateStatus(item, nextStatus)}
+                        className="inline-flex h-8 items-center justify-center rounded-lg border border-indigo-200 bg-indigo-50 px-3 text-xs font-semibold text-indigo-800 transition hover:bg-indigo-100 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        {quickStatusId === item.id
+                          ? "Saving…"
+                          : `Move to ${toStatusLabel(nextStatus)}`}
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+
+                {isEditing && editState ? (
+                  <div className="mt-4 grid gap-3 border-t border-slate-200 pt-4">
+                    <div className="grid gap-3 md:grid-cols-3">
+                      <label className="space-y-1 text-sm font-medium text-slate-700">
+                        <span>Template key</span>
+                        <input
+                          type="text"
+                          value={editState.templateKey}
+                          onChange={(event) =>
+                            setEditState((prev) =>
+                              prev ? { ...prev, templateKey: event.target.value } : prev
+                            )
+                          }
+                          className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                        />
+                      </label>
+                      <label className="space-y-1 text-sm font-medium text-slate-700">
+                        <span>Locale</span>
+                        <input
+                          type="text"
+                          value={editState.locale}
+                          onChange={(event) =>
+                            setEditState((prev) =>
+                              prev ? { ...prev, locale: event.target.value } : prev
+                            )
+                          }
+                          className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                        />
+                      </label>
+                      <label className="space-y-1 text-sm font-medium text-slate-700">
+                        <span>Status</span>
+                        <select
+                          value={editState.status}
+                          onChange={(event) =>
+                            setEditState((prev) =>
+                              prev
+                                ? {
+                                    ...prev,
+                                    status: event.target.value as AdminEmailTemplateStatus,
+                                  }
+                                : prev
+                            )
+                          }
+                          className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                        >
+                          {ADMIN_EMAIL_TEMPLATE_STATUS_VALUES.map((status) => (
+                            <option key={status} value={status}>
+                              {toStatusLabel(status)}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    </div>
+
+                    <label className="space-y-1 text-sm font-medium text-slate-700">
+                      <span>Subject</span>
+                      <input
+                        type="text"
+                        value={editState.subject}
+                        onChange={(event) =>
+                          setEditState((prev) =>
+                            prev ? { ...prev, subject: event.target.value } : prev
+                          )
+                        }
+                        className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                      />
+                    </label>
+
+                    <label className="space-y-1 text-sm font-medium text-slate-700">
+                      <span>Body</span>
+                      <textarea
+                        value={editState.body}
+                        onChange={(event) =>
+                          setEditState((prev) =>
+                            prev ? { ...prev, body: event.target.value } : prev
+                          )
+                        }
+                        rows={6}
+                        className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
+                      />
+                    </label>
+
+                    <div className="grid gap-3 md:grid-cols-2">
+                      <label className="space-y-1 text-sm font-medium text-slate-700">
+                        <span>Required placeholders</span>
+                        <input
+                          type="text"
+                          value={editState.requiredPlaceholders}
+                          onChange={(event) =>
+                            setEditState((prev) =>
+                              prev
+                                ? {
+                                    ...prev,
+                                    requiredPlaceholders: event.target.value,
+                                  }
+                                : prev
+                            )
+                          }
+                          className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                        />
+                      </label>
+                      <label className="space-y-1 text-sm font-medium text-slate-700">
+                        <span>Optional placeholders</span>
+                        <input
+                          type="text"
+                          value={editState.optionalPlaceholders}
+                          onChange={(event) =>
+                            setEditState((prev) =>
+                              prev
+                                ? {
+                                    ...prev,
+                                    optionalPlaceholders: event.target.value,
+                                  }
+                                : prev
+                            )
+                          }
+                          className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                        />
+                      </label>
+                    </div>
+
+                    <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-600">
+                      <span className="font-semibold text-slate-700">Detected placeholders:</span>{" "}
+                      {placeholderPreview.length > 0 ? placeholderPreview.join(", ") : "none"}
+                    </div>
+
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => void saveEdit()}
+                        disabled={Boolean(savingId) || Boolean(quickStatusId)}
+                        className="inline-flex h-9 items-center justify-center rounded-lg bg-blue-600 px-3 text-xs font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+                      >
+                        {savingId === item.id ? "Saving…" : "Save changes"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setEditState(toEditFormState(item))}
+                        disabled={Boolean(savingId) || Boolean(quickStatusId)}
+                        className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        Reset draft
+                      </button>
+                    </div>
+                  </div>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </section>
+  );
+}

--- a/components/admin/AdminHelpCenter.tsx
+++ b/components/admin/AdminHelpCenter.tsx
@@ -16,7 +16,7 @@ type ActionGroup = {
   actions: Array<{ label: string; meaning: string }>;
 };
 
-const LAST_UPDATED = "2026-03-10";
+const LAST_UPDATED = "2026-03-11";
 
 const QUICK_ACTIONS = [
   { id: "overview", label: "Start here" },
@@ -24,6 +24,7 @@ const QUICK_ACTIONS = [
   { id: "tabs", label: "Dashboard tabs" },
   { id: "content-page", label: "Content workflow" },
   { id: "qr-links", label: "QR workflow" },
+  { id: "email-templates", label: "Email templates" },
   { id: "buttons", label: "Buttons explained" },
   { id: "quality-matrix", label: "10/10 matrix" },
   { id: "controls", label: "Doc controls" },
@@ -53,6 +54,12 @@ const DASHBOARD_TABS: TabGuide[] = [
     name: "Operations",
     primaryJob: "Control runtime flags and private-access lock behavior.",
     commonRisk: "Flag changes without verification can hide or expose routes unexpectedly.",
+  },
+  {
+    name: "Email templates",
+    primaryJob:
+      "Manage lifecycle-safe email copy with placeholder validation and publish controls.",
+    commonRisk: "Publishing template text with invalid placeholders can break outbound messages.",
   },
   {
     name: "Notes",
@@ -88,7 +95,12 @@ const LEARNING_PATH = [
       "In QR Links: create slug, verify destination, activate, test stable link, then download QR files.",
   },
   {
-    title: "Step 4: Recovery drill (5 min)",
+    title: "Step 4: Email template governance cycle (10 min)",
+    detail:
+      "In Email templates: create draft, validate placeholders, move to review, then publish with rollback-ready history.",
+  },
+  {
+    title: "Step 5: Recovery drill (5 min)",
     detail:
       "Practice one rollback flow: disable broken QR or restore a content revision and confirm public result.",
   },
@@ -154,6 +166,34 @@ const QR_WORKFLOW = [
     title: "Rollback fast if something is wrong",
     detail:
       "Immediate rollback options: Disable status or restore a safe destination URL, then retest stable link.",
+  },
+];
+
+const EMAIL_TEMPLATE_WORKFLOW = [
+  {
+    title: "Start in draft with explicit placeholder declarations",
+    detail:
+      "Write subject/body first, then declare required and optional placeholders so validation can enforce contract safety.",
+  },
+  {
+    title: "Use review as internal quality gate",
+    detail:
+      "Move template to review before publish. This is where copy, locale, and placeholder usage should be peer-checked.",
+  },
+  {
+    title: "Publish only after validation passes",
+    detail:
+      "Published templates increment version and record publisher metadata for recovery and support visibility.",
+  },
+  {
+    title: "Use lifecycle transitions intentionally",
+    detail:
+      "Allowed transitions protect production safety: draft/review/published/archived are not interchangeable shortcuts.",
+  },
+  {
+    title: "Handle conflicts by reload-then-retry",
+    detail:
+      "If another operator updated a template first, reload latest state and re-apply your intended change.",
   },
 ];
 
@@ -249,6 +289,36 @@ const BUTTON_GUIDE: ActionGroup[] = [
         label: "Delete",
         meaning:
           "Permanent remove of QR row, grouped under More actions. Prefer disable when unsure.",
+      },
+    ],
+  },
+  {
+    section: "Email templates tab",
+    actions: [
+      {
+        label: "Create template",
+        meaning:
+          "Creates new template row in draft/review with placeholder validation and unique key+locale contract.",
+      },
+      {
+        label: "Edit / Close editor",
+        meaning:
+          "Opens inline edit form for subject/body/placeholders/status and closes it when done.",
+      },
+      {
+        label: "Move to Review / Move to Published / Move to Archived / Move to Draft",
+        meaning:
+          "Applies lifecycle transitions with optimistic concurrency checks to avoid silent overwrite.",
+      },
+      {
+        label: "Save changes / Reset draft",
+        meaning:
+          "Save sends the current patch with conflict protection. Reset restores editor state from latest loaded row.",
+      },
+      {
+        label: "Refresh",
+        meaning:
+          "Reloads server-canonical template list if another operator changed state or conflict warning appears.",
       },
     ],
   },
@@ -423,6 +493,7 @@ const DAILY_PLAYBOOKS: Playbook[] = [
 const RUNBOOK_LINKS = [
   "docs/runbooks/qr-redirect-operations.md",
   "docs/runbooks/site-lock-operations.md",
+  "docs/runbooks/admin-email-template-governance.md",
   "docs/runbooks/private-access-gate.md",
   "docs/runbooks/post-merge-local-sync.md",
   "docs/runbooks/ci-unblock.md",
@@ -540,6 +611,25 @@ export default function AdminHelpCenter() {
         </div>
       </section>
 
+      <section id="email-templates" className="rounded-2xl border border-slate-200 bg-white p-6">
+        <h3 className="text-base font-semibold text-slate-900">How Email Templates work</h3>
+        <p className="mt-2 text-sm text-slate-700">
+          Email Templates is lifecycle-safe message governance for operational copy that should not
+          require code edits for every wording update.
+        </p>
+        <div className="mt-3 space-y-3">
+          {EMAIL_TEMPLATE_WORKFLOW.map((item) => (
+            <article
+              key={item.title}
+              className="rounded-xl border border-slate-200 bg-slate-50/60 p-3"
+            >
+              <p className="text-sm font-semibold text-slate-900">{item.title}</p>
+              <p className="mt-1 text-sm text-slate-700">{item.detail}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
       <section id="buttons" className="rounded-2xl border border-slate-200 bg-white p-6">
         <h3 className="text-base font-semibold text-slate-900">Buttons and what they do</h3>
         <p className="mt-2 text-sm text-slate-700">
@@ -576,6 +666,9 @@ export default function AdminHelpCenter() {
               <li>Move/reorder module and lesson structure using safe workflows.</li>
               <li>Create/edit/activate/disable/delete QR registry rows.</li>
               <li>Generate/download QR assets (SVG/PNG) from registry rows.</li>
+              <li>
+                Create/edit/review/publish/archive email templates with placeholder validation.
+              </li>
               <li>Maintain notes, categories, and commerce labels.</li>
               <li>Run revision restore and QR rollback operations.</li>
             </ul>

--- a/components/admin/AdminWorkspace.tsx
+++ b/components/admin/AdminWorkspace.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import AdminCommerceManager from "@/components/admin/AdminCommerceManager";
 import AdminContentManager from "@/components/admin/AdminContentManager";
 import AdminCategoriesManager from "@/components/admin/AdminCategoriesManager";
+import AdminEmailTemplatesManager from "@/components/admin/AdminEmailTemplatesManager";
 import AdminHelpCenter from "@/components/admin/AdminHelpCenter";
 import AdminNotesManager from "@/components/admin/AdminNotesManager";
 import AdminOperationsManager from "@/components/admin/AdminOperationsManager";
@@ -14,6 +15,7 @@ type AdminTab =
   | "qr-links"
   | "commerce"
   | "operations"
+  | "email-templates"
   | "notes"
   | "categories"
   | "help";
@@ -38,6 +40,11 @@ const TAB_LABELS: Array<{ id: AdminTab; label: string; subtitle: string }> = [
     id: "operations",
     label: "Operations",
     subtitle: "Runtime flags and private-access status",
+  },
+  {
+    id: "email-templates",
+    label: "Email templates",
+    subtitle: "Draft, review, publish, and rollback-safe message copy",
   },
   {
     id: "notes",
@@ -77,7 +84,7 @@ export default function AdminWorkspace() {
 
   return (
     <div>
-      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-7">
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-8">
         {TAB_LABELS.map((tab) => {
           const isActive = tab.id === activeTab;
           return (
@@ -126,6 +133,7 @@ export default function AdminWorkspace() {
         {activeTab === "qr-links" ? <AdminQrLinksManager /> : null}
         {activeTab === "commerce" ? <AdminCommerceManager /> : null}
         {activeTab === "operations" ? <AdminOperationsManager /> : null}
+        {activeTab === "email-templates" ? <AdminEmailTemplatesManager /> : null}
         {activeTab === "notes" ? <AdminNotesManager /> : null}
         {activeTab === "categories" ? <AdminCategoriesManager /> : null}
         {activeTab === "help" ? <AdminHelpCenter /> : null}

--- a/docs/task-briefs/in-progress/2026-02-17-additional-work-backlog.md
+++ b/docs/task-briefs/in-progress/2026-02-17-additional-work-backlog.md
@@ -345,6 +345,7 @@ Apply these when backlog items graduate to dedicated implementation briefs:
 
 ## Checkpoint Log
 
+- `2026-03-11 | feat/aw-009-email-template-admin-ui-slice-3 | completed AW-009 slice-3 admin UI slice: added Email templates tab/manager in admin workspace, lifecycle transition controls over canonical API, and Help/Guide alignment (workflow + button glossary + runbook link); added e2e/unit coverage for navigation/help/schema setup paths | next: run lint:briefs + verify:pre-pr, then open PR`
 - `2026-03-11 | feat/aw-009-email-template-data-contract-slice-2 | completed AW-009 slice-2 foundation: added canonical email-template schema + revisions, fail-closed admin API routes, placeholder/status transition validation, and unauthorized negative-path coverage for new endpoints | next: run lint:briefs + verify:pre-pr, then open PR`
 - `2026-03-11 | feat/aw-009-email-template-governance-slice-1 | started AW-009 slice-1: set backlog status to in-progress, moved AW-009 brief to in-progress, and added template governance runbook baseline (`docs/runbooks/admin-email-template-governance.md`) | next: run lint:briefs + verify:pre-pr, then open PR`
 - `2026-03-10 | feat/aw-008-preview-lock-smoke-fix-slice-3@0e1e70e | AW-008 closeout evidence captured: preview workflow run 22928386773 (`lock_on` PASS) + 22928440585 (`lock_off` PASS); updated workflow/runbook smoke contract to protected API route and marked AW-008 done | next: move AW-008 brief to done and continue with next low-risk backlog slice (AW-009 or AW-012)`

--- a/docs/task-briefs/in-progress/2026-03-10-aw-009-admin-email-templates-and-governance-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-10-aw-009-admin-email-templates-and-governance-10-10.md
@@ -109,6 +109,7 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 
 ## Checkpoint Log
 
+- `2026-03-11 | feat/aw-009-email-template-admin-ui-slice-3 | completed AW-009 slice-3 admin workflow + guide alignment: added Email templates tab in Admin workspace, shipped create/edit/status-transition manager UI over canonical API contract, and updated admin Help/Guide with lifecycle workflow + button glossary + runbook link; added e2e/unit coverage for tab navigation/help content/schema setup messaging | next: run lint:briefs + verify:pre-pr, then open PR`
 - `2026-03-11 | feat/aw-009-email-template-data-contract-slice-2 | completed AW-009 slice-2 server-canonical foundation: added admin_email_templates + revision migration, fail-closed admin API routes (GET/POST/PATCH), placeholder/status transition validation, and unauthorized negative-path coverage for new endpoints | next: run lint:briefs + verify:pre-pr, then open PR`
 - `2026-03-11 | feat/aw-009-email-template-governance-slice-1 | started AW-009 slice-1: moved brief to in-progress, aligned backlog lifecycle state, and added operator runbook baseline for draft/review/publish/revert governance (`docs/runbooks/admin-email-template-governance.md`) | next: run lint:briefs + verify:pre-pr, then open PR`
 - `2026-03-10 | working tree | created AW-009 planned implementation brief with scorecard-complete governance thresholds and deterministic draft/review/publish contract | next: link this brief in backlog and use it as canonical scope when implementation starts`

--- a/tests/e2e/admin-foundation.spec.ts
+++ b/tests/e2e/admin-foundation.spec.ts
@@ -105,6 +105,7 @@ test.describe("admin foundation", () => {
     const tabQrLinks = page.getByTestId("admin-tab-qr-links");
     const tabCommerce = page.getByTestId("admin-tab-commerce");
     const tabOperations = page.getByTestId("admin-tab-operations");
+    const tabEmailTemplates = page.getByTestId("admin-tab-email-templates");
     const tabNotes = page.getByTestId("admin-tab-notes");
     const tabCategories = page.getByTestId("admin-tab-categories");
     const tabHelp = page.getByTestId("admin-tab-help");
@@ -143,6 +144,10 @@ test.describe("admin foundation", () => {
     await tabOperations.click();
     await expect(activeSectionLabel).toHaveText("Operations");
     await expect(page.getByRole("heading", { name: "Operations" })).toBeVisible();
+
+    await tabEmailTemplates.click();
+    await expect(activeSectionLabel).toHaveText("Email templates");
+    await expect(page.getByRole("heading", { name: "Email templates" })).toBeVisible();
 
     await tabNotes.click();
     await expect(activeSectionLabel).toHaveText("Notes");

--- a/tests/e2e/admin-help-center.spec.ts
+++ b/tests/e2e/admin-help-center.spec.ts
@@ -41,6 +41,7 @@ test.describe("admin help center", () => {
     ).toBeVisible();
     await expect(page.getByRole("heading", { name: "How the Content page works" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "How QR Links work" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "How Email Templates work" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Buttons and what they do" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "What can be edited right now" })).toBeVisible();
     await expect(
@@ -68,6 +69,10 @@ test.describe("admin help center", () => {
     ).toBeVisible();
     await expect(page.getByText("Open lock operations workflow:")).toBeVisible();
     await expect(page.getByText("Open password page:")).toBeVisible();
+    await expect(page.getByText("Create template:")).toBeVisible();
+    await expect(
+      page.getByText("Move to Review / Move to Published / Move to Archived / Move to Draft:")
+    ).toBeVisible();
     await expect(
       page.getByText(
         "Every new/updated brief must declare Help/Guide impact as: required update or explicit N/A with reason."
@@ -75,5 +80,6 @@ test.describe("admin help center", () => {
     ).toBeVisible();
     await expect(page.getByText("docs/runbooks/qr-redirect-operations.md")).toBeVisible();
     await expect(page.getByText("docs/runbooks/site-lock-operations.md")).toBeVisible();
+    await expect(page.getByText("docs/runbooks/admin-email-template-governance.md")).toBeVisible();
   });
 });

--- a/tests/unit/admin-schema.test.ts
+++ b/tests/unit/admin-schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  isAdminEmailTemplatesSchemaMissing,
   isAdminCommerceSchemaMissing,
   getAdminSchemaSetupMessage,
   isAdminContentSchemaMissing,
@@ -29,6 +30,14 @@ describe("admin schema helpers", () => {
     expect(isAdminNotesSchemaMissing({ code: "PGRST205" })).toBe(true);
   });
 
+  it("detects missing admin email templates schema", () => {
+    expect(
+      isAdminEmailTemplatesSchemaMissing({
+        message: 'relation "admin_email_templates" does not exist',
+      })
+    ).toBe(true);
+  });
+
   it("detects setup blocked by missing grants or policies", () => {
     expect(
       isAdminContentSchemaMissing({
@@ -54,5 +63,6 @@ describe("admin schema helpers", () => {
     expect(getAdminSchemaSetupMessage("operations")).toContain("Admin operations");
     expect(getAdminSchemaSetupMessage("notes")).toContain("Admin notes");
     expect(getAdminSchemaSetupMessage("commerce")).toContain("Admin commerce");
+    expect(getAdminSchemaSetupMessage("emailTemplates")).toContain("Admin email templates");
   });
 });


### PR DESCRIPTION
## Summary

- Added a new `Email templates` tab in `/admin` with a full create/edit/lifecycle manager backed by canonical admin API routes.
- Added lifecycle-safe quick transitions (`draft/review/published/archived`) with optimistic concurrency (`expectedUpdatedAt`) to prevent silent overwrites.
- Extended Admin Help/Guide with email-template workflow guidance, button glossary coverage, and runbook linkage.
- Logged AW-009 slice-3 progress in active checkpoint logs.

## User-visible changes

- Admin can create email templates with key, locale, subject/body, required placeholders, optional placeholders, and initial `draft/review` status.
- Admin can edit templates inline, preview detected placeholders, save/reset edits, and refresh canonical state.
- Admin can move templates between allowed lifecycle statuses using explicit transition buttons.
- Admin Help Center now documents the Email Templates workflow and related operations references.

## Technical changes

- Added `components/admin/AdminEmailTemplatesManager.tsx`.
- Updated `components/admin/AdminWorkspace.tsx` to register/render `email-templates` tab.
- Updated `components/admin/AdminHelpCenter.tsx` with workflow, glossary, links, and tab metadata.
- Updated tests:
  - `tests/e2e/admin-foundation.spec.ts`
  - `tests/e2e/admin-help-center.spec.ts`
  - `tests/unit/admin-schema.test.ts`
- Updated checkpoint logs:
  - `docs/task-briefs/in-progress/2026-03-10-aw-009-admin-email-templates-and-governance-10-10.md`
  - `docs/task-briefs/in-progress/2026-02-17-additional-work-backlog.md`
- Brief links:
  - `docs/task-briefs/in-progress/2026-03-10-aw-009-admin-email-templates-and-governance-10-10.md`
  - `docs/task-briefs/in-progress/2026-02-17-additional-work-backlog.md`

## Risk

- Main risk: UX regressions in the new admin manager form/transition flows.
- Rollback plan: revert `08daa78` (`git revert 08daa78`).

## Test Evidence

- `npm run verify:pre-pr`: **PASS** on current branch before push.
  - Includes: `lint:briefs`, `lint`, `typecheck`, `test:unit`, `build`, `test:perf:budgets`, `test:e2e`.
  - E2E summary: `76 passed`, `200 skipped`, `0 failed`.
- `npm run verify:pre-merge`: **PASS** for `08daa78` (`artifacts/verify-pre-merge/20260311-112344.json`, mode: `skipped`).
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark only boxes with proof in this PR.

- [x] `npm run lint:briefs`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [x] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [x] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [x] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`

