### PR TITLE
feat(generator): add session draft review flow

### DIFF
--- a/app/api/my-library/generator/session-draft/route.ts
+++ b/app/api/my-library/generator/session-draft/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import { buildGeneratorHandoffPayload } from "@/lib/generator-intake/shared";
+import { loadGeneratorIntakeSnapshot } from "@/lib/generator-intake/server";
+import { buildSessionDraft } from "@/lib/session-generator-v1/server";
+import {
+  normalizeSessionGeneratorFormState,
+  validateSessionGeneratorFormState,
+  type SessionDraftApiResponse,
+  type SessionGeneratorRequestBody,
+} from "@/lib/session-generator-v1/shared";
+import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
+
+function noStoreJson(
+  body: SessionDraftApiResponse | Record<string, unknown>,
+  init?: {
+    status?: number;
+  }
+) {
+  return NextResponse.json(body, {
+    status: init?.status ?? 200,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export async function POST(request: Request) {
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Unauthorized." }, { status: 401 })
+    );
+  }
+
+  let body: SessionGeneratorRequestBody;
+  try {
+    body = (await request.json()) as SessionGeneratorRequestBody;
+  } catch {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Invalid JSON body." }, { status: 400 })
+    );
+  }
+
+  const snapshot = await loadGeneratorIntakeSnapshot(supabase, user.id);
+  const handoff = buildGeneratorHandoffPayload(
+    snapshot,
+    body.selection ?? null,
+    body.overrides ?? null
+  );
+
+  if (handoff.overrides.targetType !== "session") {
+    return applySupabaseCookies(
+      noStoreJson(
+        {
+          ok: false,
+          error:
+            "Program generation stays deferred in this slice. Switch the target back to single session.",
+        },
+        { status: 422 }
+      )
+    );
+  }
+
+  const formState = normalizeSessionGeneratorFormState(body.input ?? null, handoff);
+  const validation = validateSessionGeneratorFormState(formState);
+
+  if (!validation.ok) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: validation.error }, { status: 400 })
+    );
+  }
+
+  const draft = buildSessionDraft(handoff, validation.value);
+
+  return applySupabaseCookies(
+    noStoreJson({
+      ok: true,
+      handoff,
+      draft,
+    })
+  );
+}

--- a/app/my-library/generator/page.tsx
+++ b/app/my-library/generator/page.tsx
@@ -44,9 +44,8 @@ export default async function MyLibraryGeneratorPage() {
               </p>
               <h1 className="mt-2 text-3xl font-bold text-slate-900">Generator intake</h1>
               <p className="mt-2 max-w-[68ch] text-sm text-slate-600">
-                Review which saved My Library signals should prefill later AI session or program
-                generation, then apply one-run overrides without editing your stored profile,
-                records, goals, or focus.
+                Review which saved My Library signals should prefill session generation, then apply
+                one-run overrides without editing your stored profile, records, goals, or focus.
               </p>
             </div>
             <div className="flex flex-wrap gap-2">
@@ -87,11 +86,11 @@ export default async function MyLibraryGeneratorPage() {
               </div>
               <div className="rounded-2xl border border-white/80 bg-white/80 p-4">
                 <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">
-                  Later generator work
+                  Session draft review
                 </p>
                 <p className="mt-2 text-sm text-slate-700">
-                  This page prepares a deterministic handoff payload. It does not generate or save
-                  sessions yet.
+                  This page can now generate one local draft session for review and editing. Save,
+                  accept, and builder handoff still come later.
                 </p>
               </div>
             </div>

--- a/app/my-library/page.tsx
+++ b/app/my-library/page.tsx
@@ -219,8 +219,8 @@ export default async function MyLibraryPage() {
                 <div>
                   <h2 className="text-lg font-semibold text-slate-900">Generator intake</h2>
                   <p className="mt-2 text-sm text-slate-600">
-                    Review which saved My Library signals should prefill later AI session or program
-                    generation, then add one-run overrides without editing your saved profile,
+                    Review which saved My Library signals should prefill session generation, then
+                    generate and edit one local draft workout without editing your saved profile,
                     records, goals, or focus.
                   </p>
                 </div>
@@ -228,7 +228,7 @@ export default async function MyLibraryPage() {
                   href="/my-library/generator"
                   className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700"
                 >
-                  Open generator intake
+                  Open generator
                 </Link>
               </div>
             </section>

--- a/components/my-library/generator/GeneratorIntakeHub.tsx
+++ b/components/my-library/generator/GeneratorIntakeHub.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { sendClientAnalyticsEvent } from "@/lib/analytics/client";
+import SessionGeneratorPanel from "@/components/my-library/generator/SessionGeneratorPanel";
 import {
   GENERATOR_INTAKE_BLOCK_KEYS,
   buildGeneratorHandoffPayload,
@@ -123,7 +124,9 @@ export default function GeneratorIntakeHub({ initialSnapshot, userId }: Props) {
   const [lastPreparedSignature, setLastPreparedSignature] = useState<string | null>(null);
 
   const storageKey = getStorageKey(userId);
-  const payload = buildGeneratorHandoffPayload(snapshot, selection, overrides);
+  const payload = buildGeneratorHandoffPayload(snapshot, selection, overrides, {
+    createdAt: snapshot.loadedAt,
+  });
   const payloadPreview = JSON.stringify(payload, null, 2);
   const payloadSignature = JSON.stringify(payload);
   const isPreparedCurrent = lastPreparedSignature === payloadSignature;
@@ -627,6 +630,13 @@ export default function GeneratorIntakeHub({ initialSnapshot, userId }: Props) {
           </pre>
         </div>
       </section>
+
+      <SessionGeneratorPanel
+        payload={payload}
+        selection={selection}
+        overrides={overrides}
+        handoffPrepared={isPreparedCurrent}
+      />
     </div>
   );
 }

--- a/components/my-library/generator/SessionGeneratorPanel.tsx
+++ b/components/my-library/generator/SessionGeneratorPanel.tsx
@@ -1,0 +1,1021 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { sendClientAnalyticsEvent } from "@/lib/analytics/client";
+import type {
+  GeneratorIntakeHandoffPayload,
+  GeneratorIntakeOverrides,
+  GeneratorIntakeSelection,
+} from "@/lib/generator-intake/shared";
+import {
+  SESSION_DRAFT_STEP_CATEGORIES,
+  SESSION_DRAFT_STEP_DURATION_MODES,
+  SESSION_GENERATOR_EFFORT_PRESETS,
+  SESSION_GENERATOR_ENVIRONMENTS,
+  SESSION_GENERATOR_EQUIPMENT,
+  SESSION_GENERATOR_POOL_LENGTHS,
+  SESSION_GENERATOR_SESSION_TYPES,
+  SESSION_GENERATOR_STROKES,
+  buildSessionTargetSummary,
+  computeSessionDraftDerivedTotals,
+  formatPoolLengthLabel,
+  getDefaultSessionGeneratorFormState,
+  getSessionEffortLabel,
+  getSessionEnvironmentLabel,
+  getSessionEquipmentLabel,
+  getSessionStepCategoryLabel,
+  getSessionStrokeLabel,
+  getSessionTypeLabel,
+  normalizeSessionGeneratorFormState,
+  type SessionDraft,
+  type SessionDraftApiResponse,
+  type SessionDraftStep,
+  type SessionDraftStepCategory,
+  type SessionDraftStepDurationMode,
+  type SessionGeneratorEquipment,
+  type SessionGeneratorEnvironment,
+  type SessionGeneratorFormState,
+  type SessionGeneratorPoolLength,
+  type SessionGeneratorStroke,
+} from "@/lib/session-generator-v1/shared";
+
+type Props = {
+  payload: GeneratorIntakeHandoffPayload;
+  selection: GeneratorIntakeSelection;
+  overrides: GeneratorIntakeOverrides;
+  handoffPrepared: boolean;
+};
+
+function buildBlankStep(index: number): SessionDraftStep {
+  return {
+    id: `step-${Date.now()}-${index}`,
+    category: "main",
+    name: "Custom step",
+    stroke: "choice",
+    intensity: "moderate",
+    durationMode: "distance",
+    distanceM: 100,
+    timeMin: null,
+    targetSummary: "",
+    notes: "",
+  };
+}
+
+function parsePositiveNumber(value: string) {
+  if (!/^\d+(\.\d+)?$/.test(value)) return null;
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+export default function SessionGeneratorPanel({
+  payload,
+  selection,
+  overrides,
+  handoffPrepared,
+}: Props) {
+  const [formState, setFormState] = useState<SessionGeneratorFormState>(() =>
+    getDefaultSessionGeneratorFormState(payload)
+  );
+  const [draft, setDraft] = useState<SessionDraft | null>(null);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  useEffect(() => {
+    setFormState(getDefaultSessionGeneratorFormState(payload));
+    setDraft(null);
+    setError("");
+    setSuccess("");
+  }, [payload]);
+
+  const sessionReady = payload.overrides.targetType === "session" && handoffPrepared;
+  const draftTotals = useMemo(
+    () => (draft ? computeSessionDraftDerivedTotals(draft) : null),
+    [draft]
+  );
+
+  function updateFormState<K extends keyof SessionGeneratorFormState>(
+    key: K,
+    value: SessionGeneratorFormState[K]
+  ) {
+    setFormState((current) =>
+      normalizeSessionGeneratorFormState(
+        {
+          ...current,
+          [key]: value,
+        },
+        payload
+      )
+    );
+    setError("");
+    setSuccess("");
+  }
+
+  function toggleStroke(stroke: SessionGeneratorStroke) {
+    const exists = formState.allowedStrokes.includes(stroke);
+    updateFormState(
+      "allowedStrokes",
+      exists
+        ? formState.allowedStrokes.filter((value) => value !== stroke)
+        : [...formState.allowedStrokes, stroke]
+    );
+  }
+
+  function toggleEquipment(item: SessionGeneratorEquipment) {
+    const exists = formState.equipmentAllowlist.includes(item);
+    updateFormState(
+      "equipmentAllowlist",
+      exists
+        ? formState.equipmentAllowlist.filter((value) => value !== item)
+        : [...formState.equipmentAllowlist, item]
+    );
+  }
+
+  async function generateDraft() {
+    setIsGenerating(true);
+    setError("");
+    setSuccess("");
+
+    try {
+      const response = await fetch("/api/my-library/generator/session-draft", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          selection,
+          overrides,
+          input: formState,
+        }),
+      });
+      const responseBody = (await response
+        .json()
+        .catch(() => null)) as SessionDraftApiResponse | null;
+      const responseError =
+        responseBody && !responseBody.ok
+          ? responseBody.error
+          : "Could not generate a session draft right now.";
+
+      if (!response.ok || !responseBody?.ok) {
+        setError(responseError);
+        return;
+      }
+
+      setDraft(responseBody.draft);
+      setSuccess(
+        "Session draft generated. Review and edit it locally before later save/accept work lands."
+      );
+      void sendClientAnalyticsEvent("session_draft_generated", {
+        sessionType: responseBody.draft.sessionType,
+        environment: responseBody.draft.environment,
+        sizeMode: responseBody.draft.sizeMode,
+        hasCss: Boolean(responseBody.draft.usedCssPaceLabel),
+      });
+    } catch {
+      setError("Could not generate a session draft right now.");
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  function updateDraft<K extends keyof SessionDraft>(key: K, value: SessionDraft[K]) {
+    setDraft((current) => (current ? { ...current, [key]: value } : current));
+    setSuccess("");
+  }
+
+  function updateDraftStep(stepId: string, updater: (step: SessionDraftStep) => SessionDraftStep) {
+    setDraft((current) =>
+      current
+        ? {
+            ...current,
+            steps: current.steps.map((step) => (step.id === stepId ? updater(step) : step)),
+          }
+        : current
+    );
+    setSuccess("");
+  }
+
+  function moveStep(stepId: string, direction: -1 | 1) {
+    setDraft((current) => {
+      if (!current) return current;
+      const index = current.steps.findIndex((step) => step.id === stepId);
+      const nextIndex = index + direction;
+      if (index < 0 || nextIndex < 0 || nextIndex >= current.steps.length) return current;
+      const nextSteps = [...current.steps];
+      const [step] = nextSteps.splice(index, 1);
+      nextSteps.splice(nextIndex, 0, step);
+      return {
+        ...current,
+        steps: nextSteps,
+      };
+    });
+  }
+
+  function addStep() {
+    setDraft((current) =>
+      current
+        ? {
+            ...current,
+            steps: [...current.steps, buildBlankStep(current.steps.length + 1)],
+          }
+        : current
+    );
+  }
+
+  function removeStep(stepId: string) {
+    setDraft((current) =>
+      current
+        ? {
+            ...current,
+            steps: current.steps.filter((step) => step.id !== stepId),
+          }
+        : current
+    );
+  }
+
+  function toggleDraftStroke(stroke: SessionGeneratorStroke) {
+    if (!draft) return;
+    const exists = draft.allowedStrokes.includes(stroke);
+    updateDraft(
+      "allowedStrokes",
+      exists
+        ? draft.allowedStrokes.filter((value) => value !== stroke)
+        : [...draft.allowedStrokes, stroke]
+    );
+  }
+
+  function toggleDraftEquipment(item: SessionGeneratorEquipment) {
+    if (!draft) return;
+    const exists = draft.equipmentAllowlist.includes(item);
+    updateDraft(
+      "equipmentAllowlist",
+      exists
+        ? draft.equipmentAllowlist.filter((value) => value !== item)
+        : [...draft.equipmentAllowlist, item]
+    );
+  }
+
+  return (
+    <section
+      data-testid="session-generator-panel"
+      className="rounded-2xl border border-slate-200 bg-white p-5"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Session draft generator</h2>
+          <p className="mt-2 max-w-[66ch] text-sm text-slate-600">
+            Build one Garmin-familiar swim-session draft from the prepared intake handoff, then edit
+            the entire draft locally before later save and builder handoff work lands.
+          </p>
+        </div>
+        <p className="rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700">
+          Session only
+        </p>
+      </div>
+
+      {payload.overrides.targetType === "program" ? (
+        <div
+          data-testid="session-generator-program-deferred"
+          className="mt-5 rounded-2xl border border-amber-200 bg-amber-50/80 p-4"
+        >
+          <p className="text-sm text-amber-900">
+            Program generation stays deferred for now. Switch the generator target back to
+            <span className="font-semibold"> Single session </span>
+            to draft one workout in this slice.
+          </p>
+        </div>
+      ) : null}
+
+      {payload.overrides.targetType === "session" && !handoffPrepared ? (
+        <div
+          data-testid="session-generator-prepare-needed"
+          className="mt-5 rounded-2xl border border-blue-200 bg-blue-50/80 p-4"
+        >
+          <p className="text-sm text-blue-900">
+            Prepare the deterministic handoff above before generating a session draft, so this run
+            uses the exact saved profile, goal, and focus context you just reviewed.
+          </p>
+        </div>
+      ) : null}
+
+      {sessionReady ? (
+        <>
+          <div className="mt-5 grid gap-4 md:grid-cols-3">
+            <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Goal context
+              </p>
+              <p className="mt-2 text-sm font-medium text-slate-900">
+                {payload.source.openGoals[0]?.title ?? "No goal included"}
+              </p>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Focus context
+              </p>
+              <p className="mt-2 text-sm font-medium text-slate-900">
+                {payload.overrides.focusText ?? payload.source.activeFocus?.title ?? "No focus cue"}
+              </p>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                CSS anchor
+              </p>
+              <p className="mt-2 text-sm font-medium text-slate-900">
+                {payload.source.cssMetric?.paceLabel
+                  ? `${payload.source.cssMetric.paceLabel}/100m`
+                  : "Fallback pace guidance"}
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-5 grid gap-4 md:grid-cols-2">
+            <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
+              Session type
+              <select
+                value={formState.sessionType}
+                onChange={(event) =>
+                  updateFormState(
+                    "sessionType",
+                    event.target.value as SessionGeneratorFormState["sessionType"]
+                  )
+                }
+                data-testid="session-generator-session-type"
+                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+              >
+                {SESSION_GENERATOR_SESSION_TYPES.map((value) => (
+                  <option key={value} value={value}>
+                    {getSessionTypeLabel(value)}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
+              Effort
+              <select
+                value={formState.effort}
+                onChange={(event) =>
+                  updateFormState(
+                    "effort",
+                    event.target.value as SessionGeneratorFormState["effort"]
+                  )
+                }
+                data-testid="session-generator-effort"
+                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+              >
+                {SESSION_GENERATOR_EFFORT_PRESETS.map((value) => (
+                  <option key={value} value={value}>
+                    {getSessionEffortLabel(value)}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4">
+              <legend className="px-1 text-sm font-semibold text-slate-900">Environment</legend>
+              <div className="mt-3 flex flex-wrap gap-3">
+                {SESSION_GENERATOR_ENVIRONMENTS.map((value) => (
+                  <label
+                    key={value}
+                    className="inline-flex items-center gap-2 text-sm text-slate-700"
+                  >
+                    <input
+                      type="radio"
+                      name="session-generator-environment"
+                      checked={formState.environment === value}
+                      onChange={() => updateFormState("environment", value)}
+                      data-testid={`session-generator-environment-${value}`}
+                    />
+                    {getSessionEnvironmentLabel(value)}
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+
+            {formState.environment === "pool" ? (
+              <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
+                Pool length
+                <select
+                  value={formState.poolLengthM}
+                  onChange={(event) => updateFormState("poolLengthM", event.target.value)}
+                  data-testid="session-generator-pool-length"
+                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                >
+                  {SESSION_GENERATOR_POOL_LENGTHS.map((value) => (
+                    <option key={value} value={String(value)}>
+                      {formatPoolLengthLabel(value)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ) : null}
+
+            <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4">
+              <legend className="px-1 text-sm font-semibold text-slate-900">Session size</legend>
+              <div className="mt-3 flex flex-wrap gap-3">
+                <label className="inline-flex items-center gap-2 text-sm text-slate-700">
+                  <input
+                    type="radio"
+                    name="session-generator-size-mode"
+                    checked={formState.sizeMode === "distance"}
+                    onChange={() => updateFormState("sizeMode", "distance")}
+                    data-testid="session-generator-size-distance"
+                  />
+                  Distance
+                </label>
+                <label className="inline-flex items-center gap-2 text-sm text-slate-700">
+                  <input
+                    type="radio"
+                    name="session-generator-size-mode"
+                    checked={formState.sizeMode === "estimated_time"}
+                    onChange={() => updateFormState("sizeMode", "estimated_time")}
+                    data-testid="session-generator-size-time"
+                  />
+                  Estimated time
+                </label>
+              </div>
+
+              {formState.sizeMode === "distance" ? (
+                <label className="mt-4 block text-sm text-slate-700">
+                  Target distance (m)
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    value={formState.targetDistanceM}
+                    onChange={(event) => updateFormState("targetDistanceM", event.target.value)}
+                    data-testid="session-generator-target-distance"
+                    className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                  />
+                </label>
+              ) : (
+                <label className="mt-4 block text-sm text-slate-700">
+                  Estimated duration (min)
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    value={formState.targetTimeMin}
+                    onChange={(event) => updateFormState("targetTimeMin", event.target.value)}
+                    data-testid="session-generator-target-time"
+                    className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                  />
+                </label>
+              )}
+            </fieldset>
+
+            <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4">
+              <legend className="px-1 text-sm font-semibold text-slate-900">
+                Optional structure
+              </legend>
+              <div className="mt-3 flex flex-col gap-3">
+                <label className="inline-flex items-center gap-2 text-sm text-slate-700">
+                  <input
+                    type="checkbox"
+                    checked={formState.includeDrills}
+                    onChange={(event) => updateFormState("includeDrills", event.target.checked)}
+                    data-testid="session-generator-include-drills"
+                  />
+                  Include drills
+                </label>
+                <label className="inline-flex items-center gap-2 text-sm text-slate-700">
+                  <input
+                    type="checkbox"
+                    checked={formState.includeKick}
+                    onChange={(event) => updateFormState("includeKick", event.target.checked)}
+                    data-testid="session-generator-include-kick"
+                  />
+                  Include kick work
+                </label>
+              </div>
+            </fieldset>
+
+            <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 md:col-span-2">
+              <legend className="px-1 text-sm font-semibold text-slate-900">Allowed strokes</legend>
+              <div className="mt-3 flex flex-wrap gap-3">
+                {SESSION_GENERATOR_STROKES.map((stroke) => (
+                  <label
+                    key={stroke}
+                    className="inline-flex items-center gap-2 text-sm text-slate-700"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={formState.allowedStrokes.includes(stroke)}
+                      onChange={() => toggleStroke(stroke)}
+                      data-testid={`session-generator-stroke-${stroke}`}
+                    />
+                    {getSessionStrokeLabel(stroke)}
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+
+            <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 md:col-span-2">
+              <legend className="px-1 text-sm font-semibold text-slate-900">
+                Allowed equipment
+              </legend>
+              <div className="mt-3 flex flex-wrap gap-3">
+                {SESSION_GENERATOR_EQUIPMENT.map((item) => (
+                  <label
+                    key={item}
+                    className="inline-flex items-center gap-2 text-sm text-slate-700"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={formState.equipmentAllowlist.includes(item)}
+                      onChange={() => toggleEquipment(item)}
+                      data-testid={`session-generator-equipment-${item}`}
+                    />
+                    {getSessionEquipmentLabel(item)}
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+          </div>
+
+          {error ? (
+            <div className="mt-5 rounded-2xl border border-rose-200 bg-rose-50/80 p-4">
+              <p className="text-sm text-rose-900">{error}</p>
+            </div>
+          ) : null}
+
+          {success ? (
+            <div className="mt-5 rounded-2xl border border-emerald-200 bg-emerald-50/80 p-4">
+              <p className="text-sm text-emerald-900">{success}</p>
+            </div>
+          ) : null}
+
+          <div className="mt-5 flex flex-wrap items-center justify-between gap-3">
+            <p className="text-sm text-slate-600">
+              Drafts stay local in this slice. They do not save or overwrite a canonical workout
+              yet.
+            </p>
+            <button
+              type="button"
+              onClick={generateDraft}
+              disabled={isGenerating}
+              data-testid="session-generator-generate"
+              className="inline-flex h-11 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isGenerating
+                ? "Generating..."
+                : draft
+                  ? "Regenerate draft"
+                  : "Generate session draft"}
+            </button>
+          </div>
+        </>
+      ) : null}
+
+      {draft ? (
+        <div className="mt-6 space-y-5 border-t border-slate-200 pt-6">
+          <div className="rounded-2xl border border-blue-200 bg-blue-50/80 p-4">
+            <p className="text-sm text-blue-900">
+              Draft only: review and edit everything below. Save/accept into the shared workout
+              editor lands in a later slice once canonical workout entities exist.
+            </p>
+          </div>
+
+          {draft.warnings.length > 0 ? (
+            <div className="rounded-2xl border border-amber-200 bg-amber-50/80 p-4">
+              <ul className="space-y-2 text-sm text-amber-900">
+                {draft.warnings.map((warning) => (
+                  <li key={warning}>{warning}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Status</p>
+              <p className="mt-2 text-2xl font-semibold text-slate-900">Draft</p>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Session
+              </p>
+              <p className="mt-2 text-sm font-semibold text-slate-900">
+                {buildSessionTargetSummary({
+                  ...draft,
+                  totalDistanceM: draftTotals?.totalDistanceM ?? draft.totalDistanceM,
+                  estimatedDurationMin:
+                    draftTotals?.estimatedDurationMin ?? draft.estimatedDurationMin,
+                })}
+              </p>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Context
+              </p>
+              <p className="mt-2 text-sm font-semibold text-slate-900">
+                {draft.goalTitle ?? draft.focusText ?? "Session-only request"}
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-slate-200 bg-white p-4">
+            <h3 className="text-base font-semibold text-slate-900">Title suggestions</h3>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {draft.titleSuggestions.map((suggestion) => (
+                <button
+                  key={suggestion}
+                  type="button"
+                  onClick={() => updateDraft("title", suggestion)}
+                  className="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-sm text-slate-700 transition hover:bg-slate-100"
+                >
+                  {suggestion}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
+              Draft title
+              <input
+                type="text"
+                value={draft.title}
+                onChange={(event) => updateDraft("title", event.target.value)}
+                data-testid="session-draft-title"
+                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+              />
+            </label>
+
+            <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
+              Session type
+              <select
+                value={draft.sessionType}
+                onChange={(event) =>
+                  updateDraft("sessionType", event.target.value as SessionDraft["sessionType"])
+                }
+                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+              >
+                {SESSION_GENERATOR_SESSION_TYPES.map((value) => (
+                  <option key={value} value={value}>
+                    {getSessionTypeLabel(value)}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700 md:col-span-2">
+              Draft description
+              <textarea
+                value={draft.description}
+                onChange={(event) => updateDraft("description", event.target.value)}
+                data-testid="session-draft-description"
+                rows={4}
+                className="mt-2 block w-full rounded-xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+              />
+            </label>
+
+            <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4">
+              <legend className="px-1 text-sm font-semibold text-slate-900">Environment</legend>
+              <div className="mt-3 flex flex-wrap gap-3">
+                {SESSION_GENERATOR_ENVIRONMENTS.map((value) => (
+                  <label
+                    key={value}
+                    className="inline-flex items-center gap-2 text-sm text-slate-700"
+                  >
+                    <input
+                      type="radio"
+                      name="session-draft-environment"
+                      checked={draft.environment === value}
+                      onChange={() =>
+                        updateDraft("environment", value as SessionGeneratorEnvironment)
+                      }
+                    />
+                    {getSessionEnvironmentLabel(value)}
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+
+            {draft.environment === "pool" ? (
+              <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
+                Pool length
+                <select
+                  value={draft.poolLengthM ? String(draft.poolLengthM) : ""}
+                  onChange={(event) =>
+                    updateDraft(
+                      "poolLengthM",
+                      (parsePositiveNumber(
+                        event.target.value
+                      ) as SessionGeneratorPoolLength | null) ?? null
+                    )
+                  }
+                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                >
+                  {SESSION_GENERATOR_POOL_LENGTHS.map((value) => (
+                    <option key={value} value={String(value)}>
+                      {formatPoolLengthLabel(value)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ) : null}
+
+            <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
+              Effort
+              <select
+                value={draft.effort}
+                onChange={(event) =>
+                  updateDraft("effort", event.target.value as SessionDraft["effort"])
+                }
+                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+              >
+                {SESSION_GENERATOR_EFFORT_PRESETS.map((value) => (
+                  <option key={value} value={value}>
+                    {getSessionEffortLabel(value)}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 md:col-span-2">
+              <legend className="px-1 text-sm font-semibold text-slate-900">Session strokes</legend>
+              <div className="mt-3 flex flex-wrap gap-3">
+                {SESSION_GENERATOR_STROKES.map((stroke) => (
+                  <label
+                    key={stroke}
+                    className="inline-flex items-center gap-2 text-sm text-slate-700"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={draft.allowedStrokes.includes(stroke)}
+                      onChange={() => toggleDraftStroke(stroke)}
+                    />
+                    {getSessionStrokeLabel(stroke)}
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+
+            <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 md:col-span-2">
+              <legend className="px-1 text-sm font-semibold text-slate-900">Equipment</legend>
+              <div className="mt-3 flex flex-wrap gap-3">
+                {SESSION_GENERATOR_EQUIPMENT.map((item) => (
+                  <label
+                    key={item}
+                    className="inline-flex items-center gap-2 text-sm text-slate-700"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={draft.equipmentAllowlist.includes(item)}
+                      onChange={() => toggleDraftEquipment(item)}
+                    />
+                    {getSessionEquipmentLabel(item)}
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+          </div>
+
+          <div className="rounded-2xl border border-slate-200 bg-white p-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <h3 className="text-base font-semibold text-slate-900">Editable draft steps</h3>
+              <button
+                type="button"
+                onClick={addStep}
+                data-testid="session-draft-add-step"
+                className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+              >
+                Add step
+              </button>
+            </div>
+
+            <div className="mt-4 space-y-4">
+              {draft.steps.map((step, index) => (
+                <article
+                  key={step.id}
+                  className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Step {index + 1}
+                      </p>
+                      <p className="mt-1 text-sm font-medium text-slate-900">
+                        {getSessionStepCategoryLabel(step.category)}
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => moveStep(step.id, -1)}
+                        disabled={index === 0}
+                        className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        Move up
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => moveStep(step.id, 1)}
+                        disabled={index === draft.steps.length - 1}
+                        className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        Move down
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => removeStep(step.id)}
+                        className="inline-flex h-9 items-center justify-center rounded-xl border border-rose-200 bg-white px-3 text-sm text-rose-700 transition hover:bg-rose-50"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  </div>
+
+                  <div className="mt-4 grid gap-4 md:grid-cols-2">
+                    <label className="text-sm text-slate-700">
+                      Step name
+                      <input
+                        type="text"
+                        value={step.name}
+                        onChange={(event) =>
+                          updateDraftStep(step.id, (current) => ({
+                            ...current,
+                            name: event.target.value,
+                          }))
+                        }
+                        data-testid={`session-draft-step-name-${index}`}
+                        className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                      />
+                    </label>
+
+                    <label className="text-sm text-slate-700">
+                      Category
+                      <select
+                        value={step.category}
+                        onChange={(event) =>
+                          updateDraftStep(step.id, (current) => ({
+                            ...current,
+                            category: event.target.value as SessionDraftStepCategory,
+                          }))
+                        }
+                        className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                      >
+                        {SESSION_DRAFT_STEP_CATEGORIES.map((value) => (
+                          <option key={value} value={value}>
+                            {getSessionStepCategoryLabel(value)}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+
+                    <label className="text-sm text-slate-700">
+                      Stroke
+                      <select
+                        value={step.stroke}
+                        onChange={(event) =>
+                          updateDraftStep(step.id, (current) => ({
+                            ...current,
+                            stroke: event.target.value as SessionDraftStep["stroke"],
+                          }))
+                        }
+                        className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                      >
+                        <option value="choice">Stroke choice</option>
+                        {SESSION_GENERATOR_STROKES.map((value) => (
+                          <option key={value} value={value}>
+                            {getSessionStrokeLabel(value)}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+
+                    <label className="text-sm text-slate-700">
+                      Intensity
+                      <select
+                        value={step.intensity}
+                        onChange={(event) =>
+                          updateDraftStep(step.id, (current) => ({
+                            ...current,
+                            intensity: event.target.value as SessionDraft["effort"],
+                          }))
+                        }
+                        className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                      >
+                        {SESSION_GENERATOR_EFFORT_PRESETS.map((value) => (
+                          <option key={value} value={value}>
+                            {getSessionEffortLabel(value)}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+
+                    <label className="text-sm text-slate-700">
+                      Duration mode
+                      <select
+                        value={step.durationMode}
+                        onChange={(event) =>
+                          updateDraftStep(step.id, (current) => ({
+                            ...current,
+                            durationMode: event.target.value as SessionDraftStepDurationMode,
+                            distanceM:
+                              event.target.value === "distance" ? (current.distanceM ?? 100) : null,
+                            timeMin: event.target.value === "time" ? (current.timeMin ?? 10) : null,
+                          }))
+                        }
+                        className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                      >
+                        {SESSION_DRAFT_STEP_DURATION_MODES.map((value) => (
+                          <option key={value} value={value}>
+                            {value === "distance" ? "Distance" : "Time"}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+
+                    {step.durationMode === "distance" ? (
+                      <label className="text-sm text-slate-700">
+                        Distance (m)
+                        <input
+                          type="text"
+                          inputMode="numeric"
+                          value={step.distanceM ?? ""}
+                          onChange={(event) =>
+                            updateDraftStep(step.id, (current) => ({
+                              ...current,
+                              distanceM: parsePositiveNumber(event.target.value),
+                            }))
+                          }
+                          className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                        />
+                      </label>
+                    ) : (
+                      <label className="text-sm text-slate-700">
+                        Time (min)
+                        <input
+                          type="text"
+                          inputMode="numeric"
+                          value={step.timeMin ?? ""}
+                          onChange={(event) =>
+                            updateDraftStep(step.id, (current) => ({
+                              ...current,
+                              timeMin: parsePositiveNumber(event.target.value),
+                            }))
+                          }
+                          className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                        />
+                      </label>
+                    )}
+
+                    <label className="text-sm text-slate-700 md:col-span-2">
+                      Target summary
+                      <input
+                        type="text"
+                        value={step.targetSummary}
+                        onChange={(event) =>
+                          updateDraftStep(step.id, (current) => ({
+                            ...current,
+                            targetSummary: event.target.value,
+                          }))
+                        }
+                        className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                      />
+                    </label>
+
+                    <label className="text-sm text-slate-700 md:col-span-2">
+                      Notes
+                      <textarea
+                        value={step.notes}
+                        onChange={(event) =>
+                          updateDraftStep(step.id, (current) => ({
+                            ...current,
+                            notes: event.target.value,
+                          }))
+                        }
+                        rows={3}
+                        className="mt-2 block w-full rounded-xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                      />
+                    </label>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+
+          <div className="overflow-hidden rounded-2xl border border-slate-200 bg-slate-950">
+            <pre
+              data-testid="session-generator-draft-preview"
+              className="max-h-[420px] overflow-auto px-4 py-4 text-xs leading-relaxed text-slate-100"
+            >
+              {JSON.stringify(
+                {
+                  ...draft,
+                  totalDistanceM: draftTotals?.totalDistanceM ?? draft.totalDistanceM,
+                  estimatedDurationMin:
+                    draftTotals?.estimatedDurationMin ?? draft.estimatedDurationMin,
+                },
+                null,
+                2
+              )}
+            </pre>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/docs/runbooks/core-flow-incident-response.md
+++ b/docs/runbooks/core-flow-incident-response.md
@@ -51,9 +51,11 @@ Additional `My Library` sub-route checks:
   - confirm existing local focus/note draft text is preserved when goal-prefill is applied.
 - `/my-library/generator`
   - confirm `/api/my-library/generator-intake` returns owner-scoped `200` or fail-closed `401`,
+  - confirm `/api/my-library/generator/session-draft` returns owner-scoped `200` for session target, `401` for unauthenticated reads, and explicit `422` when program target is chosen in this slice,
   - confirm stale/missing block copy names the affected source area (`profile`, `goals`, `focus`),
   - confirm refresh does not mutate saved My Library records,
-  - confirm notes remain excluded from default intake prefill in v1.
+  - confirm notes remain excluded from default intake prefill in v1,
+  - confirm generated drafts stay local/editable and no save/accept CTA claims canonical persistence yet.
 
 ## i18n Triage Overlay (When Locale Work Starts)
 

--- a/docs/task-briefs/in-progress/2026-03-20-ai-session-generator-v1-garmin-minimum-draft-review-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-20-ai-session-generator-v1-garmin-minimum-draft-review-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-03-20-ai-session-generator-v1-garmin-minimum-draft-review-10-10`
-- `status`: `planned`
+- `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-03-20`
 - `updated`: `2026-03-20`
@@ -108,6 +108,10 @@ Generate one Garmin-familiar swim-session draft from reviewed generator-intake c
 ## Scope
 
 - Authenticated AI session-generation entrypoint for `planning_horizon = session`.
+- Current runtime implementation slice under this brief:
+  - generate one local session draft from prepared intake context on `/my-library/generator`,
+  - support full local draft review/editing on that same page,
+  - keep canonical save/accept and shared workout-builder handoff explicitly deferred until the workout entity layer exists in code.
 - Input contract for one generated session:
   - intake handoff payload,
   - selected session type,
@@ -148,6 +152,7 @@ Generate one Garmin-familiar swim-session draft from reviewed generator-intake c
 - Competition-date generation and taper/peak orchestration.
 - Automatic calendar scheduling.
 - Automatic send to Garmin.
+- Canonical save/accept into a shared persisted workout entity in the current runtime slice.
 - Completed-history ingestion or retrospective AI analysis.
 - Public sharing or SEO surfaces.
 
@@ -246,3 +251,7 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - `2026-03-20 | planning | set v1 assumptions to support pool and open water, supported pool lengths, distance or estimated-time sizing, explicit session types, simple effort presets, drills/kick preferences, stroke selection, and optional minimal equipment constraints | next: validate these assumptions with owner feedback later and only then start implementation work`
 - `2026-03-20 | planning | kept threshold zones in the canonical model while deferring direct raw zone-picking as the primary generator UX, so v1 can stay simple for swimmers without breaking later advanced editing/export | next: use this brief to decide whether the first implementation slice should start with session-only generation UI or with the underlying generation/save contract`
 - `2026-03-20 | checkpoint | perf trend during verify recommended tighten after consecutive weekly green runs; decision for this docs-only planning slice is hold because no route-performance implementation changed | next: revisit tightening in the next performance-owning implementation or PR summary that changes route budgets directly`
+- `2026-03-20 | working tree | moved this brief to in-progress and narrowed the first runtime implementation to a truthful draft-review slice on /my-library/generator: authenticated session-draft generation API, deterministic Garmin-familiar draft output, and full local draft editing while canonical save/accept stays deferred until shared workout entities land | next: implement route, UI, tests, and run local verify gates before PR handoff`
+- `2026-03-20 | working tree | implemented the first runtime slice on /my-library/generator with server-validated session drafting, program-deferred messaging, full local draft editing, route/runbook updates, and new unit + e2e coverage; targeted unit suites and desktop generator e2e passed | next: package for PR after local gate review and note that canonical save/accept into the shared workout builder is still deferred`
+- `2026-03-20 | working tree | local npm run verify:pre-pr reached full Playwright and failed only on the known unrelated desktop athlete-profile flake (`tests/e2e/my-library-athlete-profile.spec.ts`); targeted rerun of that exact spec passed immediately afterward, while the new generator flow also passed in the full matrix and in targeted reruns | next: cite the athlete-profile flake in PR validation notes and keep this slice focused on generator delivery unless that legacy flake needs its own follow-up`
+- `2026-03-20 | working tree | perf trend during the implementation gate again recommended tighten after consecutive weekly green runs; decision for this generator slice is hold because no new public-route budget target was deliberately tightened in this PR and the active workstream is primarily workflow/contract delivery | next: revisit one stretch-target ratchet in the next perf-owning PR summary or brief update`

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -28,6 +28,7 @@ export const ANALYTICS_EVENT_NAMES = [
   "generator_intake_refreshed",
   "generator_intake_block_toggled",
   "generator_intake_handoff_prepared",
+  "session_draft_generated",
   "item_preview_opened",
   "item_download_started",
   "resume_clicked",

--- a/lib/generator-intake/shared.ts
+++ b/lib/generator-intake/shared.ts
@@ -249,8 +249,8 @@ export function buildGeneratorIntakeSnapshot(input: {
 
 export function buildGeneratorHandoffPayload(
   snapshot: GeneratorIntakeSnapshot,
-  selection: GeneratorIntakeSelection,
-  overrides: GeneratorIntakeOverrides,
+  selection: Partial<GeneratorIntakeSelection> | null | undefined,
+  overrides: Partial<GeneratorIntakeOverrides> | null | undefined,
   options?: {
     createdAt?: string;
   }

--- a/lib/session-generator-v1/server.ts
+++ b/lib/session-generator-v1/server.ts
@@ -1,0 +1,619 @@
+import type { GeneratorIntakeHandoffPayload } from "@/lib/generator-intake/shared";
+import {
+  buildSessionTargetSummary,
+  computeSessionDraftDerivedTotals,
+  formatPoolLengthLabel,
+  getSessionEffortLabel,
+  getSessionEnvironmentLabel,
+  getSessionStrokeLabel,
+  getSessionTypeLabel,
+  roundDistanceForEnvironment,
+  type SessionDraft,
+  type SessionDraftStep,
+  type SessionDraftStepCategory,
+  type SessionGeneratorEquipment,
+  type SessionGeneratorInput,
+  type SessionGeneratorPoolLength,
+  type SessionGeneratorSessionType,
+  type SessionGeneratorStroke,
+} from "@/lib/session-generator-v1/shared";
+
+type BuildSessionDraftOptions = {
+  createdAt?: string;
+};
+
+type SegmentPlan = {
+  warmup: number;
+  drill: number;
+  kick: number;
+  main: number;
+  cooldown: number;
+};
+
+export function buildSessionDraft(
+  handoff: GeneratorIntakeHandoffPayload,
+  input: SessionGeneratorInput,
+  options?: BuildSessionDraftOptions
+): SessionDraft {
+  const createdAt = options?.createdAt ?? new Date().toISOString();
+  const goalTitle =
+    handoff.source.openGoals[0]?.title ?? handoff.source.activeFocus?.goalTitle ?? null;
+  const focusText = handoff.overrides.focusText ?? handoff.source.activeFocus?.title ?? null;
+  const constraintText = handoff.overrides.constraintText;
+  const warnings: string[] = [];
+
+  const adjustedInput = applyGuardrails(input, warnings);
+  const basePaceSecondsPer100m = estimateBasePaceSecondsPer100m(handoff, adjustedInput);
+  const usedCssPaceLabel = handoff.source.cssMetric?.paceLabel ?? null;
+
+  const totalDistanceM =
+    adjustedInput.sizeMode === "distance"
+      ? adjustedInput.targetDistanceM
+      : estimateDistanceFromTime(
+          adjustedInput.targetTimeMin ?? 45,
+          basePaceSecondsPer100m,
+          adjustedInput
+        );
+  const estimatedDurationMin =
+    adjustedInput.sizeMode === "estimated_time"
+      ? adjustedInput.targetTimeMin
+      : estimateDurationFromDistance(totalDistanceM ?? 0, basePaceSecondsPer100m);
+
+  const segmentPlan = buildSegmentPlan(adjustedInput);
+  const steps =
+    adjustedInput.environment === "open_water" && adjustedInput.sizeMode === "estimated_time"
+      ? buildTimeBasedSteps({
+          input: adjustedInput,
+          totalMinutes: adjustedInput.targetTimeMin ?? estimatedDurationMin ?? 45,
+          focusText,
+          constraintText,
+          basePaceSecondsPer100m,
+        })
+      : buildDistanceBasedSteps({
+          input: adjustedInput,
+          totalDistanceM: totalDistanceM ?? 2000,
+          segmentPlan,
+          focusText,
+          constraintText,
+          usedCssPaceLabel,
+        });
+
+  const titleSuggestions = buildTitleSuggestions(adjustedInput, goalTitle, focusText);
+  const description = buildDraftDescription({
+    input: adjustedInput,
+    goalTitle,
+    focusText,
+    constraintText,
+    usedCssPaceLabel,
+  });
+
+  const draft: SessionDraft = {
+    version: 1,
+    status: "draft",
+    generatorKind: "rule_engine_v1",
+    createdAt,
+    sourceFingerprint: handoff.sourceFingerprint,
+    title: titleSuggestions[0],
+    titleSuggestions,
+    description,
+    environment: adjustedInput.environment,
+    poolLengthM: adjustedInput.poolLengthM,
+    sessionType: adjustedInput.sessionType,
+    effort: adjustedInput.effort,
+    sizeMode: adjustedInput.sizeMode,
+    targetDistanceM: adjustedInput.targetDistanceM,
+    targetTimeMin: adjustedInput.targetTimeMin,
+    totalDistanceM,
+    estimatedDurationMin,
+    basePaceSecondsPer100m,
+    usedCssPaceLabel,
+    allowedStrokes: adjustedInput.allowedStrokes,
+    equipmentAllowlist: adjustedInput.equipmentAllowlist,
+    focusText,
+    goalTitle,
+    constraintText,
+    warnings,
+    steps,
+  };
+
+  const totals = computeSessionDraftDerivedTotals(draft);
+  return {
+    ...draft,
+    totalDistanceM: totals.totalDistanceM ?? draft.totalDistanceM,
+    estimatedDurationMin: totals.estimatedDurationMin ?? draft.estimatedDurationMin,
+  };
+}
+
+function applyGuardrails(input: SessionGeneratorInput, warnings: string[]): SessionGeneratorInput {
+  if (input.environment === "pool") return input;
+
+  const next = {
+    ...input,
+    includeDrills: false,
+    includeKick: false,
+    poolLengthM: null,
+  };
+
+  if (input.includeDrills) {
+    warnings.push("Open-water draft review skips dedicated drill blocks in this first slice.");
+  }
+
+  if (input.includeKick) {
+    warnings.push("Open-water draft review skips dedicated kick blocks in this first slice.");
+  }
+
+  return next;
+}
+
+function estimateBasePaceSecondsPer100m(
+  handoff: GeneratorIntakeHandoffPayload,
+  input: SessionGeneratorInput
+) {
+  const cssSeconds = handoff.source.cssMetric?.valueSeconds ?? null;
+
+  if (cssSeconds) {
+    switch (input.effort) {
+      case "easy":
+        return cssSeconds + 18;
+      case "moderate":
+        return cssSeconds + 10;
+      case "hard":
+        return cssSeconds + 4;
+      case "very_hard":
+        return Math.max(55, cssSeconds);
+      case "race_pace":
+        return Math.max(52, cssSeconds - 2);
+    }
+  }
+
+  switch (input.effort) {
+    case "easy":
+      return 140;
+    case "moderate":
+      return 132;
+    case "hard":
+      return 124;
+    case "very_hard":
+      return 118;
+    case "race_pace":
+      return 114;
+  }
+}
+
+function estimateDistanceFromTime(
+  targetTimeMin: number,
+  basePaceSecondsPer100m: number,
+  input: SessionGeneratorInput
+) {
+  const rawDistance = (targetTimeMin * 60 * 100) / basePaceSecondsPer100m;
+  return roundDistanceForEnvironment(rawDistance, input.environment, input.poolLengthM);
+}
+
+function estimateDurationFromDistance(distanceM: number, basePaceSecondsPer100m: number) {
+  return Math.max(1, Math.round(((distanceM / 100) * basePaceSecondsPer100m) / 60));
+}
+
+function buildSegmentPlan(input: SessionGeneratorInput): SegmentPlan {
+  const baseByType: Record<SessionGeneratorSessionType, SegmentPlan> = {
+    recovery: { warmup: 30, drill: 0, kick: 0, main: 45, cooldown: 25 },
+    endurance: { warmup: 20, drill: 0, kick: 0, main: 60, cooldown: 20 },
+    technique: { warmup: 20, drill: 30, kick: 0, main: 30, cooldown: 20 },
+    threshold_css: { warmup: 20, drill: 0, kick: 0, main: 60, cooldown: 20 },
+    speed: { warmup: 20, drill: 10, kick: 0, main: 50, cooldown: 20 },
+    race_pace: { warmup: 20, drill: 5, kick: 0, main: 55, cooldown: 20 },
+  };
+
+  const plan = { ...baseByType[input.sessionType] };
+
+  if (input.includeDrills && plan.drill === 0) {
+    plan.drill = 10;
+    plan.main -= 10;
+  }
+
+  if (input.includeKick) {
+    plan.kick = 10;
+    plan.main -= 5;
+    plan.warmup -= 5;
+  }
+
+  return plan;
+}
+
+function buildDistanceBasedSteps(input: {
+  input: SessionGeneratorInput;
+  totalDistanceM: number;
+  segmentPlan: SegmentPlan;
+  focusText: string | null;
+  constraintText: string | null;
+  usedCssPaceLabel: string | null;
+}): SessionDraftStep[] {
+  const {
+    input: sessionInput,
+    totalDistanceM,
+    segmentPlan,
+    focusText,
+    constraintText,
+    usedCssPaceLabel,
+  } = input;
+  const roundingUnit = sessionInput.environment === "pool" ? (sessionInput.poolLengthM ?? 25) : 50;
+  const segments = allocateRoundedValues(totalDistanceM, segmentPlan, roundingUnit);
+  const strokeChoice = selectStrokeChoice(sessionInput.allowedStrokes);
+  const steps: SessionDraftStep[] = [];
+
+  steps.push({
+    id: "warmup-1",
+    category: "warmup",
+    name: "Easy warmup swim",
+    stroke: strokeChoice,
+    intensity: "easy",
+    durationMode: "distance",
+    distanceM: segments.warmup,
+    timeMin: null,
+    targetSummary: "Easy swimming with relaxed breathing and long strokes.",
+    notes: focusText
+      ? `Keep ${focusText.toLowerCase()} present from the first length.`
+      : "Start smooth and settle the stroke before the main work.",
+  });
+
+  if (segments.drill > 0) {
+    steps.push({
+      id: "drill-1",
+      category: "drill",
+      name: "Technique drill block",
+      stroke: strokeChoice,
+      intensity: "easy",
+      durationMode: "distance",
+      distanceM: segments.drill,
+      timeMin: null,
+      targetSummary: "Alternate drill and swim to keep form ahead of speed.",
+      notes: focusText
+        ? `Suggested format: 25 drill / 25 swim with ${focusText.toLowerCase()} as the main cue.`
+        : "Suggested format: 25 drill / 25 swim on short rest.",
+    });
+  }
+
+  if (segments.kick > 0) {
+    steps.push({
+      id: "kick-1",
+      category: "kick",
+      name: "Kick set",
+      stroke: "choice",
+      intensity: "moderate",
+      durationMode: "distance",
+      distanceM: segments.kick,
+      timeMin: null,
+      targetSummary: "Controlled kick that supports body line without spiking fatigue.",
+      notes: buildKickNote(sessionInput.equipmentAllowlist, constraintText),
+    });
+  }
+
+  steps.push({
+    id: "main-1",
+    category: "main",
+    name: buildMainStepName(sessionInput.sessionType),
+    stroke: strokeChoice,
+    intensity: sessionInput.effort,
+    durationMode: "distance",
+    distanceM: segments.main,
+    timeMin: null,
+    targetSummary: buildMainTargetSummary(
+      sessionInput.sessionType,
+      sessionInput.effort,
+      usedCssPaceLabel
+    ),
+    notes: buildDistanceMainSetNote({
+      input: sessionInput,
+      mainDistanceM: segments.main,
+      usedCssPaceLabel,
+      focusText,
+    }),
+  });
+
+  steps.push({
+    id: "cooldown-1",
+    category: "cooldown",
+    name: "Cooldown swim",
+    stroke: "choice",
+    intensity: "easy",
+    durationMode: "distance",
+    distanceM: segments.cooldown,
+    timeMin: null,
+    targetSummary: "Easy swim to bring the heart rate and tension down.",
+    notes: "Finish smoother than you started and leave the water feeling controlled.",
+  });
+
+  return steps;
+}
+
+function buildTimeBasedSteps(input: {
+  input: SessionGeneratorInput;
+  totalMinutes: number;
+  focusText: string | null;
+  constraintText: string | null;
+  basePaceSecondsPer100m: number;
+}): SessionDraftStep[] {
+  const {
+    input: sessionInput,
+    totalMinutes,
+    focusText,
+    constraintText,
+    basePaceSecondsPer100m,
+  } = input;
+  const segments = allocateMinuteSegments(totalMinutes, buildSegmentPlan(sessionInput));
+  const strokeChoice = selectStrokeChoice(sessionInput.allowedStrokes);
+
+  return [
+    {
+      id: "warmup-1",
+      category: "warmup",
+      name: "Easy entry and warmup",
+      stroke: strokeChoice,
+      intensity: "easy",
+      durationMode: "time",
+      distanceM: null,
+      timeMin: segments.warmup,
+      targetSummary: "Easy swim with relaxed breathing and sighting setup.",
+      notes: focusText
+        ? `Keep ${focusText.toLowerCase()} present while finding rhythm.`
+        : "Settle rhythm, breathing, and sighting before the main work.",
+    },
+    {
+      id: "main-1",
+      category: "main",
+      name: buildMainStepName(sessionInput.sessionType),
+      stroke: strokeChoice,
+      intensity: sessionInput.effort,
+      durationMode: "time",
+      distanceM: null,
+      timeMin: segments.main,
+      targetSummary: buildMainTargetSummary(sessionInput.sessionType, sessionInput.effort, null),
+      notes: buildOpenWaterMainSetNote({
+        input: sessionInput,
+        mainMinutes: segments.main,
+        focusText,
+        constraintText,
+        basePaceSecondsPer100m,
+      }),
+    },
+    {
+      id: "cooldown-1",
+      category: "cooldown",
+      name: "Cooldown swim",
+      stroke: strokeChoice,
+      intensity: "easy",
+      durationMode: "time",
+      distanceM: null,
+      timeMin: segments.cooldown,
+      targetSummary: "Easy swimming to reset stroke length before finishing.",
+      notes: "Ease off the pressure and finish with calm breathing.",
+    },
+  ];
+}
+
+function allocateRoundedValues(
+  total: number,
+  plan: SegmentPlan,
+  roundingUnit: number
+): Record<SessionDraftStepCategory, number> {
+  const categories: SessionDraftStepCategory[] = ["warmup", "drill", "kick", "main", "cooldown"];
+  const result = {
+    warmup: 0,
+    drill: 0,
+    kick: 0,
+    main: 0,
+    cooldown: 0,
+  } satisfies Record<SessionDraftStepCategory, number>;
+
+  for (const category of categories) {
+    if (plan[category] <= 0) continue;
+    result[category] = Math.max(
+      roundingUnit,
+      Math.round((total * plan[category]) / 100 / roundingUnit) * roundingUnit
+    );
+  }
+
+  let currentTotal = categories.reduce((sum, category) => sum + result[category], 0);
+
+  while (currentTotal !== total) {
+    const diff = total - currentTotal;
+    const targetCategory: SessionDraftStepCategory =
+      diff > 0 ? "main" : result.cooldown > roundingUnit ? "cooldown" : "main";
+    const nextValue = result[targetCategory] + Math.sign(diff) * roundingUnit;
+    if (nextValue < 0) break;
+    result[targetCategory] = nextValue;
+    currentTotal = categories.reduce((sum, category) => sum + result[category], 0);
+  }
+
+  return result;
+}
+
+function allocateMinuteSegments(totalMinutes: number, plan: SegmentPlan) {
+  const warmup = Math.max(5, Math.round((totalMinutes * plan.warmup) / 100));
+  const main = Math.max(10, Math.round((totalMinutes * plan.main) / 100));
+  const cooldown = Math.max(5, totalMinutes - warmup - main);
+
+  return {
+    warmup,
+    main,
+    cooldown,
+  };
+}
+
+function buildMainStepName(sessionType: SessionGeneratorSessionType) {
+  switch (sessionType) {
+    case "recovery":
+      return "Recovery main set";
+    case "endurance":
+      return "Endurance main set";
+    case "technique":
+      return "Technique integration set";
+    case "threshold_css":
+      return "Threshold / CSS main set";
+    case "speed":
+      return "Speed main set";
+    case "race_pace":
+      return "Race-pace main set";
+  }
+}
+
+function buildMainTargetSummary(
+  sessionType: SessionGeneratorSessionType,
+  effort: SessionDraft["effort"],
+  usedCssPaceLabel: string | null
+) {
+  switch (sessionType) {
+    case "recovery":
+      return "Relaxed aerobic swimming with clean timing and no pressure to force the pace.";
+    case "endurance":
+      return "Steady aerobic work that stays repeatable from start to finish.";
+    case "technique":
+      return "Hold form quality while swimming at a controllable working pace.";
+    case "threshold_css":
+      return usedCssPaceLabel
+        ? `Swim around CSS-derived pacing using ${usedCssPaceLabel}/100m as the anchor.`
+        : "Swim at strong sustainable threshold effort even without a saved CSS anchor.";
+    case "speed":
+      return "Short fast repeats with enough recovery to keep the speed clean.";
+    case "race_pace":
+      return `Touch ${getSessionEffortLabel(effort).toLowerCase()} race-specific speed without losing control.`;
+  }
+}
+
+function buildDistanceMainSetNote(input: {
+  input: SessionGeneratorInput;
+  mainDistanceM: number;
+  usedCssPaceLabel: string | null;
+  focusText: string | null;
+}) {
+  const { input: sessionInput, mainDistanceM, usedCssPaceLabel, focusText } = input;
+  const poolLength = sessionInput.poolLengthM ?? 25;
+  const repeatDistance = chooseRepeatDistance(sessionInput.sessionType, poolLength);
+  const repeats = Math.max(1, Math.round(mainDistanceM / repeatDistance));
+  const focusSentence = focusText ? ` Keep ${focusText.toLowerCase()} in every repeat.` : "";
+
+  if (sessionInput.sessionType === "threshold_css") {
+    if (usedCssPaceLabel) {
+      return `Suggested structure: ${repeats} x ${repeatDistance}m holding around CSS (${usedCssPaceLabel}/100m) with 15-20s easy rest.${focusSentence}`;
+    }
+
+    return `Suggested structure: ${repeats} x ${repeatDistance}m at strong sustainable effort with 15-20s easy rest.${focusSentence}`;
+  }
+
+  if (sessionInput.sessionType === "speed") {
+    return `Suggested structure: ${repeats} x ${repeatDistance}m fast, clean, and controlled with generous easy rest between repeats.${focusSentence}`;
+  }
+
+  if (sessionInput.sessionType === "race_pace") {
+    return `Suggested structure: ${repeats} x ${repeatDistance}m around goal race rhythm with short controlled rest between repeats.${focusSentence}`;
+  }
+
+  if (sessionInput.sessionType === "technique") {
+    return `Suggested structure: ${repeats} x ${repeatDistance}m as drill + swim or cue-led swimming, keeping form quality higher than raw speed.${focusSentence}`;
+  }
+
+  return `Suggested structure: ${repeats} x ${repeatDistance}m at a ${getSessionEffortLabel(sessionInput.effort).toLowerCase()} aerobic rhythm with consistent pacing.${focusSentence}`;
+}
+
+function buildOpenWaterMainSetNote(input: {
+  input: SessionGeneratorInput;
+  mainMinutes: number;
+  focusText: string | null;
+  constraintText: string | null;
+  basePaceSecondsPer100m: number;
+}) {
+  const { mainMinutes, focusText, constraintText, basePaceSecondsPer100m } = input;
+  const segments = Math.max(2, Math.min(4, Math.round(mainMinutes / 8)));
+  const minutesPerSegment = Math.max(4, Math.round(mainMinutes / segments));
+  const estimatedMeters = roundDistanceForEnvironment(
+    (mainMinutes * 60 * 100) / basePaceSecondsPer100m,
+    "open_water",
+    null
+  );
+
+  return `Suggested structure: ${segments} x ${minutesPerSegment} min steady work with 1 min very easy between segments (~${estimatedMeters}m total main work).${focusText ? ` Keep ${focusText.toLowerCase()} present while sighting.` : ""}${constraintText ? ` Constraint: ${constraintText}` : ""}`;
+}
+
+function buildKickNote(
+  equipmentAllowlist: SessionGeneratorEquipment[],
+  constraintText: string | null
+) {
+  const hasKickboard = equipmentAllowlist.includes("kickboard");
+  const equipmentText = hasKickboard
+    ? "Use the kickboard if that feels useful today."
+    : "Kick on the side or back if you do not want a board.";
+
+  return `${equipmentText}${constraintText ? ` Keep this aligned with the run constraint: ${constraintText}` : ""}`;
+}
+
+function buildTitleSuggestions(
+  input: SessionGeneratorInput,
+  goalTitle: string | null,
+  focusText: string | null
+) {
+  const environmentLabel =
+    input.environment === "pool" && input.poolLengthM
+      ? `${formatPoolLengthLabel(input.poolLengthM)} ${getSessionEnvironmentLabel(input.environment)}`
+      : getSessionEnvironmentLabel(input.environment);
+  const sessionLabel = getSessionTypeLabel(input.sessionType);
+  const primary = `${sessionLabel} ${environmentLabel} draft`;
+  const secondary = `${getSessionEffortLabel(input.effort)} ${sessionLabel} session`;
+  const tertiary = goalTitle
+    ? `${sessionLabel} for ${goalTitle}`
+    : focusText
+      ? `${sessionLabel}: ${focusText}`
+      : `${sessionLabel} swim session`;
+
+  return Array.from(new Set([primary, secondary, tertiary]));
+}
+
+function buildDraftDescription(input: {
+  input: SessionGeneratorInput;
+  goalTitle: string | null;
+  focusText: string | null;
+  constraintText: string | null;
+  usedCssPaceLabel: string | null;
+}) {
+  const parts = [
+    `${getSessionTypeLabel(input.input.sessionType)} session in ${getSessionEnvironmentLabel(input.input.environment).toLowerCase()} mode.`,
+    input.usedCssPaceLabel ? `CSS anchor available: ${input.usedCssPaceLabel}/100m.` : null,
+    input.goalTitle ? `Goal context: ${input.goalTitle}.` : null,
+    input.focusText ? `Focus cue: ${input.focusText}.` : null,
+    input.constraintText ? `Constraint: ${input.constraintText}.` : null,
+  ].filter(Boolean);
+
+  return parts.join(" ");
+}
+
+function chooseRepeatDistance(
+  sessionType: SessionGeneratorSessionType,
+  poolLength: SessionGeneratorPoolLength
+) {
+  if (sessionType === "speed") return poolLength >= 50 ? 50 : 25;
+  if (sessionType === "technique") return poolLength >= 50 ? 100 : 50;
+  if (sessionType === "threshold_css" || sessionType === "race_pace") return 100;
+  return poolLength >= 50 ? 200 : 100;
+}
+
+function selectStrokeChoice(
+  allowedStrokes: SessionGeneratorStroke[]
+): SessionGeneratorStroke | "choice" {
+  if (allowedStrokes.length === 1) return allowedStrokes[0];
+  if (allowedStrokes.includes("freestyle")) return "freestyle";
+  return allowedStrokes[0] ?? "choice";
+}
+
+export function buildSessionDraftSummary(draft: SessionDraft) {
+  return [
+    buildSessionTargetSummary(draft),
+    draft.goalTitle ? `Goal: ${draft.goalTitle}` : null,
+    draft.focusText ? `Focus: ${draft.focusText}` : null,
+    draft.usedCssPaceLabel ? `CSS ${draft.usedCssPaceLabel}/100m` : "Fallback pace guidance",
+    draft.steps.length > 0
+      ? `Steps: ${draft.steps
+          .map((step) => `${step.name} (${getSessionStrokeLabel(step.stroke)})`)
+          .join(" · ")}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join(" | ");
+}

--- a/lib/session-generator-v1/shared.ts
+++ b/lib/session-generator-v1/shared.ts
@@ -1,0 +1,470 @@
+import type {
+  GeneratorIntakeHandoffPayload,
+  GeneratorIntakeOverrides,
+  GeneratorIntakeSelection,
+} from "@/lib/generator-intake/shared";
+
+export const SESSION_GENERATOR_ENVIRONMENTS = ["pool", "open_water"] as const;
+export const SESSION_GENERATOR_POOL_LENGTHS = [12.5, 25, 50] as const;
+export const SESSION_GENERATOR_SESSION_TYPES = [
+  "recovery",
+  "endurance",
+  "technique",
+  "threshold_css",
+  "speed",
+  "race_pace",
+] as const;
+export const SESSION_GENERATOR_EFFORT_PRESETS = [
+  "easy",
+  "moderate",
+  "hard",
+  "very_hard",
+  "race_pace",
+] as const;
+export const SESSION_GENERATOR_SIZE_MODES = ["distance", "estimated_time"] as const;
+export const SESSION_GENERATOR_STROKES = [
+  "freestyle",
+  "backstroke",
+  "breaststroke",
+  "butterfly",
+  "individual_medley",
+] as const;
+export const SESSION_GENERATOR_EQUIPMENT = [
+  "kickboard",
+  "pull_buoy",
+  "fins",
+  "paddles",
+  "snorkel",
+] as const;
+export const SESSION_DRAFT_STEP_CATEGORIES = [
+  "warmup",
+  "drill",
+  "kick",
+  "main",
+  "cooldown",
+] as const;
+export const SESSION_DRAFT_STEP_DURATION_MODES = ["distance", "time"] as const;
+
+export type SessionGeneratorEnvironment = (typeof SESSION_GENERATOR_ENVIRONMENTS)[number];
+export type SessionGeneratorPoolLength = (typeof SESSION_GENERATOR_POOL_LENGTHS)[number];
+export type SessionGeneratorSessionType = (typeof SESSION_GENERATOR_SESSION_TYPES)[number];
+export type SessionGeneratorEffortPreset = (typeof SESSION_GENERATOR_EFFORT_PRESETS)[number];
+export type SessionGeneratorSizeMode = (typeof SESSION_GENERATOR_SIZE_MODES)[number];
+export type SessionGeneratorStroke = (typeof SESSION_GENERATOR_STROKES)[number];
+export type SessionGeneratorEquipment = (typeof SESSION_GENERATOR_EQUIPMENT)[number];
+export type SessionDraftStepCategory = (typeof SESSION_DRAFT_STEP_CATEGORIES)[number];
+export type SessionDraftStepDurationMode = (typeof SESSION_DRAFT_STEP_DURATION_MODES)[number];
+
+export type SessionGeneratorFormState = {
+  environment: SessionGeneratorEnvironment;
+  poolLengthM: string;
+  sessionType: SessionGeneratorSessionType;
+  effort: SessionGeneratorEffortPreset;
+  sizeMode: SessionGeneratorSizeMode;
+  targetDistanceM: string;
+  targetTimeMin: string;
+  includeDrills: boolean;
+  includeKick: boolean;
+  allowedStrokes: SessionGeneratorStroke[];
+  equipmentAllowlist: SessionGeneratorEquipment[];
+};
+
+export type SessionGeneratorInput = {
+  environment: SessionGeneratorEnvironment;
+  poolLengthM: SessionGeneratorPoolLength | null;
+  sessionType: SessionGeneratorSessionType;
+  effort: SessionGeneratorEffortPreset;
+  sizeMode: SessionGeneratorSizeMode;
+  targetDistanceM: number | null;
+  targetTimeMin: number | null;
+  includeDrills: boolean;
+  includeKick: boolean;
+  allowedStrokes: SessionGeneratorStroke[];
+  equipmentAllowlist: SessionGeneratorEquipment[];
+};
+
+export type SessionGeneratorRequestBody = {
+  selection?: Partial<GeneratorIntakeSelection> | null;
+  overrides?: Partial<GeneratorIntakeOverrides> | null;
+  input?: Partial<SessionGeneratorFormState> | null;
+};
+
+export type SessionDraftStep = {
+  id: string;
+  category: SessionDraftStepCategory;
+  name: string;
+  stroke: SessionGeneratorStroke | "choice";
+  intensity: SessionGeneratorEffortPreset;
+  durationMode: SessionDraftStepDurationMode;
+  distanceM: number | null;
+  timeMin: number | null;
+  targetSummary: string;
+  notes: string;
+};
+
+export type SessionDraft = {
+  version: 1;
+  status: "draft";
+  generatorKind: "rule_engine_v1";
+  createdAt: string;
+  sourceFingerprint: string;
+  title: string;
+  titleSuggestions: string[];
+  description: string;
+  environment: SessionGeneratorEnvironment;
+  poolLengthM: SessionGeneratorPoolLength | null;
+  sessionType: SessionGeneratorSessionType;
+  effort: SessionGeneratorEffortPreset;
+  sizeMode: SessionGeneratorSizeMode;
+  targetDistanceM: number | null;
+  targetTimeMin: number | null;
+  totalDistanceM: number | null;
+  estimatedDurationMin: number | null;
+  basePaceSecondsPer100m: number;
+  usedCssPaceLabel: string | null;
+  allowedStrokes: SessionGeneratorStroke[];
+  equipmentAllowlist: SessionGeneratorEquipment[];
+  focusText: string | null;
+  goalTitle: string | null;
+  constraintText: string | null;
+  warnings: string[];
+  steps: SessionDraftStep[];
+};
+
+export type SessionDraftApiSuccess = {
+  ok: true;
+  handoff: GeneratorIntakeHandoffPayload;
+  draft: SessionDraft;
+};
+
+export type SessionDraftApiError = {
+  ok: false;
+  error: string;
+};
+
+export type SessionDraftApiResponse = SessionDraftApiSuccess | SessionDraftApiError;
+
+const ENVIRONMENT_LABELS: Record<SessionGeneratorEnvironment, string> = {
+  pool: "Pool",
+  open_water: "Open water",
+};
+
+const SESSION_TYPE_LABELS: Record<SessionGeneratorSessionType, string> = {
+  recovery: "Recovery",
+  endurance: "Endurance",
+  technique: "Technique",
+  threshold_css: "Threshold / CSS",
+  speed: "Speed",
+  race_pace: "Race pace",
+};
+
+const EFFORT_LABELS: Record<SessionGeneratorEffortPreset, string> = {
+  easy: "Easy",
+  moderate: "Moderate",
+  hard: "Hard",
+  very_hard: "Very hard",
+  race_pace: "Race pace",
+};
+
+const STROKE_LABELS: Record<SessionGeneratorStroke, string> = {
+  freestyle: "Freestyle",
+  backstroke: "Backstroke",
+  breaststroke: "Breaststroke",
+  butterfly: "Butterfly",
+  individual_medley: "Individual medley",
+};
+
+const EQUIPMENT_LABELS: Record<SessionGeneratorEquipment, string> = {
+  kickboard: "Kickboard",
+  pull_buoy: "Pull buoy",
+  fins: "Fins",
+  paddles: "Paddles",
+  snorkel: "Snorkel",
+};
+
+const STEP_CATEGORY_LABELS: Record<SessionDraftStepCategory, string> = {
+  warmup: "Warmup",
+  drill: "Drill",
+  kick: "Kick",
+  main: "Main",
+  cooldown: "Cooldown",
+};
+
+export function getSessionEnvironmentLabel(value: SessionGeneratorEnvironment) {
+  return ENVIRONMENT_LABELS[value];
+}
+
+export function getSessionTypeLabel(value: SessionGeneratorSessionType) {
+  return SESSION_TYPE_LABELS[value];
+}
+
+export function getSessionEffortLabel(value: SessionGeneratorEffortPreset) {
+  return EFFORT_LABELS[value];
+}
+
+export function getSessionStrokeLabel(value: SessionGeneratorStroke | "choice") {
+  if (value === "choice") return "Stroke choice";
+  return STROKE_LABELS[value];
+}
+
+export function getSessionEquipmentLabel(value: SessionGeneratorEquipment) {
+  return EQUIPMENT_LABELS[value];
+}
+
+export function getSessionStepCategoryLabel(value: SessionDraftStepCategory) {
+  return STEP_CATEGORY_LABELS[value];
+}
+
+export function formatPoolLengthLabel(value: SessionGeneratorPoolLength) {
+  return `${value}m`;
+}
+
+export function getDefaultSessionGeneratorFormState(
+  handoff: GeneratorIntakeHandoffPayload
+): SessionGeneratorFormState {
+  const defaultPoolLength = handoff.source.preferences?.poolLengthM;
+  const defaultMinutes = handoff.effectiveDefaults.sessionMinutes;
+  const defaultStrokes = deriveDefaultAllowedStrokes(handoff);
+
+  return {
+    environment: "pool",
+    poolLengthM:
+      defaultPoolLength && isPoolLength(defaultPoolLength) ? String(defaultPoolLength) : "25",
+    sessionType: handoff.source.activeFocus ? "technique" : "endurance",
+    effort: "moderate",
+    sizeMode: defaultMinutes ? "estimated_time" : "distance",
+    targetDistanceM: defaultMinutes ? "" : "2000",
+    targetTimeMin: defaultMinutes ? String(defaultMinutes) : "45",
+    includeDrills: Boolean(handoff.source.activeFocus),
+    includeKick: false,
+    allowedStrokes: defaultStrokes,
+    equipmentAllowlist: [],
+  };
+}
+
+export function normalizeSessionGeneratorFormState(
+  input: Partial<SessionGeneratorFormState> | null | undefined,
+  handoff: GeneratorIntakeHandoffPayload
+): SessionGeneratorFormState {
+  const defaults = getDefaultSessionGeneratorFormState(handoff);
+
+  return {
+    environment: isSessionEnvironment(input?.environment)
+      ? input.environment
+      : defaults.environment,
+    poolLengthM:
+      typeof input?.poolLengthM === "string" && input.poolLengthM.length > 0
+        ? input.poolLengthM
+        : defaults.poolLengthM,
+    sessionType: isSessionType(input?.sessionType) ? input.sessionType : defaults.sessionType,
+    effort: isEffortPreset(input?.effort) ? input.effort : defaults.effort,
+    sizeMode: isSizeMode(input?.sizeMode) ? input.sizeMode : defaults.sizeMode,
+    targetDistanceM: normalizeIntegerString(input?.targetDistanceM, 5) || defaults.targetDistanceM,
+    targetTimeMin: normalizeIntegerString(input?.targetTimeMin, 3) || defaults.targetTimeMin,
+    includeDrills:
+      typeof input?.includeDrills === "boolean" ? input.includeDrills : defaults.includeDrills,
+    includeKick: typeof input?.includeKick === "boolean" ? input.includeKick : defaults.includeKick,
+    allowedStrokes: uniqueEnumList(
+      input?.allowedStrokes,
+      SESSION_GENERATOR_STROKES,
+      defaults.allowedStrokes
+    ),
+    equipmentAllowlist: uniqueEnumList(
+      input?.equipmentAllowlist,
+      SESSION_GENERATOR_EQUIPMENT,
+      defaults.equipmentAllowlist
+    ),
+  };
+}
+
+export function validateSessionGeneratorFormState(
+  input: SessionGeneratorFormState
+): { ok: true; value: SessionGeneratorInput } | { ok: false; error: string } {
+  const poolLength = input.environment === "pool" ? parsePoolLength(input.poolLengthM) : null;
+
+  if (input.environment === "pool" && poolLength === null) {
+    return { ok: false, error: "Choose a supported pool length before generating a session." };
+  }
+
+  if (input.allowedStrokes.length === 0) {
+    return { ok: false, error: "Select at least one stroke the swimmer can use in this session." };
+  }
+
+  const targetDistance =
+    input.sizeMode === "distance" ? parsePositiveInteger(input.targetDistanceM) : null;
+  const targetTime =
+    input.sizeMode === "estimated_time" ? parsePositiveInteger(input.targetTimeMin) : null;
+
+  if (input.sizeMode === "distance") {
+    if (targetDistance === null) {
+      return { ok: false, error: "Enter a target distance in meters for this draft." };
+    }
+    if (targetDistance < 400 || targetDistance > 10000) {
+      return {
+        ok: false,
+        error: "Distance-based sessions must stay between 400m and 10000m in this first slice.",
+      };
+    }
+  }
+
+  if (input.sizeMode === "estimated_time") {
+    if (targetTime === null) {
+      return { ok: false, error: "Enter an estimated session length in minutes for this draft." };
+    }
+    if (targetTime < 15 || targetTime > 180) {
+      return {
+        ok: false,
+        error: "Time-based sessions must stay between 15 and 180 minutes in this first slice.",
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    value: {
+      environment: input.environment,
+      poolLengthM: poolLength,
+      sessionType: input.sessionType,
+      effort: input.effort,
+      sizeMode: input.sizeMode,
+      targetDistanceM: targetDistance,
+      targetTimeMin: targetTime,
+      includeDrills: input.includeDrills,
+      includeKick: input.includeKick,
+      allowedStrokes: input.allowedStrokes,
+      equipmentAllowlist: input.equipmentAllowlist,
+    },
+  };
+}
+
+export function roundDistanceForEnvironment(
+  distanceM: number,
+  environment: SessionGeneratorEnvironment,
+  poolLengthM: SessionGeneratorPoolLength | null
+) {
+  const roundingUnit = environment === "pool" ? (poolLengthM ?? 25) : 50;
+  if (roundingUnit <= 0) return Math.max(0, Math.round(distanceM));
+  return Math.max(roundingUnit, Math.round(distanceM / roundingUnit) * roundingUnit);
+}
+
+export function computeSessionDraftDerivedTotals(draft: SessionDraft): {
+  totalDistanceM: number | null;
+  estimatedDurationMin: number | null;
+} {
+  let totalDistanceM = 0;
+  let estimatedMinutes = 0;
+
+  for (const step of draft.steps) {
+    if (step.distanceM) {
+      totalDistanceM += step.distanceM;
+      estimatedMinutes +=
+        ((step.distanceM / 100) *
+          draft.basePaceSecondsPer100m *
+          getIntensityMultiplier(step.intensity)) /
+        60;
+    }
+
+    if (step.timeMin) {
+      estimatedMinutes += step.timeMin;
+    }
+  }
+
+  return {
+    totalDistanceM: totalDistanceM > 0 ? totalDistanceM : null,
+    estimatedDurationMin: estimatedMinutes > 0 ? Math.round(estimatedMinutes) : null,
+  };
+}
+
+export function buildSessionTargetSummary(draft: SessionDraft) {
+  const parts = [
+    draft.totalDistanceM ? `${draft.totalDistanceM}m` : null,
+    draft.estimatedDurationMin ? `~${draft.estimatedDurationMin} min` : null,
+    getSessionEffortLabel(draft.effort),
+  ].filter(Boolean);
+
+  return parts.join(" · ");
+}
+
+function deriveDefaultAllowedStrokes(
+  handoff: GeneratorIntakeHandoffPayload
+): SessionGeneratorStroke[] {
+  const recordStrokes = handoff.source.personalRecords
+    .map((record) => mapRecordStroke(record.stroke))
+    .filter((value): value is SessionGeneratorStroke => value !== null);
+
+  const uniqueStrokes = Array.from(new Set(recordStrokes));
+  return uniqueStrokes.length > 0 ? uniqueStrokes : ["freestyle"];
+}
+
+function mapRecordStroke(value: string): SessionGeneratorStroke | null {
+  if (value === "freestyle") return "freestyle";
+  if (value === "backstroke") return "backstroke";
+  if (value === "breaststroke") return "breaststroke";
+  if (value === "butterfly") return "butterfly";
+  if (value === "individual_medley") return "individual_medley";
+  return null;
+}
+
+function normalizeIntegerString(value: unknown, maxLength: number) {
+  if (typeof value !== "string") return "";
+  return value.replace(/[^\d]/g, "").slice(0, maxLength);
+}
+
+function parsePositiveInteger(value: string) {
+  if (!/^\d+$/.test(value)) return null;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+function parsePoolLength(value: string): SessionGeneratorPoolLength | null {
+  if (!/^\d+(\.\d+)?$/.test(value)) return null;
+  const parsed = Number.parseFloat(value);
+  return isPoolLength(parsed) ? parsed : null;
+}
+
+function uniqueEnumList<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  fallback: readonly T[]
+): T[] {
+  if (!Array.isArray(value)) return [...fallback];
+
+  const next = value.filter((entry): entry is T => allowed.includes(entry as T));
+  return Array.from(new Set(next));
+}
+
+function isPoolLength(value: number): value is SessionGeneratorPoolLength {
+  return SESSION_GENERATOR_POOL_LENGTHS.includes(value as SessionGeneratorPoolLength);
+}
+
+function isSessionEnvironment(value: unknown): value is SessionGeneratorEnvironment {
+  return SESSION_GENERATOR_ENVIRONMENTS.includes(value as SessionGeneratorEnvironment);
+}
+
+function isSessionType(value: unknown): value is SessionGeneratorSessionType {
+  return SESSION_GENERATOR_SESSION_TYPES.includes(value as SessionGeneratorSessionType);
+}
+
+function isEffortPreset(value: unknown): value is SessionGeneratorEffortPreset {
+  return SESSION_GENERATOR_EFFORT_PRESETS.includes(value as SessionGeneratorEffortPreset);
+}
+
+function isSizeMode(value: unknown): value is SessionGeneratorSizeMode {
+  return SESSION_GENERATOR_SIZE_MODES.includes(value as SessionGeneratorSizeMode);
+}
+
+function getIntensityMultiplier(value: SessionGeneratorEffortPreset) {
+  switch (value) {
+    case "easy":
+      return 1.12;
+    case "moderate":
+      return 1.06;
+    case "hard":
+      return 1;
+    case "very_hard":
+      return 0.96;
+    case "race_pace":
+      return 0.93;
+  }
+}

--- a/tests/e2e/my-library-generator-intake.spec.ts
+++ b/tests/e2e/my-library-generator-intake.spec.ts
@@ -34,7 +34,7 @@ test.describe("my library generator intake", () => {
     runOnceOnDesktopChromium(testInfo.project.name);
 
     await loginToMyLibraryViaDevBypass(page);
-    const openGeneratorLink = page.getByRole("link", { name: "Open generator intake" });
+    const openGeneratorLink = page.getByRole("link", { name: "Open generator" });
     await expect(openGeneratorLink).toBeVisible();
     await expect(openGeneratorLink).toHaveAttribute("href", "/my-library/generator");
     await openGeneratorLink.click();
@@ -75,6 +75,42 @@ test.describe("my library generator intake", () => {
     );
     await expect(page.getByTestId("generator-intake-handoff-preview")).toContainText(
       '"notesIncluded": false'
+    );
+  });
+
+  test("generates and locally edits a session draft", async ({ page }, testInfo) => {
+    runOnceOnDesktopChromium(testInfo.project.name);
+
+    await loginToMyLibraryViaDevBypass(page);
+    await page.goto("/my-library/generator", { waitUntil: "domcontentloaded", timeout: 60_000 });
+    await expect(page).toHaveURL(/\/my-library\/generator$/);
+    await waitForGeneratorIntakeClientReady(page);
+
+    await page.getByTestId("generator-intake-target-session").check();
+    await page.getByTestId("generator-intake-prepare").click();
+
+    const generateResponsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes("/api/my-library/generator/session-draft") &&
+        response.request().method() === "POST" &&
+        response.status() === 200
+    );
+
+    await page.getByTestId("session-generator-generate").click();
+    await generateResponsePromise;
+
+    const titleInput = page.getByTestId("session-draft-title");
+    await expect(titleInput).toBeVisible();
+    await titleInput.fill("QA edited session draft");
+
+    const firstStepName = page.getByTestId("session-draft-step-name-0");
+    await firstStepName.fill("QA warmup block");
+
+    await expect(page.getByTestId("session-generator-draft-preview")).toContainText(
+      "QA edited session draft"
+    );
+    await expect(page.getByTestId("session-generator-draft-preview")).toContainText(
+      "QA warmup block"
     );
   });
 });

--- a/tests/unit/session-generator-panel.test.tsx
+++ b/tests/unit/session-generator-panel.test.tsx
@@ -1,0 +1,284 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import SessionGeneratorPanel from "@/components/my-library/generator/SessionGeneratorPanel";
+import type { GeneratorIntakeHandoffPayload } from "@/lib/generator-intake/shared";
+import type { SessionDraft } from "@/lib/session-generator-v1/shared";
+
+vi.mock("@/lib/analytics/client", () => ({
+  sendClientAnalyticsEvent: vi.fn(),
+}));
+
+function buildPayload(
+  overrides?: Partial<GeneratorIntakeHandoffPayload["overrides"]>
+): GeneratorIntakeHandoffPayload {
+  return {
+    version: 1,
+    createdAt: "2026-03-20T12:00:00.000Z",
+    sourceFingerprint: "fingerprint-1",
+    notesIncluded: false,
+    includedBlocks: ["profile", "css", "preferences", "goals", "focus"],
+    omittedBlocks: ["personal_records"],
+    source: {
+      profile: {
+        id: "profile-1",
+        displayName: "Poolside Stian",
+        firstName: "Stian",
+        lastName: "Vikra",
+        primaryName: "Poolside Stian",
+        ageBand: "35_44",
+        ageBandLabel: "35-44",
+        createdAt: "2026-03-20T10:00:00.000Z",
+        updatedAt: "2026-03-20T10:00:00.000Z",
+      },
+      cssMetric: {
+        id: "metric-1",
+        metricKey: "css",
+        unit: "seconds_per_100m",
+        valueSeconds: 118,
+        paceLabel: "1:58",
+        recordedOn: "2026-03-20",
+        sourceNote: null,
+        createdAt: "2026-03-20T10:00:00.000Z",
+        updatedAt: "2026-03-20T10:00:00.000Z",
+      },
+      preferences: {
+        id: "pref-1",
+        poolLengthM: 25,
+        poolLengthLabel: "25m pool",
+        availableDays: ["monday", "wednesday"],
+        availableDayLabels: ["Monday", "Wednesday"],
+        preferredWeeklySessionCount: 3,
+        preferredSessionMinutes: 45,
+        preferredSessionMinutesLabel: "45 min",
+        createdAt: "2026-03-20T10:00:00.000Z",
+        updatedAt: "2026-03-20T10:00:00.000Z",
+      },
+      personalRecords: [],
+      openGoals: [
+        {
+          id: "goal-1",
+          title: "Swim 1500m stronger",
+          summary: "Build toward a stronger 1500m freestyle.",
+          status: "on_track",
+          statusLabel: "On track",
+          statusTone: "blue",
+          goalType: "custom",
+          source: "custom",
+          progressPercent: 35,
+          progressLabel: "35%",
+          progressValue: 35,
+          targetValue: null,
+          targetDate: "2026-05-01",
+          targetDistanceM: null,
+          targetTimeSeconds: null,
+          targetCount: null,
+          targetRef: null,
+          celebratedAt: null,
+          showCelebration: false,
+          primaryAction: {
+            kind: "link",
+            label: "Open goals",
+            href: "/my-library/goals",
+          },
+        },
+      ],
+      activeFocus: {
+        id: "focus-1",
+        title: "Breathing timing",
+        details: "Keep the head quiet through the inhale.",
+        status: "active",
+        statusLabel: "Active",
+        goalId: "goal-1",
+        goalTitle: "Swim 1500m stronger",
+        contextType: null,
+        contextRef: null,
+        createdAt: "2026-03-20T10:00:00.000Z",
+        updatedAt: "2026-03-20T10:00:00.000Z",
+        completedAt: null,
+        archivedAt: null,
+      },
+    },
+    overrides: {
+      targetType: "session",
+      desiredSessionCount: null,
+      desiredSessionMinutes: 45,
+      focusText: null,
+      constraintText: "Keep the first half controlled.",
+      ...overrides,
+    },
+    effectiveDefaults: {
+      targetType: "session",
+      sessionCount: 3,
+      sessionMinutes: 45,
+      focusText: "Breathing timing",
+    },
+  };
+}
+
+function buildDraft(): SessionDraft {
+  return {
+    version: 1,
+    status: "draft",
+    generatorKind: "rule_engine_v1",
+    createdAt: "2026-03-20T12:10:00.000Z",
+    sourceFingerprint: "fingerprint-1",
+    title: "Threshold / CSS 25m Pool draft",
+    titleSuggestions: ["Threshold / CSS 25m Pool draft", "Moderate Threshold / CSS session"],
+    description: "Threshold session in pool mode.",
+    environment: "pool",
+    poolLengthM: 25,
+    sessionType: "threshold_css",
+    effort: "moderate",
+    sizeMode: "distance",
+    targetDistanceM: 2200,
+    targetTimeMin: null,
+    totalDistanceM: 2200,
+    estimatedDurationMin: 45,
+    basePaceSecondsPer100m: 128,
+    usedCssPaceLabel: "1:58",
+    allowedStrokes: ["freestyle"],
+    equipmentAllowlist: ["kickboard"],
+    focusText: "Breathing timing",
+    goalTitle: "Swim 1500m stronger",
+    constraintText: "Keep the first half controlled.",
+    warnings: [],
+    steps: [
+      {
+        id: "step-1",
+        category: "warmup",
+        name: "Easy warmup swim",
+        stroke: "freestyle",
+        intensity: "easy",
+        durationMode: "distance",
+        distanceM: 400,
+        timeMin: null,
+        targetSummary: "Easy swimming with relaxed breathing.",
+        notes: "Start smooth.",
+      },
+      {
+        id: "step-2",
+        category: "main",
+        name: "Threshold / CSS main set",
+        stroke: "freestyle",
+        intensity: "moderate",
+        durationMode: "distance",
+        distanceM: 1400,
+        timeMin: null,
+        targetSummary: "Swim around CSS-derived pacing.",
+        notes: "Suggested structure: 14 x 100m around CSS pace.",
+      },
+      {
+        id: "step-3",
+        category: "cooldown",
+        name: "Cooldown swim",
+        stroke: "choice",
+        intensity: "easy",
+        durationMode: "distance",
+        distanceM: 400,
+        timeMin: null,
+        targetSummary: "Easy swim to bring the heart rate down.",
+        notes: "Finish calmer than you started.",
+      },
+    ],
+  };
+}
+
+describe("SessionGeneratorPanel", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("keeps program generation deferred in the UI", () => {
+    render(
+      <SessionGeneratorPanel
+        payload={buildPayload({ targetType: "program" })}
+        selection={{
+          profile: true,
+          css: true,
+          preferences: true,
+          personal_records: false,
+          goals: true,
+          focus: true,
+        }}
+        overrides={{
+          targetType: "program",
+          desiredSessionCount: "",
+          desiredSessionMinutes: "45",
+          focusText: "",
+          constraintText: "",
+        }}
+        handoffPrepared
+      />
+    );
+
+    expect(screen.getByTestId("session-generator-program-deferred")).toBeInTheDocument();
+  });
+
+  it("generates and allows local editing of a draft session", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () =>
+        ({
+          ok: true,
+          handoff: buildPayload(),
+          draft: buildDraft(),
+        }) satisfies { ok: true; handoff: GeneratorIntakeHandoffPayload; draft: SessionDraft },
+    } as Response);
+
+    render(
+      <SessionGeneratorPanel
+        payload={buildPayload()}
+        selection={{
+          profile: true,
+          css: true,
+          preferences: true,
+          personal_records: false,
+          goals: true,
+          focus: true,
+        }}
+        overrides={{
+          targetType: "session",
+          desiredSessionCount: "",
+          desiredSessionMinutes: "45",
+          focusText: "",
+          constraintText: "Keep the first half controlled.",
+        }}
+        handoffPrepared
+      />
+    );
+
+    fireEvent.change(screen.getByTestId("session-generator-session-type"), {
+      target: { value: "threshold_css" },
+    });
+    fireEvent.click(screen.getByTestId("session-generator-size-distance"));
+    fireEvent.change(screen.getByTestId("session-generator-target-distance"), {
+      target: { value: "2200" },
+    });
+    fireEvent.click(screen.getByTestId("session-generator-generate"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session-draft-title")).toHaveValue(
+        "Threshold / CSS 25m Pool draft"
+      );
+    });
+
+    fireEvent.change(screen.getByTestId("session-draft-title"), {
+      target: { value: "My edited threshold draft" },
+    });
+    fireEvent.change(screen.getByTestId("session-draft-step-name-0"), {
+      target: { value: "Gentle warmup swim" },
+    });
+
+    expect(screen.getByTestId("session-draft-title")).toHaveValue("My edited threshold draft");
+    expect(screen.getByTestId("session-draft-step-name-0")).toHaveValue("Gentle warmup swim");
+    expect(screen.getByTestId("session-generator-draft-preview").textContent ?? "").toContain(
+      "My edited threshold draft"
+    );
+  });
+});

--- a/tests/unit/session-generator-route.test.ts
+++ b/tests/unit/session-generator-route.test.ts
@@ -1,0 +1,325 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createRouteHandlerSupabaseClientMock, loadGeneratorIntakeSnapshotMock } = vi.hoisted(
+  () => ({
+    createRouteHandlerSupabaseClientMock: vi.fn(),
+    loadGeneratorIntakeSnapshotMock: vi.fn(),
+  })
+);
+
+vi.mock("@/lib/supabase/route-handler", () => ({
+  createRouteHandlerSupabaseClient: createRouteHandlerSupabaseClientMock,
+}));
+
+vi.mock("@/lib/generator-intake/server", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/generator-intake/server")>(
+    "@/lib/generator-intake/server"
+  );
+
+  return {
+    ...actual,
+    loadGeneratorIntakeSnapshot: loadGeneratorIntakeSnapshotMock,
+  };
+});
+
+import { POST as postSessionDraft } from "@/app/api/my-library/generator/session-draft/route";
+
+function applyResponseCookiesIdentity<T>(response: T): T {
+  return response;
+}
+
+function buildRouteClient(userId: string | null) {
+  return {
+    supabase: {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: {
+            user: userId ? { id: userId } : null,
+          },
+        }),
+      },
+    },
+    applySupabaseCookies: applyResponseCookiesIdentity,
+  };
+}
+
+function buildSnapshot() {
+  return {
+    loadedAt: "2026-03-20T10:00:00.000Z",
+    sourceFingerprint: "fingerprint-1",
+    loadError: null,
+    notesIncluded: false,
+    profileSchemaReady: true,
+    metricsSchemaReady: true,
+    preferencesSchemaReady: true,
+    personalRecordsSchemaReady: true,
+    trainingContextSchemaReady: true,
+    goalsLoadError: null,
+    profile: {
+      id: "profile-1",
+      displayName: "Poolside Stian",
+      firstName: "Stian",
+      lastName: "Vikra",
+      primaryName: "Poolside Stian",
+      ageBand: "35_44",
+      ageBandLabel: "35-44",
+      createdAt: "2026-03-20T10:00:00.000Z",
+      updatedAt: "2026-03-20T10:00:00.000Z",
+    },
+    cssMetric: {
+      id: "metric-1",
+      metricKey: "css",
+      unit: "seconds_per_100m",
+      valueSeconds: 118,
+      paceLabel: "1:58",
+      recordedOn: "2026-03-20",
+      sourceNote: null,
+      createdAt: "2026-03-20T10:00:00.000Z",
+      updatedAt: "2026-03-20T10:00:00.000Z",
+    },
+    preferences: {
+      id: "pref-1",
+      poolLengthM: 25,
+      poolLengthLabel: "25m pool",
+      availableDays: ["monday", "wednesday"],
+      availableDayLabels: ["Monday", "Wednesday"],
+      preferredWeeklySessionCount: 3,
+      preferredSessionMinutes: 45,
+      preferredSessionMinutesLabel: "45 min",
+      createdAt: "2026-03-20T10:00:00.000Z",
+      updatedAt: "2026-03-20T10:00:00.000Z",
+    },
+    personalRecords: [],
+    openGoals: [
+      {
+        id: "goal-1",
+        title: "Swim 1500m stronger",
+        summary: "Build toward a stronger 1500m freestyle.",
+        status: "on_track",
+        statusLabel: "On track",
+        statusTone: "blue",
+        goalType: "custom",
+        source: "custom",
+        progressPercent: 35,
+        progressLabel: "35%",
+        progressValue: 35,
+        targetValue: null,
+        targetDate: "2026-05-01",
+        targetDistanceM: null,
+        targetTimeSeconds: null,
+        targetCount: null,
+        targetRef: null,
+        celebratedAt: null,
+        showCelebration: false,
+        primaryAction: {
+          kind: "link",
+          label: "Open goals",
+          href: "/my-library/goals",
+        },
+      },
+    ],
+    activeFocus: {
+      id: "focus-1",
+      title: "Breathing timing",
+      details: "Keep the head quiet through the inhale.",
+      status: "active",
+      statusLabel: "Active",
+      goalId: "goal-1",
+      goalTitle: "Swim 1500m stronger",
+      contextType: null,
+      contextRef: null,
+      createdAt: "2026-03-20T10:00:00.000Z",
+      updatedAt: "2026-03-20T10:00:00.000Z",
+      completedAt: null,
+      archivedAt: null,
+    },
+    blocks: {
+      profile: {
+        key: "profile",
+        label: "Athlete profile",
+        description: "desc",
+        state: "available",
+        available: true,
+        includedByDefault: true,
+        summary: "Poolside Stian · 35-44",
+        missingReason: null,
+        sourceIds: ["profile-1"],
+        lastUpdatedAt: "2026-03-20T10:00:00.000Z",
+        manageHref: "/my-library/profile",
+        manageLabel: "Edit athlete profile",
+      },
+      css: {
+        key: "css",
+        label: "CSS pace",
+        description: "desc",
+        state: "available",
+        available: true,
+        includedByDefault: true,
+        summary: "CSS 1:58/100m",
+        missingReason: null,
+        sourceIds: ["metric-1"],
+        lastUpdatedAt: "2026-03-20T10:00:00.000Z",
+        manageHref: "/my-library/profile",
+        manageLabel: "Edit CSS",
+      },
+      preferences: {
+        key: "preferences",
+        label: "Training preferences",
+        description: "desc",
+        state: "available",
+        available: true,
+        includedByDefault: true,
+        summary: "25m pool · 3 sessions/week · 45 min",
+        missingReason: null,
+        sourceIds: ["pref-1"],
+        lastUpdatedAt: "2026-03-20T10:00:00.000Z",
+        manageHref: "/my-library/profile",
+        manageLabel: "Edit preferences",
+      },
+      personal_records: {
+        key: "personal_records",
+        label: "Personal records",
+        description: "desc",
+        state: "empty",
+        available: false,
+        includedByDefault: false,
+        summary: "No personal records saved yet.",
+        missingReason: "Add personal records if later generation should see benchmark events.",
+        sourceIds: [],
+        lastUpdatedAt: null,
+        manageHref: "/my-library/profile",
+        manageLabel: "Edit personal records",
+      },
+      goals: {
+        key: "goals",
+        label: "Open goals",
+        description: "desc",
+        state: "available",
+        available: true,
+        includedByDefault: true,
+        summary: "1 open goal ready for intake.",
+        missingReason: null,
+        sourceIds: ["goal-1"],
+        lastUpdatedAt: null,
+        manageHref: "/my-library/goals",
+        manageLabel: "Edit goals",
+      },
+      focus: {
+        key: "focus",
+        label: "Active focus",
+        description: "desc",
+        state: "available",
+        available: true,
+        includedByDefault: true,
+        summary: "Breathing timing",
+        missingReason: null,
+        sourceIds: ["focus-1"],
+        lastUpdatedAt: "2026-03-20T10:00:00.000Z",
+        manageHref: "/my-library/training",
+        manageLabel: "Edit focus",
+      },
+    },
+  };
+}
+
+describe("session generator route", () => {
+  beforeEach(() => {
+    createRouteHandlerSupabaseClientMock.mockReset();
+    loadGeneratorIntakeSnapshotMock.mockResolvedValue(buildSnapshot());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fails closed for unauthenticated generation requests", async () => {
+    createRouteHandlerSupabaseClientMock.mockResolvedValue(buildRouteClient(null));
+
+    const response = await postSessionDraft(
+      new Request("http://127.0.0.1:3000/api/my-library/generator/session-draft", {
+        method: "POST",
+        body: JSON.stringify({}),
+      })
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns one generated session draft for the authenticated owner", async () => {
+    createRouteHandlerSupabaseClientMock.mockResolvedValue(buildRouteClient("user-1"));
+
+    const response = await postSessionDraft(
+      new Request("http://127.0.0.1:3000/api/my-library/generator/session-draft", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          selection: {
+            profile: true,
+            css: true,
+            preferences: true,
+            personal_records: false,
+            goals: true,
+            focus: true,
+          },
+          overrides: {
+            targetType: "session",
+            desiredSessionCount: "",
+            desiredSessionMinutes: "45",
+            focusText: "",
+            constraintText: "Keep it smooth.",
+          },
+          input: {
+            environment: "pool",
+            poolLengthM: "25",
+            sessionType: "threshold_css",
+            effort: "moderate",
+            sizeMode: "distance",
+            targetDistanceM: "2200",
+            targetTimeMin: "45",
+            includeDrills: false,
+            includeKick: true,
+            allowedStrokes: ["freestyle"],
+            equipmentAllowlist: ["kickboard"],
+          },
+        }),
+      })
+    );
+
+    const payload = (await response.json()) as {
+      ok: boolean;
+      draft: { status: string; title: string; steps: Array<{ category: string }> };
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(payload.draft.status).toBe("draft");
+    expect(payload.draft.title).toContain("Threshold / CSS");
+    expect(payload.draft.steps[0]?.category).toBe("warmup");
+  });
+
+  it("keeps program generation deferred in this slice", async () => {
+    createRouteHandlerSupabaseClientMock.mockResolvedValue(buildRouteClient("user-1"));
+
+    const response = await postSessionDraft(
+      new Request("http://127.0.0.1:3000/api/my-library/generator/session-draft", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          overrides: {
+            targetType: "program",
+          },
+        }),
+      })
+    );
+
+    const payload = (await response.json()) as { ok: boolean; error: string };
+
+    expect(response.status).toBe(422);
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toContain("Program generation stays deferred");
+  });
+});

--- a/tests/unit/session-generator-server.test.ts
+++ b/tests/unit/session-generator-server.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import { buildSessionDraft } from "@/lib/session-generator-v1/server";
+import { validateSessionGeneratorFormState } from "@/lib/session-generator-v1/shared";
+import type { GeneratorIntakeHandoffPayload } from "@/lib/generator-intake/shared";
+
+function buildHandoff(): GeneratorIntakeHandoffPayload {
+  return {
+    version: 1,
+    createdAt: "2026-03-20T12:00:00.000Z",
+    sourceFingerprint: "fingerprint-1",
+    notesIncluded: false,
+    includedBlocks: ["profile", "css", "preferences", "goals", "focus"],
+    omittedBlocks: ["personal_records"],
+    source: {
+      profile: {
+        id: "profile-1",
+        displayName: "Poolside Stian",
+        firstName: "Stian",
+        lastName: "Vikra",
+        primaryName: "Poolside Stian",
+        ageBand: "35_44",
+        ageBandLabel: "35-44",
+        createdAt: "2026-03-20T10:00:00.000Z",
+        updatedAt: "2026-03-20T10:00:00.000Z",
+      },
+      cssMetric: {
+        id: "metric-1",
+        metricKey: "css",
+        unit: "seconds_per_100m",
+        valueSeconds: 118,
+        paceLabel: "1:58",
+        recordedOn: "2026-03-20",
+        sourceNote: null,
+        createdAt: "2026-03-20T10:00:00.000Z",
+        updatedAt: "2026-03-20T10:00:00.000Z",
+      },
+      preferences: {
+        id: "pref-1",
+        poolLengthM: 25,
+        poolLengthLabel: "25m pool",
+        availableDays: ["monday", "wednesday"],
+        availableDayLabels: ["Monday", "Wednesday"],
+        preferredWeeklySessionCount: 3,
+        preferredSessionMinutes: 45,
+        preferredSessionMinutesLabel: "45 min",
+        createdAt: "2026-03-20T10:00:00.000Z",
+        updatedAt: "2026-03-20T10:00:00.000Z",
+      },
+      personalRecords: [],
+      openGoals: [
+        {
+          id: "goal-1",
+          title: "Swim 1500m stronger",
+          summary: "Build toward a stronger 1500m freestyle.",
+          status: "on_track",
+          statusLabel: "On track",
+          statusTone: "blue",
+          goalType: "custom",
+          source: "custom",
+          progressPercent: 35,
+          progressLabel: "35%",
+          progressValue: 35,
+          targetValue: null,
+          targetDate: "2026-05-01",
+          targetDistanceM: null,
+          targetTimeSeconds: null,
+          targetCount: null,
+          targetRef: null,
+          celebratedAt: null,
+          showCelebration: false,
+          primaryAction: {
+            kind: "link",
+            label: "Open goals",
+            href: "/my-library/goals",
+          },
+        },
+      ],
+      activeFocus: {
+        id: "focus-1",
+        title: "Breathing timing",
+        details: "Keep the head quiet through the inhale.",
+        status: "active",
+        statusLabel: "Active",
+        goalId: "goal-1",
+        goalTitle: "Swim 1500m stronger",
+        contextType: null,
+        contextRef: null,
+        createdAt: "2026-03-20T10:00:00.000Z",
+        updatedAt: "2026-03-20T10:00:00.000Z",
+        completedAt: null,
+        archivedAt: null,
+      },
+    },
+    overrides: {
+      targetType: "session",
+      desiredSessionCount: null,
+      desiredSessionMinutes: 45,
+      focusText: null,
+      constraintText: "Keep the first half controlled.",
+    },
+    effectiveDefaults: {
+      targetType: "session",
+      sessionCount: 3,
+      sessionMinutes: 45,
+      focusText: "Breathing timing",
+    },
+  };
+}
+
+describe("session generator server", () => {
+  it("builds a pool threshold draft with CSS-aware main-set guidance", () => {
+    const validation = validateSessionGeneratorFormState({
+      environment: "pool",
+      poolLengthM: "25",
+      sessionType: "threshold_css",
+      effort: "moderate",
+      sizeMode: "distance",
+      targetDistanceM: "2400",
+      targetTimeMin: "45",
+      includeDrills: false,
+      includeKick: true,
+      allowedStrokes: ["freestyle", "backstroke"],
+      equipmentAllowlist: ["kickboard", "fins"],
+    });
+
+    expect(validation.ok).toBe(true);
+    if (!validation.ok) return;
+
+    const draft = buildSessionDraft(buildHandoff(), validation.value, {
+      createdAt: "2026-03-20T12:05:00.000Z",
+    });
+
+    expect(draft.status).toBe("draft");
+    expect(draft.titleSuggestions[0]).toContain("Threshold / CSS");
+    expect(draft.usedCssPaceLabel).toBe("1:58");
+    expect(draft.steps.map((step) => step.category)).toEqual([
+      "warmup",
+      "kick",
+      "main",
+      "cooldown",
+    ]);
+    expect(draft.steps[2]?.notes).toContain("CSS");
+    expect(draft.totalDistanceM).toBe(2400);
+    expect(draft.estimatedDurationMin).toBeGreaterThan(0);
+  });
+
+  it("guards open-water drafts away from dedicated drill and kick blocks", () => {
+    const validation = validateSessionGeneratorFormState({
+      environment: "open_water",
+      poolLengthM: "25",
+      sessionType: "endurance",
+      effort: "moderate",
+      sizeMode: "estimated_time",
+      targetDistanceM: "2000",
+      targetTimeMin: "50",
+      includeDrills: true,
+      includeKick: true,
+      allowedStrokes: ["freestyle"],
+      equipmentAllowlist: ["snorkel"],
+    });
+
+    expect(validation.ok).toBe(true);
+    if (!validation.ok) return;
+
+    const draft = buildSessionDraft(buildHandoff(), validation.value);
+
+    expect(draft.environment).toBe("open_water");
+    expect(draft.steps.map((step) => step.category)).toEqual(["warmup", "main", "cooldown"]);
+    expect(draft.warnings).toContain(
+      "Open-water draft review skips dedicated drill blocks in this first slice."
+    );
+    expect(draft.warnings).toContain(
+      "Open-water draft review skips dedicated kick blocks in this first slice."
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- This PR adds the first actual AI session-generator runtime slice on `/my-library/generator`: an owner-scoped swim-session draft flow that turns reviewed intake context plus explicit session choices into one editable Garmin-familiar draft.
- User-visible changes: authenticated swimmers can generate one session draft for `planning_horizon = session`, review and fully edit the draft locally on the generator page, and see an explicit message that longer program generation is still deferred.
- Technical changes: adds a protected session-draft API route, deterministic session-generation rules and shared contracts, a new `SessionGeneratorPanel` with full local draft editing, route/runbook/analytics updates, and new unit + e2e coverage for generate-and-edit flows.
- Policy impact: yes - this slice adds a new authenticated analytics event (`session_draft_generated`) in the generator flow, so policy-impact review applies even though consent UI, retention behavior, and processor scope do not change.
- Policy version note: N/A (policy review completed for an internal analytics-only event addition; no public policy text or regulated workflow copy changed in this slice).
- Brief link(s): `docs/task-briefs/in-progress/2026-03-20-ai-session-generator-v1-garmin-minimum-draft-review-10-10.md`

## Scope

- In scope: one-session AI draft generation on `/my-library/generator`, deterministic Garmin-familiar draft shaping for swim sessions, local draft review/editing before acceptance, protected route validation, and supporting tests/docs/runbook updates.
- Out of scope: canonical workout persistence/acceptance, shared workout-entity handoff, multi-session program generation, calendar scheduling, Garmin send/publish, and completed-history reconciliation.

## Risk

- Main risk: the new draft editor and generator contract are larger than a normal slice, and the temporary local-only review model could drift from the future shared workout-entity contract if follow-on slices are delayed.
- Rollback plan: revert `ea1c400` to remove the session-draft route, panel, and generator contracts, returning `/my-library/generator` to the prior intake-only state with no saved data migration required.

## Test Evidence

- Policy-impact checklist: PASS (reviewed against `docs/checklists/policy-impact-release-review.md`; impact is limited to an internal authenticated analytics event with no new consent surface, processor scope, or policy-text change).
- `npm run lint:briefs` PASS
- `npm run lint` PASS (via local verify gate)
- `npm run typecheck` PASS (via local verify gate)
- `npm run test:unit` PASS (via local verify gate and targeted generator unit suites)
- `npm run build` PASS (via local verify gate)
- `npm run test:e2e` PASS for targeted generator desktop Chromium flow: `npx playwright test tests/e2e/my-library-generator-intake.spec.ts --project=desktop-chromium`
- `npm run verify:pre-pr` FAIL locally on an earlier run due the known unrelated desktop Chromium flake in `tests/e2e/my-library-athlete-profile.spec.ts`; targeted rerun of that exact spec passed immediately after, and the new generator flow passed.
- `npm run verify:pre-merge` PASS on current HEAD `ea1c400`
- [x] `npm run lint:briefs`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] `npm run test:e2e` (targeted generator flow; full matrix also passed inside `verify:pre-merge`)
- [ ] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge` (must be `PASS` on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added
- PR size note: intentionally above 500 changed lines because this first runtime slice needed the generator rule engine, protected route, draft editor UI, tests, and brief/runbook alignment in one end-to-end deliverable.

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/251`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d feat/ai-session-generator-draft-review`
- [ ] Optional: `git fetch --prune`
