### PR TITLE
docs(generator): expand horizon selection matrix

### DIFF
--- a/docs/task-briefs/planned/2026-02-28-ai-plan-generator-json-guardrails-10-10.md
+++ b/docs/task-briefs/planned/2026-02-28-ai-plan-generator-json-guardrails-10-10.md
@@ -10,7 +10,7 @@
 
 ## Goal
 
-Generate AI-authored swim session/program drafts across explicit planning horizons so users can choose anything from one session to a competition-date plan while keeping deterministic safety, schema correctness, Garmin-ready step structure, threshold-based targeting, and predictable quality.
+Generate AI-authored swim session/program drafts across explicit planning horizons so users can choose anything from one session to a fixed-duration, custom date-range, or competition-date plan while keeping deterministic safety, schema correctness, Garmin-ready step structure, threshold-based targeting, and predictable quality.
 
 ## Dependencies And Boundaries
 
@@ -34,13 +34,21 @@ Generate AI-authored swim session/program drafts across explicit planning horizo
     - `session`,
     - `week`,
     - `month`,
+    - `three_months`,
     - `six_months`,
+    - `twelve_months`,
+    - `date_range`,
     - `to_competition_date`,
   - selected goal/focus/profile/metric/preference context from intake,
+  - optional calendar framing for date-based generations:
+    - `start_date`,
+    - `end_date`,
+    - for rolling horizons, default start is the generation date unless the user explicitly overrides it,
   - optional competition planning intent for competition-driven generations:
     - target competition date,
     - optional competition label,
     - explicit `peak_for_competition` / taper intent instead of hidden AI inference,
+    - optional explicit training start date when the user does not want the plan to begin immediately,
   - available time/sessions,
   - per-run constraints.
 - Output contract:
@@ -57,7 +65,8 @@ Generate AI-authored swim session/program drafts across explicit planning horizo
   - taper/peak logic only when competition-date intent explicitly requests it,
   - step-count budget for export compatibility,
   - no unsupported ad hoc zone system outside the canonical threshold-based method,
-  - no hidden competition/taper assumptions when the user did not select a competition-driven horizon.
+  - no hidden competition/taper assumptions when the user did not select a competition-driven horizon,
+  - no hidden calendar-window assumptions when the user selected a custom date range.
 - Fallback UX when AI response is invalid/unavailable.
 
 ## Child Slice Sequencing
@@ -69,8 +78,13 @@ Generate AI-authored swim session/program drafts across explicit planning horizo
    - one week,
    - one month,
    - progression/recovery across short cycles.
-3. AI long-horizon program generator:
+3. AI medium- and long-horizon program generator:
+   - three months,
    - six months,
+   - twelve months,
+   - custom `date_range`,
+   - explicit calendar window handling.
+4. AI competition-target generator:
    - to competition date,
    - explicit peak/taper intent and periodization guardrails.
 
@@ -89,7 +103,7 @@ Generate AI-authored swim session/program drafts across explicit planning horizo
 - Local-only:
   - accepted generator-intake handoff for the current run,
   - prompt draft input derived from that handoff,
-  - selected planning horizon and one-run competition intent before save,
+  - selected planning horizon and one-run calendar/competition intent before save,
   - transient preview of generated output,
   - temporary user edits before save/confirm.
 - Sync behavior:
@@ -104,12 +118,12 @@ Generate AI-authored swim session/program drafts across explicit planning horizo
 - Canonical stable IDs:
   - AI-generated plans/sessions/steps must either create new canonical IDs explicitly or map to existing canonical IDs via validated references; the model must never invent implicit identity from titles or week labels alone.
 - Human-readable identifiers:
-  - generated titles/labels, week labels such as `build`/`taper`, and competition display names are editable presentation fields and must not be treated as canonical keys during later edits/saves.
+  - generated titles/labels, week labels such as `build`/`taper`, date-window labels, and competition display names are editable presentation fields and must not be treated as canonical keys during later edits/saves.
 - Mutability rules:
   - post-generation edits may change titles/copy without rewriting canonical IDs for already-persisted entities.
 - Rename vs repurpose:
   - regenerating or materially replacing a plan/session should create a new entity/version unless the workflow explicitly confirms in-place overwrite against the same canonical object.
-  - changing the saved planning horizon or competition target/peak intent after persistence should be treated as a material repurpose unless the workflow explicitly supports a versioned rewrite.
+  - changing the saved planning horizon, date window, or competition target/peak intent after persistence should be treated as a material repurpose unless the workflow explicitly supports a versioned rewrite.
 - Compatibility contract:
   - generate -> validate -> save flows must reject unresolved references deterministically; no silent rebinding of AI output onto the wrong existing entity.
 - Observability and repair:
@@ -119,33 +133,33 @@ Generate AI-authored swim session/program drafts across explicit planning horizo
 
 Reference: `docs/quality/platform-10-10-scorecard.md`
 
-| Category                                      | Mapping      | Target Threshold                                                                                                                                     | Evidence                              |
-| --------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| Product goals and IA                          | `target`     | AI plan generation fits a clear select-horizon -> generate -> inspect -> edit -> accept workflow with no ambiguity about save or competition intent. | UX contract + flow diagrams           |
-| UX flow clarity                               | `target`     | Users always understand whether output is draft, invalid, accepted, or needs retry, and which planning horizon/competition assumptions are active.   | e2e + manual QA                       |
-| Visual design quality                         | `supporting` | Supporting only: visual presentation of generated output is owned by later builder/planner UI slices.                                                | scope rationale                       |
-| Business logic correctness and data integrity | `target`     | Invalid AI output never reaches canonical data store and accepted plans preserve canonical identity rules.                                           | schema tests + save invariants        |
-| Admin editor ergonomics                       | `supporting` | Supporting only: no direct admin editing workflow is introduced in this slice.                                                                       | scope rationale                       |
-| Accessibility (a11y)                          | `supporting` | Supporting only: user-facing review UI belongs to downstream workflow slices, but error states must stay accessible.                                 | scope rationale + downstream contract |
-| Performance (CWV + payloads)                  | `supporting` | Supporting only: generation latency and preview payloads must not obviously degrade core builder flows.                                              | perf notes + scope rationale          |
-| Data placement and sync boundaries            | `target`     | Generated output remains local/provisional until validated save; server-canonical ownership is explicit.                                             | data contract + integration tests     |
-| Caching and invalidation strategy             | `supporting` | Supporting only: accepted/regenerated output must define deterministic invalidation of stale preview state.                                          | flow contract + scope rationale       |
-| Reliability and failure handling              | `target`     | Users always get actionable fallback on AI failure and no dead-end invalid-output state.                                                             | e2e + integration                     |
-| Security and authz                            | `target`     | AI endpoints are input-validated, rate-limited where needed, and protected save paths fail closed.                                                   | API tests                             |
-| Privacy and compliance                        | `supporting` | Supporting only: prompts and telemetry must avoid unnecessary sensitive data leakage.                                                                | payload review + scope rationale      |
-| Content governance                            | `supporting` | Supporting only: canonical plan/workout governance is defined by data-contract and program-builder slices.                                           | linked brief + scope rationale        |
-| Admin workflow and editability                | `supporting` | Supporting only: no admin workflow is directly changed in this AI guardrail slice.                                                                   | scope rationale                       |
-| SEO and crawlability                          | `supporting` | Supporting only: generated plans are not primary public crawl surfaces in this slice.                                                                | scope rationale                       |
-| AI discoverability                            | `supporting` | Supporting only: this slice governs AI generation safety, not public AI-discoverable content surfaces.                                               | scope rationale                       |
-| Analytics and KPI observability               | `supporting` | Supporting only: generation success/failure/acceptance events must stay available with safe payloads.                                                | event contract notes                  |
-| Commerce and revenue ops                      | `supporting` | Supporting only: no direct commerce mutation ships in this AI generation guardrail slice.                                                            | scope rationale                       |
-| Incident response and support operations      | `supporting` | Supporting only: rejected/rewritten AI output must leave support-visible diagnostics and operator guidance.                                          | error contract + scope rationale      |
-| Finance and reporting operations              | `supporting` | Supporting only: no finance/reporting mutation in this AI-only slice.                                                                                | scope rationale                       |
-| i18n operational readiness                    | `supporting` | Supporting only: generated labels and validation copy must remain locale-extensible later.                                                           | copy/schema review + scope rationale  |
-| Stack-fit and dependency discipline           | `target`     | Use existing schema-validation and app stack patterns; avoid unnecessary AI orchestration dependencies.                                              | dependency diff + code review         |
-| Testing and QA automation                     | `target`     | Golden tests, schema tests, and generate->validate->save integration coverage pass before merge.                                                     | CI + verify outputs                   |
-| Scalability and cost efficiency               | `supporting` | Supporting only: generation flow should avoid obvious runaway retries or oversized prompt/output churn.                                              | scope rationale + usage notes         |
-| DevOps and rollback readiness                 | `target`     | AI generation can be disabled or rolled back without corrupting canonical saved plans.                                                               | rollout notes + release checklist     |
+| Category                                      | Mapping      | Target Threshold                                                                                                                                                       | Evidence                              |
+| --------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| Product goals and IA                          | `target`     | AI plan generation fits a clear select-horizon -> generate -> inspect -> edit -> accept workflow with no ambiguity about save, calendar window, or competition intent. | UX contract + flow diagrams           |
+| UX flow clarity                               | `target`     | Users always understand whether output is draft, invalid, accepted, or needs retry, and which planning horizon/calendar/competition assumptions are active.            | e2e + manual QA                       |
+| Visual design quality                         | `supporting` | Supporting only: visual presentation of generated output is owned by later builder/planner UI slices.                                                                  | scope rationale                       |
+| Business logic correctness and data integrity | `target`     | Invalid AI output never reaches canonical data store and accepted plans preserve canonical identity rules.                                                             | schema tests + save invariants        |
+| Admin editor ergonomics                       | `supporting` | Supporting only: no direct admin editing workflow is introduced in this slice.                                                                                         | scope rationale                       |
+| Accessibility (a11y)                          | `supporting` | Supporting only: user-facing review UI belongs to downstream workflow slices, but error states must stay accessible.                                                   | scope rationale + downstream contract |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: generation latency and preview payloads must not obviously degrade core builder flows.                                                                | perf notes + scope rationale          |
+| Data placement and sync boundaries            | `target`     | Generated output remains local/provisional until validated save; server-canonical ownership is explicit.                                                               | data contract + integration tests     |
+| Caching and invalidation strategy             | `supporting` | Supporting only: accepted/regenerated output must define deterministic invalidation of stale preview state.                                                            | flow contract + scope rationale       |
+| Reliability and failure handling              | `target`     | Users always get actionable fallback on AI failure and no dead-end invalid-output state.                                                                               | e2e + integration                     |
+| Security and authz                            | `target`     | AI endpoints are input-validated, rate-limited where needed, and protected save paths fail closed.                                                                     | API tests                             |
+| Privacy and compliance                        | `supporting` | Supporting only: prompts and telemetry must avoid unnecessary sensitive data leakage.                                                                                  | payload review + scope rationale      |
+| Content governance                            | `supporting` | Supporting only: canonical plan/workout governance is defined by data-contract and program-builder slices.                                                             | linked brief + scope rationale        |
+| Admin workflow and editability                | `supporting` | Supporting only: no admin workflow is directly changed in this AI guardrail slice.                                                                                     | scope rationale                       |
+| SEO and crawlability                          | `supporting` | Supporting only: generated plans are not primary public crawl surfaces in this slice.                                                                                  | scope rationale                       |
+| AI discoverability                            | `supporting` | Supporting only: this slice governs AI generation safety, not public AI-discoverable content surfaces.                                                                 | scope rationale                       |
+| Analytics and KPI observability               | `supporting` | Supporting only: generation success/failure/acceptance events must stay available with safe payloads.                                                                  | event contract notes                  |
+| Commerce and revenue ops                      | `supporting` | Supporting only: no direct commerce mutation ships in this AI generation guardrail slice.                                                                              | scope rationale                       |
+| Incident response and support operations      | `supporting` | Supporting only: rejected/rewritten AI output must leave support-visible diagnostics and operator guidance.                                                            | error contract + scope rationale      |
+| Finance and reporting operations              | `supporting` | Supporting only: no finance/reporting mutation in this AI-only slice.                                                                                                  | scope rationale                       |
+| i18n operational readiness                    | `supporting` | Supporting only: generated labels and validation copy must remain locale-extensible later.                                                                             | copy/schema review + scope rationale  |
+| Stack-fit and dependency discipline           | `target`     | Use existing schema-validation and app stack patterns; avoid unnecessary AI orchestration dependencies.                                                                | dependency diff + code review         |
+| Testing and QA automation                     | `target`     | Golden tests, schema tests, and generate->validate->save integration coverage pass before merge.                                                                       | CI + verify outputs                   |
+| Scalability and cost efficiency               | `supporting` | Supporting only: generation flow should avoid obvious runaway retries or oversized prompt/output churn.                                                                | scope rationale + usage notes         |
+| DevOps and rollback readiness                 | `target`     | AI generation can be disabled or rolled back without corrupting canonical saved plans.                                                                                 | rollout notes + release checklist     |
 
 ## Acceptance Criteria
 
@@ -153,6 +167,8 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - AI generation consumes canonical generator-intake handoff payloads without re-guessing raw My Library context or mutable labels.
 - AI goal-based generation remains a distinct flow from manual workout/session/program building.
 - Users explicitly choose the planning horizon before generation rather than the model inferring `session` vs `program` implicitly.
+- Supported horizon choices include `session`, `week`, `month`, `three_months`, `six_months`, `twelve_months`, `date_range`, and `to_competition_date`.
+- If `date_range` is selected, explicit start/end dates are required or deterministically defaulted by product rules; the model must not guess a hidden calendar window.
 - If `to_competition_date` is selected, competition date and explicit peak/taper intent are required inputs rather than hidden AI assumptions.
 - Generated sessions/programs use the canonical Garmin-compatible step model and do not invent incompatible repeat/target structures.
 - When threshold context is available, generated intensity targets use the shared threshold-based swim-zone/pace model rather than a parallel AI-only zone scheme.
@@ -172,4 +188,4 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 
 - `2026-03-19 | planning | clarified that this brief owns AI-authored session/program draft generation from generator-intake handoff, while manual workout/program building remains separate and downstream editing/review can happen after generation | next: request owner detail later on first generator scope, goal model, and generated-draft review/edit expectations before implementation starts`
 - `2026-03-20 | planning | aligned AI generation requirements to the canonical Garmin-style step model and shared threshold-based swim-zone method, and kept retrospective completed-session analysis explicitly out of this generation brief | next: request owner detail later on whether the first AI slice should generate one session, one week, or a longer program`
-- `2026-03-20 | planning | expanded generator UX to require an explicit planning-horizon choice (`session`, `week`, `month`, `six_months`, or `to_competition_date`) and made competition-date generation carry explicit peak/taper intent instead of hidden AI assumptions | next: decide which horizon becomes the first shipped AI slice and keep the data contract/builder/history briefs aligned to the same plan-intent metadata`
+- `2026-03-20 | planning | expanded generator UX to require an explicit planning-horizon choice (`session`, `week`, `month`, `three_months`, `six_months`, `twelve_months`, `date_range`, or `to_competition_date`), added calendar-window inputs for date-range planning, and kept competition-date generation on explicit peak/taper intent instead of hidden AI assumptions | next: decide which subset of the full horizon matrix ships first and keep the data contract/builder/history briefs aligned to the same plan-intent metadata`

--- a/docs/task-briefs/planned/2026-02-28-program-builder-calendar-completion-10-10.md
+++ b/docs/task-briefs/planned/2026-02-28-program-builder-calendar-completion-10-10.md
@@ -20,7 +20,7 @@ Enable users to manually turn workouts into clear weekly programs with determini
 - This brief sets measurable 10/10 thresholds so later slices can ship with predictable quality gates.
 - This brief is the manual program-building track.
 - AI-generated session/program creation belongs to a separate generator brief and must not be conflated with this manual planner flow.
-- Accepted AI-generated week/month/six-month/competition-date plans should still hand off into one editable planner surface after canonical save.
+- Accepted AI-generated plans across supported fixed-duration, date-range, and competition-date horizons should still hand off into one editable planner surface after canonical save.
 - Canonical training-history state, manual done/cancel/comments, and Garmin-completed reconciliation belong to a separate history brief and must not be hidden inside planner-only flags.
 
 ## Scope
@@ -139,4 +139,4 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - `2026-03-16 | working tree | added explicit identity-and-rename contract so future program-builder implementation cannot couple canonical IDs to week/day order, editable labels, or reschedule flows | next: carry the same contract into implementation slices before schema/UI work starts`
 - `2026-03-19 | planning | clarified product direction that this brief owns manual program building from user-authored workouts, while AI goal-based session/program generation stays in a separate generator brief | next: request owner detail later on how AI-generated plans should hand off into editable builder/program flows`
 - `2026-03-20 | planning | narrowed this brief to the manual program builder and planner-status track, and moved canonical done/cancel/comments/history ownership into a separate training-history brief so scheduling truth and outcome truth stay cleanly separated | next: keep planner UI aligned to canonical history state instead of adding planner-local completion flags`
-- `2026-03-20 | planning | clarified that accepted AI-generated plans across week/month/six-month/competition-date horizons should still converge into this same editable planner after canonical save, while horizon selection and competition intent remain upstream generator concerns | next: keep later planner implementation compatible with AI-authored plan metadata without turning this brief into a generation brief`
+- `2026-03-20 | planning | clarified that accepted AI-generated plans across supported fixed-duration, date-range, and competition-date horizons should still converge into this same editable planner after canonical save, while horizon selection and competition intent remain upstream generator concerns | next: keep later planner implementation compatible with AI-authored plan metadata without turning this brief into a generation brief`

--- a/docs/task-briefs/planned/2026-02-28-workout-builder-garmin-familiar-epic-10-10.md
+++ b/docs/task-briefs/planned/2026-02-28-workout-builder-garmin-familiar-epic-10-10.md
@@ -24,7 +24,7 @@ Deliver a Garmin-familiar workout creation, generation, planning, history, and e
 - Optimize for:
   - quick workout creation,
   - generator intake before AI/session creation when My Library context exists,
-  - explicit planning-horizon choice from one session to competition-date programs,
+  - explicit planning-horizon choice from one session to fixed-duration, custom date-range, and competition-date programs,
   - explicit peak/taper intent when a competition-date horizon is chosen,
   - poolside execution,
   - threshold-based swim-zone targeting from supported threshold tests,
@@ -121,7 +121,10 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
    - `session`,
    - `week`,
    - `month`,
+   - `three_months`,
    - `six_months`,
+   - `twelve_months`,
+   - `date_range`,
    - `to_competition_date` with explicit peak/taper intent.
 6. Training history/completion foundation with manual done/cancel/comments and later Garmin Activity API reconciliation hooks.
 7. Export adapters (Garmin-ready format + PDF).
@@ -143,7 +146,7 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 
 - `2026-03-19 | planning | clarified epic product split into manual builder/program track, generator-intake bridge, and AI generator track so future 10/10 briefs and implementation slices do not blur authoring, generation, export, and Garmin responsibilities | next: request owner detail later on exact AI session/program generator scope before turning planned briefs into implementation sequence`
 - `2026-03-20 | planning | expanded the epic into four explicit product tracks (manual session builder, automatic generator, manual program builder, and training history), aligned the contract to threshold-based swim zones, and separated Garmin Training API send from later Garmin Activity API history reconciliation | next: update child briefs and use the new training-history brief as the parent track for done/cancel/comments and retrospective evaluation`
-- `2026-03-20 | planning | expanded the automatic-generator direction so users can explicitly choose `session`, `week`, `month`, `six_months`, or `to_competition_date`, and made competition-date planning carry explicit peak/taper intent rather than hidden logic | next: keep the AI generator, data contract, builder handoff, and history briefs aligned to the same plan-intent metadata before implementation starts`
+- `2026-03-20 | planning | expanded the automatic-generator direction so users can explicitly choose `session`, `week`, `month`, `three_months`, `six_months`, `twelve_months`, `date_range`, or `to_competition_date`, and made competition-date planning carry explicit peak/taper intent rather than hidden logic | next: keep the AI generator, data contract, builder handoff, and history briefs aligned to the same plan-intent metadata before implementation starts`
 
 ## Completion Criteria For Epic
 

--- a/docs/task-briefs/planned/2026-02-28-workout-data-contract-and-step-engine-10-10.md
+++ b/docs/task-briefs/planned/2026-02-28-workout-data-contract-and-step-engine-10-10.md
@@ -34,12 +34,20 @@ Define a canonical, Garmin-compatible workout schema and deterministic step engi
     - `session`,
     - `week`,
     - `month`,
+    - `three_months`,
     - `six_months`,
+    - `twelve_months`,
+    - `date_range`,
     - `to_competition_date`,
+  - optional calendar-window metadata:
+    - `start_date`,
+    - `end_date`,
+    - explicit rule for whether omitted `start_date` defaults to generation date / `today`,
   - optional competition intent metadata:
     - `competition_date`,
     - optional competition label,
-    - explicit `peak_for_competition` boolean or equivalent structured intent field.
+    - explicit `peak_for_competition` boolean or equivalent structured intent field,
+    - optional explicit competition-plan start date when different from default `today`.
 - Define canonical `steps` JSON schema:
   - step types (`warmup`, `drill`, `main`, `cooldown`, `rest`, `repeat_block`),
   - duration and distance target,
@@ -95,7 +103,7 @@ Define a canonical, Garmin-compatible workout schema and deterministic step engi
 - Human-readable identifiers:
   - titles/slugs/labels are operator-facing and may be renameable where product UX needs it,
   - human-readable fields must never be the sole canonical key for progress, notes, exports, analytics, or plan references,
-  - week labels, phase labels such as `build`/`taper`, and competition display names are presentation only unless a separate canonical field explicitly owns that meaning.
+  - week labels, phase labels such as `build`/`taper`, date-window labels, and competition display names are presentation only unless a separate canonical field explicitly owns that meaning.
 - Mutability rules:
   - canonical IDs are write-once,
   - reorder operations change ordering fields only,
@@ -103,7 +111,7 @@ Define a canonical, Garmin-compatible workout schema and deterministic step engi
 - Rename vs repurpose:
   - rename in place is allowed only when the underlying drill/template/workout/plan object is still semantically the same,
   - materially different content should create a new entity instead of overwriting an existing canonical ID,
-  - changing a saved plan from one planning horizon to another or changing its target competition/peak intent should default to new/versioned plan semantics rather than silent in-place repurpose.
+  - changing a saved plan from one planning horizon to another, changing its calendar window, or changing its target competition/peak intent should default to new/versioned plan semantics rather than silent in-place repurpose.
 - Compatibility contract:
   - import/AI/export flows must preserve canonical IDs for existing entities or create explicit new entities,
   - no production logic may infer canonical identity from editable labels or ordinal strings alone.
@@ -145,7 +153,7 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 ## Acceptance Criteria
 
 - Canonical schema documented and implemented in TS + DB.
-- Canonical plan/program entities support explicit planning-horizon metadata and optional competition-date/peak intent without relying on titles or week labels.
+- Canonical plan/program entities support explicit planning-horizon metadata, optional calendar-window metadata, and optional competition-date/peak intent without relying on titles or week labels.
 - Step payloads are validated and normalized before persistence.
 - Totals (`meters`, step count, interval count) are deterministic.
 - Canonical step model can express Garmin-familiar single steps, repeats, and interval sets without ambiguous translation.
@@ -167,4 +175,4 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 ## Checkpoint Log
 
 - `2026-03-20 | planning | aligned the canonical workout contract to Garmin-style duration/target/repeat semantics and threshold-based swim-zone normalization from 1000m or CSS sources so manual builder, AI generator, export, and later Garmin delivery share the same language | next: keep downstream builder/generator/export briefs pinned to this contract and avoid parallel zone systems`
-- `2026-03-20 | planning | added explicit plan-intent metadata expectations for planning horizon and competition-date/peak intent so AI generation, planner editing, export, and later history evaluation do not infer those semantics from mutable labels | next: keep builder/generator/history briefs pinned to these canonical plan metadata fields before implementation starts`
+- `2026-03-20 | planning | added explicit plan-intent metadata expectations for planning horizon, optional calendar windows, and competition-date/peak intent so AI generation, planner editing, export, and later history evaluation do not infer those semantics from mutable labels | next: keep builder/generator/history briefs pinned to these canonical plan metadata fields before implementation starts`

--- a/docs/task-briefs/planned/2026-03-20-training-history-completion-reconciliation-and-retrospective-evaluation-10-10.md
+++ b/docs/task-briefs/planned/2026-03-20-training-history-completion-reconciliation-and-retrospective-evaluation-10-10.md
@@ -66,7 +66,7 @@ Establish a canonical training-history system so planned sessions can move into 
   - conflicting final-state outcomes must surface explicit review state, not silently overwrite.
 - Retrospective AI-readiness hooks:
   - canonical history payload can later feed AI evaluation of individual sessions and longer-term progress against goals,
-  - linked plan-intent metadata should preserve planning horizon and any competition-date/peak intent that shaped the original plan.
+  - linked plan-intent metadata should preserve planning horizon, any original date window, and any competition-date/peak intent that shaped the original plan.
 
 ## Child Slice Sequencing
 
@@ -97,7 +97,7 @@ Establish a canonical training-history system so planned sessions can move into 
   - manual comments,
   - external provider references,
   - reconciliation status,
-  - plan-intent snapshot or references needed so later retrospective AI can understand original horizon and competition intent without guessing from mutable labels.
+  - plan-intent snapshot or references needed so later retrospective AI can understand original horizon, date window, and competition intent without guessing from mutable labels.
 - Local-only:
   - transient history filters,
   - unsaved comment draft,
@@ -171,7 +171,7 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - Planner/calendar views read canonical history outcome state rather than maintaining a second completion truth.
 - Conflicting provider/manual outcomes enter explicit `needs_review` state instead of silent overwrite.
 - Later retrospective AI evaluation can consume canonical history entries and comments without becoming the source of truth for outcome state.
-- Later retrospective AI evaluation can also consume original plan-intent metadata, including planning horizon and competition-date/peak intent where present, without becoming the source of truth for outcome state.
+- Later retrospective AI evaluation can also consume original plan-intent metadata, including planning horizon, original date window, and competition-date/peak intent where present, without becoming the source of truth for outcome state.
 - Brief is scorecard-complete and identity-safe before implementation starts.
 
 ## Validation
@@ -185,4 +185,4 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 ## Checkpoint Log
 
 - `2026-03-20 | planning | created a dedicated history/completion parent brief so manual done/cancel/comments, later Garmin Activity API reconciliation, and retrospective AI evaluation have one canonical state model instead of being split across planner and send-to-Garmin slices | next: use this brief to keep planner, Garmin send, and later provider-ingest work from inventing parallel completion/history truth`
-- `2026-03-20 | planning | clarified that retrospective evaluation should retain original plan-intent context such as planning horizon and explicit competition-date peak/taper intent, so future AI review can judge sessions against what the plan was actually trying to do | next: keep later history schema and AI evaluation slices aligned to canonical plan-intent metadata rather than mutable week labels`
+- `2026-03-20 | planning | clarified that retrospective evaluation should retain original plan-intent context such as planning horizon, explicit date window, and explicit competition-date peak/taper intent, so future AI review can judge sessions against what the plan was actually trying to do | next: keep later history schema and AI evaluation slices aligned to canonical plan-intent metadata rather than mutable week labels`


### PR DESCRIPTION
## Summary
- expand the AI generator horizon matrix so users can explicitly choose `session`, `week`, `month`, `three_months`, `six_months`, `twelve_months`, `date_range`, or `to_competition_date`
- add canonical date-window metadata (`start_date`, `end_date`) and clarify that competition plans can still default from `today` unless the user overrides the start
- align epic, planner handoff, and training-history briefs so accepted AI plans and later retrospective evaluation preserve the same horizon/date-window/competition intent metadata

## Validation
- `npm run verify:pre-pr`
- `npm run verify:pre-merge`

## Notes
- docs-only PR; no runtime, schema, or API behavior changed
- all 5 changed briefs passed `npm run lint:briefs`
- `npm run lint:briefs:all` still has older unrelated legacy brief failures elsewhere in the repo, but none of them are in scope for this PR
- perf trend again recommended `tighten`; decision for this docs-only PR is `hold` and carry the ratchet decision in the AW-010/performance governance track
- manual QA and Vercel preview QA: `N/A` for docs-only scope
