### PR TITLE
docs(generator): define ai session v1 brief

### DIFF
--- a/docs/task-briefs/planned/2026-02-28-ai-plan-generator-json-guardrails-10-10.md
+++ b/docs/task-briefs/planned/2026-02-28-ai-plan-generator-json-guardrails-10-10.md
@@ -40,6 +40,36 @@ Generate AI-authored swim session/program drafts across explicit planning horizo
     - `date_range`,
     - `to_competition_date`,
   - selected goal/focus/profile/metric/preference context from intake,
+  - explicit generation-intent fields for the chosen horizon, such as:
+    - environment:
+      - `pool`,
+      - `open_water`,
+    - when `pool` is selected, explicit `pool_length_m`:
+      - `12.5`,
+      - `25`,
+      - `50`,
+    - preferred planning unit:
+      - `distance`,
+      - `estimated_time`,
+    - explicit duration target for the run:
+      - `target_distance_m`,
+      - or `target_time_min`,
+    - desired session/program intent such as:
+      - `recovery`,
+      - `endurance`,
+      - `technique`,
+      - `threshold_css`,
+      - `speed`,
+      - `race_pace`,
+    - user-facing effort selection:
+      - `easy`,
+      - `moderate`,
+      - `hard`,
+      - `very_hard`,
+      - `race_pace`,
+    - allowed stroke list for the current swimmer/run,
+    - whether drills and/or kick work should be included,
+    - optional allowed-equipment constraints where product chooses to support them,
   - optional calendar framing for date-based generations:
     - `start_date`,
     - `end_date`,
@@ -56,8 +86,11 @@ Generate AI-authored swim session/program drafts across explicit planning horizo
   - one `session -> steps` draft for `session` horizon,
   - `weeks -> sessions -> steps` for multi-session horizons,
   - plan-level metadata that preserves selected planning horizon and competition intent when present,
+  - editable title/name suggestions rather than fixed AI-authored names,
+  - draft-first output state so generated content can be reviewed/edited before acceptance,
   - Garmin-compatible duration/target/repeat semantics,
-  - threshold-based swim-zone or pace targets when threshold context is available.
+  - threshold-based swim-zone or pace targets when threshold context is available,
+  - user-facing effort presets may stay simpler than exact zones, but canonical output must still map cleanly onto the shared threshold-based method when context exists.
 - Guardrails:
   - horizon-specific progression and recovery rules,
   - progression caps,
@@ -73,6 +106,8 @@ Generate AI-authored swim session/program drafts across explicit planning horizo
 
 1. AI session generator:
    - one-session horizon,
+   - Garmin-minimum swim workout structure,
+   - explicit pool/open-water, duration, session-type, and effort inputs,
    - clean single-session draft review/edit handoff.
 2. AI short-horizon program generator:
    - one week,
@@ -168,12 +203,15 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - AI goal-based generation remains a distinct flow from manual workout/session/program building.
 - Users explicitly choose the planning horizon before generation rather than the model inferring `session` vs `program` implicitly.
 - Supported horizon choices include `session`, `week`, `month`, `three_months`, `six_months`, `twelve_months`, `date_range`, and `to_competition_date`.
+- Generation input includes explicit environment, pool-length, effort, duration, and session/program intent fields where relevant for the chosen horizon rather than relying on hidden AI assumptions.
 - If `date_range` is selected, explicit start/end dates are required or deterministically defaulted by product rules; the model must not guess a hidden calendar window.
 - If `to_competition_date` is selected, competition date and explicit peak/taper intent are required inputs rather than hidden AI assumptions.
 - Generated sessions/programs use the canonical Garmin-compatible step model and do not invent incompatible repeat/target structures.
-- When threshold context is available, generated intensity targets use the shared threshold-based swim-zone/pace model rather than a parallel AI-only zone scheme.
+- When threshold context is available, generated intensity targets use the shared threshold-based swim-zone/pace model rather than a parallel AI-only zone scheme, even if the user-facing input surface starts with simpler effort presets such as `easy`/`moderate`/`hard`.
 - Generated output preserves plan-level horizon/competition metadata so later builder, export, and history slices can understand original plan intent.
 - Users can edit generated plan without data loss.
+- Generated titles are suggestions only and can be edited before acceptance.
+- Generated output is treated as draft until the user reviews and accepts it.
 - Failures are explicit and recoverable.
 - AI output never mutates canonical entity identity implicitly through renamed labels or reordered weeks/sessions.
 - Brief is scorecard-complete and identity-safe before implementation starts.
@@ -189,3 +227,4 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - `2026-03-19 | planning | clarified that this brief owns AI-authored session/program draft generation from generator-intake handoff, while manual workout/program building remains separate and downstream editing/review can happen after generation | next: request owner detail later on first generator scope, goal model, and generated-draft review/edit expectations before implementation starts`
 - `2026-03-20 | planning | aligned AI generation requirements to the canonical Garmin-style step model and shared threshold-based swim-zone method, and kept retrospective completed-session analysis explicitly out of this generation brief | next: request owner detail later on whether the first AI slice should generate one session, one week, or a longer program`
 - `2026-03-20 | planning | expanded generator UX to require an explicit planning-horizon choice (`session`, `week`, `month`, `three_months`, `six_months`, `twelve_months`, `date_range`, or `to_competition_date`), added calendar-window inputs for date-range planning, and kept competition-date generation on explicit peak/taper intent instead of hidden AI assumptions | next: decide which subset of the full horizon matrix ships first and keep the data contract/builder/history briefs aligned to the same plan-intent metadata`
+- `2026-03-20 | planning | added explicit generation-intent expectations for environment, pool length, duration mode, session/program intent, effort presets, drills/kick inclusion, and editable draft-first naming so the first AI session slice can stay Garmin-familiar without forcing raw zone-picking UX on day one | next: land a dedicated AI session generator v1 brief that turns these assumptions into one implementation-ready child slice`

--- a/docs/task-briefs/planned/2026-02-28-workout-builder-and-poolside-execution-10-10.md
+++ b/docs/task-briefs/planned/2026-02-28-workout-builder-and-poolside-execution-10-10.md
@@ -17,11 +17,20 @@ Ship a Garmin-familiar manual session builder and poolside execution experience 
 - Manual workout/session authoring for user-built training sessions.
 - Editing surface for accepted single-session AI drafts after they become canonical workouts, without moving generation logic into this brief.
 - Builder UI patterns:
+  - workout-level metadata editing,
   - step cards,
   - add step,
   - add repeat block,
   - reorder/remove,
   - section totals.
+- Workout-level metadata editing:
+  - title/name,
+  - environment (`pool` or `open_water`),
+  - when `pool`, `pool_length_m` (`12.5`, `25`, `50`),
+  - session intent/type,
+  - total target by distance and/or estimated time,
+  - overall effort preset,
+  - editable summary/description.
 - Garmin-familiar structured step authoring:
   - duration + target pairing,
   - repeat/interval block editing,
@@ -118,6 +127,7 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - Users can create, reorder, repeat, and save workouts without confusion.
 - Users can manually author their own workouts without being routed through AI generation.
 - Accepted AI-generated single-session drafts can be edited through the same canonical workout editor once they exist, without forking identity rules.
+- The same editor can change workout-level metadata such as pool/open-water context, pool length, title, effort preset, session intent, and total target after AI generation or manual creation.
 - Users can author Garmin-familiar target/duration/repeat structures without learning a hidden export model later.
 - Threshold-based swim zone targets, when shown, use the shared published method rather than a separate builder-only zone system.
 - Poolside mode supports clean execution with minimal cognitive load.
@@ -137,3 +147,4 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - `2026-03-19 | planning | clarified that this brief owns manual workout/session building and poolside execution only; AI generation and weekly program authoring remain separate briefs | next: request owner detail later on exact manual-builder ergonomics, save model, and Garmin-export handoff expectations before implementation starts`
 - `2026-03-20 | planning | tightened this brief into the explicit manual session builder track, added Garmin-familiar target/duration/repeat authoring requirements, and aligned swim-intensity editing to the shared threshold-based zone method | next: request owner detail later on exact builder editing ergonomics and how much compatibility guidance should be visible before export/send exists`
 - `2026-03-20 | planning | clarified that accepted AI-generated single-session drafts should hand off into this same editor after canonical save, while horizon selection and competition intent remain upstream generator concerns | next: keep later implementation focused on canonical workout editing and avoid mixing generation controls into the manual builder UI`
+- `2026-03-20 | planning | added explicit workout-level metadata editing expectations for environment, pool length, session intent, effort preset, and normalized distance/time totals so AI-authored drafts and manual workouts can truly share the same editor instead of only the same step cards | next: keep future builder implementation centered on one canonical workout form that can edit both metadata and steps`

--- a/docs/task-briefs/planned/2026-02-28-workout-builder-garmin-familiar-epic-10-10.md
+++ b/docs/task-briefs/planned/2026-02-28-workout-builder-garmin-familiar-epic-10-10.md
@@ -42,10 +42,11 @@ This epic is split into dedicated briefs for delivery quality and rollback safet
 4. `2026-02-28-program-builder-calendar-completion-10-10.md`
 5. `2026-03-19-my-library-generator-intake-and-prefill-foundation-10-10.md`
 6. `2026-02-28-ai-plan-generator-json-guardrails-10-10.md`
-7. `2026-03-20-training-history-completion-reconciliation-and-retrospective-evaluation-10-10.md`
-8. `2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md`
-9. `2026-02-28-workout-commercial-analytics-funnel-10-10.md`
-10. `2026-02-28-garmin-training-api-partner-integration-10-10.md` (`blocked` until partner/API readiness)
+7. `2026-03-20-ai-session-generator-v1-garmin-minimum-draft-review-10-10.md`
+8. `2026-03-20-training-history-completion-reconciliation-and-retrospective-evaluation-10-10.md`
+9. `2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md`
+10. `2026-02-28-workout-commercial-analytics-funnel-10-10.md`
+11. `2026-02-28-garmin-training-api-partner-integration-10-10.md` (`blocked` until partner/API readiness)
 
 ## Out Of Scope (Current)
 
@@ -118,7 +119,7 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 3. Manual program builder/calendar/completion.
 4. Generator intake/prefill bridge from My Library context.
 5. AI session/program generation across explicit horizons:
-   - `session`,
+   - `session` first, with explicit pool/open-water choice, supported pool lengths, session intent, effort preset, and time/distance targeting,
    - `week`,
    - `month`,
    - `three_months`,
@@ -147,6 +148,7 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - `2026-03-19 | planning | clarified epic product split into manual builder/program track, generator-intake bridge, and AI generator track so future 10/10 briefs and implementation slices do not blur authoring, generation, export, and Garmin responsibilities | next: request owner detail later on exact AI session/program generator scope before turning planned briefs into implementation sequence`
 - `2026-03-20 | planning | expanded the epic into four explicit product tracks (manual session builder, automatic generator, manual program builder, and training history), aligned the contract to threshold-based swim zones, and separated Garmin Training API send from later Garmin Activity API history reconciliation | next: update child briefs and use the new training-history brief as the parent track for done/cancel/comments and retrospective evaluation`
 - `2026-03-20 | planning | expanded the automatic-generator direction so users can explicitly choose `session`, `week`, `month`, `three_months`, `six_months`, `twelve_months`, `date_range`, or `to_competition_date`, and made competition-date planning carry explicit peak/taper intent rather than hidden logic | next: keep the AI generator, data contract, builder handoff, and history briefs aligned to the same plan-intent metadata before implementation starts`
+- `2026-03-20 | planning | tightened the first generator milestone around one editable AI session draft with explicit pool/open-water, pool-length, duration, session-intent, and effort choices so the epic proves the canonical workout model before expanding into larger program horizons | next: add and use a dedicated AI session generator v1 brief before broader program-generation implementation starts`
 
 ## Completion Criteria For Epic
 

--- a/docs/task-briefs/planned/2026-02-28-workout-data-contract-and-step-engine-10-10.md
+++ b/docs/task-briefs/planned/2026-02-28-workout-data-contract-and-step-engine-10-10.md
@@ -29,6 +29,34 @@ Define a canonical, Garmin-compatible workout schema and deterministic step engi
 
 - Define canonical entities:
   - `drill`, `workout_template`, `workout`, `plan`, `plan_session`, `training_history_entry`.
+- Define canonical workout/session metadata:
+  - environment:
+    - `pool`,
+    - `open_water`,
+  - when environment is `pool`, supported `pool_length_m` values:
+    - `12.5`,
+    - `25`,
+    - `50`,
+  - session intent/type such as:
+    - `recovery`,
+    - `endurance`,
+    - `technique`,
+    - `threshold_css`,
+    - `speed`,
+    - `race_pace`,
+  - user-facing effort preset metadata:
+    - `easy`,
+    - `moderate`,
+    - `hard`,
+    - `very_hard`,
+    - `race_pace`,
+  - primary planning unit:
+    - `distance`,
+    - `estimated_time`,
+  - normalized workout totals:
+    - `target_distance_m`,
+    - `estimated_duration_sec`,
+  - editable workout title/summary fields that are presentation, not identity.
 - Define canonical plan metadata:
   - `planning_horizon` enum:
     - `session`,
@@ -63,7 +91,8 @@ Define a canonical, Garmin-compatible workout schema and deterministic step engi
 - Define threshold-based swim-zone support:
   - normalized `threshold_sec_per_100`,
   - supported threshold source metadata,
-  - deterministic zone-band projection rules for workout targeting and export mapping.
+  - deterministic zone-band projection rules for workout targeting and export mapping,
+  - user-facing generator/builder flows may start from simpler effort presets, but canonical storage must still preserve deterministic mapping into the threshold-based method when threshold context exists.
 - Add invariant rules:
   - max step count,
   - repeat nesting constraints,
@@ -154,6 +183,7 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 
 - Canonical schema documented and implemented in TS + DB.
 - Canonical plan/program entities support explicit planning-horizon metadata, optional calendar-window metadata, and optional competition-date/peak intent without relying on titles or week labels.
+- Canonical workout/session entities support explicit environment, pool length, session intent/type, effort preset metadata, and normalized time/distance totals without relying on free-text notes.
 - Step payloads are validated and normalized before persistence.
 - Totals (`meters`, step count, interval count) are deterministic.
 - Canonical step model can express Garmin-familiar single steps, repeats, and interval sets without ambiguous translation.
@@ -176,3 +206,4 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 
 - `2026-03-20 | planning | aligned the canonical workout contract to Garmin-style duration/target/repeat semantics and threshold-based swim-zone normalization from 1000m or CSS sources so manual builder, AI generator, export, and later Garmin delivery share the same language | next: keep downstream builder/generator/export briefs pinned to this contract and avoid parallel zone systems`
 - `2026-03-20 | planning | added explicit plan-intent metadata expectations for planning horizon, optional calendar windows, and competition-date/peak intent so AI generation, planner editing, export, and later history evaluation do not infer those semantics from mutable labels | next: keep builder/generator/history briefs pinned to these canonical plan metadata fields before implementation starts`
+- `2026-03-20 | planning | expanded the canonical workout/session metadata to cover pool vs open-water context, supported pool lengths, session intent, effort presets, and normalized time/distance totals so the first AI session generator and later manual builder can share one editable model | next: keep AI session input UX simple while still mapping canonically onto threshold-based targeting and Garmin-ready step data`

--- a/docs/task-briefs/planned/2026-03-20-ai-session-generator-v1-garmin-minimum-draft-review-10-10.md
+++ b/docs/task-briefs/planned/2026-03-20-ai-session-generator-v1-garmin-minimum-draft-review-10-10.md
@@ -1,0 +1,248 @@
+# Task Brief: AI Session Generator V1 Garmin-Minimum Draft Review (10/10)
+
+## Metadata
+
+- `id`: `2026-03-20-ai-session-generator-v1-garmin-minimum-draft-review-10-10`
+- `status`: `planned`
+- `owner`: `stianvikra`
+- `created`: `2026-03-20`
+- `updated`: `2026-03-20`
+
+## Goal
+
+Generate one Garmin-familiar swim-session draft from reviewed generator-intake context plus explicit user choices, then hand that draft into the same editable workout flow as a manual workout while keeping it in `draft` state until the swimmer reviews and accepts it.
+
+## Why This Brief Exists
+
+- The broad AI generator parent brief is intentionally larger than the first safe implementation slice.
+- The right first proof is not a full week/month/program generator.
+- The right first proof is one editable session draft that:
+  - respects My Library intake context,
+  - asks the swimmer what kind of session they want,
+  - produces Garmin-minimum structured swim steps,
+  - stays editable in the same builder model as manual workouts,
+  - and remains `draft` until approved.
+- This lets product, UX, data contract, and Garmin alignment harden on the smallest meaningful unit before longer-horizon planning adds progression, tapering, and history feedback loops.
+
+## Dependencies And Boundaries
+
+- Upstream intake handoff:
+  - `docs/task-briefs/done/2026-03-19-my-library-generator-intake-and-prefill-foundation-10-10.md`
+- Upstream AI generator parent:
+  - `docs/task-briefs/planned/2026-02-28-ai-plan-generator-json-guardrails-10-10.md`
+- Upstream canonical workout contract:
+  - `docs/task-briefs/planned/2026-02-28-workout-data-contract-and-step-engine-10-10.md`
+- Downstream editing handoff:
+  - `docs/task-briefs/planned/2026-02-28-workout-builder-and-poolside-execution-10-10.md`
+- This brief owns:
+  - one-session AI generation,
+  - single-run user input UX for that generation,
+  - draft review/save rules for one generated session.
+- This brief does not own:
+  - multi-session program generation,
+  - calendar planning,
+  - competition-date taper/peak logic,
+  - Garmin send/publish,
+  - completed-history reconciliation,
+  - or a separate AI-only editor.
+
+## Product Assumptions For V1
+
+- Supported environments:
+  - `pool`
+  - `open_water`
+- Supported pool lengths when environment is `pool`:
+  - `12.5m`
+  - `25m`
+  - `50m`
+- Supported session types in v1:
+  - `recovery`
+  - `endurance`
+  - `technique`
+  - `threshold_css`
+  - `speed`
+  - `race_pace`
+- Supported user-facing effort choices in v1:
+  - `easy`
+  - `moderate`
+  - `hard`
+  - `very_hard`
+  - `race_pace`
+- Supported primary sizing modes in v1:
+  - `distance`
+  - `estimated_time`
+- Supported extra structure preferences in v1:
+  - include drills
+  - include kick work
+  - allowed strokes the swimmer is comfortable using
+  - optional allowed-equipment list:
+    - `kickboard`
+    - `pull_buoy`
+    - `fins`
+    - `paddles`
+    - `snorkel`
+- Naming:
+  - AI provides one or more editable title suggestions.
+  - Title is never fixed or identity-bearing.
+
+## UX Direction For V1
+
+- Ask for the minimum information that materially shapes one session:
+  - session type,
+  - effort,
+  - pool vs open water,
+  - pool length when relevant,
+  - distance or estimated-time target,
+  - whether drills/kick should appear,
+  - which strokes can be used,
+  - optional equipment constraints.
+- Do not force the swimmer to pick raw threshold zones as the primary UX.
+- If threshold/CSS context exists, use it behind the scenes to shape pace/zone targets in the generated workout.
+- Keep advanced exact-zone editing in the later manual workout editor rather than in the first AI input form.
+- Default generated pool sessions should include:
+  - an easy warmup,
+  - a main set matched to session type and effort,
+  - a cooldown,
+  - unless a documented short-session or open-water rule intentionally changes that structure.
+
+## Scope
+
+- Authenticated AI session-generation entrypoint for `planning_horizon = session`.
+- Input contract for one generated session:
+  - intake handoff payload,
+  - selected session type,
+  - selected effort preset,
+  - selected environment,
+  - selected pool length when environment is `pool`,
+  - selected primary sizing mode:
+    - `distance`
+    - or `estimated_time`,
+  - explicit `target_distance_m` or `target_time_min`,
+  - include-drills flag,
+  - include-kick flag,
+  - allowed strokes list,
+  - optional equipment allowlist,
+  - optional one-run notes/constraints.
+- Generation rules:
+  - Garmin-familiar structured step output only,
+  - deterministic warmup/main/cooldown structure rules,
+  - simple effort UX mapped to canonical threshold-based targeting when threshold context exists,
+  - deterministic fallback when threshold context does not exist,
+  - avoid incompatible step shapes for later export/send,
+  - constrain incompatible combinations explicitly:
+    - e.g. `open_water` plus drill-heavy or kick-heavy requests may need guardrails or reduced support.
+- Output rules:
+  - create one generated workout draft,
+  - keep draft separate from accepted canonical workout state until review/accept,
+  - show editable title suggestion(s),
+  - preserve generation metadata needed for later review and analytics,
+  - hand accepted draft into the same workout editor used for manual workouts.
+- Review/edit handoff:
+  - swimmer can edit the full generated session before accepting it,
+  - title, metadata, steps, targets, strokes, notes, and equipment stay editable,
+  - no AI-only hidden fields should be required to keep the workout valid.
+
+## Out Of Scope
+
+- Multi-session week/month/date-range/program generation.
+- Competition-date generation and taper/peak orchestration.
+- Automatic calendar scheduling.
+- Automatic send to Garmin.
+- Completed-history ingestion or retrospective AI analysis.
+- Public sharing or SEO surfaces.
+
+## Data Placement And Sync Contract (Required)
+
+- Server-canonical:
+  - accepted canonical workout entities after explicit save/accept,
+  - validated normalized step payload,
+  - canonical workout metadata such as environment, pool length, session intent, totals, and title.
+- Local-only:
+  - current generation form state,
+  - transient generated preview,
+  - draft review edits before acceptance,
+  - discarded draft variants,
+  - temporary title suggestions.
+- Sync behavior:
+  - generation output is provisional until explicit accept/save succeeds,
+  - regeneration must not silently overwrite a previously accepted workout,
+  - draft review edits must survive transient generate/save failures where practical,
+  - accepted AI sessions must re-enter later reads as normal canonical workouts, not AI-special cases.
+- Invalidation:
+  - accept/delete/regenerate invalidates workout-detail, builder, and export reads for the affected draft/workout.
+
+## Identity And Rename Contract
+
+- Canonical stable IDs:
+  - generated previews may use ephemeral client IDs,
+  - accepted workouts and steps receive canonical immutable IDs from the shared workout contract.
+- Human-readable identifiers:
+  - generated workout titles and section labels are editable display fields only.
+- Mutability rules:
+  - rename/edit after generation must not rewrite canonical IDs for already-accepted entities.
+- Rename vs repurpose:
+  - materially regenerating a session should create a new draft version rather than silently mutating an already-accepted workout in place.
+- Compatibility contract:
+  - the manual workout editor, program planner, history, and export surfaces must consume the accepted output through the shared canonical workout contract, not through an AI-only adapter.
+- Observability and repair:
+  - rejected output, invalid schema rewrites, and unresolved step mappings must be logged/measured with support-visible diagnostics.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+| Category                                      | Mapping      | Target Threshold                                                                                                                                | Evidence                              |
+| --------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| Product goals and IA                          | `target`     | Users can generate one swim session from explicit choices and clearly understand `draft` vs `accepted` state with no hidden AI assumptions.     | UX flow + route/state contract        |
+| UX flow clarity                               | `target`     | Users can request, review, and hand off one generated session for editing in <= 2 minutes median without documentation.                         | e2e + timed manual QA                 |
+| Visual design quality                         | `supporting` | Supporting only: visual language should align with My Library/workout flows, but broader UI system ownership is downstream.                     | scope rationale + downstream QA       |
+| Business logic correctness and data integrity | `target`     | Generated output always validates against the canonical workout contract before acceptance and never mutates accepted workouts implicitly.      | schema tests + integration invariants |
+| Admin editor ergonomics                       | `supporting` | Supporting only: no direct admin/editor workflow is introduced in this user-facing generator slice.                                             | scope rationale                       |
+| Accessibility (a11y)                          | `target`     | Session-type, effort, pool-length, stroke, and review controls are keyboard/touch accessible with clear labels and focus recovery.              | a11y checks + e2e                     |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: one-session generation flow should avoid obvious payload bloat or blocking regressions on authenticated routes.                | scope rationale + perf review         |
+| Data placement and sync boundaries            | `target`     | Generated previews stay local/provisional until accepted, and accepted workouts become normal canonical workouts with no AI-only storage model. | data contract + integration tests     |
+| Caching and invalidation strategy             | `supporting` | Supporting only: regenerate/accept/delete actions must invalidate stale preview and workout reads deterministically.                            | cache notes + scope rationale         |
+| Reliability and failure handling              | `target`     | Invalid output, missing threshold context, and AI failures all produce recoverable states with no dead-end draft confusion.                     | negative-path tests + e2e             |
+| Security and authz                            | `target`     | Protected generation/save flows fail closed and cannot expose or save another user's private intake context or workout draft.                   | API negative-path tests               |
+| Privacy and compliance                        | `supporting` | Supporting only: prompts, constraints, and analytics must avoid leaking unnecessary private free text.                                          | payload review + scope rationale      |
+| Content governance                            | `supporting` | Supporting only: canonical workout governance is inherited from the shared workout contract and builder slices.                                 | linked brief + scope rationale        |
+| Admin workflow and editability                | `supporting` | Supporting only: editability is owned by the shared workout editor rather than a dedicated admin surface.                                       | scope rationale                       |
+| SEO and crawlability                          | `supporting` | Supporting only: authenticated generator drafts are not primary public crawl surfaces.                                                          | scope rationale                       |
+| AI discoverability                            | `supporting` | Supporting only: this slice is about private AI generation safety, not public AI-discoverable publishing.                                       | scope rationale                       |
+| Analytics and KPI observability               | `supporting` | Supporting only: generation start/success/failure/acceptance events should remain available with safe payloads.                                 | event contract notes                  |
+| Commerce and revenue ops                      | `supporting` | Supporting only: no direct billing/entitlement mutation ships in this session-generator slice.                                                  | scope rationale                       |
+| Incident response and support operations      | `supporting` | Supporting only: AI rejection and save-failure states must leave support-visible diagnostics and recovery guidance.                             | runbook/error contract                |
+| Finance and reporting operations              | `N/A`        | N/A because this slice introduces no finance/reporting mutation or ledger-affecting behavior.                                                   | explicit scope rationale              |
+| i18n operational readiness                    | `supporting` | Supporting only: labels such as session type, effort, and generated guidance must remain locale-extensible later.                               | copy review + scope rationale         |
+| Stack-fit and dependency discipline           | `target`     | Use existing app validation, storage, and test patterns; avoid new orchestration dependencies unless clearly justified.                         | dependency diff + code review         |
+| Testing and QA automation                     | `target`     | Generate/review/accept/edit handoff, invalid-output fallback, and protected negative paths are covered before merge.                            | unit/integration/e2e + verify         |
+| Scalability and cost efficiency               | `supporting` | Supporting only: one-session generation should avoid runaway retries, oversized prompts, or oversized JSON output.                              | scope rationale + usage notes         |
+| DevOps and rollback readiness                 | `target`     | The session generator can be disabled or rolled back without corrupting saved canonical workouts or manual-builder reads.                       | rollout notes + release checklist     |
+
+## Acceptance Criteria
+
+- Users can generate exactly one swim-session draft from explicit session choices without choosing a longer planning horizon.
+- Supported v1 inputs include pool/open-water environment, supported pool lengths, duration by distance or estimated time, session type, effort, drills/kick inclusion, and allowed strokes.
+- If threshold/CSS context exists, the generator uses it for pacing/zone shaping without forcing raw zone-picking as the primary UX.
+- If threshold/CSS context does not exist, generation still succeeds with deterministic simpler targeting guidance.
+- Generated pool sessions default to including easy warmup and cooldown structure unless documented rules intentionally exempt a special case.
+- Generated output meets the Garmin-minimum structured-workout contract and is editable through the same workflow as a manually built workout.
+- Generated title suggestions remain editable.
+- Generated output stays in `draft` state until the user reviews and accepts it.
+- Regeneration does not silently overwrite an already accepted workout.
+- Brief is scorecard-complete and lintable before implementation starts.
+
+## Validation
+
+- `npm run lint:briefs`
+- targeted schema tests for one-session generation contract
+- targeted integration tests for generate -> review/edit -> accept handoff
+- targeted negative-path tests for invalid/unauthorized generation and save flows
+- `npm run verify:pre-pr`
+
+## Checkpoint Log
+
+- `2026-03-20 | planning | created a dedicated first-slice brief for AI session generation so the team can prove one Garmin-familiar editable workout draft before expanding into week/month/program generation | next: keep parent AI brief, workout contract, and manual builder aligned to this one-session draft-first workflow`
+- `2026-03-20 | planning | set v1 assumptions to support pool and open water, supported pool lengths, distance or estimated-time sizing, explicit session types, simple effort presets, drills/kick preferences, stroke selection, and optional minimal equipment constraints | next: validate these assumptions with owner feedback later and only then start implementation work`
+- `2026-03-20 | planning | kept threshold zones in the canonical model while deferring direct raw zone-picking as the primary generator UX, so v1 can stay simple for swimmers without breaking later advanced editing/export | next: use this brief to decide whether the first implementation slice should start with session-only generation UI or with the underlying generation/save contract`
+- `2026-03-20 | checkpoint | perf trend during verify recommended tighten after consecutive weekly green runs; decision for this docs-only planning slice is hold because no route-performance implementation changed | next: revisit tightening in the next performance-owning implementation or PR summary that changes route budgets directly`


### PR DESCRIPTION
## Summary

- add a dedicated planned brief for AI session generator v1 with Garmin-minimum swim session scope and draft-first review
- expand the parent AI generator and canonical workout contract around pool/open-water context, supported pool lengths, distance/time targeting, effort presets, and editable naming
- align the manual workout builder and epic orchestration so AI-generated sessions and manual workouts share the same editable metadata model

## Validation

- `npm run lint:briefs`
- `npm run verify:pre-pr`
- `npm run verify:pre-merge` hit a desktop Chromium flake in two unrelated My Library e2e specs during the local run; one targeted rerun passed:
  - `npx playwright test tests/e2e/my-library-athlete-profile.spec.ts tests/e2e/my-library-training-context.spec.ts --project=desktop-chromium`
- required GitHub checks for `#250` are green

## Notes

- perf trend recommended `tighten`; decision for this docs-only planning slice is `hold`, and that decision is recorded in the new AI session generator brief
- local untracked `artifacts/` and `supabase/.temp/` were not included
