### PR TITLE
docs(workouts): align Garmin briefs and add history track

### DIFF
--- a/docs/task-briefs/blocked/2026-02-28-garmin-training-api-partner-integration-10-10.md
+++ b/docs/task-briefs/blocked/2026-02-28-garmin-training-api-partner-integration-10-10.md
@@ -6,11 +6,11 @@
 - `status`: `blocked`
 - `owner`: `stianvikra`
 - `created`: `2026-02-28`
-- `updated`: `2026-03-16`
+- `updated`: `2026-03-20`
 
 ## Goal
 
-Integrate one-click "Send to Garmin" using Garmin Training API once partner access and operational prerequisites are approved.
+Integrate one-click `Send to Garmin` for workouts/programs using Garmin Training API once partner access and operational prerequisites are approved.
 
 ## Why Blocked
 
@@ -18,7 +18,7 @@ This work requires external prerequisites not guaranteed by code alone:
 
 - Garmin partner/application approval.
 - API credentials and environment configuration.
-- Confirmed scope/limits for swim workout upload.
+- Confirmed scope/limits for swim workout and training-plan upload.
 - Legal/policy confirmation for data usage and terms.
 
 ## Unblock Criteria
@@ -27,15 +27,22 @@ All of the following must be true:
 
 1. Garmin partner status approved.
 2. Production and preview credentials provisioned securely.
-3. Supported workout step-mapping matrix signed off.
+3. Supported workout/program step-mapping matrix signed off.
 4. Rollback/runbook approved by owner.
 
 ## Planned Scope After Unblock
 
 - OAuth connect/disconnect flow with encrypted token storage.
-- Send workout endpoint with queue/retry handling.
+- Send workout and training-plan endpoints with queue/retry handling.
 - Sync status model (`queued`, `sent`, `failed`, `needs-attention`).
 - Deterministic failure UX and admin/audit visibility.
+- Explicit guarantee that send status does not mark sessions complete or move them into training history.
+
+## Explicit Non-Scope While Blocked
+
+- Garmin Activity API completed-session ingestion.
+- Training-history reconciliation for `completed` vs `cancelled`.
+- Retrospective AI evaluation of completed sessions.
 
 ## Data Placement And Sync Contract (Post-Unblock)
 
@@ -108,3 +115,7 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - `npm run verify:pre-pr`
 - integration tests with Garmin adapter stubs
 - staged end-to-end send test in preview env
+
+## Checkpoint Log
+
+- `2026-03-20 | planning | tightened this blocked brief around Garmin Training API send-to-calendar/device delivery for workouts and programs, and explicitly separated later completed-session/history ingestion into a different history track that can depend on Garmin Activity API | next: keep this brief blocked until partner approval, auth setup, and mapping matrix signoff are concrete`

--- a/docs/task-briefs/planned/2026-02-28-ai-plan-generator-json-guardrails-10-10.md
+++ b/docs/task-briefs/planned/2026-02-28-ai-plan-generator-json-guardrails-10-10.md
@@ -10,7 +10,7 @@
 
 ## Goal
 
-Generate AI-authored swim session/program drafts that help users reach goals while keeping deterministic safety, schema correctness, and predictable quality.
+Generate AI-authored swim session/program drafts that help users reach goals while keeping deterministic safety, schema correctness, Garmin-ready step structure, and predictable quality.
 
 ## Dependencies And Boundaries
 
@@ -35,17 +35,21 @@ Generate AI-authored swim session/program drafts that help users reach goals whi
   - per-run constraints.
 - Output contract:
   - strict JSON schema only,
-  - weeks -> sessions -> steps.
+  - weeks -> sessions -> steps,
+  - Garmin-compatible duration/target/repeat semantics,
+  - threshold-based swim-zone or pace targets when threshold context is available.
 - Guardrails:
   - progression caps,
   - recovery rules,
-  - step-count budget for export compatibility.
+  - step-count budget for export compatibility,
+  - no unsupported ad hoc zone system outside the canonical threshold-based method.
 - Fallback UX when AI response is invalid/unavailable.
 
 ## Out Of Scope
 
 - Fine-tuning custom model.
 - Full coaching recommendation engine.
+- Retrospective AI evaluation of completed history entries after execution.
 
 ## Data Placement And Sync Contract (Required)
 
@@ -116,6 +120,8 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - AI output always passes schema/invariant checks before save.
 - AI generation consumes canonical generator-intake handoff payloads without re-guessing raw My Library context or mutable labels.
 - AI goal-based generation remains a distinct flow from manual workout/session/program building.
+- Generated sessions/programs use the canonical Garmin-compatible step model and do not invent incompatible repeat/target structures.
+- When threshold context is available, generated intensity targets use the shared threshold-based swim-zone/pace model rather than a parallel AI-only zone scheme.
 - Users can edit generated plan without data loss.
 - Failures are explicit and recoverable.
 - AI output never mutates canonical entity identity implicitly through renamed labels or reordered weeks/sessions.
@@ -130,3 +136,4 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 ## Checkpoint Log
 
 - `2026-03-19 | planning | clarified that this brief owns AI-authored session/program draft generation from generator-intake handoff, while manual workout/program building remains separate and downstream editing/review can happen after generation | next: request owner detail later on first generator scope, goal model, and generated-draft review/edit expectations before implementation starts`
+- `2026-03-20 | planning | aligned AI generation requirements to the canonical Garmin-style step model and shared threshold-based swim-zone method, and kept retrospective completed-session analysis explicitly out of this generation brief | next: request owner detail later on whether the first AI slice should generate one session, one week, or a longer program`

--- a/docs/task-briefs/planned/2026-02-28-program-builder-calendar-completion-10-10.md
+++ b/docs/task-briefs/planned/2026-02-28-program-builder-calendar-completion-10-10.md
@@ -6,19 +6,21 @@
 - `status`: `planned`
 - `owner`: `stianvikra`
 - `created`: `2026-02-28`
-- `updated`: `2026-03-19`
+- `updated`: `2026-03-20`
 
 ## Goal
 
-Enable users to manually turn workouts into clear weekly programs with deterministic completion tracking and review.
+Enable users to manually turn workouts into clear weekly programs with deterministic scheduling, readable calendar review, and a clean handoff into completion/history workflows.
 
 ## Why This Brief Exists
 
 - Planned workout features need a scorecard-complete execution brief before implementation starts.
 - Calendar scheduling and completion logging are stateful flows and require explicit data-boundary decisions up front.
+- Calendar scheduling and planner-visible completion state are stateful flows and require explicit data-boundary decisions up front.
 - This brief sets measurable 10/10 thresholds so later slices can ship with predictable quality gates.
 - This brief is the manual program-building track.
 - AI-generated session/program creation belongs to a separate generator brief and must not be conflated with this manual planner flow.
+- Canonical training-history state, manual done/cancel/comments, and Garmin-completed reconciliation belong to a separate history brief and must not be hidden inside planner-only flags.
 
 ## Scope
 
@@ -26,10 +28,9 @@ Enable users to manually turn workouts into clear weekly programs with determini
   - assign workouts to days,
   - simple progression controls,
   - rest day support.
-- Completion logging:
-  - manual `done`,
-  - notes on completed sessions,
-  - completion source metadata.
+- Planner-facing status visibility:
+  - show scheduled vs completed vs cancelled state from canonical history/completion records,
+  - expose clear handoff entry points into completion/history flows where needed.
 - Program summary:
   - weekly meters,
   - intensity distribution,
@@ -41,30 +42,35 @@ Enable users to manually turn workouts into clear weekly programs with determini
 - Goal-based automatic planning.
 - External activity imports.
 - Garmin partner sync.
+- Canonical training-history detail, manual completion/cancel comments, and retrospective evaluation logic.
 
 ## Data Placement And Sync Contract (Required)
 
 - Server-canonical:
-  - program weeks, workout-to-day assignments, completion records, completion notes, completion source metadata.
+  - program weeks and workout-to-day assignments,
+  - planner-visible completion/cancelled indicators only insofar as they are derived from canonical history/completion records owned by the training-history slice.
 - Local-only:
   - unsaved builder draft edits before explicit save,
   - temporary UI filters/sort state in builder views.
 - Sync behavior:
   - optimistic UI allowed only for non-destructive edits,
-  - server response remains source of truth for persisted schedule/completion state,
+  - server response remains source of truth for persisted schedule state,
+  - planner surfaces must read canonical completion/history state rather than maintaining a separate completion truth,
   - stale writes must return deterministic conflict guidance and refresh canonical state.
 - Invalidation:
-  - any assignment/completion mutation invalidates weekly summary, adherence metrics, and day cells for affected week.
+  - any assignment mutation invalidates weekly summary, adherence metrics, and day cells for affected week,
+  - any upstream history/completion mutation invalidates planner completion indicators and affected summaries for the relevant week.
 
 ## Identity And Rename Contract
 
 - Canonical stable IDs:
-  - `program`, `program_week`, `program_assignment`/`plan_session`, and `completed_session` records must use immutable canonical IDs that do not depend on week/day position or workout title.
+  - `program`, `program_week`, and `program_assignment`/`plan_session` records must use immutable canonical IDs that do not depend on week/day position or workout title.
+  - planner-visible completion/history state may reference separate canonical history IDs, but those are owned by the training-history slice rather than planner-local identity.
 - Human-readable identifiers:
   - workout/program names and optional slugs are editorial/operator-facing only,
   - calendar placement labels such as week/day are presentation, not identity.
 - Mutability rules:
-  - rescheduling, reordering, and completion toggles must not mint or rewrite canonical IDs for the same underlying assignment/completion record,
+  - rescheduling and reordering must not mint or rewrite canonical IDs for the same underlying assignment,
   - title/label edits must not change completion linkage.
 - Rename vs repurpose:
   - rename a workout/program in place only when it is still the same underlying object,
@@ -79,47 +85,47 @@ Enable users to manually turn workouts into clear weekly programs with determini
 
 Reference: `docs/quality/platform-10-10-scorecard.md`
 
-| Category                                      | Mapping      | Target Threshold                                                                                       | Evidence                                     |
-| --------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
-| Product goals and IA                          | `target`     | Program builder IA supports create/edit/complete/review in one continuous weekly flow.                 | UX spec + e2e journey assertions             |
-| UX flow clarity                               | `target`     | Users can schedule one week and mark one workout complete in <=3 minutes without documentation.        | timed manual QA + e2e                        |
-| Visual design quality                         | `supporting` | N/A                                                                                                    | N/A                                          |
-| Business logic correctness and data integrity | `target`     | No duplicate or orphan completion records after retries/rapid edits; state transitions deterministic.  | unit/integration invariants                  |
-| Admin editor ergonomics                       | `supporting` | N/A                                                                                                    | N/A                                          |
-| Accessibility (a11y)                          | `target`     | Keyboard-only users can assign/edit/complete workouts with no critical a11y violations on core views.  | e2e a11y + manual keyboard QA                |
-| Performance (CWV + payloads)                  | `target`     | Changed builder routes stay within route budgets and avoid >10% JS payload regression.                 | perf budget checks + bundle diff             |
-| Data placement and sync boundaries            | `target`     | Local-vs-server ownership and conflict policy are explicitly documented and reflected in tests.        | brief contract + integration tests           |
-| Caching and invalidation strategy             | `target`     | Week summary and day-cell views refresh deterministically after any mutation with no stale totals.     | integration tests + cache notes              |
-| Reliability and failure handling              | `target`     | Failure states provide retry/recover paths; no dead-end states for save/complete actions.              | e2e failure-path coverage                    |
-| Security and authz                            | `target`     | Unauthorized schedule/completion mutations fail closed (`401/403`) and never mutate state.             | negative-path API tests                      |
-| Privacy and compliance                        | `supporting` | N/A                                                                                                    | N/A                                          |
-| Content governance                            | `supporting` | N/A                                                                                                    | N/A                                          |
-| Admin workflow and editability                | `supporting` | N/A                                                                                                    | N/A                                          |
-| SEO and crawlability                          | `supporting` | N/A                                                                                                    | N/A                                          |
-| AI discoverability                            | `supporting` | N/A                                                                                                    | N/A                                          |
-| Analytics and KPI observability               | `target`     | Schedule and completion events emit with stable taxonomy and safe payloads for adherence KPI tracking. | analytics event tests + event catalog        |
-| Commerce and revenue ops                      | `supporting` | N/A                                                                                                    | N/A                                          |
-| Incident response and support operations      | `supporting` | N/A                                                                                                    | N/A                                          |
-| Finance and reporting operations              | `supporting` | N/A                                                                                                    | N/A                                          |
-| i18n operational readiness                    | `supporting` | N/A                                                                                                    | N/A                                          |
-| Stack-fit and dependency discipline           | `target`     | Implementation uses existing Next.js/TypeScript/test stack without unnecessary new dependencies.       | package diff + architecture review           |
-| Testing and QA automation                     | `target`     | Critical schedule/complete/edit paths and negative paths are covered in unit+integration+e2e gates.    | test matrix + verify outputs                 |
-| Scalability and cost efficiency               | `supporting` | N/A                                                                                                    | N/A                                          |
-| DevOps and rollback readiness                 | `target`     | Feature rollout includes rollback path and deterministic data repair guidance for partial failures.    | runbook + release notes + rollback checklist |
+| Category                                      | Mapping      | Target Threshold                                                                                                                            | Evidence                                     |
+| --------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| Product goals and IA                          | `target`     | Program builder IA supports create/edit/review of weekly schedules with clear transition into later completion/history workflows.           | UX spec + e2e journey assertions             |
+| UX flow clarity                               | `target`     | Users can schedule one week and understand next-step execution/history state in <=3 minutes without documentation.                          | timed manual QA + e2e                        |
+| Visual design quality                         | `supporting` | Supporting only: planner visuals must stay production-ready, but no new design system is owned by this brief.                               | scope rationale + planner QA                 |
+| Business logic correctness and data integrity | `target`     | No duplicate or orphan assignments after retries/rapid edits; planner status reads canonical history state without forked completion truth. | unit/integration invariants                  |
+| Admin editor ergonomics                       | `supporting` | Supporting only: no primary admin content-edit workflow changes in this manual planner brief.                                               | scope rationale                              |
+| Accessibility (a11y)                          | `target`     | Keyboard-only users can assign/edit/review scheduled workouts and read planner status with no critical a11y violations on core views.       | e2e a11y + manual keyboard QA                |
+| Performance (CWV + payloads)                  | `target`     | Changed builder routes stay within route budgets and avoid >10% JS payload regression.                                                      | perf budget checks + bundle diff             |
+| Data placement and sync boundaries            | `target`     | Local-vs-server ownership and conflict policy are explicitly documented and reflected in tests.                                             | brief contract + integration tests           |
+| Caching and invalidation strategy             | `target`     | Week summary and day-cell views refresh deterministically after schedule or upstream history mutations with no stale totals.                | integration tests + cache notes              |
+| Reliability and failure handling              | `target`     | Failure states provide retry/recover paths; no dead-end states for save or planner-to-history handoff.                                      | e2e failure-path coverage                    |
+| Security and authz                            | `target`     | Unauthorized schedule mutations and protected planner status reads fail closed (`401/403`) and never mutate state.                          | negative-path API tests                      |
+| Privacy and compliance                        | `supporting` | Supporting only: planner status and summaries must avoid leaking unrelated history comments or personal data.                               | scope rationale + payload review             |
+| Content governance                            | `supporting` | Supporting only: canonical workout/program governance is upstream, but planner must preserve stable references to it.                       | linked brief + scope rationale               |
+| Admin workflow and editability                | `supporting` | Supporting only: no primary admin workflow is changed in this end-user planner slice.                                                       | scope rationale                              |
+| SEO and crawlability                          | `supporting` | Supporting only: authenticated planner surfaces are not primary crawl targets.                                                              | scope rationale                              |
+| AI discoverability                            | `supporting` | Supporting only: this brief consumes canonical workout data but does not define public AI-discoverable surfaces.                            | scope rationale                              |
+| Analytics and KPI observability               | `target`     | Schedule and planner-status events emit with stable taxonomy and safe payloads for adherence KPI tracking.                                  | analytics event tests + event catalog        |
+| Commerce and revenue ops                      | `supporting` | Supporting only: no direct checkout or entitlement mutation ships in this planner slice.                                                    | scope rationale                              |
+| Incident response and support operations      | `supporting` | Supporting only: planner/history handoff failures should leave support-visible diagnostics and recovery guidance.                           | scope rationale + error contract             |
+| Finance and reporting operations              | `supporting` | Supporting only: no finance/reporting mutation is introduced by this planner brief.                                                         | scope rationale                              |
+| i18n operational readiness                    | `supporting` | Supporting only: planner labels and status copy must remain locale-extensible later.                                                        | copy contract + scope rationale              |
+| Stack-fit and dependency discipline           | `target`     | Implementation uses existing Next.js/TypeScript/test stack without unnecessary new dependencies.                                            | package diff + architecture review           |
+| Testing and QA automation                     | `target`     | Critical schedule/edit/status-handoff paths and negative paths are covered in unit+integration+e2e gates.                                   | test matrix + verify outputs                 |
+| Scalability and cost efficiency               | `supporting` | Supporting only: planner scheduling/status reads must avoid obvious duplicate-write or summary-recompute cost spikes.                       | scope rationale + perf notes                 |
+| DevOps and rollback readiness                 | `target`     | Feature rollout includes rollback path and deterministic data repair guidance for partial failures.                                         | runbook + release notes + rollback checklist |
 
 ## Acceptance Criteria
 
 - Users can manually build and edit their own weekly programs quickly.
-- Completion status is reliable and audit-friendly.
+- Planner completion/cancelled state is reliable because it is read from canonical history/completion records, not planner-local flags.
 - Program metrics align with canonical workout data.
 - Data-boundary and conflict rules are implemented exactly as specified in this brief.
 - Calendar and completion identity stays stable across reorder, rename, and reschedule operations.
-- The manual planner flow remains distinct from later AI-generated program creation.
+- The manual planner flow remains distinct from later AI-generated program creation and from the separate history/reconciliation brief.
 
 ## Validation
 
-- targeted unit/integration tests for schedule + completion state
-- e2e for schedule/edit/complete flow
+- targeted unit/integration tests for schedule + planner-status state
+- e2e for schedule/edit/status-handoff flow
 - `npm run lint:briefs`
 - `npm run verify:pre-pr`
 
@@ -128,3 +134,4 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - `2026-03-09 | working tree | upgraded planned brief to canonical 10/10 scorecard mapping with explicit state-boundary contract and measurable target thresholds | next: use this brief as source when implementation branch starts`
 - `2026-03-16 | working tree | added explicit identity-and-rename contract so future program-builder implementation cannot couple canonical IDs to week/day order, editable labels, or reschedule flows | next: carry the same contract into implementation slices before schema/UI work starts`
 - `2026-03-19 | planning | clarified product direction that this brief owns manual program building from user-authored workouts, while AI goal-based session/program generation stays in a separate generator brief | next: request owner detail later on how AI-generated plans should hand off into editable builder/program flows`
+- `2026-03-20 | planning | narrowed this brief to the manual program builder and planner-status track, and moved canonical done/cancel/comments/history ownership into a separate training-history brief so scheduling truth and outcome truth stay cleanly separated | next: keep planner UI aligned to canonical history state instead of adding planner-local completion flags`

--- a/docs/task-briefs/planned/2026-02-28-workout-builder-and-poolside-execution-10-10.md
+++ b/docs/task-briefs/planned/2026-02-28-workout-builder-and-poolside-execution-10-10.md
@@ -6,11 +6,11 @@
 - `status`: `planned`
 - `owner`: `stianvikra`
 - `created`: `2026-02-28`
-- `updated`: `2026-03-19`
+- `updated`: `2026-03-20`
 
 ## Goal
 
-Ship a Garmin-familiar manual workout/session builder and poolside execution experience that is fast, clear, and reliable on mobile.
+Ship a Garmin-familiar manual session builder and poolside execution experience that is fast, clear, reliable on mobile, and aligned to the canonical Garmin-ready workout contract.
 
 ## Scope
 
@@ -21,8 +21,20 @@ Ship a Garmin-familiar manual workout/session builder and poolside execution exp
   - add repeat block,
   - reorder/remove,
   - section totals.
+- Garmin-familiar structured step authoring:
+  - duration + target pairing,
+  - repeat/interval block editing,
+  - rest editing,
+  - compatibility hints where a step shape cannot map cleanly downstream.
 - Step editor:
-  - duration type, distance, stroke, drill type, equipment, intensity target, notes.
+  - duration type,
+  - distance,
+  - stroke,
+  - drill type,
+  - equipment,
+  - intensity target,
+  - threshold-based swim zone target when threshold context exists,
+  - notes.
 - Poolside mode:
   - one primary action per screen (`Next`/`Done`),
   - large tap targets,
@@ -36,6 +48,7 @@ Ship a Garmin-familiar manual workout/session builder and poolside execution exp
 - Goal-based automatic session creation.
 - Weekly program/calendar authoring beyond the single-workout builder flow.
 - Garmin API push.
+- Canonical training history review, cancellation flows, and retrospective evaluation after completion.
 
 ## Data Placement And Sync Contract (Required)
 
@@ -102,6 +115,8 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 
 - Users can create, reorder, repeat, and save workouts without confusion.
 - Users can manually author their own workouts without being routed through AI generation.
+- Users can author Garmin-familiar target/duration/repeat structures without learning a hidden export model later.
+- Threshold-based swim zone targets, when shown, use the shared published method rather than a separate builder-only zone system.
 - Poolside mode supports clean execution with minimal cognitive load.
 - Save/cancel/dirty-state behavior is deterministic.
 - Builder is Garmin-familiar in structure without brand cloning.
@@ -117,3 +132,4 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 ## Checkpoint Log
 
 - `2026-03-19 | planning | clarified that this brief owns manual workout/session building and poolside execution only; AI generation and weekly program authoring remain separate briefs | next: request owner detail later on exact manual-builder ergonomics, save model, and Garmin-export handoff expectations before implementation starts`
+- `2026-03-20 | planning | tightened this brief into the explicit manual session builder track, added Garmin-familiar target/duration/repeat authoring requirements, and aligned swim-intensity editing to the shared threshold-based zone method | next: request owner detail later on exact builder editing ergonomics and how much compatibility guidance should be visible before export/send exists`

--- a/docs/task-briefs/planned/2026-02-28-workout-builder-garmin-familiar-epic-10-10.md
+++ b/docs/task-briefs/planned/2026-02-28-workout-builder-garmin-familiar-epic-10-10.md
@@ -6,23 +6,27 @@
 - `status`: `planned`
 - `owner`: `stianvikra`
 - `created`: `2026-02-28`
-- `updated`: `2026-03-19`
+- `updated`: `2026-03-20`
 
 ## Goal
 
-Deliver a Garmin-familiar workout-builder experience in FreeSwimming that is easy to use for swimmers, commercially useful, and technically compatible with future Garmin Training API export.
+Deliver a Garmin-familiar workout creation, generation, planning, history, and export ecosystem in FreeSwimming that is easy to use for swimmers, commercially useful, and technically compatible with future Garmin Training API delivery and later activity-history reconciliation.
 
 ## Product Positioning And UX Direction
 
 - Use **Garmin-familiar interaction patterns** (steps, repeats, distance/rest, pool size, notes).
 - Do **not** clone Garmin branding/look 1:1. Keep FreeSwimming visual identity.
-- Keep two product tracks explicit:
-  - `manual builder`: user-authored workouts/programs that can later be exported to Garmin,
-  - `AI generator`: goal-based session/program creation that produces drafts for review/editing.
+- Keep four product tracks explicit:
+  - `manual session builder`: user-authored workouts that can later be exported or sent to Garmin,
+  - `automatic generator`: goal-based session/program creation that produces drafts for review/editing,
+  - `manual program builder`: weekly scheduling and calendar planning for saved workouts,
+  - `training history`: completed/cancelled outcomes, comments, and later retrospective review.
 - Optimize for:
   - quick workout creation,
   - generator intake before AI/session creation when My Library context exists,
   - poolside execution,
+  - threshold-based swim-zone targeting from supported threshold tests,
+  - clear separation between planned schedule state and historical outcome state,
   - future export compatibility,
   - upsell paths (coaching/products) without harming lesson UX.
 
@@ -36,9 +40,10 @@ This epic is split into dedicated briefs for delivery quality and rollback safet
 4. `2026-02-28-program-builder-calendar-completion-10-10.md`
 5. `2026-03-19-my-library-generator-intake-and-prefill-foundation-10-10.md`
 6. `2026-02-28-ai-plan-generator-json-guardrails-10-10.md`
-7. `2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md`
-8. `2026-02-28-workout-commercial-analytics-funnel-10-10.md`
-9. `2026-02-28-garmin-training-api-partner-integration-10-10.md` (`blocked` until partner/API readiness)
+7. `2026-03-20-training-history-completion-reconciliation-and-retrospective-evaluation-10-10.md`
+8. `2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md`
+9. `2026-02-28-workout-commercial-analytics-funnel-10-10.md`
+10. `2026-02-28-garmin-training-api-partner-integration-10-10.md` (`blocked` until partner/API readiness)
 
 ## Out Of Scope (Current)
 
@@ -81,7 +86,7 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 ## Data Placement And Sync Contract (Required)
 
 - Server-canonical:
-  - drills, templates, workouts, plans, completion logs, export job state.
+  - drills, templates, workouts, plans, training-history/completion records, export job state.
 - Local-only:
   - transient editor state, temporary unsaved drafts.
 - Sync policy:
@@ -111,9 +116,10 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 3. Manual program builder/calendar/completion.
 4. Generator intake/prefill bridge from My Library context.
 5. AI session/program generation.
-6. Export adapters (Garmin-ready format + PDF).
-7. Commercial analytics and conversion hooks.
-8. Garmin partner integration when unblocked.
+6. Training history/completion foundation with manual done/cancel/comments and later Garmin Activity API reconciliation hooks.
+7. Export adapters (Garmin-ready format + PDF).
+8. Commercial analytics and conversion hooks.
+9. Garmin partner integration when unblocked.
 
 ## Success KPIs
 
@@ -129,6 +135,7 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 ## Checkpoint Log
 
 - `2026-03-19 | planning | clarified epic product split into manual builder/program track, generator-intake bridge, and AI generator track so future 10/10 briefs and implementation slices do not blur authoring, generation, export, and Garmin responsibilities | next: request owner detail later on exact AI session/program generator scope before turning planned briefs into implementation sequence`
+- `2026-03-20 | planning | expanded the epic into four explicit product tracks (manual session builder, automatic generator, manual program builder, and training history), aligned the contract to threshold-based swim zones, and separated Garmin Training API send from later Garmin Activity API history reconciliation | next: update child briefs and use the new training-history brief as the parent track for done/cancel/comments and retrospective evaluation`
 
 ## Completion Criteria For Epic
 

--- a/docs/task-briefs/planned/2026-02-28-workout-data-contract-and-step-engine-10-10.md
+++ b/docs/task-briefs/planned/2026-02-28-workout-data-contract-and-step-engine-10-10.md
@@ -6,27 +6,51 @@
 - `status`: `planned`
 - `owner`: `stianvikra`
 - `created`: `2026-02-28`
-- `updated`: `2026-03-16`
+- `updated`: `2026-03-20`
 
 ## Goal
 
-Define a canonical, Garmin-compatible workout schema and deterministic step engine so all builder, AI, poolside, and export flows use the same trusted data contract.
+Define a canonical, Garmin-compatible workout schema and deterministic step engine so manual builders, AI generators, poolside execution, export, and later Garmin delivery all use the same trusted data contract.
+
+## Garmin And Swim-Zone Alignment
+
+- Canonical steps must map cleanly to Garmin-familiar structured workout concepts:
+  - duration,
+  - target,
+  - rest,
+  - repeat/interval grouping.
+- Swim intensity targeting must support threshold-based swim zones derived from supported threshold tests, not ad hoc zone naming invented per feature.
+- The contract should normalize threshold inputs from either:
+  - `1000m test`,
+  - `CSS 400m + 200m`.
+- Product wording should describe these as `threshold-based swim zones`, not as universal or official swim-zone truth.
 
 ## Scope
 
 - Define canonical entities:
-  - `drill`, `workout_template`, `workout`, `plan`, `plan_session`, `completed_session`.
+  - `drill`, `workout_template`, `workout`, `plan`, `plan_session`, `training_history_entry`.
 - Define canonical `steps` JSON schema:
   - step types (`warmup`, `drill`, `main`, `cooldown`, `rest`, `repeat_block`),
-  - distance/duration target,
+  - duration and distance target,
+  - target mode (`open`, `threshold_zone`, `pace_range`, `rpe`, `rest`),
   - stroke/equipment,
   - rest,
   - optional notes.
+- Define Garmin-compatible structured-step semantics:
+  - single step,
+  - repeat/interval block,
+  - target + duration pairing,
+  - deterministic totals.
+- Define threshold-based swim-zone support:
+  - normalized `threshold_sec_per_100`,
+  - supported threshold source metadata,
+  - deterministic zone-band projection rules for workout targeting and export mapping.
 - Add invariant rules:
   - max step count,
   - repeat nesting constraints,
   - progression guardrails,
-  - totals consistency.
+  - totals consistency,
+  - Garmin-ready mapping constraints for unsupported target/duration combinations.
 - Add server-side validation (Zod + DB constraints) and deterministic normalization.
 
 ## Out Of Scope
@@ -34,11 +58,13 @@ Define a canonical, Garmin-compatible workout schema and deterministic step engi
 - Visual builder UI.
 - AI generation prompts.
 - OAuth integrations.
+- Garmin Training API partner auth/send workflow.
+- Garmin Activity API completion reconciliation and history review UX.
 
 ## Data Placement And Sync Contract (Required)
 
 - Server-canonical:
-  - canonical drill/template/workout/plan/session/completion entities,
+  - canonical drill/template/workout/plan/session/history entities,
   - normalized `steps` payload,
   - schema version metadata and validation outcome.
 - Local-only:
@@ -54,7 +80,7 @@ Define a canonical, Garmin-compatible workout schema and deterministic step engi
 ## Identity And Rename Contract
 
 - Canonical stable IDs:
-  - every persisted `drill`, `workout_template`, `workout`, `plan`, `plan_session`, and `completed_session` row gets an immutable canonical ID that is independent of display title, slug, week/day position, and sort order.
+  - every persisted `drill`, `workout_template`, `workout`, `plan`, `plan_session`, and `training_history_entry` row gets an immutable canonical ID that is independent of display title, slug, week/day position, and sort order.
 - Human-readable identifiers:
   - titles/slugs/labels are operator-facing and may be renameable where product UX needs it,
   - human-readable fields must never be the sole canonical key for progress, notes, exports, analytics, or plan references.
@@ -108,8 +134,11 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - Canonical schema documented and implemented in TS + DB.
 - Step payloads are validated and normalized before persistence.
 - Totals (`meters`, step count, interval count) are deterministic.
+- Canonical step model can express Garmin-familiar single steps, repeats, and interval sets without ambiguous translation.
+- Threshold-based swim-zone targets are normalized from supported threshold sources into deterministic pace/zone references.
 - Invalid combinations return actionable validation errors.
 - Canonical identity rules are documented for all persisted entities before implementation starts.
+- Product language and schema avoid claiming universal "official swim zones" when the contract is a published threshold-based method.
 - Brief is scorecard-complete and lintable before implementation starts.
 
 ## Validation
@@ -118,4 +147,9 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - `npm run typecheck`
 - `npm run test:unit`
 - targeted integration tests for API writes and negative paths
+- targeted contract tests for Garmin-ready target/duration/repeat normalization and threshold-zone derivation
 - `npm run verify:pre-pr`
+
+## Checkpoint Log
+
+- `2026-03-20 | planning | aligned the canonical workout contract to Garmin-style duration/target/repeat semantics and threshold-based swim-zone normalization from 1000m or CSS sources so manual builder, AI generator, export, and later Garmin delivery share the same language | next: keep downstream builder/generator/export briefs pinned to this contract and avoid parallel zone systems`

--- a/docs/task-briefs/planned/2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md
+++ b/docs/task-briefs/planned/2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md
@@ -6,11 +6,11 @@
 - `status`: `planned`
 - `owner`: `stianvikra`
 - `created`: `2026-02-28`
-- `updated`: `2026-03-19`
+- `updated`: `2026-03-20`
 
 ## Goal
 
-Build export adapters so workouts are usable immediately (PDF/poolside) and technically ready for Garmin Training API mapping later.
+Build export adapters so canonical workouts/programs are usable immediately (PDF/poolside) and technically ready for Garmin Training API publish mapping later.
 
 ## Dependencies And Boundaries
 
@@ -29,14 +29,15 @@ Build export adapters so workouts are usable immediately (PDF/poolside) and tech
 ## Scope
 
 - Export adapter layer:
-  - canonical workout -> `garmin-ready` intermediate format,
-  - canonical workout -> printable PDF model.
+  - canonical workout/program -> `garmin-ready` intermediate format,
+  - canonical workout/program -> printable PDF model.
 - PDF export UX:
   - clear, professional layout,
   - poolside legibility,
   - QR-ready if needed later.
 - Validation:
-  - enforce Garmin-compatible bounds in adapter.
+  - enforce Garmin-compatible bounds in adapter,
+  - enforce threshold-based swim-zone target mapping or explicit rejection when unsupported.
 
 ## Out Of Scope
 
@@ -44,6 +45,7 @@ Build export adapters so workouts are usable immediately (PDF/poolside) and tech
 - AI generation of workout/session/program drafts.
 - Live Garmin push.
 - OAuth token handling.
+- Garmin Activity API completion/history ingestion.
 
 ## Data Placement And Sync Contract (Required)
 
@@ -109,7 +111,8 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 ## Acceptance Criteria
 
 - PDF export renders consistently and readable on phone print view.
-- Garmin-ready adapter produces valid mapped payload for future API submission.
+- Garmin-ready adapter produces valid mapped workout/program payloads for future Training API submission.
+- Threshold-based swim-zone targets either map deterministically into export output or fail with actionable errors.
 - Adapter rejects unsupported step combos with actionable errors.
 - Adapter/output identity stays derived from canonical workout IDs, not mutable labels.
 - Export works from canonical workouts regardless of whether the source draft was created manually or originated from an accepted AI-generated draft.
@@ -124,3 +127,4 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 ## Checkpoint Log
 
 - `2026-03-19 | planning | clarified that export is downstream of canonical workouts from either manual builder or accepted AI-generated drafts, while live Garmin push remains a separate later slice | next: keep export adapter rules aligned with the canonical workout contract and future Garmin partner mapping`
+- `2026-03-20 | planning | expanded export scope to cover Garmin-ready workout/program mapping and threshold-based zone target handling, while keeping live send and activity-history ingestion outside this adapter brief | next: align later export adapters with the exact Training API publish model once partner docs and supported step matrix are finalized`

--- a/docs/task-briefs/planned/2026-03-20-training-history-completion-reconciliation-and-retrospective-evaluation-10-10.md
+++ b/docs/task-briefs/planned/2026-03-20-training-history-completion-reconciliation-and-retrospective-evaluation-10-10.md
@@ -1,0 +1,184 @@
+# Task Brief: Training History Completion Reconciliation And Retrospective Evaluation (10/10)
+
+## Metadata
+
+- `id`: `2026-03-20-training-history-completion-reconciliation-and-retrospective-evaluation-10-10`
+- `status`: `planned`
+- `owner`: `stianvikra`
+- `created`: `2026-03-20`
+- `updated`: `2026-03-20`
+
+## Goal
+
+Establish a canonical training-history system so planned sessions can move into `completed` or `cancelled` history with source metadata, manual comments, and later Garmin Activity API reconciliation plus retrospective AI review against long-term goals.
+
+## Why This Brief Exists
+
+- Program scheduling and historical training truth are different responsibilities and should not share one fragile state model.
+- Garmin Training API `send to Garmin` and Garmin Activity API `completed activity back from Garmin` are different integration problems and should not be collapsed into one brief.
+- Later AI review of completed sessions needs canonical history and explicit outcome states, not ad hoc planner flags.
+- Users need manual control even without Garmin integration:
+  - mark done manually,
+  - cancel when not completed,
+  - leave manual comments,
+  - review outcome history later.
+
+## Dependencies And Boundaries
+
+- Upstream canonical workout/program/entity contract:
+  - `docs/task-briefs/planned/2026-02-28-workout-data-contract-and-step-engine-10-10.md`
+- Upstream manual program builder:
+  - `docs/task-briefs/planned/2026-02-28-program-builder-calendar-completion-10-10.md`
+- Upstream manual session builder:
+  - `docs/task-briefs/planned/2026-02-28-workout-builder-and-poolside-execution-10-10.md`
+- Upstream AI-generated future-plan creation:
+  - `docs/task-briefs/planned/2026-02-28-ai-plan-generator-json-guardrails-10-10.md`
+- This brief owns historical outcome truth and reconciliation behavior.
+- This brief does not own:
+  - future-plan generation,
+  - manual program scheduling UX,
+  - live `send to Garmin` Training API delivery,
+  - or full biometric analysis/health ingestion.
+
+## Scope
+
+- Canonical training-history model:
+  - immutable `training_history_entry` identity,
+  - linkage to `plan_session`, `workout`, and optional external provider activity,
+  - final outcome states:
+    - `completed`,
+    - `cancelled`,
+    - `needs_review` for explicit conflict handling when sources disagree.
+- Manual outcome actions:
+  - mark scheduled session `done`,
+  - mark scheduled session `cancelled`,
+  - optional edit/add manual comment on the history entry.
+- History UX:
+  - timeline/list of completed and cancelled sessions,
+  - detail surface with outcome source, timestamps, and comments,
+  - filters for date/outcome/source where useful.
+- Source metadata:
+  - `manual`,
+  - `garmin_activity_api`,
+  - `system_reconciled` or equivalent deterministic source values.
+- Reconciliation contract for later provider sync:
+  - Garmin-completed activities can attach to canonical scheduled sessions when a deterministic match exists,
+  - conflicting final-state outcomes must surface explicit review state, not silently overwrite.
+- Retrospective AI-readiness hooks:
+  - canonical history payload can later feed AI evaluation of individual sessions and longer-term progress against goals.
+
+## Child Slice Sequencing
+
+1. History foundation:
+   - manual `done`,
+   - manual `cancelled`,
+   - manual comments,
+   - planner/history read model.
+2. Garmin Activity API reconciliation:
+   - blocked until partner access and activity-ingestion design are ready.
+3. Retrospective AI evaluation:
+   - evaluate completed history entries individually and against longer-term goals without mutating history truth implicitly.
+
+## Out Of Scope
+
+- Live Garmin Training API send/publish workflow.
+- Auto-generation of future workouts or programs.
+- Full health/biometric ingestion from Garmin Health APIs.
+- Automatic replanning of future schedules without explicit user review.
+
+## Data Placement And Sync Contract (Required)
+
+- Server-canonical:
+  - `training_history_entry`,
+  - final outcome state,
+  - source metadata,
+  - timestamps,
+  - manual comments,
+  - external provider references,
+  - reconciliation status.
+- Local-only:
+  - transient history filters,
+  - unsaved comment draft,
+  - temporary optimistic UI for non-destructive view state.
+- Sync behavior:
+  - scheduled program/session records remain planning truth until a final outcome is created,
+  - marking `done` or `cancelled` must create or update one canonical history entry deterministically,
+  - planner views must read history state rather than storing a separate completion truth,
+  - provider reconciliation must never silently delete manual comments or overwrite conflicting outcomes.
+- Conflict policy:
+  - `manual_cancelled` vs provider `completed`, duplicate provider matches, or unresolved provider-to-session matches must enter explicit `needs_review` state instead of silent coercion.
+- Invalidation:
+  - any history mutation invalidates planner completion indicators, adherence summaries, history lists/details, and later retrospective-AI input views.
+
+## Identity And Rename Contract
+
+- Canonical stable IDs:
+  - every history entry gets an immutable canonical ID independent of workout title, calendar position, or provider identifiers.
+- Foreign references:
+  - history entries may reference canonical `plan_session`, `workout`, and optional provider activity IDs, but those foreign IDs do not replace the history entry's own canonical ID.
+- Human-readable identifiers:
+  - workout/program names shown in history are presentation fields and may change later without rewriting history identity.
+- Mutability rules:
+  - outcome updates for the same underlying scheduled session must update the same canonical history entry unless product rules explicitly require a new versioned entry,
+  - provider re-sync must not rebind one history entry onto a different scheduled session implicitly.
+- Rename vs repurpose:
+  - renaming a workout/program in place must preserve history linkage,
+  - materially repurposing a future scheduled session should create a new canonical planning entity so older history remains semantically correct.
+- Compatibility contract:
+  - analytics, comments, retrospective AI, and later exports must resolve history by canonical IDs even if titles or calendar positions change.
+- Observability and repair:
+  - duplicate matches, orphan history entries, and provider-link drift must be measurable and surfaced with repair guidance.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+| Category                                      | Mapping      | Target Threshold                                                                                                                      | Evidence                              |
+| --------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| Product goals and IA                          | `target`     | Users can understand planned vs completed vs cancelled vs needs-review states with one coherent planner-to-history IA.                | UX flows + route/state map            |
+| UX flow clarity                               | `target`     | User can mark a scheduled session done or cancelled and find it again in history in <= 2 minutes without documentation.               | e2e + timed manual QA                 |
+| Visual design quality                         | `supporting` | Supporting only: history views must feel production-ready, but broader visual system ownership lives in shared app UI patterns.       | design QA + scope rationale           |
+| Business logic correctness and data integrity | `target`     | No duplicate/orphan history records under retry/conflict paths; conflicting outcomes never silently overwrite each other.             | unit/integration invariants           |
+| Admin editor ergonomics                       | `supporting` | Supporting only: no high-frequency admin content-edit workflow is introduced in this user-history slice.                              | scope rationale                       |
+| Accessibility (a11y)                          | `target`     | Keyboard/screen-reader users can trigger done/cancel actions, read outcome state, and manage comments without critical blockers.      | a11y checks + manual keyboard QA      |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: history routes and planner overlays must avoid obvious regressions and stay within normal route budgets.             | perf checks + scope rationale         |
+| Data placement and sync boundaries            | `target`     | Planner state vs canonical history truth vs provider reconciliation ownership is explicit and reflected in tests.                     | brief contract + integration tests    |
+| Caching and invalidation strategy             | `target`     | Planner indicators, adherence summaries, and history views refresh deterministically after any history mutation or reconciliation.    | integration tests + cache notes       |
+| Reliability and failure handling              | `target`     | Manual/provider failure and conflict states always produce retry/review guidance with no dead-end or ambiguous outcome state.         | e2e + negative-path tests             |
+| Security and authz                            | `target`     | Protected history mutations and comments fail closed (`401/403`) and malformed provider payloads cannot mutate another user's state.  | negative-path API tests               |
+| Privacy and compliance                        | `supporting` | Supporting only: manual comments and provider metadata must avoid leaking unrelated personal or prompt data beyond defined scope.     | payload review + scope rationale      |
+| Content governance                            | `supporting` | Supporting only: canonical workout/program governance is upstream, but history must preserve stable references to it.                 | linked briefs + scope rationale       |
+| Admin workflow and editability                | `supporting` | Supporting only: support/ops visibility may be needed later, but primary admin tooling is not owned by this foundation brief.         | scope rationale                       |
+| SEO and crawlability                          | `supporting` | Supporting only: authenticated history pages are not primary public crawl targets for this slice.                                     | scope rationale                       |
+| AI discoverability                            | `supporting` | Supporting only: this brief prepares retrospective AI inputs, but does not create public AI-discoverable pages.                       | scope rationale                       |
+| Analytics and KPI observability               | `target`     | Completion, cancellation, source, and review-state events emit with stable taxonomy and safe canonical references.                    | event catalog + analytics tests       |
+| Commerce and revenue ops                      | `supporting` | Supporting only: no direct billing or entitlement mutation ships in this history foundation slice.                                    | scope rationale                       |
+| Incident response and support operations      | `supporting` | Supporting only: repair guidance and support diagnostics must exist for provider mismatch/conflict states before those slices launch. | runbook notes + scope rationale       |
+| Finance and reporting operations              | `supporting` | Supporting only: no finance/reporting mutation is introduced; training-history status must not affect finance truth.                  | scope rationale                       |
+| i18n operational readiness                    | `supporting` | Supporting only: outcome labels, comments UI, and review-state copy must remain locale-extensible later.                              | copy contract + scope rationale       |
+| Stack-fit and dependency discipline           | `target`     | Use existing Next.js/TypeScript/Supabase/job patterns first; avoid unnecessary activity-sync or comment-editor dependencies.          | architecture review + dependency diff |
+| Testing and QA automation                     | `target`     | Manual complete/cancel/comment flows, conflict paths, and protected API paths are covered with low-flake unit/integration/e2e tests.  | test matrix + verify outputs          |
+| Scalability and cost efficiency               | `supporting` | Supporting only: reconciliation and later AI review hooks must avoid runaway duplicate writes or expensive reprocessing loops.        | scope rationale + architecture review |
+| DevOps and rollback readiness                 | `target`     | History schema and reconciliation rollout include reversible migrations, repair guidance, and safe disable paths for provider sync.   | migration notes + rollback checklist  |
+
+## Acceptance Criteria
+
+- Users can mark a scheduled session `done` manually and see it appear in training history as `completed`.
+- Users can mark a scheduled session `cancelled` manually and see it appear in training history as `cancelled`.
+- Manual comments persist on history entries without breaking canonical identity or later reconciliation.
+- Planner/calendar views read canonical history outcome state rather than maintaining a second completion truth.
+- Conflicting provider/manual outcomes enter explicit `needs_review` state instead of silent overwrite.
+- Later retrospective AI evaluation can consume canonical history entries and comments without becoming the source of truth for outcome state.
+- Brief is scorecard-complete and identity-safe before implementation starts.
+
+## Validation
+
+- targeted unit/integration tests for done/cancel/comment state transitions and conflict handling
+- negative-path tests for unauthorized/forbidden history mutations
+- e2e for planner -> complete/cancel -> history review flow
+- `npm run lint:briefs`
+- `npm run verify:pre-pr`
+
+## Checkpoint Log
+
+- `2026-03-20 | planning | created a dedicated history/completion parent brief so manual done/cancel/comments, later Garmin Activity API reconciliation, and retrospective AI evaluation have one canonical state model instead of being split across planner and send-to-Garmin slices | next: use this brief to keep planner, Garmin send, and later provider-ingest work from inventing parallel completion/history truth`

--- a/tests/e2e/my-library-athlete-profile.spec.ts
+++ b/tests/e2e/my-library-athlete-profile.spec.ts
@@ -128,11 +128,24 @@ test.describe("my library athlete profile", () => {
     await page.getByTestId("athlete-record-stroke").selectOption("freestyle");
     await page.getByTestId("athlete-record-course").selectOption("pool_25m");
     await page.getByTestId("athlete-record-time").fill("9:59.99");
+    const createRecordResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        response.url().includes("/api/my-library/profile/records") &&
+        response.ok()
+    );
     await page.getByTestId("athlete-record-save").click();
 
+    await createRecordResponse;
     await expect(page.getByText("Personal record saved.")).toBeVisible();
     await expect(page.getByRole("heading", { name: eventLabel })).toBeVisible();
 
+    const deleteRecordResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "DELETE" &&
+        response.url().includes("/api/my-library/profile/records/") &&
+        response.ok()
+    );
     page.once("dialog", async (dialog) => {
       await dialog.accept();
     });
@@ -142,6 +155,7 @@ test.describe("my library athlete profile", () => {
       .getByRole("button", { name: "Delete" })
       .click();
 
-    await expect(page.getByText("Personal record deleted.")).toBeVisible();
+    await deleteRecordResponse;
+    await expect(page.locator("article").filter({ hasText: eventLabel })).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary
- align the workout/session/program/generator brief chain to Garmin's split between Training API send-to-calendar delivery and later Activity API completed-session ingestion
- add a new 10/10 training-history brief for manual done/cancel/comments, later Garmin reconciliation, and retrospective AI evaluation
- harden the athlete-profile personal-record delete e2e flow by waiting for canonical create/delete responses and record removal instead of a transient toast

## Validation
- `npm run lint:briefs`
- `npx playwright test tests/e2e/my-library-athlete-profile.spec.ts --project=desktop-chromium`
- `npm run verify:pre-pr`

## Notes
- no direct end-user runtime feature shipped in this PR; the product change here is planning/governance alignment plus one e2e stability fix
- Garmin alignment in these briefs now assumes `Training API` for workout/program delivery and a separate later `Activity API` track for completion/history ingestion
- perf trend decision: `hold` in this PR; the budget tool recommended tightening, but that follow-up belongs in the AW-010 performance-governance track rather than this workout-docs PR
