### PR TITLE
feat(my-library): add training metrics and preferences foundation

### DIFF
--- a/app/api/my-library/profile/metrics/route.ts
+++ b/app/api/my-library/profile/metrics/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from "next/server";
+import { buildCssMetricUpsert } from "@/lib/athlete-profile/training-setup";
+import { loadAthleteProfileSnapshot } from "@/lib/athlete-profile/server";
+import { isTrainingMetricSchemaMissing } from "@/lib/athlete-profile/schema";
+import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
+
+type TrainingMetricRequestBody = {
+  pace?: string | null;
+  recordedOn?: string | null;
+  sourceNote?: string | null;
+};
+
+function noStoreJson(
+  body: Record<string, unknown>,
+  init?: {
+    status?: number;
+  }
+) {
+  return NextResponse.json(body, {
+    status: init?.status ?? 200,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export async function PUT(request: Request) {
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Unauthorized." }, { status: 401 })
+    );
+  }
+
+  let body: TrainingMetricRequestBody;
+  try {
+    body = (await request.json()) as TrainingMetricRequestBody;
+  } catch {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Invalid JSON body." }, { status: 400 })
+    );
+  }
+
+  const nextMetric = buildCssMetricUpsert(body);
+
+  if (nextMetric.kind === "invalid") {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: nextMetric.error }, { status: 400 })
+    );
+  }
+
+  if (nextMetric.kind === "empty") {
+    const deleteResult = await supabase
+      .from("training_metrics")
+      .delete()
+      .eq("user_id", user.id)
+      .eq("metric_key", "css");
+
+    if (isTrainingMetricSchemaMissing(deleteResult.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          { ok: false, error: "Training metrics are still syncing in this environment." },
+          { status: 503 }
+        )
+      );
+    }
+
+    if (deleteResult.error) {
+      console.error("[AthleteProfileApi] Could not clear training metric", deleteResult.error);
+      return applySupabaseCookies(
+        noStoreJson({ ok: false, error: "Could not clear CSS right now." }, { status: 500 })
+      );
+    }
+
+    return applySupabaseCookies(
+      noStoreJson({
+        ok: true,
+        snapshot: await loadAthleteProfileSnapshot(supabase, user.id),
+      })
+    );
+  }
+
+  const result = await supabase
+    .from("training_metrics")
+    .upsert(
+      {
+        user_id: user.id,
+        ...nextMetric.value,
+      },
+      { onConflict: "user_id,metric_key" }
+    )
+    .select("id")
+    .single();
+
+  if (isTrainingMetricSchemaMissing(result.error)) {
+    return applySupabaseCookies(
+      noStoreJson(
+        {
+          ok: false,
+          error: "Training metrics are still syncing in this environment.",
+        },
+        { status: 503 }
+      )
+    );
+  }
+
+  if (result.error) {
+    console.error("[AthleteProfileApi] Could not save training metric", result.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not save CSS right now." }, { status: 500 })
+    );
+  }
+
+  return applySupabaseCookies(
+    noStoreJson({
+      ok: true,
+      snapshot: await loadAthleteProfileSnapshot(supabase, user.id),
+    })
+  );
+}

--- a/app/api/my-library/profile/preferences/route.ts
+++ b/app/api/my-library/profile/preferences/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from "next/server";
+import { buildTrainingPreferencesUpsert } from "@/lib/athlete-profile/training-setup";
+import { loadAthleteProfileSnapshot } from "@/lib/athlete-profile/server";
+import { isTrainingPreferencesSchemaMissing } from "@/lib/athlete-profile/schema";
+import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
+
+type TrainingPreferencesRequestBody = {
+  poolLengthM?: number | string | null;
+  availableDays?: string[] | null;
+  preferredWeeklySessionCount?: number | string | null;
+  preferredSessionMinutes?: number | string | null;
+};
+
+function noStoreJson(
+  body: Record<string, unknown>,
+  init?: {
+    status?: number;
+  }
+) {
+  return NextResponse.json(body, {
+    status: init?.status ?? 200,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export async function PUT(request: Request) {
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Unauthorized." }, { status: 401 })
+    );
+  }
+
+  let body: TrainingPreferencesRequestBody;
+  try {
+    body = (await request.json()) as TrainingPreferencesRequestBody;
+  } catch {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Invalid JSON body." }, { status: 400 })
+    );
+  }
+
+  const nextPreferences = buildTrainingPreferencesUpsert(body);
+
+  if (nextPreferences.kind === "invalid") {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: nextPreferences.error }, { status: 400 })
+    );
+  }
+
+  if (nextPreferences.kind === "empty") {
+    const deleteResult = await supabase
+      .from("training_preferences")
+      .delete()
+      .eq("user_id", user.id);
+
+    if (isTrainingPreferencesSchemaMissing(deleteResult.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: "Training preferences are still syncing in this environment.",
+          },
+          { status: 503 }
+        )
+      );
+    }
+
+    if (deleteResult.error) {
+      console.error("[AthleteProfileApi] Could not clear training preferences", deleteResult.error);
+      return applySupabaseCookies(
+        noStoreJson(
+          { ok: false, error: "Could not clear training preferences right now." },
+          { status: 500 }
+        )
+      );
+    }
+
+    return applySupabaseCookies(
+      noStoreJson({
+        ok: true,
+        snapshot: await loadAthleteProfileSnapshot(supabase, user.id),
+      })
+    );
+  }
+
+  const result = await supabase
+    .from("training_preferences")
+    .upsert(
+      {
+        user_id: user.id,
+        ...nextPreferences.value,
+      },
+      { onConflict: "user_id" }
+    )
+    .select("id")
+    .single();
+
+  if (isTrainingPreferencesSchemaMissing(result.error)) {
+    return applySupabaseCookies(
+      noStoreJson(
+        {
+          ok: false,
+          error: "Training preferences are still syncing in this environment.",
+        },
+        { status: 503 }
+      )
+    );
+  }
+
+  if (result.error) {
+    console.error("[AthleteProfileApi] Could not save training preferences", result.error);
+    return applySupabaseCookies(
+      noStoreJson(
+        { ok: false, error: "Could not save training preferences right now." },
+        { status: 500 }
+      )
+    );
+  }
+
+  return applySupabaseCookies(
+    noStoreJson({
+      ok: true,
+      snapshot: await loadAthleteProfileSnapshot(supabase, user.id),
+    })
+  );
+}

--- a/app/api/user/export/route.ts
+++ b/app/api/user/export/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { COURSE_MODULES } from "@/app/course/courseData";
-import { isAthleteProfileSchemaMissing } from "@/lib/athlete-profile/schema";
+import {
+  isAthleteProfileSchemaMissing,
+  isTrainingMetricSchemaMissing,
+  isTrainingPreferencesSchemaMissing,
+} from "@/lib/athlete-profile/schema";
 import { loadCourseModulesByStatus } from "@/lib/admin/content-course";
 import { normalizeCourseProgressRows } from "@/lib/course/progress";
 import {
@@ -47,6 +51,8 @@ export async function GET() {
   const [
     profileResult,
     athleteProfileResult,
+    trainingMetricsResult,
+    trainingPreferencesResult,
     entitlementsResult,
     courseProgressResult,
     guideProgressResult,
@@ -64,6 +70,20 @@ export async function GET() {
     supabase
       .from("athlete_profiles")
       .select("id, display_name, first_name, last_name, age_band, created_at, updated_at")
+      .eq("user_id", userId)
+      .maybeSingle(),
+    supabase
+      .from("training_metrics")
+      .select(
+        "id, metric_key, unit, value_seconds, recorded_on, source_note, created_at, updated_at"
+      )
+      .eq("user_id", userId)
+      .order("updated_at", { ascending: false }),
+    supabase
+      .from("training_preferences")
+      .select(
+        "id, pool_length_m, available_days, preferred_weekly_session_count, preferred_session_minutes, created_at, updated_at"
+      )
       .eq("user_id", userId)
       .maybeSingle(),
     supabase
@@ -119,6 +139,15 @@ export async function GET() {
     athleteProfileResult.error && isAthleteProfileSchemaMissing(athleteProfileResult.error)
       ? null
       : (athleteProfileResult.data ?? null);
+  const normalizedTrainingMetrics =
+    trainingMetricsResult.error && isTrainingMetricSchemaMissing(trainingMetricsResult.error)
+      ? []
+      : (trainingMetricsResult.data ?? []);
+  const normalizedTrainingPreferences =
+    trainingPreferencesResult.error &&
+    isTrainingPreferencesSchemaMissing(trainingPreferencesResult.error)
+      ? null
+      : (trainingPreferencesResult.data ?? null);
   const normalizedTrainingFocuses =
     trainingFocusesResult.error && isTrainingContextSchemaMissing(trainingFocusesResult.error)
       ? []
@@ -132,6 +161,13 @@ export async function GET() {
     profileResult.error ??
     (athleteProfileResult.error && !isAthleteProfileSchemaMissing(athleteProfileResult.error)
       ? athleteProfileResult.error
+      : null) ??
+    (trainingMetricsResult.error && !isTrainingMetricSchemaMissing(trainingMetricsResult.error)
+      ? trainingMetricsResult.error
+      : null) ??
+    (trainingPreferencesResult.error &&
+    !isTrainingPreferencesSchemaMissing(trainingPreferencesResult.error)
+      ? trainingPreferencesResult.error
       : null) ??
     entitlementsResult.error ??
     courseProgressResult.error ??
@@ -158,6 +194,8 @@ export async function GET() {
       userEmail: user.email ?? null,
       profile: profileResult.data ?? null,
       athleteProfile: normalizedAthleteProfile,
+      trainingMetrics: normalizedTrainingMetrics,
+      trainingPreferences: normalizedTrainingPreferences,
       entitlements: entitlementsResult.data ?? [],
       courseProgress: normalizeCourseProgressRows(courseProgressResult.data ?? [], {
         resolveLessonId,

--- a/app/my-library/page.tsx
+++ b/app/my-library/page.tsx
@@ -139,20 +139,36 @@ export default async function MyLibraryPage() {
             <section className="rounded-2xl border border-slate-200 bg-white p-5">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
-                  <h2 className="text-lg font-semibold text-slate-900">Athlete profile</h2>
+                  <h2 className="text-lg font-semibold text-slate-900">
+                    Athlete profile & training setup
+                  </h2>
                   <p className="mt-2 text-sm text-slate-600">
-                    {!athleteProfileSnapshot.schemaReady
+                    {!athleteProfileSnapshot.profileSchemaReady
                       ? "This athlete profile foundation is still syncing in this environment."
-                      : athleteProfileSnapshot.profile
-                        ? `${athleteProfileSnapshot.profile.primaryName ?? "Private swimmer"} is saved${athleteProfileSnapshot.profile.ageBandLabel ? ` · ${athleteProfileSnapshot.profile.ageBandLabel}` : ""}. Metrics, records, and broader preferences can build on this later.`
-                        : "Add your private swimmer profile now so later metrics, records, and preferences have a clear foundation."}
+                      : athleteProfileSnapshot.profile ||
+                          athleteProfileSnapshot.cssMetric ||
+                          athleteProfileSnapshot.preferences
+                        ? [
+                            athleteProfileSnapshot.profile?.primaryName ?? "Private swimmer",
+                            athleteProfileSnapshot.profile?.ageBandLabel ?? null,
+                            athleteProfileSnapshot.cssMetric
+                              ? `CSS ${athleteProfileSnapshot.cssMetric.paceLabel}/100m`
+                              : null,
+                            athleteProfileSnapshot.preferences?.poolLengthLabel ?? null,
+                            athleteProfileSnapshot.preferences?.preferredWeeklySessionCount
+                              ? `${athleteProfileSnapshot.preferences.preferredWeeklySessionCount} sessions/week`
+                              : null,
+                          ]
+                            .filter(Boolean)
+                            .join(" · ")
+                        : "Add your private swimmer profile, current CSS, and practical preferences now so later generator work has a real foundation."}
                   </p>
                 </div>
                 <Link
                   href="/my-library/profile"
                   className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700"
                 >
-                  Open athlete profile
+                  Open training setup
                 </Link>
               </div>
             </section>

--- a/app/my-library/profile/page.tsx
+++ b/app/my-library/profile/page.tsx
@@ -27,7 +27,11 @@ export default async function MyLibraryProfilePage() {
           eventName="athlete_profile_viewed"
           payload={{
             hasProfile: Boolean(initialSnapshot.profile),
-            schemaReady: initialSnapshot.schemaReady,
+            hasCssMetric: Boolean(initialSnapshot.cssMetric),
+            hasPreferences: Boolean(initialSnapshot.preferences),
+            profileSchemaReady: initialSnapshot.profileSchemaReady,
+            metricsSchemaReady: initialSnapshot.metricsSchemaReady,
+            preferencesSchemaReady: initialSnapshot.preferencesSchemaReady,
           }}
         />
         <div className="rounded-3xl border border-blue-100 bg-white/95 p-8 shadow-[0_16px_60px_rgba(24,58,107,0.14)]">
@@ -36,10 +40,12 @@ export default async function MyLibraryProfilePage() {
               <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
                 My Library
               </p>
-              <h1 className="mt-2 text-3xl font-bold text-slate-900">Athlete profile</h1>
+              <h1 className="mt-2 text-3xl font-bold text-slate-900">
+                Athlete profile & training setup
+              </h1>
               <p className="mt-2 max-w-[64ch] text-sm text-slate-600">
-                Keep a private swimmer profile that stays separate from Goals, Focus, and Notes.
-                Training metrics, personal records, and broader preferences can build on this later.
+                Keep a private swimmer profile, trusted CSS, and practical training preferences
+                together in one place without mixing them into Goals, Focus, or Notes.
               </p>
             </div>
             <div className="flex flex-wrap gap-2">
@@ -70,17 +76,19 @@ export default async function MyLibraryProfilePage() {
                 </p>
               </div>
               <div className="rounded-2xl border border-white/80 bg-white/80 p-4">
-                <p className="text-xs font-semibold uppercase tracking-wide text-emerald-700">
-                  Goals
+                <p className="text-xs font-semibold uppercase tracking-wide text-cyan-700">
+                  Metrics & preferences
                 </p>
-                <p className="mt-2 text-sm text-slate-700">Where you want to go over time.</p>
+                <p className="mt-2 text-sm text-slate-700">
+                  Trusted CSS and practical defaults that later help shape session generation.
+                </p>
               </div>
               <div className="rounded-2xl border border-white/80 bg-white/80 p-4">
                 <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">
-                  Focus & Notes
+                  Goals, Focus & Notes
                 </p>
                 <p className="mt-2 text-sm text-slate-700">
-                  What you are working on now and what you notice in the pool.
+                  Direction, current work, and reflections still stay separate from training setup.
                 </p>
               </div>
             </div>

--- a/components/my-library/profile/AthleteProfileHub.tsx
+++ b/components/my-library/profile/AthleteProfileHub.tsx
@@ -7,7 +7,20 @@ import {
   buildAthleteProfilePrimaryName,
   type AthleteAgeBand,
 } from "@/lib/athlete-profile/mvp";
-import type { AthleteProfileSnapshot, AthleteProfileView } from "@/lib/athlete-profile/server";
+import {
+  formatCssSecondsPer100m,
+  TRAINING_POOL_LENGTH_OPTIONS,
+  TRAINING_SESSION_DURATION_OPTIONS,
+  TRAINING_WEEKDAY_OPTIONS,
+  TRAINING_WEEKDAY_VALUES,
+  type TrainingWeekday,
+} from "@/lib/athlete-profile/training-setup";
+import type {
+  AthleteProfileSnapshot,
+  AthleteProfileView,
+  TrainingMetricView,
+  TrainingPreferencesView,
+} from "@/lib/athlete-profile/server";
 import { readNavigatorOnlineState } from "@/lib/utils/navigator-online";
 
 type Props = {
@@ -28,7 +41,20 @@ type AthleteProfileDraft = {
   ageBand: AthleteAgeBand | "";
 };
 
-function buildDraft(profile: AthleteProfileView | null): AthleteProfileDraft {
+type CssMetricDraft = {
+  pace: string;
+  recordedOn: string;
+  sourceNote: string;
+};
+
+type TrainingPreferencesDraft = {
+  poolLengthM: "" | "25" | "50";
+  availableDays: TrainingWeekday[];
+  preferredWeeklySessionCount: string;
+  preferredSessionMinutes: "" | "30" | "45" | "60" | "75" | "90";
+};
+
+function buildProfileDraft(profile: AthleteProfileView | null): AthleteProfileDraft {
   return {
     displayName: profile?.displayName ?? "",
     firstName: profile?.firstName ?? "",
@@ -37,8 +63,33 @@ function buildDraft(profile: AthleteProfileView | null): AthleteProfileDraft {
   };
 }
 
-function getStorageKey(userId: string) {
-  return `my-library-athlete-profile-draft:${userId}`;
+function buildCssMetricDraft(metric: TrainingMetricView | null): CssMetricDraft {
+  return {
+    pace: formatCssSecondsPer100m(metric?.valueSeconds ?? null) ?? "",
+    recordedOn: metric?.recordedOn ?? "",
+    sourceNote: metric?.sourceNote ?? "",
+  };
+}
+
+function buildPreferencesDraft(
+  preferences: TrainingPreferencesView | null
+): TrainingPreferencesDraft {
+  return {
+    poolLengthM: preferences?.poolLengthM ? (String(preferences.poolLengthM) as "25" | "50") : "",
+    availableDays: preferences?.availableDays ?? [],
+    preferredWeeklySessionCount: preferences?.preferredWeeklySessionCount
+      ? String(preferences.preferredWeeklySessionCount)
+      : "",
+    preferredSessionMinutes: preferences?.preferredSessionMinutes
+      ? (String(
+          preferences.preferredSessionMinutes
+        ) as TrainingPreferencesDraft["preferredSessionMinutes"])
+      : "",
+  };
+}
+
+function getStorageKey(userId: string, scope: "profile" | "css" | "preferences") {
+  return `my-library-athlete-profile-${scope}-draft:${userId}`;
 }
 
 function getStorageValue<T>(key: string, fallback: T): T {
@@ -66,35 +117,84 @@ function clearStorageValue(key: string) {
   } catch {}
 }
 
-function serializeDraft(draft: AthleteProfileDraft) {
-  return JSON.stringify(draft);
+function serializeDraft(value: unknown) {
+  return JSON.stringify(value);
+}
+
+function buildAvailableDaysSummary(days: string[]): string {
+  return days.join(", ");
 }
 
 export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
   const [snapshot, setSnapshot] = useState(initialSnapshot);
-  const [draft, setDraft] = useState(() => buildDraft(initialSnapshot.profile));
-  const [actionError, setActionError] = useState(initialSnapshot.loadError ?? "");
+  const [profileDraft, setProfileDraft] = useState(() =>
+    buildProfileDraft(initialSnapshot.profile)
+  );
+  const [cssDraft, setCssDraft] = useState(() => buildCssMetricDraft(initialSnapshot.cssMetric));
+  const [preferencesDraft, setPreferencesDraft] = useState(() =>
+    buildPreferencesDraft(initialSnapshot.preferences)
+  );
+  const [actionError, setActionError] = useState("");
   const [actionSuccess, setActionSuccess] = useState("");
   const [isOnline, setIsOnline] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const [pendingSave, setPendingSave] = useState(false);
-  const [draftRecovered, setDraftRecovered] = useState(false);
+  const [pendingProfileSave, setPendingProfileSave] = useState(false);
+  const [pendingCssSave, setPendingCssSave] = useState(false);
+  const [pendingPreferencesSave, setPendingPreferencesSave] = useState(false);
+  const [profileDraftRecovered, setProfileDraftRecovered] = useState(false);
+  const [cssDraftRecovered, setCssDraftRecovered] = useState(false);
+  const [preferencesDraftRecovered, setPreferencesDraftRecovered] = useState(false);
 
-  const storageKey = useMemo(() => getStorageKey(userId), [userId]);
-  const savedDraft = useMemo(() => buildDraft(snapshot.profile), [snapshot.profile]);
-  const hasUnsavedChanges = useMemo(
-    () => serializeDraft(draft) !== serializeDraft(savedDraft),
-    [draft, savedDraft]
+  const profileStorageKey = useMemo(() => getStorageKey(userId, "profile"), [userId]);
+  const cssStorageKey = useMemo(() => getStorageKey(userId, "css"), [userId]);
+  const preferencesStorageKey = useMemo(() => getStorageKey(userId, "preferences"), [userId]);
+
+  const savedProfileDraft = useMemo(() => buildProfileDraft(snapshot.profile), [snapshot.profile]);
+  const savedCssDraft = useMemo(
+    () => buildCssMetricDraft(snapshot.cssMetric),
+    [snapshot.cssMetric]
+  );
+  const savedPreferencesDraft = useMemo(
+    () => buildPreferencesDraft(snapshot.preferences),
+    [snapshot.preferences]
+  );
+
+  const hasUnsavedProfileChanges = useMemo(
+    () => serializeDraft(profileDraft) !== serializeDraft(savedProfileDraft),
+    [profileDraft, savedProfileDraft]
+  );
+  const hasUnsavedCssChanges = useMemo(
+    () => serializeDraft(cssDraft) !== serializeDraft(savedCssDraft),
+    [cssDraft, savedCssDraft]
+  );
+  const hasUnsavedPreferencesChanges = useMemo(
+    () => serializeDraft(preferencesDraft) !== serializeDraft(savedPreferencesDraft),
+    [preferencesDraft, savedPreferencesDraft]
   );
 
   useEffect(() => {
     setIsOnline(readNavigatorOnlineState());
 
-    const fallback = buildDraft(initialSnapshot.profile);
-    const storedDraft = getStorageValue(storageKey, fallback);
-    setDraft(storedDraft);
-    setDraftRecovered(serializeDraft(storedDraft) !== serializeDraft(fallback));
-    setActionError(initialSnapshot.loadError ?? "");
+    const nextProfileFallback = buildProfileDraft(initialSnapshot.profile);
+    const nextCssFallback = buildCssMetricDraft(initialSnapshot.cssMetric);
+    const nextPreferencesFallback = buildPreferencesDraft(initialSnapshot.preferences);
+
+    const storedProfileDraft = getStorageValue(profileStorageKey, nextProfileFallback);
+    const storedCssDraft = getStorageValue(cssStorageKey, nextCssFallback);
+    const storedPreferencesDraft = getStorageValue(preferencesStorageKey, nextPreferencesFallback);
+
+    setProfileDraft(storedProfileDraft);
+    setCssDraft(storedCssDraft);
+    setPreferencesDraft(storedPreferencesDraft);
+
+    setProfileDraftRecovered(
+      serializeDraft(storedProfileDraft) !== serializeDraft(nextProfileFallback)
+    );
+    setCssDraftRecovered(serializeDraft(storedCssDraft) !== serializeDraft(nextCssFallback));
+    setPreferencesDraftRecovered(
+      serializeDraft(storedPreferencesDraft) !== serializeDraft(nextPreferencesFallback)
+    );
+    setActionError("");
 
     function onOnline() {
       setIsOnline(true);
@@ -111,16 +211,41 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
       window.removeEventListener("online", onOnline);
       window.removeEventListener("offline", onOffline);
     };
-  }, [initialSnapshot.loadError, initialSnapshot.profile, storageKey]);
+  }, [
+    cssStorageKey,
+    initialSnapshot.cssMetric,
+    initialSnapshot.preferences,
+    initialSnapshot.profile,
+    preferencesStorageKey,
+    profileStorageKey,
+  ]);
 
   useEffect(() => {
-    if (serializeDraft(draft) === serializeDraft(savedDraft)) {
-      clearStorageValue(storageKey);
+    if (serializeDraft(profileDraft) === serializeDraft(savedProfileDraft)) {
+      clearStorageValue(profileStorageKey);
       return;
     }
 
-    setStorageValue(storageKey, draft);
-  }, [draft, savedDraft, storageKey]);
+    setStorageValue(profileStorageKey, profileDraft);
+  }, [profileDraft, profileStorageKey, savedProfileDraft]);
+
+  useEffect(() => {
+    if (serializeDraft(cssDraft) === serializeDraft(savedCssDraft)) {
+      clearStorageValue(cssStorageKey);
+      return;
+    }
+
+    setStorageValue(cssStorageKey, cssDraft);
+  }, [cssDraft, cssStorageKey, savedCssDraft]);
+
+  useEffect(() => {
+    if (serializeDraft(preferencesDraft) === serializeDraft(savedPreferencesDraft)) {
+      clearStorageValue(preferencesStorageKey);
+      return;
+    }
+
+    setStorageValue(preferencesStorageKey, preferencesDraft);
+  }, [preferencesDraft, preferencesStorageKey, savedPreferencesDraft]);
 
   async function parseError(response: Response, fallback: string) {
     const payload = (await response.json().catch(() => null)) as ApiError | null;
@@ -139,35 +264,46 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
       });
 
       if (!response.ok) {
-        setActionError(await parseError(response, "Could not refresh athlete profile right now."));
+        setActionError(await parseError(response, "Could not refresh training setup right now."));
         return;
       }
 
       const payload = (await response.json().catch(() => null)) as ApiError | null;
       if (!payload?.ok || !payload.snapshot) {
-        setActionError("Could not refresh athlete profile right now.");
+        setActionError("Could not refresh training setup right now.");
         return;
       }
 
       setSnapshot(payload.snapshot);
-      if (!hasUnsavedChanges) {
-        setDraft(buildDraft(payload.snapshot.profile));
+
+      if (!hasUnsavedProfileChanges) {
+        setProfileDraft(buildProfileDraft(payload.snapshot.profile));
+      }
+
+      if (!hasUnsavedCssChanges) {
+        setCssDraft(buildCssMetricDraft(payload.snapshot.cssMetric));
+      }
+
+      if (!hasUnsavedPreferencesChanges) {
+        setPreferencesDraft(buildPreferencesDraft(payload.snapshot.preferences));
       }
 
       void sendClientAnalyticsEvent("athlete_profile_refreshed", {
         hasProfile: Boolean(payload.snapshot.profile),
+        hasCssMetric: Boolean(payload.snapshot.cssMetric),
+        hasPreferences: Boolean(payload.snapshot.preferences),
       });
     } catch {
-      setActionError("Could not refresh athlete profile right now.");
+      setActionError("Could not refresh training setup right now.");
     } finally {
       setIsRefreshing(false);
     }
   }
 
-  async function saveProfile(e: React.FormEvent) {
-    e.preventDefault();
+  async function saveProfile(event: React.FormEvent) {
+    event.preventDefault();
 
-    if (!snapshot.schemaReady) {
+    if (!snapshot.profileSchemaReady) {
       setActionError("Athlete profile is still syncing in this environment.");
       return;
     }
@@ -177,7 +313,7 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
       return;
     }
 
-    setPendingSave(true);
+    setPendingProfileSave(true);
     setActionError("");
     setActionSuccess("");
 
@@ -187,7 +323,7 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(draft),
+        body: JSON.stringify(profileDraft),
       });
 
       if (!response.ok) {
@@ -201,11 +337,11 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
         return;
       }
 
-      const nextDraft = buildDraft(payload.snapshot.profile);
+      const nextDraft = buildProfileDraft(payload.snapshot.profile);
       setSnapshot(payload.snapshot);
-      setDraft(nextDraft);
-      clearStorageValue(storageKey);
-      setDraftRecovered(false);
+      setProfileDraft(nextDraft);
+      clearStorageValue(profileStorageKey);
+      setProfileDraftRecovered(false);
       setActionSuccess("Athlete profile saved.");
 
       void sendClientAnalyticsEvent("athlete_profile_saved", {
@@ -215,54 +351,194 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
     } catch {
       setActionError("Could not save athlete profile right now.");
     } finally {
-      setPendingSave(false);
+      setPendingProfileSave(false);
     }
   }
 
-  function resetDraftToSaved() {
-    setDraft(savedDraft);
-    clearStorageValue(storageKey);
-    setDraftRecovered(false);
+  async function saveCssMetric(event: React.FormEvent) {
+    event.preventDefault();
+
+    if (!snapshot.metricsSchemaReady) {
+      setActionError("Training metrics are still syncing in this environment.");
+      return;
+    }
+
+    if (!isOnline) {
+      setActionError("You are offline. Reconnect before saving CSS.");
+      return;
+    }
+
+    setPendingCssSave(true);
+    setActionError("");
+    setActionSuccess("");
+
+    try {
+      const response = await fetch("/api/my-library/profile/metrics", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(cssDraft),
+      });
+
+      if (!response.ok) {
+        setActionError(await parseError(response, "Could not save CSS right now."));
+        return;
+      }
+
+      const payload = (await response.json().catch(() => null)) as ApiError | null;
+      if (!payload?.ok || !payload.snapshot) {
+        setActionError("Could not save CSS right now.");
+        return;
+      }
+
+      const nextDraft = buildCssMetricDraft(payload.snapshot.cssMetric);
+      setSnapshot(payload.snapshot);
+      setCssDraft(nextDraft);
+      clearStorageValue(cssStorageKey);
+      setCssDraftRecovered(false);
+      setActionSuccess(payload.snapshot.cssMetric ? "CSS saved." : "CSS cleared.");
+
+      void sendClientAnalyticsEvent("training_metric_saved", {
+        metricKey: payload.snapshot.cssMetric?.metricKey ?? "css",
+        hasCssMetric: Boolean(payload.snapshot.cssMetric),
+      });
+    } catch {
+      setActionError("Could not save CSS right now.");
+    } finally {
+      setPendingCssSave(false);
+    }
+  }
+
+  async function savePreferences(event: React.FormEvent) {
+    event.preventDefault();
+
+    if (!snapshot.preferencesSchemaReady) {
+      setActionError("Training preferences are still syncing in this environment.");
+      return;
+    }
+
+    if (!isOnline) {
+      setActionError("You are offline. Reconnect before saving training preferences.");
+      return;
+    }
+
+    setPendingPreferencesSave(true);
+    setActionError("");
+    setActionSuccess("");
+
+    try {
+      const response = await fetch("/api/my-library/profile/preferences", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(preferencesDraft),
+      });
+
+      if (!response.ok) {
+        setActionError(
+          await parseError(response, "Could not save training preferences right now.")
+        );
+        return;
+      }
+
+      const payload = (await response.json().catch(() => null)) as ApiError | null;
+      if (!payload?.ok || !payload.snapshot) {
+        setActionError("Could not save training preferences right now.");
+        return;
+      }
+
+      const nextDraft = buildPreferencesDraft(payload.snapshot.preferences);
+      setSnapshot(payload.snapshot);
+      setPreferencesDraft(nextDraft);
+      clearStorageValue(preferencesStorageKey);
+      setPreferencesDraftRecovered(false);
+      setActionSuccess(
+        payload.snapshot.preferences
+          ? "Training preferences saved."
+          : "Training preferences cleared."
+      );
+
+      void sendClientAnalyticsEvent("training_preferences_saved", {
+        hasPreferences: Boolean(payload.snapshot.preferences),
+        availableDayCount: payload.snapshot.preferences?.availableDays.length ?? 0,
+      });
+    } catch {
+      setActionError("Could not save training preferences right now.");
+    } finally {
+      setPendingPreferencesSave(false);
+    }
+  }
+
+  function resetProfileDraftToSaved() {
+    setProfileDraft(savedProfileDraft);
+    clearStorageValue(profileStorageKey);
+    setProfileDraftRecovered(false);
     setActionError("");
     setActionSuccess("Draft reset to saved athlete profile.");
   }
 
-  const primaryName = buildAthleteProfilePrimaryName({
-    displayName: draft.displayName.trim() || null,
-    firstName: draft.firstName.trim() || null,
-    lastName: draft.lastName.trim() || null,
-  });
-
-  if (!snapshot.schemaReady) {
-    return (
-      <div className="rounded-2xl border border-amber-200 bg-amber-50/80 p-5 text-sm text-amber-900">
-        <p className="font-semibold">Athlete profile is still syncing in this environment.</p>
-        <p className="mt-2">
-          The profile foundation code is ready, but this environment cannot read the new schema yet.
-          Reload later once the database migration is live.
-        </p>
-        <button
-          type="button"
-          onClick={() => void refreshProfile()}
-          className="mt-4 inline-flex h-10 items-center justify-center rounded-xl border border-amber-300 bg-white px-4 text-sm font-medium text-amber-900 transition hover:bg-amber-50"
-        >
-          {isRefreshing ? "Refreshing..." : "Retry"}
-        </button>
-      </div>
-    );
+  function resetCssDraftToSaved() {
+    setCssDraft(savedCssDraft);
+    clearStorageValue(cssStorageKey);
+    setCssDraftRecovered(false);
+    setActionError("");
+    setActionSuccess("Draft reset to saved CSS.");
   }
+
+  function resetPreferencesDraftToSaved() {
+    setPreferencesDraft(savedPreferencesDraft);
+    clearStorageValue(preferencesStorageKey);
+    setPreferencesDraftRecovered(false);
+    setActionError("");
+    setActionSuccess("Draft reset to saved training preferences.");
+  }
+
+  function toggleAvailableDay(day: TrainingWeekday) {
+    setPreferencesDraft((current) => {
+      const hasDay = current.availableDays.includes(day);
+      const nextSet = hasDay
+        ? current.availableDays.filter((value) => value !== day)
+        : [...current.availableDays, day];
+
+      return {
+        ...current,
+        availableDays: TRAINING_WEEKDAY_VALUES.filter((value) => nextSet.includes(value)),
+      };
+    });
+  }
+
+  const primaryName = buildAthleteProfilePrimaryName({
+    displayName: profileDraft.displayName.trim() || null,
+    firstName: profileDraft.firstName.trim() || null,
+    lastName: profileDraft.lastName.trim() || null,
+  });
 
   return (
     <div className="space-y-6">
       {!isOnline ? (
         <div className="rounded-2xl border border-amber-200 bg-amber-50/80 px-4 py-3 text-sm text-amber-900">
-          You are offline. Draft changes stay on this device until you reconnect and save.
+          You are offline. Unsaved profile, CSS, and preferences changes stay on this device until
+          you reconnect and save.
         </div>
       ) : null}
 
-      {draftRecovered ? (
+      {profileDraftRecovered ? (
         <div className="rounded-2xl border border-blue-200 bg-blue-50/80 px-4 py-3 text-sm text-blue-900">
           Unsaved athlete-profile edits were restored on this device.
+        </div>
+      ) : null}
+
+      {cssDraftRecovered ? (
+        <div className="rounded-2xl border border-blue-200 bg-blue-50/80 px-4 py-3 text-sm text-blue-900">
+          Unsaved CSS edits were restored on this device.
+        </div>
+      ) : null}
+
+      {preferencesDraftRecovered ? (
+        <div className="rounded-2xl border border-blue-200 bg-blue-50/80 px-4 py-3 text-sm text-blue-900">
+          Unsaved training preferences edits were restored on this device.
         </div>
       ) : null}
 
@@ -284,14 +560,28 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
         </div>
       ) : null}
 
-      <div className="grid gap-4 lg:grid-cols-[1.1fr_0.9fr]">
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => void refreshProfile()}
+          disabled={isRefreshing}
+          className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-400"
+        >
+          {isRefreshing ? "Refreshing..." : "Refresh all"}
+        </button>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-3">
         <section className="rounded-2xl border border-slate-200 bg-white p-5">
           <h2 className="text-lg font-semibold text-slate-900">Current athlete profile</h2>
-          {!snapshot.profile ? (
-            <p className="mt-3 text-sm text-slate-600">
-              No private athlete profile is saved yet. Add the swimmer details you want to reuse
-              later when metrics, personal records, and broader preferences arrive.
+          {!snapshot.profileSchemaReady ? (
+            <p className="mt-3 text-sm text-amber-800">
+              Athlete profile is still syncing in this environment.
             </p>
+          ) : snapshot.loadError ? (
+            <p className="mt-3 text-sm text-rose-700">{snapshot.loadError}</p>
+          ) : !snapshot.profile ? (
+            <p className="mt-3 text-sm text-slate-600">No private athlete profile is saved yet.</p>
           ) : (
             <div className="mt-4 space-y-3 text-sm text-slate-700">
               <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
@@ -314,18 +604,6 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
                     </p>
                     <p className="mt-1">{snapshot.profile.ageBandLabel ?? "Not set"}</p>
                   </div>
-                  <div>
-                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                      First name
-                    </p>
-                    <p className="mt-1">{snapshot.profile.firstName ?? "Not set"}</p>
-                  </div>
-                  <div>
-                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                      Last name
-                    </p>
-                    <p className="mt-1">{snapshot.profile.lastName ?? "Not set"}</p>
-                  </div>
                 </div>
               </div>
             </div>
@@ -333,27 +611,113 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
         </section>
 
         <section className="rounded-2xl border border-slate-200 bg-white p-5">
-          <h2 className="text-lg font-semibold text-slate-900">Why save this now</h2>
-          <ul className="mt-3 space-y-2 text-sm text-slate-700">
-            <li>Private swimmer context lives here instead of being mixed into notes.</li>
-            <li>
-              Goals stay about direction. Focus stays about current work. Profile stays stable.
-            </li>
-            <li>Later generator slices can reuse this context without redesigning the model.</li>
-          </ul>
-          <p className="mt-4 text-xs leading-relaxed text-slate-500">
-            This profile is private to your account. Training metrics, personal records, and broader
-            preferences come in later slices.
-          </p>
+          <h2 className="text-lg font-semibold text-slate-900">Current CSS</h2>
+          {!snapshot.metricsSchemaReady ? (
+            <p className="mt-3 text-sm text-amber-800">
+              Training metrics are still syncing in this environment.
+            </p>
+          ) : snapshot.metricsLoadError ? (
+            <p className="mt-3 text-sm text-rose-700">{snapshot.metricsLoadError}</p>
+          ) : !snapshot.cssMetric ? (
+            <p className="mt-3 text-sm text-slate-600">
+              No CSS is saved yet. Add your current pace per 100m so later generator work has a
+              trusted baseline.
+            </p>
+          ) : (
+            <div className="mt-4 rounded-2xl border border-slate-200 bg-slate-50/70 p-4 text-sm text-slate-700">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Canonical pace
+              </p>
+              <p className="mt-2 text-base font-semibold text-slate-900">
+                {snapshot.cssMetric.paceLabel}/100m
+              </p>
+              <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    Recorded on
+                  </p>
+                  <p className="mt-1">{snapshot.cssMetric.recordedOn ?? "Not set"}</p>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    Source note
+                  </p>
+                  <p className="mt-1">{snapshot.cssMetric.sourceNote ?? "Not set"}</p>
+                </div>
+              </div>
+            </div>
+          )}
+        </section>
+
+        <section className="rounded-2xl border border-slate-200 bg-white p-5">
+          <h2 className="text-lg font-semibold text-slate-900">Current preferences</h2>
+          {!snapshot.preferencesSchemaReady ? (
+            <p className="mt-3 text-sm text-amber-800">
+              Training preferences are still syncing in this environment.
+            </p>
+          ) : snapshot.preferencesLoadError ? (
+            <p className="mt-3 text-sm text-rose-700">{snapshot.preferencesLoadError}</p>
+          ) : !snapshot.preferences ? (
+            <p className="mt-3 text-sm text-slate-600">
+              No training preferences are saved yet. Add the pool and weekly defaults you want later
+              session generation to respect.
+            </p>
+          ) : (
+            <div className="mt-4 rounded-2xl border border-slate-200 bg-slate-50/70 p-4 text-sm text-slate-700">
+              <div className="grid gap-2 sm:grid-cols-2">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    Pool length
+                  </p>
+                  <p className="mt-1">{snapshot.preferences.poolLengthLabel ?? "Not set"}</p>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    Weekly sessions
+                  </p>
+                  <p className="mt-1">
+                    {snapshot.preferences.preferredWeeklySessionCount ?? "Not set"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    Preferred duration
+                  </p>
+                  <p className="mt-1">
+                    {snapshot.preferences.preferredSessionMinutesLabel ?? "Not set"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    Available days
+                  </p>
+                  <p className="mt-1">
+                    {snapshot.preferences.availableDayLabels.length > 0
+                      ? buildAvailableDaysSummary(snapshot.preferences.availableDayLabels)
+                      : "Not set"}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
         </section>
       </div>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-5">
+        <h2 className="text-lg font-semibold text-slate-900">Why keep this here</h2>
+        <ul className="mt-3 space-y-2 text-sm text-slate-700">
+          <li>Profile stays about the swimmer. CSS stays about current test pace.</li>
+          <li>Preferences stay about practical planning defaults, not goals or notes.</li>
+          <li>Later generator slices can reuse this context without redesigning the model.</li>
+        </ul>
+      </section>
 
       <form onSubmit={saveProfile} className="rounded-2xl border border-slate-200 bg-white p-5">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <h2 className="text-lg font-semibold text-slate-900">Edit athlete profile</h2>
             <p className="mt-2 text-sm text-slate-600">
-              Save enough context to make this feel like your own training space now.
+              Save enough private swimmer context to make this feel like your own training space.
             </p>
           </div>
           <div className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600">
@@ -367,9 +731,9 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
             <input
               data-testid="athlete-profile-display-name"
               type="text"
-              value={draft.displayName}
+              value={profileDraft.displayName}
               onChange={(event) =>
-                setDraft((current) => ({ ...current, displayName: event.target.value }))
+                setProfileDraft((current) => ({ ...current, displayName: event.target.value }))
               }
               placeholder="How you want your swimmer profile to read"
               className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
@@ -380,9 +744,9 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
             <span>Age band</span>
             <select
               data-testid="athlete-profile-age-band"
-              value={draft.ageBand}
+              value={profileDraft.ageBand}
               onChange={(event) =>
-                setDraft((current) => ({
+                setProfileDraft((current) => ({
                   ...current,
                   ageBand: event.target.value as AthleteAgeBand | "",
                 }))
@@ -403,9 +767,9 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
             <input
               data-testid="athlete-profile-first-name"
               type="text"
-              value={draft.firstName}
+              value={profileDraft.firstName}
               onChange={(event) =>
-                setDraft((current) => ({ ...current, firstName: event.target.value }))
+                setProfileDraft((current) => ({ ...current, firstName: event.target.value }))
               }
               placeholder="Optional"
               className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
@@ -417,9 +781,9 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
             <input
               data-testid="athlete-profile-last-name"
               type="text"
-              value={draft.lastName}
+              value={profileDraft.lastName}
               onChange={(event) =>
-                setDraft((current) => ({ ...current, lastName: event.target.value }))
+                setProfileDraft((current) => ({ ...current, lastName: event.target.value }))
               }
               placeholder="Optional"
               className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
@@ -431,26 +795,222 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
           <button
             data-testid="athlete-profile-save"
             type="submit"
-            disabled={pendingSave || !isOnline}
+            disabled={pendingProfileSave || !isOnline}
             className="inline-flex h-11 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-slate-300"
           >
-            {pendingSave ? "Saving..." : "Save athlete profile"}
+            {pendingProfileSave ? "Saving..." : "Save athlete profile"}
           </button>
           <button
             type="button"
-            onClick={resetDraftToSaved}
-            disabled={!hasUnsavedChanges}
+            onClick={resetProfileDraftToSaved}
+            disabled={!hasUnsavedProfileChanges}
             className="inline-flex h-11 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-400"
           >
             Reset draft
           </button>
+        </div>
+      </form>
+
+      <form onSubmit={saveCssMetric} className="rounded-2xl border border-slate-200 bg-white p-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Current CSS</h2>
+            <p className="mt-2 text-sm text-slate-600">
+              Save your current critical swim speed as pace per 100m so later generator work can
+              trust one canonical value.
+            </p>
+          </div>
+          <div className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600">
+            Stored canonically as seconds per 100m
+          </div>
+        </div>
+
+        <div className="mt-5 grid gap-4 md:grid-cols-3">
+          <label className="space-y-2 text-sm font-medium text-slate-700">
+            <span>CSS pace (m:ss)</span>
+            <input
+              data-testid="athlete-profile-css-pace"
+              type="text"
+              inputMode="numeric"
+              value={cssDraft.pace}
+              onChange={(event) =>
+                setCssDraft((current) => ({ ...current, pace: event.target.value }))
+              }
+              placeholder="1:58"
+              className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+            />
+          </label>
+
+          <label className="space-y-2 text-sm font-medium text-slate-700">
+            <span>Recorded on</span>
+            <input
+              data-testid="athlete-profile-css-recorded-on"
+              type="date"
+              value={cssDraft.recordedOn}
+              onChange={(event) =>
+                setCssDraft((current) => ({ ...current, recordedOn: event.target.value }))
+              }
+              className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+            />
+          </label>
+
+          <label className="space-y-2 text-sm font-medium text-slate-700 md:col-span-3">
+            <span>Source note</span>
+            <textarea
+              data-testid="athlete-profile-css-source-note"
+              value={cssDraft.sourceNote}
+              onChange={(event) =>
+                setCssDraft((current) => ({ ...current, sourceNote: event.target.value }))
+              }
+              placeholder="Optional note about the test set or source"
+              rows={3}
+              className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+            />
+          </label>
+        </div>
+
+        <div className="mt-5 flex flex-wrap items-center gap-2">
           <button
+            data-testid="athlete-profile-css-save"
+            type="submit"
+            disabled={pendingCssSave || !isOnline}
+            className="inline-flex h-11 items-center justify-center rounded-xl bg-cyan-600 px-4 text-sm font-semibold text-white transition hover:bg-cyan-500 disabled:cursor-not-allowed disabled:bg-slate-300"
+          >
+            {pendingCssSave ? "Saving..." : "Save CSS"}
+          </button>
+          <button
+            data-testid="athlete-profile-css-reset"
             type="button"
-            onClick={() => void refreshProfile()}
-            disabled={isRefreshing}
+            onClick={resetCssDraftToSaved}
+            disabled={!hasUnsavedCssChanges}
             className="inline-flex h-11 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-400"
           >
-            {isRefreshing ? "Refreshing..." : "Refresh"}
+            Reset draft
+          </button>
+        </div>
+      </form>
+
+      <form onSubmit={savePreferences} className="rounded-2xl border border-slate-200 bg-white p-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Training preferences</h2>
+            <p className="mt-2 text-sm text-slate-600">
+              Save the pool and planning defaults you want later session generation to respect.
+            </p>
+          </div>
+          <div className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600">
+            Private to your account
+          </div>
+        </div>
+
+        <div className="mt-5 grid gap-4 md:grid-cols-2">
+          <label className="space-y-2 text-sm font-medium text-slate-700">
+            <span>Default pool length</span>
+            <select
+              data-testid="athlete-preferences-pool-length"
+              value={preferencesDraft.poolLengthM}
+              onChange={(event) =>
+                setPreferencesDraft((current) => ({
+                  ...current,
+                  poolLengthM: event.target.value as TrainingPreferencesDraft["poolLengthM"],
+                }))
+              }
+              className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+            >
+              <option value="">Not set</option>
+              {TRAINING_POOL_LENGTH_OPTIONS.map((option) => (
+                <option key={option.value} value={String(option.value)}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="space-y-2 text-sm font-medium text-slate-700">
+            <span>Preferred weekly session count</span>
+            <input
+              data-testid="athlete-preferences-weekly-session-count"
+              type="number"
+              min={1}
+              max={14}
+              value={preferencesDraft.preferredWeeklySessionCount}
+              onChange={(event) =>
+                setPreferencesDraft((current) => ({
+                  ...current,
+                  preferredWeeklySessionCount: event.target.value,
+                }))
+              }
+              placeholder="5"
+              className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+            />
+          </label>
+
+          <label className="space-y-2 text-sm font-medium text-slate-700 md:col-span-2">
+            <span>Preferred session duration</span>
+            <select
+              data-testid="athlete-preferences-session-minutes"
+              value={preferencesDraft.preferredSessionMinutes}
+              onChange={(event) =>
+                setPreferencesDraft((current) => ({
+                  ...current,
+                  preferredSessionMinutes: event.target
+                    .value as TrainingPreferencesDraft["preferredSessionMinutes"],
+                }))
+              }
+              className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+            >
+              <option value="">Not set</option>
+              {TRAINING_SESSION_DURATION_OPTIONS.map((option) => (
+                <option key={option.value} value={String(option.value)}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <fieldset className="space-y-3 md:col-span-2">
+            <legend className="text-sm font-medium text-slate-700">Available training days</legend>
+            <div className="grid gap-2 sm:grid-cols-4">
+              {TRAINING_WEEKDAY_OPTIONS.map((option) => {
+                const checked = preferencesDraft.availableDays.includes(option.value);
+
+                return (
+                  <label
+                    key={option.value}
+                    className="flex items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700"
+                  >
+                    <input
+                      data-testid={`athlete-preferences-day-${option.value}`}
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleAvailableDay(option.value)}
+                      className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-200"
+                    />
+                    <span>{option.label}</span>
+                  </label>
+                );
+              })}
+            </div>
+          </fieldset>
+        </div>
+
+        <div className="mt-5 flex flex-wrap items-center gap-2">
+          <button
+            data-testid="athlete-preferences-save"
+            type="submit"
+            disabled={pendingPreferencesSave || !isOnline}
+            className="inline-flex h-11 items-center justify-center rounded-xl bg-emerald-600 px-4 text-sm font-semibold text-white transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:bg-slate-300"
+          >
+            {pendingPreferencesSave ? "Saving..." : "Save preferences"}
+          </button>
+          <button
+            data-testid="athlete-preferences-reset"
+            type="button"
+            onClick={resetPreferencesDraftToSaved}
+            disabled={!hasUnsavedPreferencesChanges}
+            className="inline-flex h-11 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-400"
+          >
+            Reset draft
           </button>
         </div>
       </form>

--- a/docs/task-briefs/in-progress/2026-03-19-my-library-training-metrics-and-preferences-foundation-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-19-my-library-training-metrics-and-preferences-foundation-10-10.md
@@ -1,0 +1,278 @@
+# Task Brief: My Library Training Metrics And Preferences Foundation (10/10)
+
+## Metadata
+
+- `id`: `2026-03-19-my-library-training-metrics-and-preferences-foundation-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-03-19`
+- `updated`: `2026-03-19`
+
+## Goal
+
+Users can maintain private, generator-ready training metrics and training preferences inside My Library, clearly separated from `Athlete profile`, `Goals`, `Focus`, and `Notes`, while remaining practical enough for immediate personal swim use.
+
+## Why This Brief Exists
+
+- The parent brief `docs/task-briefs/planned/2026-03-19-my-library-athlete-profile-training-metrics-and-preferences-10-10.md` defines the broader direction.
+- The first child slice shipped the private athlete-profile foundation on `main`.
+- The next highest-value move is not `Personal records` yet.
+- The next highest-value move is:
+  - add a trusted current `CSS` metric with a canonical unit contract,
+  - add practical training preferences that can later shape session/program generation,
+  - keep these private, server-canonical, and clearly separate from profile text fields,
+  - leave `Personal records` for a later child slice so this merge stays narrow enough to dogfood immediately.
+- The owner is actively swimming `5` sessions per week and wants to use this data layer personally before the session generator/program builder is fully finished.
+
+## Dependencies And Boundaries
+
+- Parent direction:
+  - `docs/task-briefs/planned/2026-03-19-my-library-athlete-profile-training-metrics-and-preferences-10-10.md`
+- Already-shipped child slice:
+  - `docs/task-briefs/done/2026-03-19-my-library-athlete-profile-foundation-10-10.md`
+- Existing nearby private user-owned training surfaces that must stay separate but compatible:
+  - `docs/task-briefs/done/2026-03-19-my-library-goals-focus-notes-training-context-10-10.md`
+  - `app/my-library/page.tsx`
+  - `app/my-library/profile/page.tsx`
+  - `components/my-library/profile/AthleteProfileHub.tsx`
+  - `lib/athlete-profile/server.ts`
+  - `lib/training-context/server.ts`
+- This slice is only for:
+  - private training metrics foundation,
+  - private preferences foundation,
+  - generator-ready data contracts,
+  - My Library UX for editing and revisiting these fields now.
+- This slice is not for:
+  - `Personal records`,
+  - session/program generator implementation,
+  - automatic workout generation,
+  - admin/operator workflows,
+  - public profile/sharing,
+  - pricing or entitlements.
+
+## Product Model
+
+- `Athlete profile`
+  - private swimmer identity/context.
+  - already shipped separately.
+- `Training metrics`
+  - trusted current swim-test values.
+  - phase 1 in this slice: `CSS`.
+- `Preferences`
+  - practical training defaults and constraints that later help shape session generation.
+  - phase 1 in this slice:
+    - pool length,
+    - available training days,
+    - preferred weekly session count,
+    - preferred session duration band.
+
+These are not the same as:
+
+- `Goals`
+  - where the swimmer wants to go.
+- `Focus`
+  - what the swimmer is working on right now.
+- `Notes`
+  - what the swimmer noticed or wants to revisit.
+- `Personal records`
+  - best-known performances across distances/strokes, deferred to a later child slice.
+
+## Platform 10/10 Scorecard Mapping (Required)
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `Product goals and IA`
+- `UX flow clarity`
+- `Business logic correctness and data integrity`
+- `Reliability and failure handling`
+- `Security and authz`
+- `Privacy and compliance`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                                                | Evidence                                |
+| --------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| Product goals and IA                          | `target`     | Users can distinguish `Athlete profile`, `Training metrics`, and `Preferences` from `Goals`, `Focus`, and `Notes` without role confusion or duplicated data jobs.             | IA review + child-brief contract + e2e  |
+| UX flow clarity                               | `target`     | Mobile and desktop users can view/edit/save CSS and preferences with explicit `loading`, `empty`, `saved`, `error`, and `retry` states in <=2 actions from My Library.        | manual QA + e2e                         |
+| Visual design quality                         | `target`     | Metrics/preferences UI fits the existing My Library visual language and avoids becoming a generic settings dump.                                                              | screenshot review + manual QA           |
+| Business logic correctness and data integrity | `target`     | `CSS` is stored with one canonical unit contract, preferences are validated deterministically, and saved metric/preference entities remain separate from profile text fields. | unit tests + runtime validation         |
+| Admin editor ergonomics                       | `N/A`        | N/A because this slice changes private end-user My Library data, not admin/editor workflows.                                                                                  | scope rationale only                    |
+| Accessibility (a11y)                          | `target`     | Metrics and preference controls remain keyboard/touch accessible with proper labels, field grouping, helper text, and save feedback semantics.                                | Playwright + manual QA                  |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: additions must avoid obvious payload/render regressions on `/my-library` and `/my-library/profile`.                                                          | build + perf budgets + code review      |
+| Data placement and sync boundaries            | `target`     | Saved metrics/preferences are server-canonical; unsaved edits remain local-only and recoverable enough for safe retry without corrupting canonical values.                    | contract review + tests                 |
+| Caching and invalidation strategy             | `target`     | My Library summary and profile hub refresh deterministically after saving metrics/preferences with no stale CSS or preference summaries.                                      | integration tests + invalidation review |
+| Reliability and failure handling              | `target`     | Validation/auth/network failures fail clearly without silently losing saved data or silently coercing invalid metrics/preferences.                                            | negative-path tests + manual QA         |
+| Security and authz                            | `target`     | Metric/preference reads and writes are owner-only; unauthenticated/unauthorized requests fail closed with `401/403`.                                                          | API negative-path tests                 |
+| Privacy and compliance                        | `target`     | Metrics/preferences remain private by default, excluded from public routes, and not leaked through logs, errors, or analytics payloads.                                       | scope review + tests + log review       |
+| Content governance                            | `supporting` | Supporting only: private user training data still needs explicit ownership, timestamps, and source-of-truth rules even though it is not editorial content.                    | schema/model review                     |
+| Admin workflow and editability                | `N/A`        | N/A because no admin/operator workflow changes are introduced in this child slice.                                                                                            | scope rationale only                    |
+| SEO and crawlability                          | `N/A`        | N/A because this is a private authenticated My Library surface with no public crawl/index contract.                                                                           | scope rationale only                    |
+| AI discoverability                            | `N/A`        | N/A because this slice prepares private generator-ready context, not public AI-discoverable content.                                                                          | scope rationale only                    |
+| Analytics and KPI observability               | `supporting` | Supporting only: create/update usage should be measurable enough to evaluate real dogfooding and later generator adoption.                                                    | event review                            |
+| Commerce and revenue ops                      | `N/A`        | N/A because pricing, bundles, and entitlements are explicitly deferred.                                                                                                       | scope rationale only                    |
+| Incident response and support operations      | `supporting` | Supporting only: failed metric/preference saves should be diagnosable with privacy-safe logs and recoverable user-facing messaging.                                           | runbook/help review                     |
+| Finance and reporting operations              | `N/A`        | N/A because no billing, reconciliation, or financial reporting logic is introduced by private metrics/preferences.                                                            | scope rationale only                    |
+| i18n operational readiness                    | `supporting` | Supporting only: day labels, units, and preference enumerations must remain locale-extensible for later multilingual product work.                                            | copy/schema review                      |
+| Stack-fit and dependency discipline           | `target`     | Implementation uses existing Next.js/TypeScript/Supabase/test patterns with no unnecessary new dependencies.                                                                  | dependency diff + code review           |
+| Testing and QA automation                     | `target`     | Unit/integration/e2e coverage protects metric/preference CRUD, unit validation, authz, export inclusion, and local draft persistence before merge.                            | tests + verify outputs                  |
+| Scalability and cost efficiency               | `supporting` | Supporting only: one current metric row plus one preference row per user should avoid wasteful query patterns and stay cheap to read in later generator flows.                | schema/query review                     |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: migration rollout must be backward-compatible for users who have athlete profiles but no metric/preference rows yet.                                         | migration + rollback notes              |
+
+## Data Placement And Sync Contract (Required For Stateful Features)
+
+- Server-canonical:
+  - current training metric rows,
+  - training preferences row,
+  - ownership,
+  - timestamps,
+  - canonical units and enumerations,
+  - export serialization.
+- Local-only:
+  - unsaved metrics/preferences draft edits,
+  - transient save banners,
+  - transient expanded/collapsed UI state.
+- Sync policy:
+  - explicit save,
+  - server response becomes source of truth,
+  - unsaved local drafts survive reload long enough for retry,
+  - stale auth fails clearly and preserves local unsaved input.
+- Unit contract:
+  - `CSS` is stored canonically as seconds-per-100m,
+  - input UX may be swimmer-friendly, but persisted canonical value must stay deterministic.
+- Preference contract:
+  - available days are explicit weekday values, not free text,
+  - pool length and duration are explicit enumerations or bounded numeric fields, not ambiguous strings.
+
+## Identity And Rename Contract (Required When Entities Are Persisted Or Linkable)
+
+- Canonical stable IDs:
+  - `training_metric.id` is canonical for metric rows,
+  - `training_preferences.id` is canonical for the preferences row.
+- Human-readable identifiers:
+  - metric labels and preference helper text are editable display copy only.
+- Mutability rules:
+  - IDs are immutable,
+  - metric values are editable through explicit user actions,
+  - preferences are editable current settings,
+  - later generator integrations must read canonical IDs and canonical units, not mutable display labels.
+- Rename vs repurpose:
+  - updating current `CSS` is an in-place update of the same metric type for the same user,
+  - materially different future metric types must become distinct rows rather than overwriting unrelated meaning,
+  - preferences are current-state values and may be edited in place.
+- Compatibility contract:
+  - users with no metric/preference rows must still get deterministic empty states,
+  - later generator-prefill slices must tolerate missing values gracefully.
+- Observability and repair:
+  - invalid units, duplicate current metric conflicts, or malformed day/preference payloads must fail deterministically instead of being silently coerced.
+
+## Scope
+
+- Add private My Library `Training metrics` and `Preferences` sections on top of the shipped athlete-profile foundation.
+- Add a first-class `training_metrics` entity with phase-1 support for:
+  - `CSS`,
+  - measured/recorded date,
+  - optional source note,
+  - canonical stored value in seconds-per-100m.
+- Add a first-class `training_preferences` entity with phase-1 support for:
+  - pool length,
+  - available training days,
+  - preferred weekly session count,
+  - preferred session duration band.
+- Keep these clearly separate from:
+  - athlete profile text fields,
+  - `Goals`,
+  - `Focus`,
+  - `Notes`.
+- Surface this inside My Library/profile in a phone-friendly way.
+- Update the My Library summary card so the athlete-profile entry reflects whether metrics/preferences are present.
+- Include metrics/preferences in user export.
+- Keep the page generator-ready without building generator logic yet.
+
+## Out Of Scope
+
+- `Personal records`.
+- Session/program generator implementation.
+- Automatic workout/program generation from metrics/preferences.
+- Admin/operator surfaces.
+- Public sharing.
+- Pricing, subscriptions, or bundles.
+
+## Acceptance Criteria
+
+1. A signed-in user can view and edit private `Training metrics` and `Preferences` from My Library.
+2. `Training metrics` and `Preferences` remain clearly separate from `Athlete profile`, `Goals`, `Focus`, and `Notes`.
+3. `CSS` is saved using an explicit canonical unit contract suitable for later generator use.
+4. Preferences are saved as deterministic structured values, not ambiguous free text.
+5. Saved metrics/preferences are server-canonical and survive refresh/device changes.
+6. Unsaved metric/preference edits remain local-only and recoverable enough to avoid obvious frustration after accidental refresh.
+7. Users with no metrics/preferences rows see deterministic empty states and can create them without errors.
+8. Unauthorized access to another user's metrics/preferences is not possible.
+9. Export payload includes metrics/preferences when present and remains valid when absent.
+10. `npm run lint:briefs`, relevant tests, and `npm run verify:pre-pr` pass before PR update.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run lint`
+- `npm run typecheck`
+- targeted unit tests for:
+  - CSS unit parsing/normalization,
+  - preference validation,
+  - route authz,
+  - export payload shape
+- targeted e2e for:
+  - open/save/reload metrics and preferences,
+  - local draft recovery,
+  - My Library summary entry point
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3000/my-library`
+  - `http://127.0.0.1:3000/my-library/profile`
+- Preview:
+  - Vercel preview URL from PR checks
+- Recommended matrix:
+  - iPhone Safari
+  - Android Chromium
+  - iPad/tablet viewport
+  - Desktop Chrome
+  - Desktop Safari/WebKit
+  - Desktop Firefox
+
+## Constraints
+
+- Keep this slice narrow and genuinely useful now.
+- Do not pull `Personal records` into the same merge.
+- Keep `My Library` naming unchanged.
+- Follow existing Next.js/Supabase/My Library patterns.
+- Avoid collecting fields without clear training or generator-prefill value.
+
+## 10/10 Quality Bar (Required For User-Facing Work)
+
+- The metrics/preferences surface must feel like a real private training tool, not a placeholder settings dump.
+- `CSS` must be explicit enough that later generator logic can trust it without guessing units.
+- Preference choices must be practical for real swimmer planning, not generic profile fluff.
+- Empty, loading, saved, and error states must all be explicit.
+- Draft recovery must protect against accidental refresh while editing.
+- Business logic must stay deterministic:
+  - one current canonical CSS value per user in this slice,
+  - one preferences row per user,
+  - no cross-user leakage,
+  - no silent save failure.
+
+## Help/Guide And Operator Training Contract (Required For Workflow Changes)
+
+- User-facing My Library workflow copy changes are in scope.
+- Help/Guide content must explain that:
+  - metrics/preferences are private,
+  - they stay separate from athlete profile text, goals, focus, and notes,
+  - generator/program use comes later.
+
+## Checkpoint Log
+
+- `2026-03-19`: Child brief created and moved to `in-progress` for private training metrics and preferences foundation. `Personal records` stay deferred to a later child slice.
+- `2026-03-19 | feat/my-library-training-metrics-preferences-foundation | implemented training metrics + preferences foundation: added private CSS metric + training preferences schema/API/UI/export support, updated My Library summary/profile surfaces, added validation/authz/export/draft-recovery coverage, and ran targeted typecheck/unit/e2e plus full \`npm run verify:pre-pr\` PASS. Perf trend recommended \`tighten\` after another weekly green run; decision for this non-perf slice is \`hold\` and carry the ratchet decision in the next perf-focused workstream.`

--- a/docs/task-briefs/planned/2026-03-19-my-library-athlete-profile-training-metrics-and-preferences-10-10.md
+++ b/docs/task-briefs/planned/2026-03-19-my-library-athlete-profile-training-metrics-and-preferences-10-10.md
@@ -235,6 +235,12 @@ Critical target categories for `10/10` claim in this brief:
 4. `Generator prefill from athlete profile + metrics + preferences`
    - read-only consumption of canonical user context in generator flows.
 
+## Checkpoint Log
+
+- `2026-03-19`: Parent brief created to lock the broader profile/metrics/preferences direction before implementation.
+- `2026-03-19 | e830b21 (main) | child slice 1 shipped via PR #237 for private athlete-profile foundation; profile hub, canonical row, local draft recovery, and export compatibility are now on main | next: take training metrics + preferences as the next child slice and continue to defer personal records`
+- `2026-03-19 | in-progress | child slice 2 started in docs/task-briefs/in-progress/2026-03-19-my-library-training-metrics-and-preferences-foundation-10-10.md with scope locked to CSS + practical preferences only; personal records remain deferred to a later child | next: implement canonical metrics/preferences schema, private My Library UX, export support, and tests`
+
 ## Acceptance Criteria
 
 1. `Athlete profile`, `Training metrics`, `Personal records`, and `Preferences` are clearly separate concepts in My Library.

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -14,6 +14,8 @@ export const ANALYTICS_EVENT_NAMES = [
   "athlete_profile_viewed",
   "athlete_profile_refreshed",
   "athlete_profile_saved",
+  "training_metric_saved",
+  "training_preferences_saved",
   "training_context_viewed",
   "training_context_refreshed",
   "training_focus_created",

--- a/lib/athlete-profile/schema.ts
+++ b/lib/athlete-profile/schema.ts
@@ -5,17 +5,7 @@ type PostgrestLikeError = {
   hint?: string | null;
 };
 
-const ATHLETE_PROFILE_MARKERS = [
-  "athlete_profiles",
-  "display_name",
-  "first_name",
-  "last_name",
-  "age_band",
-];
-
-export function isAthleteProfileSchemaMissing(
-  error: PostgrestLikeError | null | undefined
-): boolean {
+function isSchemaMissing(error: PostgrestLikeError | null | undefined, markers: string[]): boolean {
   if (!error) return false;
 
   if (error.code === "42P01" || error.code === "42703" || error.code === "PGRST204") {
@@ -23,5 +13,41 @@ export function isAthleteProfileSchemaMissing(
   }
 
   const blob = `${error.message ?? ""} ${error.details ?? ""} ${error.hint ?? ""}`.toLowerCase();
-  return ATHLETE_PROFILE_MARKERS.some((marker) => blob.includes(marker));
+  return markers.some((marker) => blob.includes(marker));
+}
+
+export function isAthleteProfileSchemaMissing(
+  error: PostgrestLikeError | null | undefined
+): boolean {
+  return isSchemaMissing(error, [
+    "athlete_profiles",
+    "display_name",
+    "first_name",
+    "last_name",
+    "age_band",
+  ]);
+}
+
+export function isTrainingMetricSchemaMissing(
+  error: PostgrestLikeError | null | undefined
+): boolean {
+  return isSchemaMissing(error, [
+    "training_metrics",
+    "metric_key",
+    "value_seconds",
+    "recorded_on",
+    "source_note",
+  ]);
+}
+
+export function isTrainingPreferencesSchemaMissing(
+  error: PostgrestLikeError | null | undefined
+): boolean {
+  return isSchemaMissing(error, [
+    "training_preferences",
+    "pool_length_m",
+    "available_days",
+    "preferred_weekly_session_count",
+    "preferred_session_minutes",
+  ]);
 }

--- a/lib/athlete-profile/server.ts
+++ b/lib/athlete-profile/server.ts
@@ -5,7 +5,23 @@ import {
   type AthleteAgeBand,
   type AthleteProfileRow,
 } from "@/lib/athlete-profile/mvp";
-import { isAthleteProfileSchemaMissing } from "@/lib/athlete-profile/schema";
+import {
+  formatCssSecondsPer100m,
+  getPoolLengthLabel,
+  getSessionDurationLabel,
+  getWeekdayLabel,
+  type TrainingMetricKey,
+  type TrainingMetricRow,
+  type TrainingPoolLength,
+  type TrainingPreferencesRow,
+  type TrainingSessionDuration,
+  type TrainingWeekday,
+} from "@/lib/athlete-profile/training-setup";
+import {
+  isAthleteProfileSchemaMissing,
+  isTrainingMetricSchemaMissing,
+  isTrainingPreferencesSchemaMissing,
+} from "@/lib/athlete-profile/schema";
 import type { Database } from "@/types/database";
 
 type TypedSupabaseClient = SupabaseClient<Database>;
@@ -17,6 +33,29 @@ export const ATHLETE_PROFILE_SELECT = `
   first_name,
   last_name,
   age_band,
+  created_at,
+  updated_at
+`;
+
+export const TRAINING_METRIC_SELECT = `
+  id,
+  user_id,
+  metric_key,
+  unit,
+  value_seconds,
+  recorded_on,
+  source_note,
+  created_at,
+  updated_at
+`;
+
+export const TRAINING_PREFERENCES_SELECT = `
+  id,
+  user_id,
+  pool_length_m,
+  available_days,
+  preferred_weekly_session_count,
+  preferred_session_minutes,
   created_at,
   updated_at
 `;
@@ -33,10 +72,41 @@ export type AthleteProfileView = {
   updatedAt: string;
 };
 
+export type TrainingMetricView = {
+  id: string;
+  metricKey: TrainingMetricKey;
+  unit: "seconds_per_100m";
+  valueSeconds: number;
+  paceLabel: string;
+  recordedOn: string | null;
+  sourceNote: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type TrainingPreferencesView = {
+  id: string;
+  poolLengthM: TrainingPoolLength | null;
+  poolLengthLabel: string | null;
+  availableDays: TrainingWeekday[];
+  availableDayLabels: string[];
+  preferredWeeklySessionCount: number | null;
+  preferredSessionMinutes: TrainingSessionDuration | null;
+  preferredSessionMinutesLabel: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export type AthleteProfileSnapshot = {
-  schemaReady: boolean;
+  profileSchemaReady: boolean;
+  metricsSchemaReady: boolean;
+  preferencesSchemaReady: boolean;
   loadError: string | null;
+  metricsLoadError: string | null;
+  preferencesLoadError: string | null;
   profile: AthleteProfileView | null;
+  cssMetric: TrainingMetricView | null;
+  preferences: TrainingPreferencesView | null;
 };
 
 export function buildAthleteProfileView(row: AthleteProfileRow): AthleteProfileView {
@@ -59,36 +129,106 @@ export function buildAthleteProfileView(row: AthleteProfileRow): AthleteProfileV
   };
 }
 
+export function buildTrainingMetricView(row: TrainingMetricRow): TrainingMetricView {
+  return {
+    id: row.id,
+    metricKey: row.metric_key as TrainingMetricKey,
+    unit: "seconds_per_100m",
+    valueSeconds: row.value_seconds,
+    paceLabel: formatCssSecondsPer100m(row.value_seconds) ?? "0:00",
+    recordedOn: row.recorded_on,
+    sourceNote: row.source_note,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function buildTrainingPreferencesView(row: TrainingPreferencesRow): TrainingPreferencesView {
+  const availableDays = (row.available_days ?? []) as TrainingWeekday[];
+  return {
+    id: row.id,
+    poolLengthM: (row.pool_length_m as TrainingPoolLength | null) ?? null,
+    poolLengthLabel: getPoolLengthLabel((row.pool_length_m as TrainingPoolLength | null) ?? null),
+    availableDays,
+    availableDayLabels: availableDays.map((value) => getWeekdayLabel(value)),
+    preferredWeeklySessionCount: row.preferred_weekly_session_count,
+    preferredSessionMinutes:
+      (row.preferred_session_minutes as TrainingSessionDuration | null) ?? null,
+    preferredSessionMinutesLabel: getSessionDurationLabel(
+      (row.preferred_session_minutes as TrainingSessionDuration | null) ?? null
+    ),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
 export async function loadAthleteProfileSnapshot(
   supabase: TypedSupabaseClient,
   userId: string
 ): Promise<AthleteProfileSnapshot> {
-  const result = await supabase
-    .from("athlete_profiles")
-    .select(ATHLETE_PROFILE_SELECT)
-    .eq("user_id", userId)
-    .maybeSingle();
+  const [profileResult, cssMetricResult, preferencesResult] = await Promise.all([
+    supabase
+      .from("athlete_profiles")
+      .select(ATHLETE_PROFILE_SELECT)
+      .eq("user_id", userId)
+      .maybeSingle(),
+    supabase
+      .from("training_metrics")
+      .select(TRAINING_METRIC_SELECT)
+      .eq("user_id", userId)
+      .eq("metric_key", "css")
+      .maybeSingle(),
+    supabase
+      .from("training_preferences")
+      .select(TRAINING_PREFERENCES_SELECT)
+      .eq("user_id", userId)
+      .maybeSingle(),
+  ]);
 
-  if (isAthleteProfileSchemaMissing(result.error)) {
-    return {
-      schemaReady: false,
-      loadError: null,
-      profile: null,
-    };
+  const profileSchemaReady = !isAthleteProfileSchemaMissing(profileResult.error);
+  const metricsSchemaReady = !isTrainingMetricSchemaMissing(cssMetricResult.error);
+  const preferencesSchemaReady = !isTrainingPreferencesSchemaMissing(preferencesResult.error);
+
+  const loadError =
+    profileResult.error && profileSchemaReady ? "Could not load athlete profile right now." : null;
+  const metricsLoadError =
+    cssMetricResult.error && metricsSchemaReady
+      ? "Could not load training metrics right now."
+      : null;
+  const preferencesLoadError =
+    preferencesResult.error && preferencesSchemaReady
+      ? "Could not load training preferences right now."
+      : null;
+
+  if (loadError) {
+    console.error("[AthleteProfile] Failed loading profile snapshot", profileResult.error);
   }
 
-  if (result.error) {
-    console.error("[AthleteProfile] Failed loading snapshot", result.error);
-    return {
-      schemaReady: true,
-      loadError: "Could not load athlete profile right now.",
-      profile: null,
-    };
+  if (metricsLoadError) {
+    console.error(
+      "[AthleteProfile] Failed loading training metrics snapshot",
+      cssMetricResult.error
+    );
+  }
+
+  if (preferencesLoadError) {
+    console.error(
+      "[AthleteProfile] Failed loading training preferences snapshot",
+      preferencesResult.error
+    );
   }
 
   return {
-    schemaReady: true,
-    loadError: null,
-    profile: result.data ? buildAthleteProfileView(result.data) : null,
+    profileSchemaReady,
+    metricsSchemaReady,
+    preferencesSchemaReady,
+    loadError,
+    metricsLoadError,
+    preferencesLoadError,
+    profile: profileResult.data ? buildAthleteProfileView(profileResult.data) : null,
+    cssMetric: cssMetricResult.data ? buildTrainingMetricView(cssMetricResult.data) : null,
+    preferences: preferencesResult.data
+      ? buildTrainingPreferencesView(preferencesResult.data)
+      : null,
   };
 }

--- a/lib/athlete-profile/training-setup.ts
+++ b/lib/athlete-profile/training-setup.ts
@@ -1,0 +1,256 @@
+import type { Database } from "@/types/database";
+
+export const TRAINING_METRIC_KEYS = ["css"] as const;
+export type TrainingMetricKey = (typeof TRAINING_METRIC_KEYS)[number];
+
+export const TRAINING_POOL_LENGTH_VALUES = [25, 50] as const;
+export type TrainingPoolLength = (typeof TRAINING_POOL_LENGTH_VALUES)[number];
+
+export const TRAINING_SESSION_DURATION_VALUES = [30, 45, 60, 75, 90] as const;
+export type TrainingSessionDuration = (typeof TRAINING_SESSION_DURATION_VALUES)[number];
+
+export const TRAINING_WEEKDAY_VALUES = [
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+  "sunday",
+] as const;
+export type TrainingWeekday = (typeof TRAINING_WEEKDAY_VALUES)[number];
+
+export const TRAINING_WEEKDAY_OPTIONS: readonly { value: TrainingWeekday; label: string }[] = [
+  { value: "monday", label: "Mon" },
+  { value: "tuesday", label: "Tue" },
+  { value: "wednesday", label: "Wed" },
+  { value: "thursday", label: "Thu" },
+  { value: "friday", label: "Fri" },
+  { value: "saturday", label: "Sat" },
+  { value: "sunday", label: "Sun" },
+] as const;
+
+export const TRAINING_POOL_LENGTH_OPTIONS: readonly {
+  value: TrainingPoolLength;
+  label: string;
+}[] = [
+  { value: 25, label: "25m pool" },
+  { value: 50, label: "50m pool" },
+] as const;
+
+export const TRAINING_SESSION_DURATION_OPTIONS: readonly {
+  value: TrainingSessionDuration;
+  label: string;
+}[] = [
+  { value: 30, label: "30 min" },
+  { value: 45, label: "45 min" },
+  { value: 60, label: "60 min" },
+  { value: 75, label: "75 min" },
+  { value: 90, label: "90 min" },
+] as const;
+
+export type TrainingMetricRow = Database["public"]["Tables"]["training_metrics"]["Row"];
+export type TrainingMetricInsert = Database["public"]["Tables"]["training_metrics"]["Insert"];
+export type TrainingPreferencesRow = Database["public"]["Tables"]["training_preferences"]["Row"];
+export type TrainingPreferencesInsert =
+  Database["public"]["Tables"]["training_preferences"]["Insert"];
+
+type CssMetricInput = {
+  pace?: string | null;
+  recordedOn?: string | null;
+  sourceNote?: string | null;
+};
+
+type TrainingPreferencesInput = {
+  poolLengthM?: number | string | null;
+  availableDays?: string[] | null;
+  preferredWeeklySessionCount?: number | string | null;
+  preferredSessionMinutes?: number | string | null;
+};
+
+type BuildResult<T> =
+  | { kind: "empty" }
+  | { kind: "invalid"; error: string }
+  | { kind: "valid"; value: T };
+
+function normalizeText(value: string | null | undefined): string {
+  return value?.trim() ?? "";
+}
+
+function normalizeNullableText(value: string | null | undefined): string | null {
+  const normalized = normalizeText(value);
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeInteger(value: number | string | null | undefined): number | null {
+  if (typeof value === "number" && Number.isInteger(value)) return value;
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  if (!normalized) return null;
+  if (!/^\d+$/.test(normalized)) return null;
+  return Number.parseInt(normalized, 10);
+}
+
+function isValidIsoDateOnly(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [year, month, day] = value.split("-").map((part) => Number.parseInt(part, 10));
+  const asDate = new Date(Date.UTC(year, month - 1, day));
+  return (
+    asDate.getUTCFullYear() === year &&
+    asDate.getUTCMonth() === month - 1 &&
+    asDate.getUTCDate() === day
+  );
+}
+
+export function formatCssSecondsPer100m(valueSeconds: number | null): string | null {
+  if (!valueSeconds || valueSeconds <= 0) return null;
+  const minutes = Math.floor(valueSeconds / 60);
+  const seconds = valueSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+export function getPoolLengthLabel(value: TrainingPoolLength | null): string | null {
+  if (!value) return null;
+  return TRAINING_POOL_LENGTH_OPTIONS.find((option) => option.value === value)?.label ?? null;
+}
+
+export function getSessionDurationLabel(value: TrainingSessionDuration | null): string | null {
+  if (!value) return null;
+  return TRAINING_SESSION_DURATION_OPTIONS.find((option) => option.value === value)?.label ?? null;
+}
+
+export function getWeekdayLabel(value: TrainingWeekday): string {
+  return TRAINING_WEEKDAY_OPTIONS.find((option) => option.value === value)?.label ?? value;
+}
+
+export function normalizeWeekdays(input: string[] | null | undefined): TrainingWeekday[] {
+  const normalized = Array.isArray(input)
+    ? input.filter((value): value is TrainingWeekday =>
+        TRAINING_WEEKDAY_VALUES.some((candidate) => candidate === value)
+      )
+    : [];
+
+  const unique = Array.from(new Set(normalized));
+  return TRAINING_WEEKDAY_VALUES.filter((weekday) => unique.includes(weekday));
+}
+
+export function buildCssMetricUpsert(
+  input: CssMetricInput
+): BuildResult<Omit<TrainingMetricInsert, "id" | "user_id" | "created_at" | "updated_at">> {
+  const pace = normalizeText(input.pace);
+  const recordedOn = normalizeNullableText(input.recordedOn);
+  const sourceNote = normalizeNullableText(input.sourceNote);
+
+  if (!pace && !recordedOn && !sourceNote) {
+    return { kind: "empty" };
+  }
+
+  if (!pace) {
+    return { kind: "invalid", error: "Add a CSS pace before saving." };
+  }
+
+  const paceMatch = /^(\d{1,2}):([0-5]\d)$/.exec(pace);
+  if (!paceMatch) {
+    return { kind: "invalid", error: "Use CSS pace format m:ss, for example 1:58." };
+  }
+
+  const minutes = Number.parseInt(paceMatch[1] ?? "0", 10);
+  const seconds = Number.parseInt(paceMatch[2] ?? "0", 10);
+  const valueSeconds = minutes * 60 + seconds;
+
+  if (valueSeconds <= 0 || valueSeconds > 3600) {
+    return { kind: "invalid", error: "CSS pace must be between 0:01 and 60:00." };
+  }
+
+  if (recordedOn && !isValidIsoDateOnly(recordedOn)) {
+    return { kind: "invalid", error: "Use a valid CSS date in YYYY-MM-DD format." };
+  }
+
+  if (sourceNote && sourceNote.length > 280) {
+    return { kind: "invalid", error: "CSS source note must be 280 characters or fewer." };
+  }
+
+  return {
+    kind: "valid",
+    value: {
+      metric_key: "css",
+      unit: "seconds_per_100m",
+      value_seconds: valueSeconds,
+      recorded_on: recordedOn,
+      source_note: sourceNote,
+    },
+  };
+}
+
+export function buildTrainingPreferencesUpsert(
+  input: TrainingPreferencesInput
+): BuildResult<Omit<TrainingPreferencesInsert, "id" | "user_id" | "created_at" | "updated_at">> {
+  const poolLengthM = normalizeInteger(input.poolLengthM);
+  const preferredWeeklySessionCount = normalizeInteger(input.preferredWeeklySessionCount);
+  const preferredSessionMinutes = normalizeInteger(input.preferredSessionMinutes);
+  const availableDays = normalizeWeekdays(input.availableDays);
+
+  const hasAnyValue =
+    poolLengthM !== null ||
+    preferredWeeklySessionCount !== null ||
+    preferredSessionMinutes !== null ||
+    availableDays.length > 0;
+
+  if (!hasAnyValue) {
+    return { kind: "empty" };
+  }
+
+  if (
+    input.poolLengthM !== undefined &&
+    input.poolLengthM !== null &&
+    `${input.poolLengthM}`.trim() !== "" &&
+    !TRAINING_POOL_LENGTH_VALUES.some((value) => value === poolLengthM)
+  ) {
+    return { kind: "invalid", error: "Pool length must be 25m or 50m." };
+  }
+
+  if (
+    input.preferredWeeklySessionCount !== undefined &&
+    input.preferredWeeklySessionCount !== null &&
+    `${input.preferredWeeklySessionCount}`.trim() !== "" &&
+    (preferredWeeklySessionCount === null ||
+      preferredWeeklySessionCount < 1 ||
+      preferredWeeklySessionCount > 14)
+  ) {
+    return {
+      kind: "invalid",
+      error: "Preferred weekly session count must be between 1 and 14.",
+    };
+  }
+
+  if (
+    input.preferredSessionMinutes !== undefined &&
+    input.preferredSessionMinutes !== null &&
+    `${input.preferredSessionMinutes}`.trim() !== "" &&
+    !TRAINING_SESSION_DURATION_VALUES.some((value) => value === preferredSessionMinutes)
+  ) {
+    return {
+      kind: "invalid",
+      error: "Preferred session duration must match one of the supported options.",
+    };
+  }
+
+  if (
+    Array.isArray(input.availableDays) &&
+    input.availableDays.length > 0 &&
+    availableDays.length !== input.availableDays.length
+  ) {
+    return { kind: "invalid", error: "Available days contain an unsupported value." };
+  }
+
+  return {
+    kind: "valid",
+    value: {
+      pool_length_m: poolLengthM as TrainingPoolLength | null,
+      available_days: availableDays.length > 0 ? availableDays : null,
+      preferred_weekly_session_count: preferredWeeklySessionCount,
+      preferred_session_minutes:
+        (preferredSessionMinutes as TrainingSessionDuration | null) ?? null,
+    },
+  };
+}

--- a/lib/user/export.ts
+++ b/lib/user/export.ts
@@ -23,6 +23,29 @@ type AthleteProfileRow = Pick<
   "id" | "display_name" | "first_name" | "last_name" | "age_band" | "created_at" | "updated_at"
 >;
 
+type TrainingMetricRow = Pick<
+  Database["public"]["Tables"]["training_metrics"]["Row"],
+  | "id"
+  | "metric_key"
+  | "unit"
+  | "value_seconds"
+  | "recorded_on"
+  | "source_note"
+  | "created_at"
+  | "updated_at"
+>;
+
+type TrainingPreferencesRow = Pick<
+  Database["public"]["Tables"]["training_preferences"]["Row"],
+  | "id"
+  | "pool_length_m"
+  | "available_days"
+  | "preferred_weekly_session_count"
+  | "preferred_session_minutes"
+  | "created_at"
+  | "updated_at"
+>;
+
 type CourseProgressRow = Pick<
   Database["public"]["Tables"]["course_progress"]["Row"],
   "lesson_id" | "done" | "video_seconds" | "updated_at"
@@ -92,6 +115,8 @@ export type BuildUserExportPayloadInput = {
   userEmail: string | null;
   profile: ProfileRow | null;
   athleteProfile: AthleteProfileRow | null;
+  trainingMetrics: TrainingMetricRow[];
+  trainingPreferences: TrainingPreferencesRow | null;
   entitlements: EntitlementRow[];
   courseProgress: CourseProgressRow[];
   guideProgress: GuideProgressRow[];
@@ -108,7 +133,7 @@ export function buildUserExportPayload(input: BuildUserExportPayloadInput) {
 
   return {
     generatedAt,
-    schemaVersion: "2026-03-19-athlete-profile",
+    schemaVersion: "2026-03-19-athlete-profile-training-setup",
     user: {
       id: input.userId,
       email: input.userEmail,
@@ -130,6 +155,27 @@ export function buildUserExportPayload(input: BuildUserExportPayloadInput) {
           ageBand: input.athleteProfile.age_band,
           createdAt: input.athleteProfile.created_at,
           updatedAt: input.athleteProfile.updated_at,
+        }
+      : null,
+    trainingMetrics: input.trainingMetrics.map((row) => ({
+      id: row.id,
+      metricKey: row.metric_key,
+      unit: row.unit,
+      valueSeconds: row.value_seconds,
+      recordedOn: row.recorded_on,
+      sourceNote: row.source_note,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    })),
+    trainingPreferences: input.trainingPreferences
+      ? {
+          id: input.trainingPreferences.id,
+          poolLengthM: input.trainingPreferences.pool_length_m,
+          availableDays: input.trainingPreferences.available_days,
+          preferredWeeklySessionCount: input.trainingPreferences.preferred_weekly_session_count,
+          preferredSessionMinutes: input.trainingPreferences.preferred_session_minutes,
+          createdAt: input.trainingPreferences.created_at,
+          updatedAt: input.trainingPreferences.updated_at,
         }
       : null,
     entitlements: input.entitlements.map((row) => ({

--- a/supabase/migrations/20260319213000_training_metrics_and_preferences_foundation.sql
+++ b/supabase/migrations/20260319213000_training_metrics_and_preferences_foundation.sql
@@ -1,0 +1,139 @@
+-- Private training metrics and training preferences foundation for My Library.
+-- Keeps trusted swim metrics and practical training defaults separate from athlete profile text.
+
+create table if not exists public.training_metrics (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  metric_key text not null check (metric_key in ('css')),
+  unit text not null check (unit in ('seconds_per_100m')),
+  value_seconds integer not null check (value_seconds between 1 and 3600),
+  recorded_on date,
+  source_note text,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint training_metrics_source_note_check
+    check (source_note is null or char_length(btrim(source_note)) between 1 and 280),
+  constraint training_metrics_unique_metric_per_user
+    unique (user_id, metric_key)
+);
+
+create index if not exists training_metrics_user_metric_updated_idx
+  on public.training_metrics (user_id, metric_key, updated_at desc);
+
+drop trigger if exists training_metrics_set_updated_at on public.training_metrics;
+create trigger training_metrics_set_updated_at
+before update on public.training_metrics
+for each row
+execute function public.set_updated_at();
+
+grant select, insert, update, delete on public.training_metrics to authenticated;
+
+alter table public.training_metrics enable row level security;
+
+drop policy if exists training_metrics_select_own on public.training_metrics;
+create policy training_metrics_select_own
+on public.training_metrics
+for select
+to authenticated
+using (auth.uid() = user_id);
+
+drop policy if exists training_metrics_insert_own on public.training_metrics;
+create policy training_metrics_insert_own
+on public.training_metrics
+for insert
+to authenticated
+with check (auth.uid() = user_id);
+
+drop policy if exists training_metrics_update_own on public.training_metrics;
+create policy training_metrics_update_own
+on public.training_metrics
+for update
+to authenticated
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+drop policy if exists training_metrics_delete_own on public.training_metrics;
+create policy training_metrics_delete_own
+on public.training_metrics
+for delete
+to authenticated
+using (auth.uid() = user_id);
+
+create table if not exists public.training_preferences (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null unique references auth.users (id) on delete cascade,
+  pool_length_m integer check (pool_length_m in (25, 50)),
+  available_days text[] check (
+    available_days is null or (
+      cardinality(available_days) > 0 and
+      available_days <@ array[
+        'monday',
+        'tuesday',
+        'wednesday',
+        'thursday',
+        'friday',
+        'saturday',
+        'sunday'
+      ]::text[]
+    )
+  ),
+  preferred_weekly_session_count integer check (
+    preferred_weekly_session_count is null or
+    preferred_weekly_session_count between 1 and 14
+  ),
+  preferred_session_minutes integer check (
+    preferred_session_minutes is null or
+    preferred_session_minutes in (30, 45, 60, 75, 90)
+  ),
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint training_preferences_not_blank_check
+    check (
+      pool_length_m is not null or
+      nullif(array_length(available_days, 1), 0) is not null or
+      preferred_weekly_session_count is not null or
+      preferred_session_minutes is not null
+    )
+);
+
+create index if not exists training_preferences_user_updated_idx
+  on public.training_preferences (user_id, updated_at desc);
+
+drop trigger if exists training_preferences_set_updated_at on public.training_preferences;
+create trigger training_preferences_set_updated_at
+before update on public.training_preferences
+for each row
+execute function public.set_updated_at();
+
+grant select, insert, update, delete on public.training_preferences to authenticated;
+
+alter table public.training_preferences enable row level security;
+
+drop policy if exists training_preferences_select_own on public.training_preferences;
+create policy training_preferences_select_own
+on public.training_preferences
+for select
+to authenticated
+using (auth.uid() = user_id);
+
+drop policy if exists training_preferences_insert_own on public.training_preferences;
+create policy training_preferences_insert_own
+on public.training_preferences
+for insert
+to authenticated
+with check (auth.uid() = user_id);
+
+drop policy if exists training_preferences_update_own on public.training_preferences;
+create policy training_preferences_update_own
+on public.training_preferences
+for update
+to authenticated
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+drop policy if exists training_preferences_delete_own on public.training_preferences;
+create policy training_preferences_delete_own
+on public.training_preferences
+for delete
+to authenticated
+using (auth.uid() = user_id);

--- a/tests/e2e/my-library-athlete-profile.spec.ts
+++ b/tests/e2e/my-library-athlete-profile.spec.ts
@@ -21,16 +21,16 @@ async function loginToMyLibraryViaDevBypass(page: Page) {
 }
 
 test.describe("my library athlete profile", () => {
-  test("opens athlete profile from My Library and preserves draft after reload", async ({
+  test("opens training setup from My Library and preserves drafts after reload", async ({
     page,
   }, testInfo) => {
     runOnceOnDesktopChromium(testInfo.project.name);
 
     await loginToMyLibraryViaDevBypass(page);
     await expect(page.getByRole("heading", { name: "My Library" })).toBeVisible();
-    await expect(page.getByRole("link", { name: "Open athlete profile" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Open training setup" })).toBeVisible();
 
-    const openProfileLink = page.getByRole("link", { name: "Open athlete profile" });
+    const openProfileLink = page.getByRole("link", { name: "Open training setup" });
     await expect(openProfileLink).toHaveAttribute("href", "/my-library/profile");
     await openProfileLink.click();
     const navigatedAfterClick = await page
@@ -45,7 +45,7 @@ test.describe("my library athlete profile", () => {
     }
     await expect(
       page.getByRole("heading", {
-        name: "Athlete profile",
+        name: "Athlete profile & training setup",
         level: 1,
       })
     ).toBeVisible();
@@ -56,16 +56,26 @@ test.describe("my library athlete profile", () => {
     }
 
     await displayNameInput.fill("Pool draft");
+    await page.getByTestId("athlete-profile-css-pace").fill("1:58");
+    await page.getByTestId("athlete-preferences-day-monday").check();
+    await page.getByTestId("athlete-preferences-session-minutes").selectOption("60");
     await page.reload({ waitUntil: "domcontentloaded", timeout: 60_000 });
     await expect(
       page.getByRole("heading", {
-        name: "Athlete profile",
+        name: "Athlete profile & training setup",
         level: 1,
       })
     ).toBeVisible();
     await expect(page.getByTestId("athlete-profile-display-name")).toHaveValue("Pool draft");
+    await expect(page.getByTestId("athlete-profile-css-pace")).toHaveValue("1:58");
+    await expect(page.getByTestId("athlete-preferences-day-monday")).toBeChecked();
+    await expect(page.getByTestId("athlete-preferences-session-minutes")).toHaveValue("60");
     await expect(
       page.getByText("Unsaved athlete-profile edits were restored on this device.")
+    ).toBeVisible();
+    await expect(page.getByText("Unsaved CSS edits were restored on this device.")).toBeVisible();
+    await expect(
+      page.getByText("Unsaved training preferences edits were restored on this device.")
     ).toBeVisible();
   });
 });

--- a/tests/unit/athlete-profile-hub.test.tsx
+++ b/tests/unit/athlete-profile-hub.test.tsx
@@ -9,9 +9,15 @@ vi.mock("@/lib/analytics/client", () => ({
 
 function buildSnapshot(profile?: AthleteProfileSnapshot["profile"]): AthleteProfileSnapshot {
   return {
-    schemaReady: true,
+    profileSchemaReady: true,
+    metricsSchemaReady: true,
+    preferencesSchemaReady: true,
     loadError: null,
+    metricsLoadError: null,
+    preferencesLoadError: null,
     profile: profile ?? null,
+    cssMetric: null,
+    preferences: null,
   };
 }
 
@@ -29,7 +35,7 @@ describe("AthleteProfileHub", () => {
 
   it("restores unsaved local draft state", () => {
     localStorage.setItem(
-      "my-library-athlete-profile-draft:user-1",
+      "my-library-athlete-profile-profile-draft:user-1",
       JSON.stringify({
         displayName: "Pool draft",
         firstName: "",
@@ -88,5 +94,115 @@ describe("AthleteProfileHub", () => {
 
     expect(screen.getAllByText("Poolside Stian").length).toBeGreaterThan(0);
     expect(localStorage.getItem("my-library-athlete-profile-draft:user-1")).toBeNull();
+  });
+
+  it("saves CSS and preferences updates", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              ok: true,
+              snapshot: {
+                ...buildSnapshot(),
+                cssMetric: {
+                  id: "metric-1",
+                  metricKey: "css",
+                  unit: "seconds_per_100m",
+                  valueSeconds: 118,
+                  paceLabel: "1:58",
+                  recordedOn: "2026-03-19",
+                  sourceNote: "400 + 200 test",
+                  createdAt: "2026-03-19T18:00:00.000Z",
+                  updatedAt: "2026-03-19T18:05:00.000Z",
+                },
+                preferences: {
+                  id: "pref-1",
+                  poolLengthM: 25,
+                  poolLengthLabel: "25m pool",
+                  availableDays: ["monday", "wednesday"],
+                  availableDayLabels: ["Mon", "Wed"],
+                  preferredWeeklySessionCount: 5,
+                  preferredSessionMinutes: 60,
+                  preferredSessionMinutesLabel: "60 min",
+                  createdAt: "2026-03-19T18:00:00.000Z",
+                  updatedAt: "2026-03-19T18:05:00.000Z",
+                },
+              },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              ok: true,
+              snapshot: {
+                ...buildSnapshot(),
+                cssMetric: {
+                  id: "metric-1",
+                  metricKey: "css",
+                  unit: "seconds_per_100m",
+                  valueSeconds: 118,
+                  paceLabel: "1:58",
+                  recordedOn: "2026-03-19",
+                  sourceNote: "400 + 200 test",
+                  createdAt: "2026-03-19T18:00:00.000Z",
+                  updatedAt: "2026-03-19T18:05:00.000Z",
+                },
+                preferences: {
+                  id: "pref-1",
+                  poolLengthM: 25,
+                  poolLengthLabel: "25m pool",
+                  availableDays: ["monday", "wednesday"],
+                  availableDayLabels: ["Mon", "Wed"],
+                  preferredWeeklySessionCount: 5,
+                  preferredSessionMinutes: 60,
+                  preferredSessionMinutesLabel: "60 min",
+                  createdAt: "2026-03-19T18:00:00.000Z",
+                  updatedAt: "2026-03-19T18:05:00.000Z",
+                },
+              },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+          )
+        )
+    );
+
+    render(<AthleteProfileHub initialSnapshot={buildSnapshot()} userId="user-1" />);
+
+    fireEvent.change(screen.getByTestId("athlete-profile-css-pace"), {
+      target: { value: "1:58" },
+    });
+    fireEvent.change(screen.getByTestId("athlete-profile-css-recorded-on"), {
+      target: { value: "2026-03-19" },
+    });
+    fireEvent.click(screen.getByTestId("athlete-profile-css-save"));
+
+    await waitFor(() => {
+      expect(screen.getByText("CSS saved.")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId("athlete-preferences-pool-length"), {
+      target: { value: "25" },
+    });
+    fireEvent.change(screen.getByTestId("athlete-preferences-weekly-session-count"), {
+      target: { value: "5" },
+    });
+    fireEvent.click(screen.getByTestId("athlete-preferences-day-monday"));
+    fireEvent.click(screen.getByTestId("athlete-preferences-day-wednesday"));
+    fireEvent.change(screen.getByTestId("athlete-preferences-session-minutes"), {
+      target: { value: "60" },
+    });
+    fireEvent.click(screen.getByTestId("athlete-preferences-save"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Training preferences saved.")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("1:58/100m")).toBeInTheDocument();
+    expect(screen.getAllByText("25m pool").length).toBeGreaterThan(0);
   });
 });

--- a/tests/unit/training-metric-routes.test.ts
+++ b/tests/unit/training-metric-routes.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createRouteHandlerSupabaseClientMock, loadAthleteProfileSnapshotMock } = vi.hoisted(() => ({
+  createRouteHandlerSupabaseClientMock: vi.fn(),
+  loadAthleteProfileSnapshotMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/route-handler", () => ({
+  createRouteHandlerSupabaseClient: createRouteHandlerSupabaseClientMock,
+}));
+
+vi.mock("@/lib/athlete-profile/server", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/athlete-profile/server")>(
+    "@/lib/athlete-profile/server"
+  );
+
+  return {
+    ...actual,
+    loadAthleteProfileSnapshot: loadAthleteProfileSnapshotMock,
+  };
+});
+
+import { PUT as putTrainingMetric } from "@/app/api/my-library/profile/metrics/route";
+
+function applyResponseCookiesIdentity<T>(response: T): T {
+  return response;
+}
+
+describe("training metric routes", () => {
+  beforeEach(() => {
+    createRouteHandlerSupabaseClientMock.mockReset();
+    loadAthleteProfileSnapshotMock.mockResolvedValue({
+      profileSchemaReady: true,
+      metricsSchemaReady: true,
+      preferencesSchemaReady: true,
+      loadError: null,
+      metricsLoadError: null,
+      preferencesLoadError: null,
+      profile: null,
+      cssMetric: null,
+      preferences: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fails closed for unauthenticated metric save", async () => {
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+        },
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await putTrainingMetric(
+      new Request("http://127.0.0.1:3000/api/my-library/profile/metrics", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ pace: "1:58" }),
+      })
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects malformed CSS before write", async () => {
+    const from = vi.fn();
+
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } } }),
+        },
+        from,
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await putTrainingMetric(
+      new Request("http://127.0.0.1:3000/api/my-library/profile/metrics", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ pace: "118" }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it("saves canonical CSS for the authenticated owner", async () => {
+    const single = vi.fn().mockResolvedValue({
+      data: { id: "metric-1" },
+      error: null,
+    });
+    const select = vi.fn(() => ({ single }));
+    const upsert = vi.fn(() => ({ select }));
+    const from = vi.fn().mockReturnValue({ upsert });
+
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } } }),
+        },
+        from,
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await putTrainingMetric(
+      new Request("http://127.0.0.1:3000/api/my-library/profile/metrics", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          pace: "1:58",
+          recordedOn: "2026-03-19",
+          sourceNote: "400 + 200 test",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(from).toHaveBeenCalledWith("training_metrics");
+    expect(upsert).toHaveBeenCalledWith(
+      {
+        user_id: "user-1",
+        metric_key: "css",
+        unit: "seconds_per_100m",
+        value_seconds: 118,
+        recorded_on: "2026-03-19",
+        source_note: "400 + 200 test",
+      },
+      { onConflict: "user_id,metric_key" }
+    );
+  });
+});

--- a/tests/unit/training-preferences-routes.test.ts
+++ b/tests/unit/training-preferences-routes.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createRouteHandlerSupabaseClientMock, loadAthleteProfileSnapshotMock } = vi.hoisted(() => ({
+  createRouteHandlerSupabaseClientMock: vi.fn(),
+  loadAthleteProfileSnapshotMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/route-handler", () => ({
+  createRouteHandlerSupabaseClient: createRouteHandlerSupabaseClientMock,
+}));
+
+vi.mock("@/lib/athlete-profile/server", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/athlete-profile/server")>(
+    "@/lib/athlete-profile/server"
+  );
+
+  return {
+    ...actual,
+    loadAthleteProfileSnapshot: loadAthleteProfileSnapshotMock,
+  };
+});
+
+import { PUT as putTrainingPreferences } from "@/app/api/my-library/profile/preferences/route";
+
+function applyResponseCookiesIdentity<T>(response: T): T {
+  return response;
+}
+
+describe("training preferences routes", () => {
+  beforeEach(() => {
+    createRouteHandlerSupabaseClientMock.mockReset();
+    loadAthleteProfileSnapshotMock.mockResolvedValue({
+      profileSchemaReady: true,
+      metricsSchemaReady: true,
+      preferencesSchemaReady: true,
+      loadError: null,
+      metricsLoadError: null,
+      preferencesLoadError: null,
+      profile: null,
+      cssMetric: null,
+      preferences: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fails closed for unauthenticated preferences save", async () => {
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+        },
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await putTrainingPreferences(
+      new Request("http://127.0.0.1:3000/api/my-library/profile/preferences", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ poolLengthM: "25" }),
+      })
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects unsupported preference values before write", async () => {
+    const from = vi.fn();
+
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } } }),
+        },
+        from,
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await putTrainingPreferences(
+      new Request("http://127.0.0.1:3000/api/my-library/profile/preferences", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ poolLengthM: "33" }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it("saves valid preferences for the authenticated owner", async () => {
+    const single = vi.fn().mockResolvedValue({
+      data: { id: "pref-1" },
+      error: null,
+    });
+    const select = vi.fn(() => ({ single }));
+    const upsert = vi.fn(() => ({ select }));
+    const from = vi.fn().mockReturnValue({ upsert });
+
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } } }),
+        },
+        from,
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await putTrainingPreferences(
+      new Request("http://127.0.0.1:3000/api/my-library/profile/preferences", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          poolLengthM: "25",
+          availableDays: ["wednesday", "monday"],
+          preferredWeeklySessionCount: "5",
+          preferredSessionMinutes: "60",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(from).toHaveBeenCalledWith("training_preferences");
+    expect(upsert).toHaveBeenCalledWith(
+      {
+        user_id: "user-1",
+        pool_length_m: 25,
+        available_days: ["monday", "wednesday"],
+        preferred_weekly_session_count: 5,
+        preferred_session_minutes: 60,
+      },
+      { onConflict: "user_id" }
+    );
+  });
+});

--- a/tests/unit/training-setup.test.ts
+++ b/tests/unit/training-setup.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCssMetricUpsert,
+  buildTrainingPreferencesUpsert,
+  formatCssSecondsPer100m,
+  normalizeWeekdays,
+} from "@/lib/athlete-profile/training-setup";
+
+describe("training setup helpers", () => {
+  it("normalizes CSS pace to canonical seconds per 100m", () => {
+    expect(
+      buildCssMetricUpsert({
+        pace: "1:58",
+        recordedOn: "2026-03-19",
+        sourceNote: "400 easy + 200 hard test",
+      })
+    ).toEqual({
+      kind: "valid",
+      value: {
+        metric_key: "css",
+        unit: "seconds_per_100m",
+        value_seconds: 118,
+        recorded_on: "2026-03-19",
+        source_note: "400 easy + 200 hard test",
+      },
+    });
+  });
+
+  it("rejects malformed CSS pace values", () => {
+    expect(
+      buildCssMetricUpsert({
+        pace: "118",
+      })
+    ).toEqual({
+      kind: "invalid",
+      error: "Use CSS pace format m:ss, for example 1:58.",
+    });
+  });
+
+  it("formats canonical CSS seconds back to swimmer-friendly pace", () => {
+    expect(formatCssSecondsPer100m(118)).toBe("1:58");
+  });
+
+  it("normalizes and sorts available days", () => {
+    expect(normalizeWeekdays(["wednesday", "monday", "wednesday"])).toEqual([
+      "monday",
+      "wednesday",
+    ]);
+  });
+
+  it("builds canonical training preferences payloads", () => {
+    expect(
+      buildTrainingPreferencesUpsert({
+        poolLengthM: "25",
+        availableDays: ["wednesday", "monday"],
+        preferredWeeklySessionCount: "5",
+        preferredSessionMinutes: "60",
+      })
+    ).toEqual({
+      kind: "valid",
+      value: {
+        pool_length_m: 25,
+        available_days: ["monday", "wednesday"],
+        preferred_weekly_session_count: 5,
+        preferred_session_minutes: 60,
+      },
+    });
+  });
+
+  it("rejects unsupported preference values", () => {
+    expect(
+      buildTrainingPreferencesUpsert({
+        poolLengthM: "33",
+      })
+    ).toEqual({
+      kind: "invalid",
+      error: "Pool length must be 25m or 50m.",
+    });
+  });
+});

--- a/tests/unit/user-export-payload.test.ts
+++ b/tests/unit/user-export-payload.test.ts
@@ -22,6 +22,27 @@ describe("buildUserExportPayload", () => {
         created_at: "2026-03-19T08:00:00.000Z",
         updated_at: "2026-03-19T08:05:00.000Z",
       },
+      trainingMetrics: [
+        {
+          id: "metric-1",
+          metric_key: "css",
+          unit: "seconds_per_100m",
+          value_seconds: 118,
+          recorded_on: "2026-03-19",
+          source_note: "400 + 200 test",
+          created_at: "2026-03-19T08:10:00.000Z",
+          updated_at: "2026-03-19T08:11:00.000Z",
+        },
+      ],
+      trainingPreferences: {
+        id: "pref-1",
+        pool_length_m: 25,
+        available_days: ["monday", "wednesday"],
+        preferred_weekly_session_count: 5,
+        preferred_session_minutes: 60,
+        created_at: "2026-03-19T08:12:00.000Z",
+        updated_at: "2026-03-19T08:13:00.000Z",
+      },
       entitlements: [
         {
           id: "ent-1",
@@ -119,7 +140,7 @@ describe("buildUserExportPayload", () => {
 
     expect(payload).toEqual({
       generatedAt: "2026-02-17T12:00:00.000Z",
-      schemaVersion: "2026-03-19-athlete-profile",
+      schemaVersion: "2026-03-19-athlete-profile-training-setup",
       user: {
         id: "user-1",
         email: "swimmer@example.com",
@@ -138,6 +159,27 @@ describe("buildUserExportPayload", () => {
         ageBand: "35_44",
         createdAt: "2026-03-19T08:00:00.000Z",
         updatedAt: "2026-03-19T08:05:00.000Z",
+      },
+      trainingMetrics: [
+        {
+          id: "metric-1",
+          metricKey: "css",
+          unit: "seconds_per_100m",
+          valueSeconds: 118,
+          recordedOn: "2026-03-19",
+          sourceNote: "400 + 200 test",
+          createdAt: "2026-03-19T08:10:00.000Z",
+          updatedAt: "2026-03-19T08:11:00.000Z",
+        },
+      ],
+      trainingPreferences: {
+        id: "pref-1",
+        poolLengthM: 25,
+        availableDays: ["monday", "wednesday"],
+        preferredWeeklySessionCount: 5,
+        preferredSessionMinutes: 60,
+        createdAt: "2026-03-19T08:12:00.000Z",
+        updatedAt: "2026-03-19T08:13:00.000Z",
       },
       entitlements: [
         {
@@ -242,6 +284,8 @@ describe("buildUserExportPayload", () => {
       generatedAt: "2026-02-17T12:00:00.000Z",
       profile: null,
       athleteProfile: null,
+      trainingMetrics: [],
+      trainingPreferences: null,
       entitlements: [],
       courseProgress: [],
       guideProgress: [],

--- a/types/database.ts
+++ b/types/database.ts
@@ -909,6 +909,75 @@ export type Database = {
         };
         Relationships: [];
       };
+      training_metrics: {
+        Row: {
+          created_at: string;
+          id: string;
+          metric_key: string;
+          recorded_on: string | null;
+          source_note: string | null;
+          unit: string;
+          updated_at: string;
+          user_id: string;
+          value_seconds: number;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          metric_key: string;
+          recorded_on?: string | null;
+          source_note?: string | null;
+          unit: string;
+          updated_at?: string;
+          user_id: string;
+          value_seconds: number;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          metric_key?: string;
+          recorded_on?: string | null;
+          source_note?: string | null;
+          unit?: string;
+          updated_at?: string;
+          user_id?: string;
+          value_seconds?: number;
+        };
+        Relationships: [];
+      };
+      training_preferences: {
+        Row: {
+          available_days: string[] | null;
+          created_at: string;
+          id: string;
+          pool_length_m: number | null;
+          preferred_session_minutes: number | null;
+          preferred_weekly_session_count: number | null;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          available_days?: string[] | null;
+          created_at?: string;
+          id?: string;
+          pool_length_m?: number | null;
+          preferred_session_minutes?: number | null;
+          preferred_weekly_session_count?: number | null;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          available_days?: string[] | null;
+          created_at?: string;
+          id?: string;
+          pool_length_m?: number | null;
+          preferred_session_minutes?: number | null;
+          preferred_weekly_session_count?: number | null;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
       profiles: {
         Row: {
           created_at: string;


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-03-19T13:41:27.173Z for branch `feat/my-library-training-metrics-preferences-foundation` (base ref `origin/main`).
- Latest commit: `7913635` - feat(my-library): add training metrics and preferences foundation.
- User-visible changes: User/admin runtime behavior may change on touched routes/components.
- Technical changes: Updated 21 file(s): `app/api/my-library/profile/metrics/route.ts`, `app/api/my-library/profile/preferences/route.ts`, `app/api/user/export/route.ts`, `app/my-library/page.tsx`, `app/my-library/profile/page.tsx`, `... and 16 more file(s)`.
- Policy impact: yes (inferred from changed scope: `app/api/user/export/route.ts`, `lib/analytics/events.ts`, `supabase/migrations/20260319213000_training_metrics_and_preferences_foundation.sql`).
- Policy version note: N/A (if policy text/version changes, replace with YYYY-MM-DD.rev and rationale).
- Brief link(s): `docs/task-briefs/in-progress/2026-03-19-my-library-training-metrics-and-preferences-foundation-10-10.md`
- Scorecard target outcomes: 12 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (2); tests (6); API handlers (3); runtime UI/routes/components (8); other files (2).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (21):
  - `app/api/my-library/profile/metrics/route.ts`
  - `app/api/my-library/profile/preferences/route.ts`
  - `app/api/user/export/route.ts`
  - `app/my-library/page.tsx`
  - `app/my-library/profile/page.tsx`
  - `components/my-library/profile/AthleteProfileHub.tsx`
  - `docs/task-briefs/in-progress/2026-03-19-my-library-training-metrics-and-preferences-foundation-10-10.md`
  - `docs/task-briefs/planned/2026-03-19-my-library-athlete-profile-training-metrics-and-preferences-10-10.md`
  - `... and 13 more file(s)`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `7913635` (`git revert 7913635`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **NOT RUN** (artifacts/test-runs/admin-short-session)
- `npm run verify:pre-merge`: **PENDING** for `7913635` (latest PASS was `2a80d8d` at 2026-03-19T12:49:23Z; rerun on current HEAD).
- Policy-impact checklist: PENDING (run docs/checklists/policy-impact-release-review.md and update to PASS/FAIL).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  - No local verify log found in `artifacts/test-runs/latest`.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
