### PR TITLE
feat(profile): add personal records foundation

### DIFF
--- a/app/api/my-library/profile/records/[recordId]/route.ts
+++ b/app/api/my-library/profile/records/[recordId]/route.ts
@@ -1,0 +1,188 @@
+import { NextResponse } from "next/server";
+import { buildPersonalRecordUpsert } from "@/lib/athlete-profile/personal-records";
+import { PERSONAL_RECORD_SELECT, loadAthleteProfileSnapshot } from "@/lib/athlete-profile/server";
+import { isPersonalRecordsSchemaMissing } from "@/lib/athlete-profile/schema";
+import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
+
+type PersonalRecordRequestBody = {
+  distanceM?: number | string | null;
+  stroke?: string | null;
+  course?: string | null;
+  time?: string | null;
+  recordedOn?: string | null;
+  sourceNote?: string | null;
+};
+
+function noStoreJson(
+  body: Record<string, unknown>,
+  init?: {
+    status?: number;
+  }
+) {
+  return NextResponse.json(body, {
+    status: init?.status ?? 200,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+function isDuplicateEventError(error: { code?: string | null } | null | undefined) {
+  return error?.code === "23505";
+}
+
+export async function PUT(
+  request: Request,
+  context: {
+    params: Promise<{ recordId: string }>;
+  }
+) {
+  const { recordId } = await context.params;
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Unauthorized." }, { status: 401 })
+    );
+  }
+
+  let body: PersonalRecordRequestBody;
+  try {
+    body = (await request.json()) as PersonalRecordRequestBody;
+  } catch {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Invalid JSON body." }, { status: 400 })
+    );
+  }
+
+  const nextRecord = buildPersonalRecordUpsert(body);
+  if (nextRecord.kind === "empty") {
+    return applySupabaseCookies(
+      noStoreJson(
+        { ok: false, error: "Add distance, stroke, course, and time before saving." },
+        { status: 400 }
+      )
+    );
+  }
+
+  if (nextRecord.kind === "invalid") {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: nextRecord.error }, { status: 400 })
+    );
+  }
+
+  const result = await supabase
+    .from("personal_records")
+    .update(nextRecord.value)
+    .eq("id", recordId)
+    .eq("user_id", user.id)
+    .select(PERSONAL_RECORD_SELECT)
+    .maybeSingle();
+
+  if (isPersonalRecordsSchemaMissing(result.error)) {
+    return applySupabaseCookies(
+      noStoreJson(
+        { ok: false, error: "Personal records are still syncing in this environment." },
+        { status: 503 }
+      )
+    );
+  }
+
+  if (isDuplicateEventError(result.error)) {
+    return applySupabaseCookies(
+      noStoreJson(
+        {
+          ok: false,
+          error: "A personal record for this event already exists. Update that record instead.",
+        },
+        { status: 409 }
+      )
+    );
+  }
+
+  if (result.error) {
+    console.error("[PersonalRecordsApi] Could not update personal record", result.error);
+    return applySupabaseCookies(
+      noStoreJson(
+        { ok: false, error: "Could not update personal record right now." },
+        { status: 500 }
+      )
+    );
+  }
+
+  if (!result.data) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Personal record not found." }, { status: 404 })
+    );
+  }
+
+  return applySupabaseCookies(
+    noStoreJson({
+      ok: true,
+      recordId: result.data.id,
+      snapshot: await loadAthleteProfileSnapshot(supabase, user.id),
+    })
+  );
+}
+
+export async function DELETE(
+  _request: Request,
+  context: {
+    params: Promise<{ recordId: string }>;
+  }
+) {
+  const { recordId } = await context.params;
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Unauthorized." }, { status: 401 })
+    );
+  }
+
+  const result = await supabase
+    .from("personal_records")
+    .delete()
+    .eq("id", recordId)
+    .eq("user_id", user.id)
+    .select("id")
+    .maybeSingle();
+
+  if (isPersonalRecordsSchemaMissing(result.error)) {
+    return applySupabaseCookies(
+      noStoreJson(
+        { ok: false, error: "Personal records are still syncing in this environment." },
+        { status: 503 }
+      )
+    );
+  }
+
+  if (result.error) {
+    console.error("[PersonalRecordsApi] Could not delete personal record", result.error);
+    return applySupabaseCookies(
+      noStoreJson(
+        { ok: false, error: "Could not delete personal record right now." },
+        { status: 500 }
+      )
+    );
+  }
+
+  if (!result.data) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Personal record not found." }, { status: 404 })
+    );
+  }
+
+  return applySupabaseCookies(
+    noStoreJson({
+      ok: true,
+      snapshot: await loadAthleteProfileSnapshot(supabase, user.id),
+    })
+  );
+}

--- a/app/api/my-library/profile/records/route.ts
+++ b/app/api/my-library/profile/records/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from "next/server";
+import { buildPersonalRecordUpsert } from "@/lib/athlete-profile/personal-records";
+import { PERSONAL_RECORD_SELECT, loadAthleteProfileSnapshot } from "@/lib/athlete-profile/server";
+import { isPersonalRecordsSchemaMissing } from "@/lib/athlete-profile/schema";
+import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
+
+type PersonalRecordRequestBody = {
+  distanceM?: number | string | null;
+  stroke?: string | null;
+  course?: string | null;
+  time?: string | null;
+  recordedOn?: string | null;
+  sourceNote?: string | null;
+};
+
+function noStoreJson(
+  body: Record<string, unknown>,
+  init?: {
+    status?: number;
+  }
+) {
+  return NextResponse.json(body, {
+    status: init?.status ?? 200,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+function isDuplicateEventError(error: { code?: string | null } | null | undefined) {
+  return error?.code === "23505";
+}
+
+export async function POST(request: Request) {
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Unauthorized." }, { status: 401 })
+    );
+  }
+
+  let body: PersonalRecordRequestBody;
+  try {
+    body = (await request.json()) as PersonalRecordRequestBody;
+  } catch {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Invalid JSON body." }, { status: 400 })
+    );
+  }
+
+  const nextRecord = buildPersonalRecordUpsert(body);
+  if (nextRecord.kind === "empty") {
+    return applySupabaseCookies(
+      noStoreJson(
+        { ok: false, error: "Add distance, stroke, course, and time before saving." },
+        { status: 400 }
+      )
+    );
+  }
+
+  if (nextRecord.kind === "invalid") {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: nextRecord.error }, { status: 400 })
+    );
+  }
+
+  const result = await supabase
+    .from("personal_records")
+    .insert({
+      user_id: user.id,
+      ...nextRecord.value,
+    })
+    .select(PERSONAL_RECORD_SELECT)
+    .single();
+
+  if (isPersonalRecordsSchemaMissing(result.error)) {
+    return applySupabaseCookies(
+      noStoreJson(
+        { ok: false, error: "Personal records are still syncing in this environment." },
+        { status: 503 }
+      )
+    );
+  }
+
+  if (isDuplicateEventError(result.error)) {
+    return applySupabaseCookies(
+      noStoreJson(
+        {
+          ok: false,
+          error:
+            "A personal record for this event already exists. Edit the existing record instead.",
+        },
+        { status: 409 }
+      )
+    );
+  }
+
+  if (result.error) {
+    console.error("[PersonalRecordsApi] Could not create personal record", result.error);
+    return applySupabaseCookies(
+      noStoreJson(
+        { ok: false, error: "Could not save personal record right now." },
+        { status: 500 }
+      )
+    );
+  }
+
+  return applySupabaseCookies(
+    noStoreJson({
+      ok: true,
+      recordId: result.data.id,
+      snapshot: await loadAthleteProfileSnapshot(supabase, user.id),
+    })
+  );
+}

--- a/app/api/my-library/profile/route.ts
+++ b/app/api/my-library/profile/route.ts
@@ -1,10 +1,6 @@
 import { NextResponse } from "next/server";
 import { buildAthleteProfileUpsert, type AthleteAgeBand } from "@/lib/athlete-profile/mvp";
-import {
-  ATHLETE_PROFILE_SELECT,
-  buildAthleteProfileView,
-  loadAthleteProfileSnapshot,
-} from "@/lib/athlete-profile/server";
+import { ATHLETE_PROFILE_SELECT, loadAthleteProfileSnapshot } from "@/lib/athlete-profile/server";
 import { isAthleteProfileSchemaMissing } from "@/lib/athlete-profile/schema";
 import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
 
@@ -121,11 +117,7 @@ export async function PUT(request: Request) {
   return applySupabaseCookies(
     noStoreJson({
       ok: true,
-      snapshot: {
-        schemaReady: true,
-        loadError: null,
-        profile: buildAthleteProfileView(result.data),
-      },
+      snapshot: await loadAthleteProfileSnapshot(supabase, user.id),
     })
   );
 }

--- a/app/api/user/export/route.ts
+++ b/app/api/user/export/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { COURSE_MODULES } from "@/app/course/courseData";
 import {
   isAthleteProfileSchemaMissing,
+  isPersonalRecordsSchemaMissing,
   isTrainingMetricSchemaMissing,
   isTrainingPreferencesSchemaMissing,
 } from "@/lib/athlete-profile/schema";
@@ -53,6 +54,7 @@ export async function GET() {
     athleteProfileResult,
     trainingMetricsResult,
     trainingPreferencesResult,
+    personalRecordsResult,
     entitlementsResult,
     courseProgressResult,
     guideProgressResult,
@@ -86,6 +88,13 @@ export async function GET() {
       )
       .eq("user_id", userId)
       .maybeSingle(),
+    supabase
+      .from("personal_records")
+      .select(
+        "id, distance_m, stroke, course, time_centiseconds, recorded_on, source_note, created_at, updated_at"
+      )
+      .eq("user_id", userId)
+      .order("distance_m", { ascending: true }),
     supabase
       .from("entitlements")
       .select(
@@ -148,6 +157,10 @@ export async function GET() {
     isTrainingPreferencesSchemaMissing(trainingPreferencesResult.error)
       ? null
       : (trainingPreferencesResult.data ?? null);
+  const normalizedPersonalRecords =
+    personalRecordsResult.error && isPersonalRecordsSchemaMissing(personalRecordsResult.error)
+      ? []
+      : (personalRecordsResult.data ?? []);
   const normalizedTrainingFocuses =
     trainingFocusesResult.error && isTrainingContextSchemaMissing(trainingFocusesResult.error)
       ? []
@@ -168,6 +181,9 @@ export async function GET() {
     (trainingPreferencesResult.error &&
     !isTrainingPreferencesSchemaMissing(trainingPreferencesResult.error)
       ? trainingPreferencesResult.error
+      : null) ??
+    (personalRecordsResult.error && !isPersonalRecordsSchemaMissing(personalRecordsResult.error)
+      ? personalRecordsResult.error
       : null) ??
     entitlementsResult.error ??
     courseProgressResult.error ??
@@ -196,6 +212,7 @@ export async function GET() {
       athleteProfile: normalizedAthleteProfile,
       trainingMetrics: normalizedTrainingMetrics,
       trainingPreferences: normalizedTrainingPreferences,
+      personalRecords: normalizedPersonalRecords,
       entitlements: entitlementsResult.data ?? [],
       courseProgress: normalizeCourseProgressRows(courseProgressResult.data ?? [], {
         resolveLessonId,

--- a/app/my-library/page.tsx
+++ b/app/my-library/page.tsx
@@ -140,14 +140,15 @@ export default async function MyLibraryPage() {
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <h2 className="text-lg font-semibold text-slate-900">
-                    Athlete profile & training setup
+                    Athlete profile, training setup & records
                   </h2>
                   <p className="mt-2 text-sm text-slate-600">
                     {!athleteProfileSnapshot.profileSchemaReady
                       ? "This athlete profile foundation is still syncing in this environment."
                       : athleteProfileSnapshot.profile ||
                           athleteProfileSnapshot.cssMetric ||
-                          athleteProfileSnapshot.preferences
+                          athleteProfileSnapshot.preferences ||
+                          athleteProfileSnapshot.personalRecords.length > 0
                         ? [
                             athleteProfileSnapshot.profile?.primaryName ?? "Private swimmer",
                             athleteProfileSnapshot.profile?.ageBandLabel ?? null,
@@ -158,10 +159,13 @@ export default async function MyLibraryPage() {
                             athleteProfileSnapshot.preferences?.preferredWeeklySessionCount
                               ? `${athleteProfileSnapshot.preferences.preferredWeeklySessionCount} sessions/week`
                               : null,
+                            athleteProfileSnapshot.personalRecords.length > 0
+                              ? `${athleteProfileSnapshot.personalRecords.length} record${athleteProfileSnapshot.personalRecords.length === 1 ? "" : "s"}`
+                              : null,
                           ]
                             .filter(Boolean)
                             .join(" · ")
-                        : "Add your private swimmer profile, current CSS, and practical preferences now so later generator work has a real foundation."}
+                        : "Add your private swimmer profile, current CSS, practical preferences, and personal records now so later generator work has a real foundation."}
                   </p>
                 </div>
                 <Link

--- a/app/my-library/profile/page.tsx
+++ b/app/my-library/profile/page.tsx
@@ -29,9 +29,11 @@ export default async function MyLibraryProfilePage() {
             hasProfile: Boolean(initialSnapshot.profile),
             hasCssMetric: Boolean(initialSnapshot.cssMetric),
             hasPreferences: Boolean(initialSnapshot.preferences),
+            personalRecordCount: initialSnapshot.personalRecords.length,
             profileSchemaReady: initialSnapshot.profileSchemaReady,
             metricsSchemaReady: initialSnapshot.metricsSchemaReady,
             preferencesSchemaReady: initialSnapshot.preferencesSchemaReady,
+            personalRecordsSchemaReady: initialSnapshot.personalRecordsSchemaReady,
           }}
         />
         <div className="rounded-3xl border border-blue-100 bg-white/95 p-8 shadow-[0_16px_60px_rgba(24,58,107,0.14)]">
@@ -41,11 +43,12 @@ export default async function MyLibraryProfilePage() {
                 My Library
               </p>
               <h1 className="mt-2 text-3xl font-bold text-slate-900">
-                Athlete profile & training setup
+                Athlete profile, training setup & records
               </h1>
               <p className="mt-2 max-w-[64ch] text-sm text-slate-600">
-                Keep a private swimmer profile, trusted CSS, and practical training preferences
-                together in one place without mixing them into Goals, Focus, or Notes.
+                Keep a private swimmer profile, trusted CSS, practical training preferences, and
+                current personal records together in one place without mixing them into Goals,
+                Focus, or Notes.
               </p>
             </div>
             <div className="flex flex-wrap gap-2">
@@ -66,7 +69,7 @@ export default async function MyLibraryProfilePage() {
 
           <div className="mt-8 rounded-2xl border border-blue-100 bg-blue-50/60 p-5">
             <h2 className="text-base font-semibold text-slate-900">How this fits</h2>
-            <div className="mt-3 grid gap-3 md:grid-cols-3">
+            <div className="mt-3 grid gap-3 lg:grid-cols-4">
               <div className="rounded-2xl border border-white/80 bg-white/80 p-4">
                 <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
                   Athlete profile
@@ -81,6 +84,14 @@ export default async function MyLibraryProfilePage() {
                 </p>
                 <p className="mt-2 text-sm text-slate-700">
                   Trusted CSS and practical defaults that later help shape session generation.
+                </p>
+              </div>
+              <div className="rounded-2xl border border-white/80 bg-white/80 p-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-emerald-700">
+                  Personal records
+                </p>
+                <p className="mt-2 text-sm text-slate-700">
+                  Private current bests for explicit swim events, ready for later generator use.
                 </p>
               </div>
               <div className="rounded-2xl border border-white/80 bg-white/80 p-4">

--- a/components/my-library/profile/AthleteProfileHub.tsx
+++ b/components/my-library/profile/AthleteProfileHub.tsx
@@ -8,6 +8,12 @@ import {
   type AthleteAgeBand,
 } from "@/lib/athlete-profile/mvp";
 import {
+  PERSONAL_RECORD_COURSE_OPTIONS,
+  PERSONAL_RECORD_STROKE_OPTIONS,
+  type PersonalRecordCourse,
+  type PersonalRecordStroke,
+} from "@/lib/athlete-profile/personal-records";
+import {
   formatCssSecondsPer100m,
   TRAINING_POOL_LENGTH_OPTIONS,
   TRAINING_SESSION_DURATION_OPTIONS,
@@ -18,6 +24,7 @@ import {
 import type {
   AthleteProfileSnapshot,
   AthleteProfileView,
+  PersonalRecordView,
   TrainingMetricView,
   TrainingPreferencesView,
 } from "@/lib/athlete-profile/server";
@@ -31,6 +38,7 @@ type Props = {
 type ApiError = {
   ok?: boolean;
   error?: string;
+  recordId?: string;
   snapshot?: AthleteProfileSnapshot;
 };
 
@@ -52,6 +60,16 @@ type TrainingPreferencesDraft = {
   availableDays: TrainingWeekday[];
   preferredWeeklySessionCount: string;
   preferredSessionMinutes: "" | "30" | "45" | "60" | "75" | "90";
+};
+
+type PersonalRecordDraft = {
+  editingRecordId: string | null;
+  distanceM: string;
+  stroke: PersonalRecordStroke | "";
+  course: PersonalRecordCourse | "";
+  time: string;
+  recordedOn: string;
+  sourceNote: string;
 };
 
 function buildProfileDraft(profile: AthleteProfileView | null): AthleteProfileDraft {
@@ -88,7 +106,19 @@ function buildPreferencesDraft(
   };
 }
 
-function getStorageKey(userId: string, scope: "profile" | "css" | "preferences") {
+function buildPersonalRecordDraft(record: PersonalRecordView | null): PersonalRecordDraft {
+  return {
+    editingRecordId: record?.id ?? null,
+    distanceM: record?.distanceM ? String(record.distanceM) : "",
+    stroke: record?.stroke ?? "",
+    course: record?.course ?? "",
+    time: record?.timeLabel ?? "",
+    recordedOn: record?.recordedOn ?? "",
+    sourceNote: record?.sourceNote ?? "",
+  };
+}
+
+function getStorageKey(userId: string, scope: "profile" | "css" | "preferences" | "records") {
   return `my-library-athlete-profile-${scope}-draft:${userId}`;
 }
 
@@ -125,6 +155,11 @@ function buildAvailableDaysSummary(days: string[]): string {
   return days.join(", ");
 }
 
+function findRecordById(records: PersonalRecordView[], recordId: string | null) {
+  if (!recordId) return null;
+  return records.find((record) => record.id === recordId) ?? null;
+}
+
 export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
   const [snapshot, setSnapshot] = useState(initialSnapshot);
   const [profileDraft, setProfileDraft] = useState(() =>
@@ -134,6 +169,7 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
   const [preferencesDraft, setPreferencesDraft] = useState(() =>
     buildPreferencesDraft(initialSnapshot.preferences)
   );
+  const [recordDraft, setRecordDraft] = useState(() => buildPersonalRecordDraft(null));
   const [actionError, setActionError] = useState("");
   const [actionSuccess, setActionSuccess] = useState("");
   const [isOnline, setIsOnline] = useState(true);
@@ -141,13 +177,17 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
   const [pendingProfileSave, setPendingProfileSave] = useState(false);
   const [pendingCssSave, setPendingCssSave] = useState(false);
   const [pendingPreferencesSave, setPendingPreferencesSave] = useState(false);
+  const [pendingRecordSave, setPendingRecordSave] = useState(false);
+  const [pendingRecordDeleteId, setPendingRecordDeleteId] = useState<string | null>(null);
   const [profileDraftRecovered, setProfileDraftRecovered] = useState(false);
   const [cssDraftRecovered, setCssDraftRecovered] = useState(false);
   const [preferencesDraftRecovered, setPreferencesDraftRecovered] = useState(false);
+  const [recordDraftRecovered, setRecordDraftRecovered] = useState(false);
 
   const profileStorageKey = useMemo(() => getStorageKey(userId, "profile"), [userId]);
   const cssStorageKey = useMemo(() => getStorageKey(userId, "css"), [userId]);
   const preferencesStorageKey = useMemo(() => getStorageKey(userId, "preferences"), [userId]);
+  const recordStorageKey = useMemo(() => getStorageKey(userId, "records"), [userId]);
 
   const savedProfileDraft = useMemo(() => buildProfileDraft(snapshot.profile), [snapshot.profile]);
   const savedCssDraft = useMemo(
@@ -157,6 +197,13 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
   const savedPreferencesDraft = useMemo(
     () => buildPreferencesDraft(snapshot.preferences),
     [snapshot.preferences]
+  );
+  const savedRecordDraft = useMemo(
+    () =>
+      buildPersonalRecordDraft(
+        findRecordById(snapshot.personalRecords, recordDraft.editingRecordId)
+      ),
+    [recordDraft.editingRecordId, snapshot.personalRecords]
   );
 
   const hasUnsavedProfileChanges = useMemo(
@@ -171,6 +218,10 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
     () => serializeDraft(preferencesDraft) !== serializeDraft(savedPreferencesDraft),
     [preferencesDraft, savedPreferencesDraft]
   );
+  const hasUnsavedRecordChanges = useMemo(
+    () => serializeDraft(recordDraft) !== serializeDraft(savedRecordDraft),
+    [recordDraft, savedRecordDraft]
+  );
 
   useEffect(() => {
     setIsOnline(readNavigatorOnlineState());
@@ -178,14 +229,17 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
     const nextProfileFallback = buildProfileDraft(initialSnapshot.profile);
     const nextCssFallback = buildCssMetricDraft(initialSnapshot.cssMetric);
     const nextPreferencesFallback = buildPreferencesDraft(initialSnapshot.preferences);
+    const nextRecordFallback = buildPersonalRecordDraft(null);
 
     const storedProfileDraft = getStorageValue(profileStorageKey, nextProfileFallback);
     const storedCssDraft = getStorageValue(cssStorageKey, nextCssFallback);
     const storedPreferencesDraft = getStorageValue(preferencesStorageKey, nextPreferencesFallback);
+    const storedRecordDraft = getStorageValue(recordStorageKey, nextRecordFallback);
 
     setProfileDraft(storedProfileDraft);
     setCssDraft(storedCssDraft);
     setPreferencesDraft(storedPreferencesDraft);
+    setRecordDraft(storedRecordDraft);
 
     setProfileDraftRecovered(
       serializeDraft(storedProfileDraft) !== serializeDraft(nextProfileFallback)
@@ -193,6 +247,9 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
     setCssDraftRecovered(serializeDraft(storedCssDraft) !== serializeDraft(nextCssFallback));
     setPreferencesDraftRecovered(
       serializeDraft(storedPreferencesDraft) !== serializeDraft(nextPreferencesFallback)
+    );
+    setRecordDraftRecovered(
+      serializeDraft(storedRecordDraft) !== serializeDraft(nextRecordFallback)
     );
     setActionError("");
 
@@ -214,10 +271,12 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
   }, [
     cssStorageKey,
     initialSnapshot.cssMetric,
+    initialSnapshot.personalRecords,
     initialSnapshot.preferences,
     initialSnapshot.profile,
     preferencesStorageKey,
     profileStorageKey,
+    recordStorageKey,
   ]);
 
   useEffect(() => {
@@ -246,6 +305,15 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
 
     setStorageValue(preferencesStorageKey, preferencesDraft);
   }, [preferencesDraft, preferencesStorageKey, savedPreferencesDraft]);
+
+  useEffect(() => {
+    if (serializeDraft(recordDraft) === serializeDraft(savedRecordDraft)) {
+      clearStorageValue(recordStorageKey);
+      return;
+    }
+
+    setStorageValue(recordStorageKey, recordDraft);
+  }, [recordDraft, recordStorageKey, savedRecordDraft]);
 
   async function parseError(response: Response, fallback: string) {
     const payload = (await response.json().catch(() => null)) as ApiError | null;
@@ -288,10 +356,19 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
         setPreferencesDraft(buildPreferencesDraft(payload.snapshot.preferences));
       }
 
+      if (!hasUnsavedRecordChanges) {
+        setRecordDraft(
+          buildPersonalRecordDraft(
+            findRecordById(payload.snapshot.personalRecords, recordDraft.editingRecordId)
+          )
+        );
+      }
+
       void sendClientAnalyticsEvent("athlete_profile_refreshed", {
         hasProfile: Boolean(payload.snapshot.profile),
         hasCssMetric: Boolean(payload.snapshot.cssMetric),
         hasPreferences: Boolean(payload.snapshot.preferences),
+        personalRecordCount: payload.snapshot.personalRecords.length,
       });
     } catch {
       setActionError("Could not refresh training setup right now.");
@@ -471,6 +548,129 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
     }
   }
 
+  async function savePersonalRecord(event: React.FormEvent) {
+    event.preventDefault();
+
+    if (!snapshot.personalRecordsSchemaReady) {
+      setActionError("Personal records are still syncing in this environment.");
+      return;
+    }
+
+    if (!isOnline) {
+      setActionError("You are offline. Reconnect before saving personal records.");
+      return;
+    }
+
+    setPendingRecordSave(true);
+    setActionError("");
+    setActionSuccess("");
+
+    const isEditing = Boolean(recordDraft.editingRecordId);
+    const requestUrl = recordDraft.editingRecordId
+      ? `/api/my-library/profile/records/${recordDraft.editingRecordId}`
+      : "/api/my-library/profile/records";
+    const requestMethod = recordDraft.editingRecordId ? "PUT" : "POST";
+
+    try {
+      const response = await fetch(requestUrl, {
+        method: requestMethod,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(recordDraft),
+      });
+
+      if (!response.ok) {
+        setActionError(await parseError(response, "Could not save personal record right now."));
+        return;
+      }
+
+      const payload = (await response.json().catch(() => null)) as ApiError | null;
+      if (!payload?.ok || !payload.snapshot) {
+        setActionError("Could not save personal record right now.");
+        return;
+      }
+
+      const nextDraft = buildPersonalRecordDraft(
+        findRecordById(payload.snapshot.personalRecords, payload.recordId ?? null)
+      );
+
+      setSnapshot(payload.snapshot);
+      setRecordDraft(nextDraft);
+      clearStorageValue(recordStorageKey);
+      setRecordDraftRecovered(false);
+      setActionSuccess(isEditing ? "Personal record updated." : "Personal record saved.");
+
+      const savedRecord = findRecordById(
+        payload.snapshot.personalRecords,
+        payload.recordId ?? null
+      );
+      void sendClientAnalyticsEvent("personal_record_saved", {
+        eventLabel: savedRecord?.eventLabel ?? null,
+        hasRecordedOn: Boolean(savedRecord?.recordedOn),
+      });
+    } catch {
+      setActionError("Could not save personal record right now.");
+    } finally {
+      setPendingRecordSave(false);
+    }
+  }
+
+  async function deletePersonalRecord(record: PersonalRecordView) {
+    if (!snapshot.personalRecordsSchemaReady) {
+      setActionError("Personal records are still syncing in this environment.");
+      return;
+    }
+
+    if (!isOnline) {
+      setActionError("You are offline. Reconnect before deleting personal records.");
+      return;
+    }
+
+    if (!window.confirm(`Delete ${record.eventLabel}?`)) {
+      return;
+    }
+
+    setPendingRecordDeleteId(record.id);
+    setActionError("");
+    setActionSuccess("");
+
+    try {
+      const response = await fetch(`/api/my-library/profile/records/${record.id}`, {
+        method: "DELETE",
+      });
+
+      if (!response.ok) {
+        setActionError(await parseError(response, "Could not delete personal record right now."));
+        return;
+      }
+
+      const payload = (await response.json().catch(() => null)) as ApiError | null;
+      if (!payload?.ok || !payload.snapshot) {
+        setActionError("Could not delete personal record right now.");
+        return;
+      }
+
+      setSnapshot(payload.snapshot);
+
+      if (recordDraft.editingRecordId === record.id) {
+        setRecordDraft(buildPersonalRecordDraft(null));
+        clearStorageValue(recordStorageKey);
+        setRecordDraftRecovered(false);
+      }
+
+      setActionSuccess("Personal record deleted.");
+
+      void sendClientAnalyticsEvent("personal_record_deleted", {
+        eventLabel: record.eventLabel,
+      });
+    } catch {
+      setActionError("Could not delete personal record right now.");
+    } finally {
+      setPendingRecordDeleteId(null);
+    }
+  }
+
   function resetProfileDraftToSaved() {
     setProfileDraft(savedProfileDraft);
     clearStorageValue(profileStorageKey);
@@ -495,6 +695,33 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
     setActionSuccess("Draft reset to saved training preferences.");
   }
 
+  function resetRecordDraftToSaved() {
+    setRecordDraft(savedRecordDraft);
+    clearStorageValue(recordStorageKey);
+    setRecordDraftRecovered(false);
+    setActionError("");
+    setActionSuccess(
+      recordDraft.editingRecordId
+        ? "Draft reset to saved personal record."
+        : "Draft reset to a new personal record."
+    );
+  }
+
+  function startEditingRecord(record: PersonalRecordView) {
+    setRecordDraft(buildPersonalRecordDraft(record));
+    setRecordDraftRecovered(false);
+    setActionError("");
+    setActionSuccess(`Editing ${record.eventLabel}.`);
+  }
+
+  function startNewRecord() {
+    setRecordDraft(buildPersonalRecordDraft(null));
+    clearStorageValue(recordStorageKey);
+    setRecordDraftRecovered(false);
+    setActionError("");
+    setActionSuccess("Ready to add a new personal record.");
+  }
+
   function toggleAvailableDay(day: TrainingWeekday) {
     setPreferencesDraft((current) => {
       const hasDay = current.availableDays.includes(day);
@@ -514,13 +741,14 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
     firstName: profileDraft.firstName.trim() || null,
     lastName: profileDraft.lastName.trim() || null,
   });
+  const currentEditedRecord = findRecordById(snapshot.personalRecords, recordDraft.editingRecordId);
 
   return (
     <div className="space-y-6">
       {!isOnline ? (
         <div className="rounded-2xl border border-amber-200 bg-amber-50/80 px-4 py-3 text-sm text-amber-900">
-          You are offline. Unsaved profile, CSS, and preferences changes stay on this device until
-          you reconnect and save.
+          You are offline. Unsaved profile, CSS, preferences, and personal-record changes stay on
+          this device until you reconnect and save.
         </div>
       ) : null}
 
@@ -539,6 +767,12 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
       {preferencesDraftRecovered ? (
         <div className="rounded-2xl border border-blue-200 bg-blue-50/80 px-4 py-3 text-sm text-blue-900">
           Unsaved training preferences edits were restored on this device.
+        </div>
+      ) : null}
+
+      {recordDraftRecovered ? (
+        <div className="rounded-2xl border border-blue-200 bg-blue-50/80 px-4 py-3 text-sm text-blue-900">
+          Unsaved personal-record edits were restored on this device.
         </div>
       ) : null}
 
@@ -571,7 +805,7 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
         </button>
       </div>
 
-      <div className="grid gap-4 xl:grid-cols-3">
+      <div className="grid gap-4 md:grid-cols-2">
         <section className="rounded-2xl border border-slate-200 bg-white p-5">
           <h2 className="text-lg font-semibold text-slate-900">Current athlete profile</h2>
           {!snapshot.profileSchemaReady ? (
@@ -701,6 +935,48 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
             </div>
           )}
         </section>
+
+        <section className="rounded-2xl border border-slate-200 bg-white p-5">
+          <h2 className="text-lg font-semibold text-slate-900">Current personal records</h2>
+          {!snapshot.personalRecordsSchemaReady ? (
+            <p className="mt-3 text-sm text-amber-800">
+              Personal records are still syncing in this environment.
+            </p>
+          ) : snapshot.personalRecordsLoadError ? (
+            <p className="mt-3 text-sm text-rose-700">{snapshot.personalRecordsLoadError}</p>
+          ) : snapshot.personalRecords.length === 0 ? (
+            <p className="mt-3 text-sm text-slate-600">
+              No personal records are saved yet. Add explicit swim events and times you want to
+              reuse later.
+            </p>
+          ) : (
+            <div className="mt-4 space-y-3">
+              <p className="text-sm text-slate-600">
+                {snapshot.personalRecords.length} current record
+                {snapshot.personalRecords.length === 1 ? "" : "s"} saved privately.
+              </p>
+              {snapshot.personalRecords.slice(0, 3).map((record) => (
+                <div
+                  key={record.id}
+                  className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4 text-sm text-slate-700"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-2">
+                    <div>
+                      <p className="text-base font-semibold text-slate-900">{record.eventLabel}</p>
+                      <p className="mt-1 text-sm text-slate-600">
+                        {record.timeLabel}
+                        {record.recordedOn ? ` · ${record.recordedOn}` : ""}
+                      </p>
+                    </div>
+                    <div className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-600">
+                      {record.courseLabel}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
       </div>
 
       <section className="rounded-2xl border border-slate-200 bg-white p-5">
@@ -708,6 +984,7 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
         <ul className="mt-3 space-y-2 text-sm text-slate-700">
           <li>Profile stays about the swimmer. CSS stays about current test pace.</li>
           <li>Preferences stay about practical planning defaults, not goals or notes.</li>
+          <li>Personal records stay about event-specific bests, not your current CSS test pace.</li>
           <li>Later generator slices can reuse this context without redesigning the model.</li>
         </ul>
       </section>
@@ -889,6 +1166,241 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
           </button>
         </div>
       </form>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Personal records</h2>
+            <p className="mt-2 text-sm text-slate-600">
+              Save one private current best per event so later generator work can reuse trusted
+              event context without guessing.
+            </p>
+          </div>
+          <div className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600">
+            One current record per event
+          </div>
+        </div>
+
+        {!snapshot.personalRecordsSchemaReady ? (
+          <p className="mt-5 text-sm text-amber-800">
+            Personal records are still syncing in this environment.
+          </p>
+        ) : snapshot.personalRecordsLoadError ? (
+          <p className="mt-5 text-sm text-rose-700">{snapshot.personalRecordsLoadError}</p>
+        ) : (
+          <div className="mt-5 space-y-4">
+            {snapshot.personalRecords.length === 0 ? (
+              <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50/70 p-4 text-sm text-slate-600">
+                No personal records saved yet. Start with the events you use most in training.
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {snapshot.personalRecords.map((record) => (
+                  <article
+                    key={record.id}
+                    className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4"
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <h3 className="text-base font-semibold text-slate-900">
+                          {record.eventLabel}
+                        </h3>
+                        <p className="mt-1 text-sm text-slate-600">
+                          {record.timeLabel}
+                          {record.recordedOn ? ` · ${record.recordedOn}` : ""}
+                        </p>
+                        {record.sourceNote ? (
+                          <p className="mt-2 text-sm text-slate-600">{record.sourceNote}</p>
+                        ) : null}
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        <button
+                          type="button"
+                          data-testid={`athlete-record-edit-${record.id}`}
+                          onClick={() => startEditingRecord(record)}
+                          className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          data-testid={`athlete-record-delete-${record.id}`}
+                          onClick={() => void deletePersonalRecord(record)}
+                          disabled={pendingRecordDeleteId === record.id}
+                          className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-700 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:text-rose-300"
+                        >
+                          {pendingRecordDeleteId === record.id ? "Deleting..." : "Delete"}
+                        </button>
+                      </div>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            )}
+
+            <form
+              onSubmit={savePersonalRecord}
+              className="rounded-2xl border border-slate-200 bg-white p-5"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <h3 className="text-base font-semibold text-slate-900">
+                    {currentEditedRecord ? "Edit personal record" : "Add personal record"}
+                  </h3>
+                  <p className="mt-2 text-sm text-slate-600">
+                    Use explicit event identity and swimmer-friendly time input: `59.87`, `1:02.34`,
+                    or `1:01:02.34`.
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {currentEditedRecord ? (
+                    <div className="rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700">
+                      Editing {currentEditedRecord.eventLabel}
+                    </div>
+                  ) : null}
+                  {currentEditedRecord ? (
+                    <button
+                      type="button"
+                      onClick={startNewRecord}
+                      className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+                    >
+                      Start new
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                <label className="space-y-2 text-sm font-medium text-slate-700">
+                  <span>Distance (m)</span>
+                  <input
+                    data-testid="athlete-record-distance-m"
+                    type="number"
+                    min={25}
+                    max={100000}
+                    value={recordDraft.distanceM}
+                    onChange={(event) =>
+                      setRecordDraft((current) => ({ ...current, distanceM: event.target.value }))
+                    }
+                    placeholder="100"
+                    className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                  />
+                </label>
+
+                <label className="space-y-2 text-sm font-medium text-slate-700">
+                  <span>Stroke</span>
+                  <select
+                    data-testid="athlete-record-stroke"
+                    value={recordDraft.stroke}
+                    onChange={(event) =>
+                      setRecordDraft((current) => ({
+                        ...current,
+                        stroke: event.target.value as PersonalRecordStroke | "",
+                      }))
+                    }
+                    className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                  >
+                    <option value="">Choose stroke</option>
+                    {PERSONAL_RECORD_STROKE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="space-y-2 text-sm font-medium text-slate-700">
+                  <span>Course</span>
+                  <select
+                    data-testid="athlete-record-course"
+                    value={recordDraft.course}
+                    onChange={(event) =>
+                      setRecordDraft((current) => ({
+                        ...current,
+                        course: event.target.value as PersonalRecordCourse | "",
+                      }))
+                    }
+                    className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                  >
+                    <option value="">Choose course</option>
+                    {PERSONAL_RECORD_COURSE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="space-y-2 text-sm font-medium text-slate-700">
+                  <span>Time</span>
+                  <input
+                    data-testid="athlete-record-time"
+                    type="text"
+                    inputMode="decimal"
+                    value={recordDraft.time}
+                    onChange={(event) =>
+                      setRecordDraft((current) => ({ ...current, time: event.target.value }))
+                    }
+                    placeholder="1:02.34"
+                    className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                  />
+                </label>
+
+                <label className="space-y-2 text-sm font-medium text-slate-700">
+                  <span>Recorded on</span>
+                  <input
+                    data-testid="athlete-record-recorded-on"
+                    type="date"
+                    value={recordDraft.recordedOn}
+                    onChange={(event) =>
+                      setRecordDraft((current) => ({ ...current, recordedOn: event.target.value }))
+                    }
+                    className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                  />
+                </label>
+
+                <label className="space-y-2 text-sm font-medium text-slate-700 md:col-span-2 xl:col-span-3">
+                  <span>Source note</span>
+                  <textarea
+                    data-testid="athlete-record-source-note"
+                    value={recordDraft.sourceNote}
+                    onChange={(event) =>
+                      setRecordDraft((current) => ({ ...current, sourceNote: event.target.value }))
+                    }
+                    placeholder="Optional note about meet, set, or source"
+                    rows={3}
+                    className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                  />
+                </label>
+              </div>
+
+              <div className="mt-5 flex flex-wrap items-center gap-2">
+                <button
+                  data-testid="athlete-record-save"
+                  type="submit"
+                  disabled={pendingRecordSave || !isOnline}
+                  className="inline-flex h-11 items-center justify-center rounded-xl bg-emerald-600 px-4 text-sm font-semibold text-white transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:bg-slate-300"
+                >
+                  {pendingRecordSave
+                    ? "Saving..."
+                    : currentEditedRecord
+                      ? "Update personal record"
+                      : "Save personal record"}
+                </button>
+                <button
+                  data-testid="athlete-record-reset"
+                  type="button"
+                  onClick={resetRecordDraftToSaved}
+                  disabled={!hasUnsavedRecordChanges}
+                  className="inline-flex h-11 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-400"
+                >
+                  Reset draft
+                </button>
+              </div>
+            </form>
+          </div>
+        )}
+      </section>
 
       <form onSubmit={savePreferences} className="rounded-2xl border border-slate-200 bg-white p-5">
         <div className="flex flex-wrap items-start justify-between gap-3">

--- a/docs/task-briefs/in-progress/2026-03-19-my-library-personal-records-foundation-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-19-my-library-personal-records-foundation-10-10.md
@@ -1,0 +1,278 @@
+# Task Brief: My Library Personal Records Foundation (10/10)
+
+## Metadata
+
+- `id`: `2026-03-19-my-library-personal-records-foundation-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-03-19`
+- `updated`: `2026-03-19`
+
+## Goal
+
+Users can maintain private, generator-ready personal swim records inside My Library with explicit event identity (`distance + stroke + course`), canonical time storage, and clear separation from `Athlete profile`, `Training metrics`, `Preferences`, `Goals`, `Focus`, and `Notes`.
+
+## Why This Brief Exists
+
+- The parent brief `docs/task-briefs/planned/2026-03-19-my-library-athlete-profile-training-metrics-and-preferences-10-10.md` defines the broader profile/metrics/preferences direction.
+- Child slice 1 already shipped private athlete profile foundation on `main`.
+- Child slice 2 already shipped private CSS + structured training preferences on `main`.
+- The next highest-value move is now:
+  - save trusted personal records for specific swim events,
+  - keep them private and server-canonical,
+  - make them usable for immediate personal swim tracking,
+  - and keep them ready for later generator/program context without building generator automation now.
+- The owner is actively swimming `5` sessions per week and wants to dogfood this directly in personal training before later generator work lands.
+
+## Dependencies And Boundaries
+
+- Parent direction:
+  - `docs/task-briefs/planned/2026-03-19-my-library-athlete-profile-training-metrics-and-preferences-10-10.md`
+- Already-shipped adjacent child slices:
+  - `docs/task-briefs/done/2026-03-19-my-library-athlete-profile-foundation-10-10.md`
+  - `docs/task-briefs/done/2026-03-19-my-library-training-metrics-and-preferences-foundation-10-10.md`
+- Existing nearby private user-owned training surfaces that must stay separate but compatible:
+  - `docs/task-briefs/done/2026-03-19-my-library-goals-focus-notes-training-context-10-10.md`
+  - `app/my-library/page.tsx`
+  - `app/my-library/profile/page.tsx`
+  - `components/my-library/profile/AthleteProfileHub.tsx`
+  - `lib/athlete-profile/server.ts`
+  - `lib/user/export.ts`
+- This slice is only for:
+  - private personal-records foundation,
+  - canonical event identity and time contract,
+  - My Library/profile UX for create/edit/delete now,
+  - export compatibility,
+  - later generator-ready serialization.
+- This slice is not for:
+  - generator/program implementation,
+  - wearable imports,
+  - public sharing,
+  - pricing or entitlements,
+  - admin/operator workflows.
+
+## Product Model
+
+- `Athlete profile`
+  - who the swimmer is.
+- `Training metrics`
+  - trusted current test values, such as `CSS`.
+- `Preferences`
+  - practical planning defaults such as pool length and weekly cadence.
+- `Personal records`
+  - best-known performances for explicit swim events.
+  - phase 1 in this slice:
+    - distance,
+    - stroke,
+    - course,
+    - canonical time,
+    - recorded date,
+    - optional source note.
+
+These are not the same as:
+
+- `Goals`
+  - where the swimmer wants to go over time.
+- `Focus`
+  - what the swimmer is training on now.
+- `Notes`
+  - what the swimmer observed or wants to revisit later.
+
+## Platform 10/10 Scorecard Mapping (Required)
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `Product goals and IA`
+- `UX flow clarity`
+- `Business logic correctness and data integrity`
+- `Reliability and failure handling`
+- `Security and authz`
+- `Privacy and compliance`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                                       | Evidence                                |
+| --------------------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| Product goals and IA                          | `target`     | Users can distinguish `Personal records` from `Athlete profile`, `Training metrics`, `Preferences`, `Goals`, `Focus`, and `Notes` without duplicate data jobs.       | IA review + child-brief contract + e2e  |
+| UX flow clarity                               | `target`     | Mobile and desktop users can create, edit, delete, and revisit private personal records with explicit `loading`, `empty`, `saved`, `error`, and `retry` states.      | manual QA + e2e                         |
+| Visual design quality                         | `target`     | Personal-record UI fits the existing My Library visual language and avoids becoming a dense generic table/settings dump.                                             | screenshot review + manual QA           |
+| Business logic correctness and data integrity | `target`     | Each record keeps deterministic event identity (`distance + stroke + course`) and canonical time storage, with no ambiguous duplicate-event writes or unit guessing. | unit tests + runtime validation         |
+| Admin editor ergonomics                       | `N/A`        | N/A because this slice changes private end-user My Library data, not admin/editor workflows.                                                                         | scope rationale only                    |
+| Accessibility (a11y)                          | `target`     | Record forms, lists, edit actions, delete confirmation, and validation feedback remain keyboard/touch accessible with proper labels and focus recovery.              | Playwright + manual QA                  |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: additions must avoid obvious payload/render regressions on `/my-library` and `/my-library/profile`.                                                 | build + perf budgets + code review      |
+| Data placement and sync boundaries            | `target`     | Saved personal records are server-canonical; unsaved record drafts stay local-only and recoverable enough for safe retry on phone/desktop.                           | contract review + tests                 |
+| Caching and invalidation strategy             | `target`     | My Library summary and profile hub refresh deterministically after record create/update/delete without stale counts or stale event summaries.                        | integration tests + invalidation review |
+| Reliability and failure handling              | `target`     | Invalid event/time payloads, auth failures, and duplicate-event conflicts fail clearly without silent coercion or silent data loss.                                  | negative-path tests + manual QA         |
+| Security and authz                            | `target`     | Personal-record reads and writes are owner-only; unauthenticated or unauthorized record access fails closed with `401/403/404` as appropriate.                       | API negative-path tests                 |
+| Privacy and compliance                        | `target`     | Personal records remain private by default, excluded from public routes, and not leaked through logs, errors, or analytics payloads.                                 | scope review + tests + log review       |
+| Content governance                            | `supporting` | Supporting only: private record data still needs explicit ownership, timestamps, and current-state semantics even though it is not editorial content.                | schema/model review                     |
+| Admin workflow and editability                | `N/A`        | N/A because no admin/operator workflow changes are introduced in this slice.                                                                                         | scope rationale only                    |
+| SEO and crawlability                          | `N/A`        | N/A because this is a private authenticated My Library surface with no public crawl/index contract.                                                                  | scope rationale only                    |
+| AI discoverability                            | `N/A`        | N/A because this slice prepares private generator-ready context, not public AI-discoverable content.                                                                 | scope rationale only                    |
+| Analytics and KPI observability               | `supporting` | Supporting only: create/update/delete usage should be measurable enough to evaluate dogfooding and later generator-prefill value.                                    | analytics review                        |
+| Commerce and revenue ops                      | `N/A`        | N/A because pricing, bundles, and entitlements are explicitly deferred.                                                                                              | scope rationale only                    |
+| Incident response and support operations      | `supporting` | Supporting only: record save/delete failures should be diagnosable with privacy-safe logs and clear recovery copy.                                                   | runbook/help review                     |
+| Finance and reporting operations              | `N/A`        | N/A because no billing, reconciliation, or financial reporting logic is introduced by private personal records.                                                      | scope rationale only                    |
+| i18n operational readiness                    | `supporting` | Supporting only: stroke labels, course labels, and time helpers must remain locale-extensible for later multilingual product work.                                   | copy/schema review                      |
+| Stack-fit and dependency discipline           | `target`     | Implementation uses existing Next.js/TypeScript/Supabase/test patterns with no unnecessary new dependencies.                                                         | dependency diff + code review           |
+| Testing and QA automation                     | `target`     | Unit/integration/e2e coverage protects personal-record CRUD, time parsing/formatting, authz, export inclusion, and draft recovery before merge.                      | tests + verify outputs                  |
+| Scalability and cost efficiency               | `supporting` | Supporting only: one current record row per user-event should avoid wasteful query patterns and remain cheap for later generator reads.                              | schema/query review                     |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: migration rollout must be backward-compatible for users who have athlete profile/CSS/preferences but no personal-record rows yet.                   | migration + rollback notes              |
+
+## Data Placement And Sync Contract (Required For Stateful Features)
+
+- Server-canonical:
+  - personal-record rows,
+  - event identity,
+  - canonical time storage,
+  - ownership,
+  - timestamps,
+  - export serialization.
+- Local-only:
+  - unsaved personal-record draft,
+  - current edit-mode state,
+  - transient success/error banners.
+- Sync policy:
+  - explicit save for create/update,
+  - explicit delete for removal,
+  - server response becomes source of truth,
+  - unsaved draft survives reload long enough for retry,
+  - stale auth fails clearly and preserves local unsaved input.
+- Canonical time contract:
+  - record time is stored canonically as centiseconds,
+  - input UX may be swimmer-friendly (`ss.hh`, `m:ss.hh`, `h:mm:ss.hh`), but persisted value must stay deterministic.
+- Event identity contract:
+  - one current record per `user + distance + stroke + course`,
+  - duplicate-event create/update conflicts must fail clearly instead of silently merging unrelated rows.
+
+## Identity And Rename Contract (Required When Entities Are Persisted Or Linkable)
+
+- Canonical stable ID:
+  - `personal_record.id` is the canonical stable ID for each saved record row.
+- Human-readable identifiers:
+  - event labels (`100m freestyle · 25m pool`) are derived display copy only.
+- Mutability rules:
+  - IDs are immutable,
+  - distance/stroke/course/time/date/source note are editable through explicit user actions,
+  - later generator integrations must read canonical IDs and canonical fields, not mutable labels alone.
+- Rename vs repurpose:
+  - changing the saved time/date/note for the same event is an in-place update,
+  - changing the event identity to a materially different record creates or targets a different row,
+  - duplicate-event collisions must be resolved explicitly, not silently overwritten.
+- Compatibility contract:
+  - users with no personal-record rows still get deterministic empty states,
+  - later generator-prefill slices must tolerate missing records gracefully.
+- Observability and repair:
+  - malformed time strings, unsupported strokes/courses, and duplicate-event conflicts surface deterministically instead of being silently coerced.
+
+## Scope
+
+- Add private My Library `Personal records` on top of the shipped athlete-profile + metrics/preferences foundation.
+- Add a first-class `personal_records` entity with phase-1 support for:
+  - distance in meters,
+  - stroke,
+  - course,
+  - canonical stored time in centiseconds,
+  - recorded date,
+  - optional source note.
+- Keep this clearly separate from:
+  - athlete profile text fields,
+  - CSS/training metrics,
+  - training preferences,
+  - `Goals`,
+  - `Focus`,
+  - `Notes`.
+- Surface this inside My Library/profile in a phone-friendly way.
+- Update the My Library summary card so the training-setup entry reflects whether personal records are present.
+- Include personal records in user export.
+- Keep the page generator-ready without building generator logic yet.
+
+## Out Of Scope
+
+- Generator/program implementation.
+- Wearable or third-party imports.
+- Public sharing.
+- Pricing, subscriptions, or bundles.
+- Admin/operator surfaces.
+
+## Acceptance Criteria
+
+1. A signed-in user can view, create, edit, and delete private `Personal records` from My Library/profile.
+2. `Personal records` remain clearly separate from `Athlete profile`, `Training metrics`, `Preferences`, `Goals`, `Focus`, and `Notes`.
+3. Each saved record has explicit canonical fields for distance, stroke, course, time, and recorded date.
+4. Record time is stored canonically in centiseconds and formatted back into swimmer-friendly display without ambiguity.
+5. Saved personal records are server-canonical and survive refresh/device changes.
+6. Unsaved record edits remain local-only and recoverable enough to avoid obvious frustration after accidental refresh.
+7. Users with no personal-record rows see a deterministic empty state and can create their first record without errors.
+8. Duplicate-event conflicts fail clearly instead of silently overwriting another row.
+9. Unauthorized access to another user's personal records is not possible.
+10. Export payload includes personal records when present and remains valid when absent.
+11. `npm run lint:briefs`, relevant tests, and `npm run verify:pre-pr` pass before PR update.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run lint`
+- `npm run typecheck`
+- targeted unit tests for:
+  - record time parsing/formatting,
+  - event validation,
+  - route authz and conflict handling,
+  - export payload shape
+- targeted e2e for:
+  - create/edit/delete personal records,
+  - local draft recovery,
+  - My Library summary entry point
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3000/my-library`
+  - `http://127.0.0.1:3000/my-library/profile`
+- Preview:
+  - Vercel preview URL from PR checks
+- Recommended matrix:
+  - iPhone Safari
+  - Android Chromium
+  - iPad/tablet viewport
+  - Desktop Chrome
+  - Desktop Safari/WebKit
+  - Desktop Firefox
+
+## Constraints
+
+- Keep this slice narrow and practically useful now.
+- Do not pull generator logic into the same merge.
+- Keep `My Library` naming unchanged.
+- Follow existing Next.js/Supabase/My Library patterns.
+- Avoid inventing ambiguous free-text event identity.
+
+## 10/10 Quality Bar (Required For User-Facing Work)
+
+- The personal-records surface must feel like a real private swim tool, not a placeholder list.
+- Event identity must be explicit enough that later generator logic can trust it without guessing.
+- Time input must be swimmer-friendly while canonical storage remains deterministic.
+- Empty, loading, saved, conflict, and error states must all be explicit.
+- Draft recovery must protect against accidental refresh while editing.
+- Business logic must stay deterministic:
+  - one current canonical row per user-event,
+  - no cross-user leakage,
+  - no silent duplicate-event merge,
+  - no silent save failure.
+
+## Help/Guide And Operator Training Contract (Required For Workflow Changes)
+
+- User-facing My Library workflow copy changes are in scope.
+- The My Library/profile surface must explain that:
+  - personal records are private,
+  - they stay separate from swimmer profile text, CSS, preferences, goals, focus, and notes,
+  - later generator/program use comes later.
+- Separate admin/operator docs are `N/A` because this slice is private end-user workflow only.
+
+## Checkpoint Log
+
+- `2026-03-19`: Child brief created and moved to `in-progress` for private personal-records foundation. Generator-prefill work stays deferred to a later child slice.
+- `2026-03-19 | feat/my-library-personal-records-foundation | implemented private personal-record CRUD, canonical event identity/time storage, My Library/profile UX, export support, and automated coverage; local targeted tests, targeted e2e, and npm run verify:pre-pr are green | next: commit, push, open PR, and run npm run verify:pre-merge before merge; perf recommendation: hold for this non-perf slice despite tighten suggestion`

--- a/docs/task-briefs/planned/2026-03-19-my-library-athlete-profile-training-metrics-and-preferences-10-10.md
+++ b/docs/task-briefs/planned/2026-03-19-my-library-athlete-profile-training-metrics-and-preferences-10-10.md
@@ -240,6 +240,8 @@ Critical target categories for `10/10` claim in this brief:
 - `2026-03-19`: Parent brief created to lock the broader profile/metrics/preferences direction before implementation.
 - `2026-03-19 | e830b21 (main) | child slice 1 shipped via PR #237 for private athlete-profile foundation; profile hub, canonical row, local draft recovery, and export compatibility are now on main | next: take training metrics + preferences as the next child slice and continue to defer personal records`
 - `2026-03-19 | 4101d21 (main) | child slice 2 shipped via PR #239 in docs/task-briefs/done/2026-03-19-my-library-training-metrics-and-preferences-foundation-10-10.md with canonical CSS, structured training preferences, My Library/profile UX, export support, and green local/CI gates | next: take Personal records as the next child slice and continue to defer generator-prefill automation`
+- `2026-03-19 | feat/my-library-personal-records-foundation | child slice 3 started in docs/task-briefs/in-progress/2026-03-19-my-library-personal-records-foundation-10-10.md with scope locked to private personal-record CRUD, canonical event identity, canonical time storage, export support, and My Library/profile UX; generator-prefill work remains deferred | next: implement schema, server/API contracts, profile hub UI, and tests`
+- `2026-03-19 | feat/my-library-personal-records-foundation | child slice 3 implemented locally with private personal-record CRUD, deterministic event identity, canonical centisecond storage, My Library/profile UX, export inclusion, and green local verify:pre-pr gate; generator-prefill automation remains deferred | next: commit, push, open PR, and require verify:pre-merge before merge`
 
 ## Acceptance Criteria
 
@@ -298,8 +300,3 @@ Critical target categories for `10/10` claim in this brief:
 - Avoid storing stale or privacy-heavy fields without clear product value.
 - Keep generator/program logic out of phase 1 while still making later integration straightforward.
 - Do not use mutable labels or human-readable text as canonical identity for metrics, records, or preferences.
-
-## Checkpoint Log
-
-- `2026-03-19 | working tree | created parent brief for athlete profile, training metrics, and preferences as the adjacent user-data foundation to Goals/Focus/Notes, with generator-ready boundaries and explicit later child slices | next: lint brief and use it as the source brief when the first implementation slice starts`
-- `2026-03-19 | e830b21 (main) | first child slice shipped via PR #237 as athlete-profile foundation with private My Library profile hub, canonical Supabase row, export support, and green local/CI gates; parent direction stays planned because training metrics, personal records, and preferences remain future child slices | next: open the next child brief when we are ready to ship metrics/records or preferences separately`

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -16,6 +16,8 @@ export const ANALYTICS_EVENT_NAMES = [
   "athlete_profile_saved",
   "training_metric_saved",
   "training_preferences_saved",
+  "personal_record_saved",
+  "personal_record_deleted",
   "training_context_viewed",
   "training_context_refreshed",
   "training_focus_created",

--- a/lib/athlete-profile/personal-records.ts
+++ b/lib/athlete-profile/personal-records.ts
@@ -1,0 +1,253 @@
+import type { Database } from "@/types/database";
+
+export const PERSONAL_RECORD_STROKE_VALUES = [
+  "freestyle",
+  "backstroke",
+  "breaststroke",
+  "butterfly",
+  "individual_medley",
+] as const;
+export type PersonalRecordStroke = (typeof PERSONAL_RECORD_STROKE_VALUES)[number];
+
+export const PERSONAL_RECORD_COURSE_VALUES = ["pool_25m", "pool_50m", "open_water"] as const;
+export type PersonalRecordCourse = (typeof PERSONAL_RECORD_COURSE_VALUES)[number];
+
+export const PERSONAL_RECORD_STROKE_OPTIONS: readonly {
+  value: PersonalRecordStroke;
+  label: string;
+}[] = [
+  { value: "freestyle", label: "Freestyle" },
+  { value: "backstroke", label: "Backstroke" },
+  { value: "breaststroke", label: "Breaststroke" },
+  { value: "butterfly", label: "Butterfly" },
+  { value: "individual_medley", label: "Individual medley" },
+] as const;
+
+export const PERSONAL_RECORD_COURSE_OPTIONS: readonly {
+  value: PersonalRecordCourse;
+  label: string;
+}[] = [
+  { value: "pool_25m", label: "25m pool" },
+  { value: "pool_50m", label: "50m pool" },
+  { value: "open_water", label: "Open water" },
+] as const;
+
+export type PersonalRecordRow = Database["public"]["Tables"]["personal_records"]["Row"];
+export type PersonalRecordInsert = Database["public"]["Tables"]["personal_records"]["Insert"];
+
+type PersonalRecordInput = {
+  distanceM?: number | string | null;
+  stroke?: string | null;
+  course?: string | null;
+  time?: string | null;
+  recordedOn?: string | null;
+  sourceNote?: string | null;
+};
+
+type BuildResult<T> =
+  | { kind: "empty" }
+  | { kind: "invalid"; error: string }
+  | { kind: "valid"; value: T };
+
+const STROKE_SORT_ORDER: Record<PersonalRecordStroke, number> = {
+  freestyle: 1,
+  backstroke: 2,
+  breaststroke: 3,
+  butterfly: 4,
+  individual_medley: 5,
+};
+
+const COURSE_SORT_ORDER: Record<PersonalRecordCourse, number> = {
+  pool_25m: 1,
+  pool_50m: 2,
+  open_water: 3,
+};
+
+function normalizeText(value: string | null | undefined): string {
+  return value?.trim() ?? "";
+}
+
+function normalizeNullableText(value: string | null | undefined): string | null {
+  const normalized = normalizeText(value);
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeInteger(value: number | string | null | undefined): number | null {
+  if (typeof value === "number" && Number.isInteger(value)) return value;
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  if (!normalized || !/^\d+$/.test(normalized)) return null;
+  return Number.parseInt(normalized, 10);
+}
+
+function isValidIsoDateOnly(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [year, month, day] = value.split("-").map((part) => Number.parseInt(part, 10));
+  const asDate = new Date(Date.UTC(year, month - 1, day));
+  return (
+    asDate.getUTCFullYear() === year &&
+    asDate.getUTCMonth() === month - 1 &&
+    asDate.getUTCDate() === day
+  );
+}
+
+export function getPersonalRecordStrokeLabel(value: PersonalRecordStroke | null): string | null {
+  if (!value) return null;
+  return PERSONAL_RECORD_STROKE_OPTIONS.find((option) => option.value === value)?.label ?? null;
+}
+
+export function getPersonalRecordCourseLabel(value: PersonalRecordCourse | null): string | null {
+  if (!value) return null;
+  return PERSONAL_RECORD_COURSE_OPTIONS.find((option) => option.value === value)?.label ?? null;
+}
+
+export function buildPersonalRecordEventLabel(input: {
+  distanceM: number;
+  stroke: PersonalRecordStroke;
+  course: PersonalRecordCourse;
+}): string {
+  return `${input.distanceM}m ${getPersonalRecordStrokeLabel(input.stroke)} · ${getPersonalRecordCourseLabel(input.course)}`;
+}
+
+export function formatPersonalRecordTime(valueCentiseconds: number | null): string | null {
+  if (!valueCentiseconds || valueCentiseconds <= 0) return null;
+
+  const hours = Math.floor(valueCentiseconds / 360000);
+  const minutes = Math.floor((valueCentiseconds % 360000) / 6000);
+  const seconds = Math.floor((valueCentiseconds % 6000) / 100);
+  const centiseconds = valueCentiseconds % 100;
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}.${String(centiseconds).padStart(2, "0")}`;
+  }
+
+  if (minutes > 0) {
+    return `${minutes}:${String(seconds).padStart(2, "0")}.${String(centiseconds).padStart(2, "0")}`;
+  }
+
+  return `${seconds}.${String(centiseconds).padStart(2, "0")}`;
+}
+
+export function parsePersonalRecordTimeToCentiseconds(
+  value: string | null | undefined
+): number | null {
+  const normalized = normalizeText(value);
+  if (!normalized) return null;
+
+  const hoursPattern = /^(\d{1,2}):([0-5]\d):([0-5]\d)(?:\.(\d{1,2}))?$/;
+  const minutesPattern = /^(\d{1,3}):([0-5]\d)(?:\.(\d{1,2}))?$/;
+  const secondsPattern = /^(\d{1,2})(?:\.(\d{1,2}))$/;
+
+  let hours = 0;
+  let minutes = 0;
+  let seconds = 0;
+  let centiseconds = 0;
+
+  const hoursMatch = hoursPattern.exec(normalized);
+  if (hoursMatch) {
+    hours = Number.parseInt(hoursMatch[1] ?? "0", 10);
+    minutes = Number.parseInt(hoursMatch[2] ?? "0", 10);
+    seconds = Number.parseInt(hoursMatch[3] ?? "0", 10);
+    centiseconds = Number.parseInt((hoursMatch[4] ?? "0").padEnd(2, "0"), 10);
+  } else {
+    const minutesMatch = minutesPattern.exec(normalized);
+    if (minutesMatch) {
+      minutes = Number.parseInt(minutesMatch[1] ?? "0", 10);
+      seconds = Number.parseInt(minutesMatch[2] ?? "0", 10);
+      centiseconds = Number.parseInt((minutesMatch[3] ?? "0").padEnd(2, "0"), 10);
+    } else {
+      const secondsMatch = secondsPattern.exec(normalized);
+      if (!secondsMatch) return null;
+      seconds = Number.parseInt(secondsMatch[1] ?? "0", 10);
+      centiseconds = Number.parseInt((secondsMatch[2] ?? "0").padEnd(2, "0"), 10);
+    }
+  }
+
+  const totalCentiseconds = hours * 360000 + minutes * 6000 + seconds * 100 + centiseconds;
+  if (totalCentiseconds <= 0 || totalCentiseconds > 8639999) return null;
+  return totalCentiseconds;
+}
+
+export function comparePersonalRecordRows(
+  left: Pick<PersonalRecordRow, "distance_m" | "stroke" | "course" | "recorded_on" | "updated_at">,
+  right: Pick<PersonalRecordRow, "distance_m" | "stroke" | "course" | "recorded_on" | "updated_at">
+): number {
+  const byDistance = left.distance_m - right.distance_m;
+  if (byDistance !== 0) return byDistance;
+
+  const byStroke =
+    STROKE_SORT_ORDER[left.stroke as PersonalRecordStroke] -
+    STROKE_SORT_ORDER[right.stroke as PersonalRecordStroke];
+  if (byStroke !== 0) return byStroke;
+
+  const byCourse =
+    COURSE_SORT_ORDER[left.course as PersonalRecordCourse] -
+    COURSE_SORT_ORDER[right.course as PersonalRecordCourse];
+  if (byCourse !== 0) return byCourse;
+
+  const leftDate = left.recorded_on ?? left.updated_at;
+  const rightDate = right.recorded_on ?? right.updated_at;
+  return leftDate.localeCompare(rightDate) * -1;
+}
+
+export function buildPersonalRecordUpsert(
+  input: PersonalRecordInput
+): BuildResult<Omit<PersonalRecordInsert, "id" | "user_id" | "created_at" | "updated_at">> {
+  const distanceM = normalizeInteger(input.distanceM);
+  const stroke = normalizeNullableText(input.stroke) as PersonalRecordStroke | null;
+  const course = normalizeNullableText(input.course) as PersonalRecordCourse | null;
+  const timeCentiseconds = parsePersonalRecordTimeToCentiseconds(input.time);
+  const recordedOn = normalizeNullableText(input.recordedOn);
+  const sourceNote = normalizeNullableText(input.sourceNote);
+
+  const hasAnyValue =
+    distanceM !== null ||
+    stroke !== null ||
+    course !== null ||
+    timeCentiseconds !== null ||
+    recordedOn !== null ||
+    sourceNote !== null;
+
+  if (!hasAnyValue) {
+    return { kind: "empty" };
+  }
+
+  if (distanceM === null || distanceM < 25 || distanceM > 100000) {
+    return { kind: "invalid", error: "Distance must be a whole number between 25m and 100000m." };
+  }
+
+  if (!stroke || !PERSONAL_RECORD_STROKE_VALUES.some((value) => value === stroke)) {
+    return { kind: "invalid", error: "Choose a supported stroke before saving." };
+  }
+
+  if (!course || !PERSONAL_RECORD_COURSE_VALUES.some((value) => value === course)) {
+    return { kind: "invalid", error: "Choose a supported course before saving." };
+  }
+
+  if (timeCentiseconds === null) {
+    return {
+      kind: "invalid",
+      error: "Use time format ss.hh, m:ss.hh, or h:mm:ss.hh before saving.",
+    };
+  }
+
+  if (recordedOn && !isValidIsoDateOnly(recordedOn)) {
+    return { kind: "invalid", error: "Use a valid date in YYYY-MM-DD format." };
+  }
+
+  if (sourceNote && sourceNote.length > 280) {
+    return { kind: "invalid", error: "Source note must be 280 characters or fewer." };
+  }
+
+  return {
+    kind: "valid",
+    value: {
+      distance_m: distanceM,
+      stroke,
+      course,
+      time_centiseconds: timeCentiseconds,
+      recorded_on: recordedOn,
+      source_note: sourceNote,
+    },
+  };
+}

--- a/lib/athlete-profile/schema.ts
+++ b/lib/athlete-profile/schema.ts
@@ -51,3 +51,17 @@ export function isTrainingPreferencesSchemaMissing(
     "preferred_session_minutes",
   ]);
 }
+
+export function isPersonalRecordsSchemaMissing(
+  error: PostgrestLikeError | null | undefined
+): boolean {
+  return isSchemaMissing(error, [
+    "personal_records",
+    "distance_m",
+    "stroke",
+    "course",
+    "time_centiseconds",
+    "recorded_on",
+    "source_note",
+  ]);
+}

--- a/lib/athlete-profile/server.ts
+++ b/lib/athlete-profile/server.ts
@@ -18,7 +18,18 @@ import {
   type TrainingWeekday,
 } from "@/lib/athlete-profile/training-setup";
 import {
+  buildPersonalRecordEventLabel,
+  comparePersonalRecordRows,
+  formatPersonalRecordTime,
+  getPersonalRecordCourseLabel,
+  getPersonalRecordStrokeLabel,
+  type PersonalRecordCourse,
+  type PersonalRecordRow,
+  type PersonalRecordStroke,
+} from "@/lib/athlete-profile/personal-records";
+import {
   isAthleteProfileSchemaMissing,
+  isPersonalRecordsSchemaMissing,
   isTrainingMetricSchemaMissing,
   isTrainingPreferencesSchemaMissing,
 } from "@/lib/athlete-profile/schema";
@@ -60,6 +71,19 @@ export const TRAINING_PREFERENCES_SELECT = `
   updated_at
 `;
 
+export const PERSONAL_RECORD_SELECT = `
+  id,
+  user_id,
+  distance_m,
+  stroke,
+  course,
+  time_centiseconds,
+  recorded_on,
+  source_note,
+  created_at,
+  updated_at
+`;
+
 export type AthleteProfileView = {
   id: string;
   displayName: string | null;
@@ -97,16 +121,35 @@ export type TrainingPreferencesView = {
   updatedAt: string;
 };
 
+export type PersonalRecordView = {
+  id: string;
+  distanceM: number;
+  stroke: PersonalRecordStroke;
+  strokeLabel: string;
+  course: PersonalRecordCourse;
+  courseLabel: string;
+  eventLabel: string;
+  timeCentiseconds: number;
+  timeLabel: string;
+  recordedOn: string | null;
+  sourceNote: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export type AthleteProfileSnapshot = {
   profileSchemaReady: boolean;
   metricsSchemaReady: boolean;
   preferencesSchemaReady: boolean;
+  personalRecordsSchemaReady: boolean;
   loadError: string | null;
   metricsLoadError: string | null;
   preferencesLoadError: string | null;
+  personalRecordsLoadError: string | null;
   profile: AthleteProfileView | null;
   cssMetric: TrainingMetricView | null;
   preferences: TrainingPreferencesView | null;
+  personalRecords: PersonalRecordView[];
 };
 
 export function buildAthleteProfileView(row: AthleteProfileRow): AthleteProfileView {
@@ -162,32 +205,60 @@ export function buildTrainingPreferencesView(row: TrainingPreferencesRow): Train
   };
 }
 
+export function buildPersonalRecordView(row: PersonalRecordRow): PersonalRecordView {
+  const stroke = row.stroke as PersonalRecordStroke;
+  const course = row.course as PersonalRecordCourse;
+
+  return {
+    id: row.id,
+    distanceM: row.distance_m,
+    stroke,
+    strokeLabel: getPersonalRecordStrokeLabel(stroke) ?? row.stroke,
+    course,
+    courseLabel: getPersonalRecordCourseLabel(course) ?? row.course,
+    eventLabel: buildPersonalRecordEventLabel({
+      distanceM: row.distance_m,
+      stroke,
+      course,
+    }),
+    timeCentiseconds: row.time_centiseconds,
+    timeLabel: formatPersonalRecordTime(row.time_centiseconds) ?? "0.00",
+    recordedOn: row.recorded_on,
+    sourceNote: row.source_note,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
 export async function loadAthleteProfileSnapshot(
   supabase: TypedSupabaseClient,
   userId: string
 ): Promise<AthleteProfileSnapshot> {
-  const [profileResult, cssMetricResult, preferencesResult] = await Promise.all([
-    supabase
-      .from("athlete_profiles")
-      .select(ATHLETE_PROFILE_SELECT)
-      .eq("user_id", userId)
-      .maybeSingle(),
-    supabase
-      .from("training_metrics")
-      .select(TRAINING_METRIC_SELECT)
-      .eq("user_id", userId)
-      .eq("metric_key", "css")
-      .maybeSingle(),
-    supabase
-      .from("training_preferences")
-      .select(TRAINING_PREFERENCES_SELECT)
-      .eq("user_id", userId)
-      .maybeSingle(),
-  ]);
+  const [profileResult, cssMetricResult, preferencesResult, personalRecordsResult] =
+    await Promise.all([
+      supabase
+        .from("athlete_profiles")
+        .select(ATHLETE_PROFILE_SELECT)
+        .eq("user_id", userId)
+        .maybeSingle(),
+      supabase
+        .from("training_metrics")
+        .select(TRAINING_METRIC_SELECT)
+        .eq("user_id", userId)
+        .eq("metric_key", "css")
+        .maybeSingle(),
+      supabase
+        .from("training_preferences")
+        .select(TRAINING_PREFERENCES_SELECT)
+        .eq("user_id", userId)
+        .maybeSingle(),
+      supabase.from("personal_records").select(PERSONAL_RECORD_SELECT).eq("user_id", userId),
+    ]);
 
   const profileSchemaReady = !isAthleteProfileSchemaMissing(profileResult.error);
   const metricsSchemaReady = !isTrainingMetricSchemaMissing(cssMetricResult.error);
   const preferencesSchemaReady = !isTrainingPreferencesSchemaMissing(preferencesResult.error);
+  const personalRecordsSchemaReady = !isPersonalRecordsSchemaMissing(personalRecordsResult.error);
 
   const loadError =
     profileResult.error && profileSchemaReady ? "Could not load athlete profile right now." : null;
@@ -198,6 +269,10 @@ export async function loadAthleteProfileSnapshot(
   const preferencesLoadError =
     preferencesResult.error && preferencesSchemaReady
       ? "Could not load training preferences right now."
+      : null;
+  const personalRecordsLoadError =
+    personalRecordsResult.error && personalRecordsSchemaReady
+      ? "Could not load personal records right now."
       : null;
 
   if (loadError) {
@@ -218,17 +293,32 @@ export async function loadAthleteProfileSnapshot(
     );
   }
 
+  if (personalRecordsLoadError) {
+    console.error(
+      "[AthleteProfile] Failed loading personal records snapshot",
+      personalRecordsResult.error
+    );
+  }
+
   return {
     profileSchemaReady,
     metricsSchemaReady,
     preferencesSchemaReady,
+    personalRecordsSchemaReady,
     loadError,
     metricsLoadError,
     preferencesLoadError,
+    personalRecordsLoadError,
     profile: profileResult.data ? buildAthleteProfileView(profileResult.data) : null,
     cssMetric: cssMetricResult.data ? buildTrainingMetricView(cssMetricResult.data) : null,
     preferences: preferencesResult.data
       ? buildTrainingPreferencesView(preferencesResult.data)
       : null,
+    personalRecords:
+      personalRecordsResult.data && personalRecordsSchemaReady
+        ? [...personalRecordsResult.data]
+            .sort(comparePersonalRecordRows)
+            .map((row) => buildPersonalRecordView(row))
+        : [],
   };
 }

--- a/lib/user/export.ts
+++ b/lib/user/export.ts
@@ -46,6 +46,19 @@ type TrainingPreferencesRow = Pick<
   | "updated_at"
 >;
 
+type PersonalRecordRow = Pick<
+  Database["public"]["Tables"]["personal_records"]["Row"],
+  | "id"
+  | "distance_m"
+  | "stroke"
+  | "course"
+  | "time_centiseconds"
+  | "recorded_on"
+  | "source_note"
+  | "created_at"
+  | "updated_at"
+>;
+
 type CourseProgressRow = Pick<
   Database["public"]["Tables"]["course_progress"]["Row"],
   "lesson_id" | "done" | "video_seconds" | "updated_at"
@@ -117,6 +130,7 @@ export type BuildUserExportPayloadInput = {
   athleteProfile: AthleteProfileRow | null;
   trainingMetrics: TrainingMetricRow[];
   trainingPreferences: TrainingPreferencesRow | null;
+  personalRecords: PersonalRecordRow[];
   entitlements: EntitlementRow[];
   courseProgress: CourseProgressRow[];
   guideProgress: GuideProgressRow[];
@@ -133,7 +147,7 @@ export function buildUserExportPayload(input: BuildUserExportPayloadInput) {
 
   return {
     generatedAt,
-    schemaVersion: "2026-03-19-athlete-profile-training-setup",
+    schemaVersion: "2026-03-19-athlete-profile-training-setup-personal-records",
     user: {
       id: input.userId,
       email: input.userEmail,
@@ -178,6 +192,17 @@ export function buildUserExportPayload(input: BuildUserExportPayloadInput) {
           updatedAt: input.trainingPreferences.updated_at,
         }
       : null,
+    personalRecords: input.personalRecords.map((row) => ({
+      id: row.id,
+      distanceM: row.distance_m,
+      stroke: row.stroke,
+      course: row.course,
+      timeCentiseconds: row.time_centiseconds,
+      recordedOn: row.recorded_on,
+      sourceNote: row.source_note,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    })),
     entitlements: input.entitlements.map((row) => ({
       id: row.id,
       productId: row.product_id,

--- a/supabase/migrations/20260319224500_personal_records_foundation.sql
+++ b/supabase/migrations/20260319224500_personal_records_foundation.sql
@@ -1,0 +1,75 @@
+-- Private personal-records foundation for My Library.
+-- Keeps current best swim events separate from profile, metrics, preferences, goals, focus, and notes.
+
+create table if not exists public.personal_records (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  distance_m integer not null check (distance_m between 25 and 100000),
+  stroke text not null check (
+    stroke in (
+      'freestyle',
+      'backstroke',
+      'breaststroke',
+      'butterfly',
+      'individual_medley'
+    )
+  ),
+  course text not null check (
+    course in (
+      'pool_25m',
+      'pool_50m',
+      'open_water'
+    )
+  ),
+  time_centiseconds integer not null check (time_centiseconds between 1 and 8639999),
+  recorded_on date,
+  source_note text,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint personal_records_source_note_check
+    check (source_note is null or char_length(btrim(source_note)) between 1 and 280),
+  constraint personal_records_unique_event_per_user
+    unique (user_id, distance_m, stroke, course)
+);
+
+create index if not exists personal_records_user_event_updated_idx
+  on public.personal_records (user_id, distance_m, stroke, course, updated_at desc);
+
+drop trigger if exists personal_records_set_updated_at on public.personal_records;
+create trigger personal_records_set_updated_at
+before update on public.personal_records
+for each row
+execute function public.set_updated_at();
+
+grant select, insert, update, delete on public.personal_records to authenticated;
+
+alter table public.personal_records enable row level security;
+
+drop policy if exists personal_records_select_own on public.personal_records;
+create policy personal_records_select_own
+on public.personal_records
+for select
+to authenticated
+using (auth.uid() = user_id);
+
+drop policy if exists personal_records_insert_own on public.personal_records;
+create policy personal_records_insert_own
+on public.personal_records
+for insert
+to authenticated
+with check (auth.uid() = user_id);
+
+drop policy if exists personal_records_update_own on public.personal_records;
+create policy personal_records_update_own
+on public.personal_records
+for update
+to authenticated
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+drop policy if exists personal_records_delete_own on public.personal_records;
+create policy personal_records_delete_own
+on public.personal_records
+for delete
+to authenticated
+using (auth.uid() = user_id);

--- a/tests/e2e/my-library-athlete-profile.spec.ts
+++ b/tests/e2e/my-library-athlete-profile.spec.ts
@@ -45,7 +45,7 @@ test.describe("my library athlete profile", () => {
     }
     await expect(
       page.getByRole("heading", {
-        name: "Athlete profile & training setup",
+        name: "Athlete profile, training setup & records",
         level: 1,
       })
     ).toBeVisible();
@@ -54,15 +54,23 @@ test.describe("my library athlete profile", () => {
     if ((await displayNameInput.count()) === 0) {
       test.skip(true, "Athlete profile schema is not available in this environment.");
     }
+    const personalRecordDistanceInput = page.getByTestId("athlete-record-distance-m");
+    const hasPersonalRecordControls = (await personalRecordDistanceInput.count()) > 0;
 
     await displayNameInput.fill("Pool draft");
     await page.getByTestId("athlete-profile-css-pace").fill("1:58");
     await page.getByTestId("athlete-preferences-day-monday").check();
     await page.getByTestId("athlete-preferences-session-minutes").selectOption("60");
+    if (hasPersonalRecordControls) {
+      await personalRecordDistanceInput.fill("200");
+      await page.getByTestId("athlete-record-stroke").selectOption("freestyle");
+      await page.getByTestId("athlete-record-course").selectOption("pool_25m");
+      await page.getByTestId("athlete-record-time").fill("2:24.18");
+    }
     await page.reload({ waitUntil: "domcontentloaded", timeout: 60_000 });
     await expect(
       page.getByRole("heading", {
-        name: "Athlete profile & training setup",
+        name: "Athlete profile, training setup & records",
         level: 1,
       })
     ).toBeVisible();
@@ -77,5 +85,53 @@ test.describe("my library athlete profile", () => {
     await expect(
       page.getByText("Unsaved training preferences edits were restored on this device.")
     ).toBeVisible();
+    if (hasPersonalRecordControls) {
+      await expect(page.getByTestId("athlete-record-distance-m")).toHaveValue("200");
+      await expect(page.getByTestId("athlete-record-time")).toHaveValue("2:24.18");
+      await expect(
+        page.getByText("Unsaved personal-record edits were restored on this device.")
+      ).toBeVisible();
+    }
+  });
+
+  test("creates and deletes a personal record", async ({ page }, testInfo) => {
+    runOnceOnDesktopChromium(testInfo.project.name);
+
+    await loginToMyLibraryViaDevBypass(page);
+    await page.goto("/my-library/profile", { waitUntil: "domcontentloaded", timeout: 60_000 });
+    await expect(
+      page.getByRole("heading", {
+        name: "Athlete profile, training setup & records",
+        level: 1,
+      })
+    ).toBeVisible();
+
+    const distanceInput = page.getByTestId("athlete-record-distance-m");
+    if ((await distanceInput.count()) === 0) {
+      test.skip(true, "Personal records schema is not available in this environment.");
+    }
+
+    const distance = String(700 + (Date.now() % 200));
+    const eventLabel = `${distance}m Freestyle · 25m pool`;
+
+    await distanceInput.fill(distance);
+    await page.getByTestId("athlete-record-stroke").selectOption("freestyle");
+    await page.getByTestId("athlete-record-course").selectOption("pool_25m");
+    await page.getByTestId("athlete-record-time").fill("9:59.99");
+    await page.getByTestId("athlete-record-save").click();
+
+    await expect(page.getByText("Personal record saved.")).toBeVisible();
+    await expect(page.getByText(eventLabel)).toBeVisible();
+
+    page.once("dialog", async (dialog) => {
+      await dialog.accept();
+    });
+    await page
+      .locator("article")
+      .filter({ hasText: eventLabel })
+      .getByRole("button", { name: "Delete" })
+      .click();
+
+    await expect(page.getByText("Personal record deleted.")).toBeVisible();
   });
 });

--- a/tests/unit/athlete-profile-hub.test.tsx
+++ b/tests/unit/athlete-profile-hub.test.tsx
@@ -12,12 +12,15 @@ function buildSnapshot(profile?: AthleteProfileSnapshot["profile"]): AthleteProf
     profileSchemaReady: true,
     metricsSchemaReady: true,
     preferencesSchemaReady: true,
+    personalRecordsSchemaReady: true,
     loadError: null,
     metricsLoadError: null,
     preferencesLoadError: null,
+    personalRecordsLoadError: null,
     profile: profile ?? null,
     cssMetric: null,
     preferences: null,
+    personalRecords: [],
   };
 }
 
@@ -43,12 +46,29 @@ describe("AthleteProfileHub", () => {
         ageBand: "",
       })
     );
+    localStorage.setItem(
+      "my-library-athlete-profile-records-draft:user-1",
+      JSON.stringify({
+        editingRecordId: null,
+        distanceM: "200",
+        stroke: "freestyle",
+        course: "pool_25m",
+        time: "2:24.18",
+        recordedOn: "",
+        sourceNote: "",
+      })
+    );
 
     render(<AthleteProfileHub initialSnapshot={buildSnapshot()} userId="user-1" />);
 
     expect(screen.getByTestId("athlete-profile-display-name")).toHaveValue("Pool draft");
+    expect(screen.getByTestId("athlete-record-distance-m")).toHaveValue(200);
+    expect(screen.getByTestId("athlete-record-time")).toHaveValue("2:24.18");
     expect(
       screen.getByText("Unsaved athlete-profile edits were restored on this device.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Unsaved personal-record edits were restored on this device.")
     ).toBeInTheDocument();
   });
 
@@ -93,7 +113,7 @@ describe("AthleteProfileHub", () => {
     });
 
     expect(screen.getAllByText("Poolside Stian").length).toBeGreaterThan(0);
-    expect(localStorage.getItem("my-library-athlete-profile-draft:user-1")).toBeNull();
+    expect(localStorage.getItem("my-library-athlete-profile-profile-draft:user-1")).toBeNull();
   });
 
   it("saves CSS and preferences updates", async () => {
@@ -204,5 +224,85 @@ describe("AthleteProfileHub", () => {
 
     expect(screen.getByText("1:58/100m")).toBeInTheDocument();
     expect(screen.getAllByText("25m pool").length).toBeGreaterThan(0);
+  });
+
+  it("saves and deletes personal records", async () => {
+    vi.stubGlobal(
+      "confirm",
+      vi.fn(() => true)
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              ok: true,
+              recordId: "record-1",
+              snapshot: {
+                ...buildSnapshot(),
+                personalRecords: [
+                  {
+                    id: "record-1",
+                    distanceM: 100,
+                    stroke: "freestyle",
+                    strokeLabel: "Freestyle",
+                    course: "pool_25m",
+                    courseLabel: "25m pool",
+                    eventLabel: "100m Freestyle · 25m pool",
+                    timeCentiseconds: 6234,
+                    timeLabel: "1:02.34",
+                    recordedOn: "2026-03-19",
+                    sourceNote: "Club night",
+                    createdAt: "2026-03-19T18:00:00.000Z",
+                    updatedAt: "2026-03-19T18:05:00.000Z",
+                  },
+                ],
+              },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              ok: true,
+              snapshot: buildSnapshot(),
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+          )
+        )
+    );
+
+    render(<AthleteProfileHub initialSnapshot={buildSnapshot()} userId="user-1" />);
+
+    fireEvent.change(screen.getByTestId("athlete-record-distance-m"), {
+      target: { value: "100" },
+    });
+    fireEvent.change(screen.getByTestId("athlete-record-stroke"), {
+      target: { value: "freestyle" },
+    });
+    fireEvent.change(screen.getByTestId("athlete-record-course"), {
+      target: { value: "pool_25m" },
+    });
+    fireEvent.change(screen.getByTestId("athlete-record-time"), {
+      target: { value: "1:02.34" },
+    });
+    fireEvent.click(screen.getByTestId("athlete-record-save"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Personal record saved.")).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText("100m Freestyle · 25m pool").length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByTestId("athlete-record-delete-record-1"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Personal record deleted.")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("100m Freestyle · 25m pool")).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/athlete-profile-routes.test.ts
+++ b/tests/unit/athlete-profile-routes.test.ts
@@ -1,12 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createRouteHandlerSupabaseClientMock } = vi.hoisted(() => ({
+const { createRouteHandlerSupabaseClientMock, loadAthleteProfileSnapshotMock } = vi.hoisted(() => ({
   createRouteHandlerSupabaseClientMock: vi.fn(),
+  loadAthleteProfileSnapshotMock: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/route-handler", () => ({
   createRouteHandlerSupabaseClient: createRouteHandlerSupabaseClientMock,
 }));
+
+vi.mock("@/lib/athlete-profile/server", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/athlete-profile/server")>(
+    "@/lib/athlete-profile/server"
+  );
+
+  return {
+    ...actual,
+    loadAthleteProfileSnapshot: loadAthleteProfileSnapshotMock,
+  };
+});
 
 import {
   GET as getAthleteProfile,
@@ -35,6 +47,20 @@ function buildRouteClient(userId: string | null) {
 describe("athlete profile routes", () => {
   beforeEach(() => {
     createRouteHandlerSupabaseClientMock.mockReset();
+    loadAthleteProfileSnapshotMock.mockResolvedValue({
+      profileSchemaReady: true,
+      metricsSchemaReady: true,
+      preferencesSchemaReady: true,
+      personalRecordsSchemaReady: true,
+      loadError: null,
+      metricsLoadError: null,
+      preferencesLoadError: null,
+      personalRecordsLoadError: null,
+      profile: null,
+      cssMetric: null,
+      preferences: null,
+      personalRecords: [],
+    });
   });
 
   afterEach(() => {

--- a/tests/unit/personal-record-routes.test.ts
+++ b/tests/unit/personal-record-routes.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createRouteHandlerSupabaseClientMock, loadAthleteProfileSnapshotMock } = vi.hoisted(() => ({
+  createRouteHandlerSupabaseClientMock: vi.fn(),
+  loadAthleteProfileSnapshotMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/route-handler", () => ({
+  createRouteHandlerSupabaseClient: createRouteHandlerSupabaseClientMock,
+}));
+
+vi.mock("@/lib/athlete-profile/server", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/athlete-profile/server")>(
+    "@/lib/athlete-profile/server"
+  );
+
+  return {
+    ...actual,
+    loadAthleteProfileSnapshot: loadAthleteProfileSnapshotMock,
+  };
+});
+
+import { POST as postPersonalRecord } from "@/app/api/my-library/profile/records/route";
+import {
+  DELETE as deletePersonalRecord,
+  PUT as putPersonalRecord,
+} from "@/app/api/my-library/profile/records/[recordId]/route";
+
+function applyResponseCookiesIdentity<T>(response: T): T {
+  return response;
+}
+
+function buildSnapshot() {
+  return {
+    profileSchemaReady: true,
+    metricsSchemaReady: true,
+    preferencesSchemaReady: true,
+    personalRecordsSchemaReady: true,
+    loadError: null,
+    metricsLoadError: null,
+    preferencesLoadError: null,
+    personalRecordsLoadError: null,
+    profile: null,
+    cssMetric: null,
+    preferences: null,
+    personalRecords: [],
+  };
+}
+
+describe("personal record routes", () => {
+  beforeEach(() => {
+    createRouteHandlerSupabaseClientMock.mockReset();
+    loadAthleteProfileSnapshotMock.mockResolvedValue(buildSnapshot());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fails closed for unauthenticated record save", async () => {
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+        },
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await postPersonalRecord(
+      new Request("http://127.0.0.1:3000/api/my-library/profile/records", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ distanceM: "100" }),
+      })
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects malformed time before write", async () => {
+    const from = vi.fn();
+
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } } }),
+        },
+        from,
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await postPersonalRecord(
+      new Request("http://127.0.0.1:3000/api/my-library/profile/records", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          distanceM: "100",
+          stroke: "freestyle",
+          course: "pool_25m",
+          time: "10234",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it("creates valid personal records for the authenticated owner", async () => {
+    const single = vi.fn().mockResolvedValue({
+      data: { id: "record-1" },
+      error: null,
+    });
+    const select = vi.fn(() => ({ single }));
+    const insert = vi.fn(() => ({ select }));
+    const from = vi.fn().mockReturnValue({ insert });
+
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } } }),
+        },
+        from,
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await postPersonalRecord(
+      new Request("http://127.0.0.1:3000/api/my-library/profile/records", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          distanceM: "100",
+          stroke: "freestyle",
+          course: "pool_25m",
+          time: "1:02.34",
+          recordedOn: "2026-03-19",
+          sourceNote: "Club night",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(from).toHaveBeenCalledWith("personal_records");
+    expect(insert).toHaveBeenCalledWith({
+      user_id: "user-1",
+      distance_m: 100,
+      stroke: "freestyle",
+      course: "pool_25m",
+      time_centiseconds: 6234,
+      recorded_on: "2026-03-19",
+      source_note: "Club night",
+    });
+  });
+
+  it("returns a conflict when another record already owns the same event", async () => {
+    const single = vi.fn().mockResolvedValue({
+      data: null,
+      error: { code: "23505" },
+    });
+    const select = vi.fn(() => ({ single }));
+    const insert = vi.fn(() => ({ select }));
+    const from = vi.fn().mockReturnValue({ insert });
+
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } } }),
+        },
+        from,
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await postPersonalRecord(
+      new Request("http://127.0.0.1:3000/api/my-library/profile/records", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          distanceM: "100",
+          stroke: "freestyle",
+          course: "pool_25m",
+          time: "1:02.34",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(409);
+  });
+
+  it("updates and deletes records owned by the authenticated user", async () => {
+    const maybeSingle = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: { id: "record-1" },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { id: "record-1" },
+        error: null,
+      });
+    const select = vi.fn(() => ({ maybeSingle }));
+    const update = vi.fn(() => ({ eq: vi.fn(() => ({ eq: vi.fn(() => ({ select })) })) }));
+    const deleteChain = {
+      eq: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({ maybeSingle })),
+        })),
+      })),
+    };
+    const from = vi
+      .fn()
+      .mockReturnValueOnce({ update })
+      .mockReturnValueOnce({ delete: vi.fn(() => deleteChain) });
+
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } } }),
+        },
+        from,
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const putResponse = await putPersonalRecord(
+      new Request("http://127.0.0.1:3000/api/my-library/profile/records/record-1", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          distanceM: "100",
+          stroke: "freestyle",
+          course: "pool_50m",
+          time: "1:05.00",
+        }),
+      }),
+      { params: Promise.resolve({ recordId: "record-1" }) }
+    );
+
+    const deleteResponse = await deletePersonalRecord(
+      new Request("http://127.0.0.1:3000/api/my-library/profile/records/record-1", {
+        method: "DELETE",
+      }),
+      { params: Promise.resolve({ recordId: "record-1" }) }
+    );
+
+    expect(putResponse.status).toBe(200);
+    expect(deleteResponse.status).toBe(200);
+  });
+});

--- a/tests/unit/personal-records.test.ts
+++ b/tests/unit/personal-records.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPersonalRecordUpsert,
+  formatPersonalRecordTime,
+  parsePersonalRecordTimeToCentiseconds,
+} from "@/lib/athlete-profile/personal-records";
+
+describe("personal records helpers", () => {
+  it("parses swimmer-friendly times into canonical centiseconds", () => {
+    expect(parsePersonalRecordTimeToCentiseconds("59.87")).toBe(5987);
+    expect(parsePersonalRecordTimeToCentiseconds("1:02.34")).toBe(6234);
+    expect(parsePersonalRecordTimeToCentiseconds("1:01:02.34")).toBe(366234);
+  });
+
+  it("formats canonical centiseconds back into swimmer-friendly labels", () => {
+    expect(formatPersonalRecordTime(5987)).toBe("59.87");
+    expect(formatPersonalRecordTime(6234)).toBe("1:02.34");
+    expect(formatPersonalRecordTime(366234)).toBe("1:01:02.34");
+  });
+
+  it("builds canonical personal record payloads", () => {
+    expect(
+      buildPersonalRecordUpsert({
+        distanceM: "100",
+        stroke: "freestyle",
+        course: "pool_25m",
+        time: "1:02.34",
+        recordedOn: "2026-03-19",
+        sourceNote: "Club night",
+      })
+    ).toEqual({
+      kind: "valid",
+      value: {
+        distance_m: 100,
+        stroke: "freestyle",
+        course: "pool_25m",
+        time_centiseconds: 6234,
+        recorded_on: "2026-03-19",
+        source_note: "Club night",
+      },
+    });
+  });
+
+  it("rejects unsupported personal record values", () => {
+    expect(
+      buildPersonalRecordUpsert({
+        distanceM: "10",
+        stroke: "freestyle",
+        course: "pool_25m",
+        time: "1:02.34",
+      })
+    ).toEqual({
+      kind: "invalid",
+      error: "Distance must be a whole number between 25m and 100000m.",
+    });
+
+    expect(
+      buildPersonalRecordUpsert({
+        distanceM: "100",
+        stroke: "freestyle",
+        course: "pool_25m",
+        time: "10234",
+      })
+    ).toEqual({
+      kind: "invalid",
+      error: "Use time format ss.hh, m:ss.hh, or h:mm:ss.hh before saving.",
+    });
+  });
+});

--- a/tests/unit/training-metric-routes.test.ts
+++ b/tests/unit/training-metric-routes.test.ts
@@ -33,12 +33,15 @@ describe("training metric routes", () => {
       profileSchemaReady: true,
       metricsSchemaReady: true,
       preferencesSchemaReady: true,
+      personalRecordsSchemaReady: true,
       loadError: null,
       metricsLoadError: null,
       preferencesLoadError: null,
+      personalRecordsLoadError: null,
       profile: null,
       cssMetric: null,
       preferences: null,
+      personalRecords: [],
     });
   });
 

--- a/tests/unit/training-preferences-routes.test.ts
+++ b/tests/unit/training-preferences-routes.test.ts
@@ -33,12 +33,15 @@ describe("training preferences routes", () => {
       profileSchemaReady: true,
       metricsSchemaReady: true,
       preferencesSchemaReady: true,
+      personalRecordsSchemaReady: true,
       loadError: null,
       metricsLoadError: null,
       preferencesLoadError: null,
+      personalRecordsLoadError: null,
       profile: null,
       cssMetric: null,
       preferences: null,
+      personalRecords: [],
     });
   });
 

--- a/tests/unit/user-export-payload.test.ts
+++ b/tests/unit/user-export-payload.test.ts
@@ -43,6 +43,19 @@ describe("buildUserExportPayload", () => {
         created_at: "2026-03-19T08:12:00.000Z",
         updated_at: "2026-03-19T08:13:00.000Z",
       },
+      personalRecords: [
+        {
+          id: "record-1",
+          distance_m: 100,
+          stroke: "freestyle",
+          course: "pool_25m",
+          time_centiseconds: 6234,
+          recorded_on: "2026-03-19",
+          source_note: "Club night",
+          created_at: "2026-03-19T08:14:00.000Z",
+          updated_at: "2026-03-19T08:15:00.000Z",
+        },
+      ],
       entitlements: [
         {
           id: "ent-1",
@@ -140,7 +153,7 @@ describe("buildUserExportPayload", () => {
 
     expect(payload).toEqual({
       generatedAt: "2026-02-17T12:00:00.000Z",
-      schemaVersion: "2026-03-19-athlete-profile-training-setup",
+      schemaVersion: "2026-03-19-athlete-profile-training-setup-personal-records",
       user: {
         id: "user-1",
         email: "swimmer@example.com",
@@ -181,6 +194,19 @@ describe("buildUserExportPayload", () => {
         createdAt: "2026-03-19T08:12:00.000Z",
         updatedAt: "2026-03-19T08:13:00.000Z",
       },
+      personalRecords: [
+        {
+          id: "record-1",
+          distanceM: 100,
+          stroke: "freestyle",
+          course: "pool_25m",
+          timeCentiseconds: 6234,
+          recordedOn: "2026-03-19",
+          sourceNote: "Club night",
+          createdAt: "2026-03-19T08:14:00.000Z",
+          updatedAt: "2026-03-19T08:15:00.000Z",
+        },
+      ],
       entitlements: [
         {
           id: "ent-1",
@@ -286,6 +312,7 @@ describe("buildUserExportPayload", () => {
       athleteProfile: null,
       trainingMetrics: [],
       trainingPreferences: null,
+      personalRecords: [],
       entitlements: [],
       courseProgress: [],
       guideProgress: [],
@@ -298,6 +325,7 @@ describe("buildUserExportPayload", () => {
 
     expect(payload.profile).toBeNull();
     expect(payload.athleteProfile).toBeNull();
+    expect(payload.personalRecords).toEqual([]);
     expect(payload.entitlements).toEqual([]);
     expect(payload.trainingFocuses).toEqual([]);
     expect(payload.trainingNotes).toEqual([]);

--- a/types/database.ts
+++ b/types/database.ts
@@ -909,6 +909,45 @@ export type Database = {
         };
         Relationships: [];
       };
+      personal_records: {
+        Row: {
+          course: string;
+          created_at: string;
+          distance_m: number;
+          id: string;
+          recorded_on: string | null;
+          source_note: string | null;
+          stroke: string;
+          time_centiseconds: number;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          course: string;
+          created_at?: string;
+          distance_m: number;
+          id?: string;
+          recorded_on?: string | null;
+          source_note?: string | null;
+          stroke: string;
+          time_centiseconds: number;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          course?: string;
+          created_at?: string;
+          distance_m?: number;
+          id?: string;
+          recorded_on?: string | null;
+          source_note?: string | null;
+          stroke?: string;
+          time_centiseconds?: number;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
       training_metrics: {
         Row: {
           created_at: string;


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-03-19T15:23:58.848Z for branch `feat/my-library-personal-records-foundation` (base ref `origin/main`).
- Latest commit: `7d7fc54` - feat(profile): add personal records foundation.
- User-visible changes: User/admin runtime behavior may change on touched routes/components.
- Technical changes: Updated 24 file(s): `app/api/my-library/profile/records/[recordId]/route.ts`, `app/api/my-library/profile/records/route.ts`, `app/api/my-library/profile/route.ts`, `app/api/user/export/route.ts`, `app/my-library/page.tsx`, `... and 19 more file(s)`.
- Policy impact: yes (inferred from changed scope: `app/api/user/export/route.ts`, `lib/analytics/events.ts`, `supabase/migrations/20260319224500_personal_records_foundation.sql`).
- Policy version note: N/A (if policy text/version changes, replace with YYYY-MM-DD.rev and rationale).
- Brief link(s): `docs/task-briefs/in-progress/2026-03-19-my-library-personal-records-foundation-10-10.md`
- Scorecard target outcomes: 12 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (2); tests (8); API handlers (4); runtime UI/routes/components (8); other files (2).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (24):
  - `app/api/my-library/profile/records/[recordId]/route.ts`
  - `app/api/my-library/profile/records/route.ts`
  - `app/api/my-library/profile/route.ts`
  - `app/api/user/export/route.ts`
  - `app/my-library/page.tsx`
  - `app/my-library/profile/page.tsx`
  - `components/my-library/profile/AthleteProfileHub.tsx`
  - `docs/task-briefs/in-progress/2026-03-19-my-library-personal-records-foundation-10-10.md`
  - `... and 16 more file(s)`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `7d7fc54` (`git revert 7d7fc54`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **NOT RUN** (artifacts/test-runs/admin-short-session)
- `npm run verify:pre-merge`: **PENDING** for `7d7fc54` (latest PASS was `53342fa` at 2026-03-19T14:15:22Z; rerun on current HEAD).
- Policy-impact checklist: PENDING (run docs/checklists/policy-impact-release-review.md and update to PASS/FAIL).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  - No local verify log found in `artifacts/test-runs/latest`.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
