### PR TITLE
docs(briefs): close out training metrics preferences foundation

### DIFF
--- a/docs/task-briefs/done/2026-03-19-my-library-training-metrics-and-preferences-foundation-10-10.md
+++ b/docs/task-briefs/done/2026-03-19-my-library-training-metrics-and-preferences-foundation-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-03-19-my-library-training-metrics-and-preferences-foundation-10-10`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-03-19`
 - `updated`: `2026-03-19`
@@ -276,3 +276,4 @@ Critical target categories for `10/10` claim in this brief:
 
 - `2026-03-19`: Child brief created and moved to `in-progress` for private training metrics and preferences foundation. `Personal records` stay deferred to a later child slice.
 - `2026-03-19 | feat/my-library-training-metrics-preferences-foundation | implemented training metrics + preferences foundation: added private CSS metric + training preferences schema/API/UI/export support, updated My Library summary/profile surfaces, added validation/authz/export/draft-recovery coverage, and ran targeted typecheck/unit/e2e plus full \`npm run verify:pre-pr\` PASS. Perf trend recommended \`tighten\` after another weekly green run; decision for this non-perf slice is \`hold\` and carry the ratchet decision in the next perf-focused workstream.`
+- `2026-03-19 | 4101d21 (main) | child slice 2 shipped via PR #239 with private CSS metric + structured training preferences on My Library/profile, export support, and green local/CI gates | next: take Personal records as the next child slice and keep generator-prefill work deferred`

--- a/docs/task-briefs/planned/2026-03-19-my-library-athlete-profile-training-metrics-and-preferences-10-10.md
+++ b/docs/task-briefs/planned/2026-03-19-my-library-athlete-profile-training-metrics-and-preferences-10-10.md
@@ -228,10 +228,10 @@ Critical target categories for `10/10` claim in this brief:
 
 1. `Athlete profile foundation`
    - private profile hub, create/edit/save flow, privacy-safe field model.
-2. `Training metrics and personal records`
-   - CSS, PR CRUD, unit validation, date/source metadata.
-3. `Training preferences and availability`
-   - available days, pool length, session duration, weekly frequency, constraints.
+2. `Training metrics and preferences foundation`
+   - CSS, pool length, available days, weekly session count, session duration band, validation, and export support.
+3. `Personal records foundation`
+   - PR CRUD, distance/stroke/course/time/date/source metadata, and generator-ready serialization.
 4. `Generator prefill from athlete profile + metrics + preferences`
    - read-only consumption of canonical user context in generator flows.
 
@@ -239,7 +239,7 @@ Critical target categories for `10/10` claim in this brief:
 
 - `2026-03-19`: Parent brief created to lock the broader profile/metrics/preferences direction before implementation.
 - `2026-03-19 | e830b21 (main) | child slice 1 shipped via PR #237 for private athlete-profile foundation; profile hub, canonical row, local draft recovery, and export compatibility are now on main | next: take training metrics + preferences as the next child slice and continue to defer personal records`
-- `2026-03-19 | in-progress | child slice 2 started in docs/task-briefs/in-progress/2026-03-19-my-library-training-metrics-and-preferences-foundation-10-10.md with scope locked to CSS + practical preferences only; personal records remain deferred to a later child | next: implement canonical metrics/preferences schema, private My Library UX, export support, and tests`
+- `2026-03-19 | 4101d21 (main) | child slice 2 shipped via PR #239 in docs/task-briefs/done/2026-03-19-my-library-training-metrics-and-preferences-foundation-10-10.md with canonical CSS, structured training preferences, My Library/profile UX, export support, and green local/CI gates | next: take Personal records as the next child slice and continue to defer generator-prefill automation`
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-03-19T14:10:20.509Z for branch `docs/training-metrics-preferences-foundation-closeout` (base ref `origin/main`).
- Latest commit: `53342fa` - docs(briefs): close out training metrics preferences foundation.
- User-visible changes: No direct end-user/admin runtime behavior change; this PR improves docs/tooling/governance workflow quality.
- Technical changes: Updated 2 file(s): `docs/task-briefs/done/2026-03-19-my-library-training-metrics-and-preferences-foundation-10-10.md`, `docs/task-briefs/planned/2026-03-19-my-library-athlete-profile-training-metrics-and-preferences-10-10.md`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/done/2026-03-19-my-library-training-metrics-and-preferences-foundation-10-10.md`
- Scorecard target outcomes: 12 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (2).
- Out of scope: Application runtime behavior, DB schema, and content payloads remain unchanged.
- Changed files (2):
  - `docs/task-briefs/done/2026-03-19-my-library-training-metrics-and-preferences-foundation-10-10.md`
  - `docs/task-briefs/planned/2026-03-19-my-library-athlete-profile-training-metrics-and-preferences-10-10.md`

## Risk

- Main risk: Operational/docs drift if generated scope/evidence text does not match final merged changes.
- Rollback plan: Revert `53342fa` (`git revert 53342fa`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **NOT RUN** (artifacts/test-runs/admin-short-session)
- `npm run verify:pre-merge`: **PENDING** for `53342fa` (latest PASS was `7913635` at 2026-03-19T13:47:52Z; rerun on current HEAD).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  - No local verify log found in `artifacts/test-runs/latest`.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
