### PR TITLE
feat(workouts): add dedicated builder route

### DIFF
--- a/app/my-library/generator/page.tsx
+++ b/app/my-library/generator/page.tsx
@@ -26,6 +26,11 @@ function getOptionalWorkoutId(value: string | string[] | undefined) {
 
 export default async function MyLibraryGeneratorPage({ searchParams }: Props) {
   const params = await searchParams;
+  const selectedWorkoutId = getOptionalWorkoutId(params.workout);
+  if (selectedWorkoutId) {
+    redirect(`/my-library/workouts/${selectedWorkoutId}`);
+  }
+
   const supabase = await createServerSupabaseClient();
   const {
     data: { user },
@@ -36,11 +41,7 @@ export default async function MyLibraryGeneratorPage({ searchParams }: Props) {
   }
 
   const initialSnapshot = await loadGeneratorIntakeSnapshot(supabase, user.id);
-  const workoutLibrary = await loadWorkoutLibrarySnapshot(
-    supabase,
-    user.id,
-    getOptionalWorkoutId(params.workout)
-  );
+  const workoutLibrary = await loadWorkoutLibrarySnapshot(supabase, user.id, null);
   const availableBlockCount = Object.values(
     initialSnapshot.blocks as Record<string, GeneratorIntakeBlockSummary>
   ).filter((block) => block.available).length;
@@ -110,8 +111,8 @@ export default async function MyLibraryGeneratorPage({ searchParams }: Props) {
                   Canonical workout save
                 </p>
                 <p className="mt-2 text-sm text-slate-700">
-                  This page can now accept one reviewed session into a canonical workout and reopen
-                  it here for later editing, even before the separate manual builder route lands.
+                  This page can now accept one reviewed session into a canonical workout and hand it
+                  off into the dedicated workout builder route for later editing.
                 </p>
               </div>
             </div>

--- a/app/my-library/page.tsx
+++ b/app/my-library/page.tsx
@@ -18,6 +18,7 @@ import { createAdminSupabaseClient } from "@/lib/supabase/admin";
 import { loadAthleteProfileSnapshot } from "@/lib/athlete-profile/server";
 import { attachGuestEntitlementsByEmail } from "@/lib/commerce/entitlements";
 import { loadTrainingContextSnapshot } from "@/lib/training-context/server";
+import { loadWorkoutLibrarySnapshot } from "@/lib/workouts/server";
 
 export const dynamic = "force-dynamic";
 
@@ -83,10 +84,12 @@ export default async function MyLibraryPage() {
     console.error("[MyLibrary] Could not load active goal count", activeGoalCountError);
   }
 
-  const [trainingContextSnapshot, athleteProfileSnapshot] = await Promise.all([
-    loadTrainingContextSnapshot(supabase, user.id),
-    loadAthleteProfileSnapshot(supabase, user.id),
-  ]);
+  const [trainingContextSnapshot, athleteProfileSnapshot, workoutLibrarySnapshot] =
+    await Promise.all([
+      loadTrainingContextSnapshot(supabase, user.id),
+      loadAthleteProfileSnapshot(supabase, user.id),
+      loadWorkoutLibrarySnapshot(supabase, user.id, null),
+    ]);
 
   const claimQuery = new URLSearchParams({ next: "/my-library" });
   if (user.email) {
@@ -229,6 +232,42 @@ export default async function MyLibraryPage() {
                   className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700"
                 >
                   Open generator
+                </Link>
+              </div>
+            </section>
+            <section className="rounded-2xl border border-slate-200 bg-white p-5">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-lg font-semibold text-slate-900">Workout builder</h2>
+                  <p className="mt-2 text-sm text-slate-600">
+                    {!workoutLibrarySnapshot.schemaReady
+                      ? "This canonical workout layer is still syncing in this environment."
+                      : workoutLibrarySnapshot.recentWorkouts[0]
+                        ? [
+                            workoutLibrarySnapshot.recentWorkouts[0].title,
+                            workoutLibrarySnapshot.recentWorkouts[0].totalDistanceM
+                              ? `${workoutLibrarySnapshot.recentWorkouts[0].totalDistanceM}m`
+                              : null,
+                            workoutLibrarySnapshot.recentWorkouts[0].estimatedDurationMin
+                              ? `~${workoutLibrarySnapshot.recentWorkouts[0].estimatedDurationMin} min`
+                              : null,
+                          ]
+                            .filter(Boolean)
+                            .join(" · ")
+                        : "Accepted AI-generated workouts will appear here for later canonical editing once you save your first session draft."}
+                  </p>
+                </div>
+                <Link
+                  href={
+                    workoutLibrarySnapshot.recentWorkouts[0]
+                      ? `/my-library/workouts/${workoutLibrarySnapshot.recentWorkouts[0].id}`
+                      : "/my-library/generator"
+                  }
+                  className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700"
+                >
+                  {workoutLibrarySnapshot.recentWorkouts[0]
+                    ? "Open workout builder"
+                    : "Create first workout"}
                 </Link>
               </div>
             </section>

--- a/app/my-library/workouts/[workoutId]/page.tsx
+++ b/app/my-library/workouts/[workoutId]/page.tsx
@@ -1,0 +1,76 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import SiteChrome from "@/components/SiteChrome";
+import WorkoutBuilderHub from "@/components/my-library/workouts/WorkoutBuilderHub";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { loadWorkoutLibrarySnapshot } from "@/lib/workouts/server";
+
+export const dynamic = "force-dynamic";
+
+type Params = Promise<{
+  workoutId: string;
+}>;
+
+type Props = {
+  params: Params;
+};
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export default async function WorkoutBuilderPage({ params }: Props) {
+  const { workoutId } = await params;
+
+  if (!UUID_PATTERN.test(workoutId)) {
+    notFound();
+  }
+
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(`/auth/sign-in?next=${encodeURIComponent(`/my-library/workouts/${workoutId}`)}`);
+  }
+
+  const workoutLibrary = await loadWorkoutLibrarySnapshot(supabase, user.id, workoutId);
+
+  return (
+    <SiteChrome>
+      <section className="mx-auto min-h-screen w-full max-w-[980px] px-6 pb-20 pt-28">
+        <div className="rounded-3xl border border-blue-100 bg-white/95 p-8 shadow-[0_16px_60px_rgba(24,58,107,0.14)]">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
+                My Library
+              </p>
+              <h1 className="mt-2 text-3xl font-bold text-slate-900">Workout builder</h1>
+              <p className="mt-2 max-w-[68ch] text-sm text-slate-600">
+                Open one accepted workout in its own route, edit the canonical step structure, and
+                keep the saved workout ready for richer builder follow-on slices.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Link
+                href="/my-library/generator"
+                className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+              >
+                Open generator
+              </Link>
+              <Link
+                href="/my-library"
+                className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+              >
+                Back to My Library
+              </Link>
+            </div>
+          </div>
+
+          <div className="mt-8">
+            <WorkoutBuilderHub workoutLibrary={workoutLibrary} />
+          </div>
+        </div>
+      </section>
+    </SiteChrome>
+  );
+}

--- a/components/my-library/generator/SessionGeneratorPanel.tsx
+++ b/components/my-library/generator/SessionGeneratorPanel.tsx
@@ -1,42 +1,33 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { sendClientAnalyticsEvent } from "@/lib/analytics/client";
+import WorkoutEditor from "@/components/my-library/workouts/WorkoutEditor";
 import type {
   GeneratorIntakeHandoffPayload,
   GeneratorIntakeOverrides,
   GeneratorIntakeSelection,
 } from "@/lib/generator-intake/shared";
 import {
-  SESSION_DRAFT_STEP_CATEGORIES,
-  SESSION_DRAFT_STEP_DURATION_MODES,
   SESSION_GENERATOR_EFFORT_PRESETS,
   SESSION_GENERATOR_ENVIRONMENTS,
   SESSION_GENERATOR_EQUIPMENT,
   SESSION_GENERATOR_POOL_LENGTHS,
   SESSION_GENERATOR_SESSION_TYPES,
   SESSION_GENERATOR_STROKES,
-  buildSessionTargetSummary,
-  computeSessionDraftDerivedTotals,
   formatPoolLengthLabel,
   getDefaultSessionGeneratorFormState,
   getSessionEffortLabel,
   getSessionEnvironmentLabel,
   getSessionEquipmentLabel,
-  getSessionStepCategoryLabel,
   getSessionStrokeLabel,
   getSessionTypeLabel,
   normalizeSessionGeneratorFormState,
   type SessionDraft,
   type SessionDraftApiResponse,
-  type SessionDraftStep,
-  type SessionDraftStepCategory,
-  type SessionDraftStepDurationMode,
   type SessionGeneratorEquipment,
-  type SessionGeneratorEnvironment,
   type SessionGeneratorFormState,
-  type SessionGeneratorPoolLength,
   type SessionGeneratorStroke,
 } from "@/lib/session-generator-v1/shared";
 import type {
@@ -53,28 +44,6 @@ type Props = {
   handoffPrepared: boolean;
   workoutLibrary: WorkoutLibrarySnapshot;
 };
-
-function buildBlankStep(index: number): SessionDraftStep {
-  return {
-    id: `step-${Date.now()}-${index}`,
-    category: "main",
-    name: "Custom step",
-    stroke: "choice",
-    intensity: "moderate",
-    durationMode: "distance",
-    distanceM: 100,
-    timeMin: null,
-    targetSummary: "",
-    notes: "",
-  };
-}
-
-function parsePositiveNumber(value: string) {
-  if (!/^\d+(\.\d+)?$/.test(value)) return null;
-  const parsed = Number.parseFloat(value);
-  if (!Number.isFinite(parsed) || parsed <= 0) return null;
-  return parsed;
-}
 
 export default function SessionGeneratorPanel({
   payload,
@@ -123,10 +92,6 @@ export default function SessionGeneratorPanel({
   }, [workoutLibrary.recentWorkouts]);
 
   const sessionReady = payload.overrides.targetType === "session" && handoffPrepared;
-  const draftTotals = useMemo(
-    () => (draft ? computeSessionDraftDerivedTotals(draft) : null),
-    [draft]
-  );
   const canonicalSaveReady = workoutLibrary.schemaReady;
   const hasLoadedCanonicalWorkout = Boolean(savedWorkout);
 
@@ -259,83 +224,6 @@ export default function SessionGeneratorPanel({
     }
   }
 
-  function updateDraft<K extends keyof SessionDraft>(key: K, value: SessionDraft[K]) {
-    setDraft((current) => (current ? { ...current, [key]: value } : current));
-    setSuccess("");
-  }
-
-  function updateDraftStep(stepId: string, updater: (step: SessionDraftStep) => SessionDraftStep) {
-    setDraft((current) =>
-      current
-        ? {
-            ...current,
-            steps: current.steps.map((step) => (step.id === stepId ? updater(step) : step)),
-          }
-        : current
-    );
-    setSuccess("");
-  }
-
-  function moveStep(stepId: string, direction: -1 | 1) {
-    setDraft((current) => {
-      if (!current) return current;
-      const index = current.steps.findIndex((step) => step.id === stepId);
-      const nextIndex = index + direction;
-      if (index < 0 || nextIndex < 0 || nextIndex >= current.steps.length) return current;
-      const nextSteps = [...current.steps];
-      const [step] = nextSteps.splice(index, 1);
-      nextSteps.splice(nextIndex, 0, step);
-      return {
-        ...current,
-        steps: nextSteps,
-      };
-    });
-  }
-
-  function addStep() {
-    setDraft((current) =>
-      current
-        ? {
-            ...current,
-            steps: [...current.steps, buildBlankStep(current.steps.length + 1)],
-          }
-        : current
-    );
-  }
-
-  function removeStep(stepId: string) {
-    setDraft((current) =>
-      current
-        ? {
-            ...current,
-            steps: current.steps.filter((step) => step.id !== stepId),
-          }
-        : current
-    );
-  }
-
-  function toggleDraftStroke(stroke: SessionGeneratorStroke) {
-    if (!draft) return;
-    const exists = draft.allowedStrokes.includes(stroke);
-    updateDraft(
-      "allowedStrokes",
-      exists
-        ? draft.allowedStrokes.filter((value) => value !== stroke)
-        : [...draft.allowedStrokes, stroke]
-    );
-  }
-
-  function toggleDraftEquipment(item: SessionGeneratorEquipment) {
-    if (!draft) return;
-    const exists = draft.equipmentAllowlist.includes(item);
-    updateDraft(
-      "equipmentAllowlist",
-      exists
-        ? draft.equipmentAllowlist.filter((value) => value !== item)
-        : [...draft.equipmentAllowlist, item]
-    );
-  }
-
   function upsertRecentWorkoutSummary(current: WorkoutSummary[], next: WorkoutSummary) {
     const existing = current.filter((summary) => summary.id !== next.id);
     return [next, ...existing].slice(0, 6);
@@ -395,24 +283,6 @@ export default function SessionGeneratorPanel({
         </div>
       ) : null}
 
-      {hasLoadedCanonicalWorkout ? (
-        <div className="mt-5 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-blue-200 bg-blue-50/80 p-4">
-          <div>
-            <p className="text-sm font-medium text-blue-900">Accepted workout loaded.</p>
-            <p className="mt-1 text-sm text-blue-900/90">
-              Save changes below, or start a fresh draft from the prepared intake when you want a
-              brand-new generated workout.
-            </p>
-          </div>
-          <Link
-            href="/my-library/generator"
-            className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-4 text-sm font-medium text-blue-800 transition hover:bg-blue-50 active:bg-blue-100"
-          >
-            Start new draft
-          </Link>
-        </div>
-      ) : null}
-
       {recentWorkouts.length > 0 ? (
         <div
           data-testid="session-generator-recent-workouts"
@@ -422,7 +292,8 @@ export default function SessionGeneratorPanel({
             <div>
               <h3 className="text-sm font-semibold text-slate-900">Recent accepted workouts</h3>
               <p className="mt-1 text-sm text-slate-600">
-                Reopen one saved session here until the dedicated workout builder route lands.
+                Open one saved session in the dedicated workout builder route, or start a fresh
+                AI-generated draft below.
               </p>
             </div>
           </div>
@@ -443,7 +314,7 @@ export default function SessionGeneratorPanel({
                   </p>
                 </div>
                 <Link
-                  href={`/my-library/generator?workout=${workout.id}`}
+                  href={`/my-library/workouts/${workout.id}`}
                   data-testid={`session-generator-open-workout-${workout.id}`}
                   className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
                 >
@@ -738,478 +609,22 @@ export default function SessionGeneratorPanel({
       ) : null}
 
       {draft ? (
-        <div className="mt-6 space-y-5 border-t border-slate-200 pt-6">
-          <div className="rounded-2xl border border-blue-200 bg-blue-50/80 p-4">
-            <p className="text-sm text-blue-900">
-              {savedWorkout
-                ? "Canonical workout loaded: edit everything below, then save changes back into the same owner-scoped workout."
-                : "Local draft only: review and edit everything below, then accept it into the canonical workout layer when you are ready."}
-            </p>
-          </div>
-
-          {draft.warnings.length > 0 ? (
-            <div className="rounded-2xl border border-amber-200 bg-amber-50/80 p-4">
-              <ul className="space-y-2 text-sm text-amber-900">
-                {draft.warnings.map((warning) => (
-                  <li key={warning}>{warning}</li>
-                ))}
-              </ul>
-            </div>
-          ) : null}
-
-          <div className="grid gap-4 md:grid-cols-3">
-            <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
-              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Status</p>
-              <p className="mt-2 text-2xl font-semibold text-slate-900">
-                {savedWorkout ? "Accepted" : "Draft"}
-              </p>
-            </div>
-            <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
-              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                Session
-              </p>
-              <p className="mt-2 text-sm font-semibold text-slate-900">
-                {buildSessionTargetSummary({
-                  ...draft,
-                  totalDistanceM: draftTotals?.totalDistanceM ?? draft.totalDistanceM,
-                  estimatedDurationMin:
-                    draftTotals?.estimatedDurationMin ?? draft.estimatedDurationMin,
-                })}
-              </p>
-            </div>
-            <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
-              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                Context
-              </p>
-              <p className="mt-2 text-sm font-semibold text-slate-900">
-                {draft.goalTitle ?? draft.focusText ?? "Session-only request"}
-              </p>
-              {savedWorkout ? (
-                <p className="mt-2 text-xs text-slate-500">
-                  Accepted {new Date(savedWorkout.acceptedAt).toLocaleDateString("en-GB")} · last
-                  saved {new Date(savedWorkout.updatedAt).toLocaleDateString("en-GB")}
-                </p>
-              ) : null}
-            </div>
-          </div>
-
-          <div className="rounded-2xl border border-slate-200 bg-white p-4">
-            <h3 className="text-base font-semibold text-slate-900">Title suggestions</h3>
-            <div className="mt-3 flex flex-wrap gap-2">
-              {draft.titleSuggestions.map((suggestion) => (
-                <button
-                  key={suggestion}
-                  type="button"
-                  onClick={() => updateDraft("title", suggestion)}
-                  className="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-sm text-slate-700 transition hover:bg-slate-100"
-                >
-                  {suggestion}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          <div className="grid gap-4 md:grid-cols-2">
-            <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
-              Draft title
-              <input
-                type="text"
-                value={draft.title}
-                onChange={(event) => updateDraft("title", event.target.value)}
-                data-testid="session-draft-title"
-                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-              />
-            </label>
-
-            <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
-              Session type
-              <select
-                value={draft.sessionType}
-                onChange={(event) =>
-                  updateDraft("sessionType", event.target.value as SessionDraft["sessionType"])
-                }
-                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-              >
-                {SESSION_GENERATOR_SESSION_TYPES.map((value) => (
-                  <option key={value} value={value}>
-                    {getSessionTypeLabel(value)}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700 md:col-span-2">
-              Draft description
-              <textarea
-                value={draft.description}
-                onChange={(event) => updateDraft("description", event.target.value)}
-                data-testid="session-draft-description"
-                rows={4}
-                className="mt-2 block w-full rounded-xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-              />
-            </label>
-
-            <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4">
-              <legend className="px-1 text-sm font-semibold text-slate-900">Environment</legend>
-              <div className="mt-3 flex flex-wrap gap-3">
-                {SESSION_GENERATOR_ENVIRONMENTS.map((value) => (
-                  <label
-                    key={value}
-                    className="inline-flex items-center gap-2 text-sm text-slate-700"
-                  >
-                    <input
-                      type="radio"
-                      name="session-draft-environment"
-                      checked={draft.environment === value}
-                      onChange={() =>
-                        updateDraft("environment", value as SessionGeneratorEnvironment)
-                      }
-                    />
-                    {getSessionEnvironmentLabel(value)}
-                  </label>
-                ))}
-              </div>
-            </fieldset>
-
-            {draft.environment === "pool" ? (
-              <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
-                Pool length
-                <select
-                  value={draft.poolLengthM ? String(draft.poolLengthM) : ""}
-                  onChange={(event) =>
-                    updateDraft(
-                      "poolLengthM",
-                      (parsePositiveNumber(
-                        event.target.value
-                      ) as SessionGeneratorPoolLength | null) ?? null
-                    )
-                  }
-                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                >
-                  {SESSION_GENERATOR_POOL_LENGTHS.map((value) => (
-                    <option key={value} value={String(value)}>
-                      {formatPoolLengthLabel(value)}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            ) : null}
-
-            <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
-              Effort
-              <select
-                value={draft.effort}
-                onChange={(event) =>
-                  updateDraft("effort", event.target.value as SessionDraft["effort"])
-                }
-                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-              >
-                {SESSION_GENERATOR_EFFORT_PRESETS.map((value) => (
-                  <option key={value} value={value}>
-                    {getSessionEffortLabel(value)}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 md:col-span-2">
-              <legend className="px-1 text-sm font-semibold text-slate-900">Session strokes</legend>
-              <div className="mt-3 flex flex-wrap gap-3">
-                {SESSION_GENERATOR_STROKES.map((stroke) => (
-                  <label
-                    key={stroke}
-                    className="inline-flex items-center gap-2 text-sm text-slate-700"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={draft.allowedStrokes.includes(stroke)}
-                      onChange={() => toggleDraftStroke(stroke)}
-                    />
-                    {getSessionStrokeLabel(stroke)}
-                  </label>
-                ))}
-              </div>
-            </fieldset>
-
-            <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 md:col-span-2">
-              <legend className="px-1 text-sm font-semibold text-slate-900">Equipment</legend>
-              <div className="mt-3 flex flex-wrap gap-3">
-                {SESSION_GENERATOR_EQUIPMENT.map((item) => (
-                  <label
-                    key={item}
-                    className="inline-flex items-center gap-2 text-sm text-slate-700"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={draft.equipmentAllowlist.includes(item)}
-                      onChange={() => toggleDraftEquipment(item)}
-                    />
-                    {getSessionEquipmentLabel(item)}
-                  </label>
-                ))}
-              </div>
-            </fieldset>
-          </div>
-
-          <div className="rounded-2xl border border-slate-200 bg-white p-4">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <h3 className="text-base font-semibold text-slate-900">Editable draft steps</h3>
-              <button
-                type="button"
-                onClick={addStep}
-                data-testid="session-draft-add-step"
-                className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
-              >
-                Add step
-              </button>
-            </div>
-
-            <div className="mt-4 space-y-4">
-              {draft.steps.map((step, index) => (
-                <article
-                  key={step.id}
-                  className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4"
-                >
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div>
-                      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                        Step {index + 1}
-                      </p>
-                      <p className="mt-1 text-sm font-medium text-slate-900">
-                        {getSessionStepCategoryLabel(step.category)}
-                      </p>
-                    </div>
-                    <div className="flex flex-wrap gap-2">
-                      <button
-                        type="button"
-                        onClick={() => moveStep(step.id, -1)}
-                        disabled={index === 0}
-                        className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-                      >
-                        Move up
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => moveStep(step.id, 1)}
-                        disabled={index === draft.steps.length - 1}
-                        className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-                      >
-                        Move down
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => removeStep(step.id)}
-                        className="inline-flex h-9 items-center justify-center rounded-xl border border-rose-200 bg-white px-3 text-sm text-rose-700 transition hover:bg-rose-50"
-                      >
-                        Remove
-                      </button>
-                    </div>
-                  </div>
-
-                  <div className="mt-4 grid gap-4 md:grid-cols-2">
-                    <label className="text-sm text-slate-700">
-                      Step name
-                      <input
-                        type="text"
-                        value={step.name}
-                        onChange={(event) =>
-                          updateDraftStep(step.id, (current) => ({
-                            ...current,
-                            name: event.target.value,
-                          }))
-                        }
-                        data-testid={`session-draft-step-name-${index}`}
-                        className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                      />
-                    </label>
-
-                    <label className="text-sm text-slate-700">
-                      Category
-                      <select
-                        value={step.category}
-                        onChange={(event) =>
-                          updateDraftStep(step.id, (current) => ({
-                            ...current,
-                            category: event.target.value as SessionDraftStepCategory,
-                          }))
-                        }
-                        className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                      >
-                        {SESSION_DRAFT_STEP_CATEGORIES.map((value) => (
-                          <option key={value} value={value}>
-                            {getSessionStepCategoryLabel(value)}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-
-                    <label className="text-sm text-slate-700">
-                      Stroke
-                      <select
-                        value={step.stroke}
-                        onChange={(event) =>
-                          updateDraftStep(step.id, (current) => ({
-                            ...current,
-                            stroke: event.target.value as SessionDraftStep["stroke"],
-                          }))
-                        }
-                        className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                      >
-                        <option value="choice">Stroke choice</option>
-                        {SESSION_GENERATOR_STROKES.map((value) => (
-                          <option key={value} value={value}>
-                            {getSessionStrokeLabel(value)}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-
-                    <label className="text-sm text-slate-700">
-                      Intensity
-                      <select
-                        value={step.intensity}
-                        onChange={(event) =>
-                          updateDraftStep(step.id, (current) => ({
-                            ...current,
-                            intensity: event.target.value as SessionDraft["effort"],
-                          }))
-                        }
-                        className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                      >
-                        {SESSION_GENERATOR_EFFORT_PRESETS.map((value) => (
-                          <option key={value} value={value}>
-                            {getSessionEffortLabel(value)}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-
-                    <label className="text-sm text-slate-700">
-                      Duration mode
-                      <select
-                        value={step.durationMode}
-                        onChange={(event) =>
-                          updateDraftStep(step.id, (current) => ({
-                            ...current,
-                            durationMode: event.target.value as SessionDraftStepDurationMode,
-                            distanceM:
-                              event.target.value === "distance" ? (current.distanceM ?? 100) : null,
-                            timeMin: event.target.value === "time" ? (current.timeMin ?? 10) : null,
-                          }))
-                        }
-                        className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                      >
-                        {SESSION_DRAFT_STEP_DURATION_MODES.map((value) => (
-                          <option key={value} value={value}>
-                            {value === "distance" ? "Distance" : "Time"}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-
-                    {step.durationMode === "distance" ? (
-                      <label className="text-sm text-slate-700">
-                        Distance (m)
-                        <input
-                          type="text"
-                          inputMode="numeric"
-                          value={step.distanceM ?? ""}
-                          onChange={(event) =>
-                            updateDraftStep(step.id, (current) => ({
-                              ...current,
-                              distanceM: parsePositiveNumber(event.target.value),
-                            }))
-                          }
-                          className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                        />
-                      </label>
-                    ) : (
-                      <label className="text-sm text-slate-700">
-                        Time (min)
-                        <input
-                          type="text"
-                          inputMode="numeric"
-                          value={step.timeMin ?? ""}
-                          onChange={(event) =>
-                            updateDraftStep(step.id, (current) => ({
-                              ...current,
-                              timeMin: parsePositiveNumber(event.target.value),
-                            }))
-                          }
-                          className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                        />
-                      </label>
-                    )}
-
-                    <label className="text-sm text-slate-700 md:col-span-2">
-                      Target summary
-                      <input
-                        type="text"
-                        value={step.targetSummary}
-                        onChange={(event) =>
-                          updateDraftStep(step.id, (current) => ({
-                            ...current,
-                            targetSummary: event.target.value,
-                          }))
-                        }
-                        className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                      />
-                    </label>
-
-                    <label className="text-sm text-slate-700 md:col-span-2">
-                      Notes
-                      <textarea
-                        value={step.notes}
-                        onChange={(event) =>
-                          updateDraftStep(step.id, (current) => ({
-                            ...current,
-                            notes: event.target.value,
-                          }))
-                        }
-                        rows={3}
-                        className="mt-2 block w-full rounded-xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                      />
-                    </label>
-                  </div>
-                </article>
-              ))}
-            </div>
-          </div>
-
-          <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
-            <p className="text-sm text-slate-600">
-              {savedWorkout
-                ? "This workout is canonical now. Saving here updates the same workout instead of creating a new copy."
-                : "Review the draft carefully, then accept it into the canonical workout layer when you are happy with it."}
-            </p>
-            <button
-              type="button"
-              onClick={saveWorkout}
-              disabled={isSaving || !canonicalSaveReady}
-              data-testid="session-generator-save"
-              className="inline-flex h-11 items-center justify-center rounded-xl bg-emerald-600 px-4 text-sm font-semibold text-white transition hover:bg-emerald-500 active:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {isSaving ? "Saving..." : savedWorkout ? "Save changes" : "Accept and save workout"}
-            </button>
-          </div>
-
-          <div className="overflow-hidden rounded-2xl border border-slate-200 bg-slate-950">
-            <pre
-              data-testid="session-generator-draft-preview"
-              className="max-h-[420px] overflow-auto px-4 py-4 text-xs leading-relaxed text-slate-100"
-            >
-              {JSON.stringify(
-                {
-                  ...draft,
-                  totalDistanceM: draftTotals?.totalDistanceM ?? draft.totalDistanceM,
-                  estimatedDurationMin:
-                    draftTotals?.estimatedDurationMin ?? draft.estimatedDurationMin,
-                },
-                null,
-                2
-              )}
-            </pre>
-          </div>
+        <div className="mt-6 border-t border-slate-200 pt-6">
+          <WorkoutEditor
+            draft={draft}
+            savedWorkout={savedWorkout}
+            recentWorkouts={[]}
+            canonicalSaveReady={canonicalSaveReady}
+            isSaving={isSaving}
+            onSave={saveWorkout}
+            onDraftChange={(nextDraft) => {
+              setDraft(nextDraft);
+              setSuccess("");
+            }}
+            startNewDraftHref="/my-library/generator"
+            recentWorkoutsDescription="Open another saved session in the dedicated workout builder route."
+            workoutHrefBuilder={(workoutId) => `/my-library/workouts/${workoutId}`}
+          />
         </div>
       ) : null}
     </section>

--- a/components/my-library/workouts/WorkoutBuilderHub.tsx
+++ b/components/my-library/workouts/WorkoutBuilderHub.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import WorkoutEditor from "@/components/my-library/workouts/WorkoutEditor";
+import type {
+  WorkoutEditorRecord,
+  WorkoutLibrarySnapshot,
+  WorkoutSaveApiResponse,
+  WorkoutSummary,
+} from "@/lib/workouts/shared";
+
+type Props = {
+  workoutLibrary: WorkoutLibrarySnapshot;
+};
+
+function upsertRecentWorkoutSummary(current: WorkoutSummary[], next: WorkoutSummary) {
+  const existing = current.filter((summary) => summary.id !== next.id);
+  return [next, ...existing].slice(0, 6);
+}
+
+export default function WorkoutBuilderHub({ workoutLibrary }: Props) {
+  const [savedWorkout, setSavedWorkout] = useState<WorkoutEditorRecord | null>(
+    workoutLibrary.selectedWorkout
+  );
+  const [draft, setDraft] = useState(workoutLibrary.selectedWorkout?.draft ?? null);
+  const [recentWorkouts, setRecentWorkouts] = useState(workoutLibrary.recentWorkouts);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [clientReady, setClientReady] = useState(false);
+
+  useEffect(() => {
+    setClientReady(true);
+  }, []);
+
+  useEffect(() => {
+    setSavedWorkout(workoutLibrary.selectedWorkout);
+    setDraft(workoutLibrary.selectedWorkout?.draft ?? null);
+    setRecentWorkouts(workoutLibrary.recentWorkouts);
+    setError("");
+    setSuccess("");
+  }, [
+    workoutLibrary.recentWorkouts,
+    workoutLibrary.selectedWorkout,
+    workoutLibrary.selectedWorkoutMissing,
+  ]);
+
+  async function saveWorkout() {
+    if (!draft || !savedWorkout) return;
+
+    setIsSaving(true);
+    setError("");
+    setSuccess("");
+
+    try {
+      const response = await fetch(`/api/my-library/workouts/${savedWorkout.id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          draft,
+        }),
+      });
+      const responseBody = (await response
+        .json()
+        .catch(() => null)) as WorkoutSaveApiResponse | null;
+      const responseError =
+        responseBody && !responseBody.ok ? responseBody.error : "Could not save workout right now.";
+
+      if (!response.ok || !responseBody?.ok) {
+        setError(responseError);
+        return;
+      }
+
+      setSavedWorkout(responseBody.workout);
+      setDraft(responseBody.workout.draft);
+      setRecentWorkouts((current) => upsertRecentWorkoutSummary(current, responseBody.summary));
+      setSuccess("Workout changes saved to the canonical workout.");
+    } catch {
+      setError("Could not save workout right now.");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <section
+      data-testid="workout-builder-hub"
+      data-client-ready={clientReady ? "true" : "false"}
+      className="rounded-2xl border border-slate-200 bg-white p-5"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Workout builder</h2>
+          <p className="mt-2 max-w-[66ch] text-sm text-slate-600">
+            Edit one accepted canonical workout in a dedicated route. This is the first step toward
+            the fuller manual builder flow.
+          </p>
+        </div>
+        <p className="rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">
+          Canonical workout
+        </p>
+      </div>
+
+      {!workoutLibrary.schemaReady ? (
+        <div className="mt-5 rounded-2xl border border-amber-200 bg-amber-50/80 p-4">
+          <p className="text-sm text-amber-900">
+            Canonical workout save is still syncing in this environment. Come back once the workouts
+            table is live to edit accepted workouts here.
+          </p>
+        </div>
+      ) : null}
+
+      {workoutLibrary.loadError ? (
+        <div className="mt-5 rounded-2xl border border-rose-200 bg-rose-50/80 p-4">
+          <p className="text-sm text-rose-900">{workoutLibrary.loadError}</p>
+        </div>
+      ) : null}
+
+      {error ? (
+        <div className="mt-5 rounded-2xl border border-rose-200 bg-rose-50/80 p-4">
+          <p className="text-sm text-rose-900">{error}</p>
+        </div>
+      ) : null}
+
+      {success ? (
+        <div className="mt-5 rounded-2xl border border-emerald-200 bg-emerald-50/80 p-4">
+          <p className="text-sm text-emerald-900">{success}</p>
+        </div>
+      ) : null}
+
+      {!savedWorkout ? (
+        <div className="mt-6 space-y-5">
+          <div className="rounded-2xl border border-amber-200 bg-amber-50/80 p-4">
+            <p className="text-sm font-medium text-amber-900">
+              {workoutLibrary.selectedWorkoutMissing
+                ? "That saved workout could not be found."
+                : "No canonical workout is loaded in this route."}
+            </p>
+            <p className="mt-2 text-sm text-amber-900/90">
+              Return to the generator when you want a brand-new AI draft, or reopen another saved
+              workout below.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <Link
+                href="/my-library/generator"
+                className="inline-flex h-10 items-center justify-center rounded-xl border border-amber-200 bg-white px-4 text-sm font-medium text-amber-900 transition hover:bg-amber-50 active:bg-amber-100"
+              >
+                Open generator
+              </Link>
+              <Link
+                href="/my-library"
+                className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+              >
+                Back to My Library
+              </Link>
+            </div>
+          </div>
+
+          {recentWorkouts.length > 0 ? (
+            <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+              <h3 className="text-sm font-semibold text-slate-900">Recent accepted workouts</h3>
+              <p className="mt-1 text-sm text-slate-600">
+                Reopen another saved canonical workout directly in this builder route.
+              </p>
+              <div className="mt-4 grid gap-3">
+                {recentWorkouts.map((workout) => (
+                  <div
+                    key={workout.id}
+                    className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-white/80 bg-white p-3"
+                  >
+                    <div>
+                      <p className="text-sm font-semibold text-slate-900">{workout.title}</p>
+                      <p className="mt-1 text-sm text-slate-600">
+                        {workout.totalDistanceM ? `${workout.totalDistanceM}m` : null}
+                        {workout.totalDistanceM && workout.estimatedDurationMin ? " · " : null}
+                        {workout.estimatedDurationMin
+                          ? `~${workout.estimatedDurationMin} min`
+                          : null}
+                      </p>
+                    </div>
+                    <Link
+                      href={`/my-library/workouts/${workout.id}`}
+                      data-testid={`workout-builder-open-workout-${workout.id}`}
+                      className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+                    >
+                      Open
+                    </Link>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {draft && savedWorkout ? (
+        <div className="mt-6">
+          <WorkoutEditor
+            draft={draft}
+            savedWorkout={savedWorkout}
+            recentWorkouts={recentWorkouts}
+            canonicalSaveReady={workoutLibrary.schemaReady}
+            isSaving={isSaving}
+            onSave={saveWorkout}
+            onDraftChange={(nextDraft) => {
+              setDraft(nextDraft);
+              setSuccess("");
+            }}
+            startNewDraftHref="/my-library/generator"
+            startNewDraftLabel="Generate new draft"
+            showLoadedBanner={false}
+            recentWorkoutsDescription="Open another saved workout here, or jump back to the generator when you want a brand-new AI draft."
+            workoutHrefBuilder={(workoutId) => `/my-library/workouts/${workoutId}`}
+            saveButtonTestId="workout-builder-save"
+          />
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -1,0 +1,675 @@
+"use client";
+
+import Link from "next/link";
+import {
+  SESSION_DRAFT_STEP_CATEGORIES,
+  SESSION_DRAFT_STEP_DURATION_MODES,
+  SESSION_GENERATOR_ENVIRONMENTS,
+  SESSION_GENERATOR_EFFORT_PRESETS,
+  SESSION_GENERATOR_EQUIPMENT,
+  SESSION_GENERATOR_POOL_LENGTHS,
+  SESSION_GENERATOR_SESSION_TYPES,
+  SESSION_GENERATOR_STROKES,
+  buildSessionTargetSummary,
+  computeSessionDraftDerivedTotals,
+  formatPoolLengthLabel,
+  getSessionEffortLabel,
+  getSessionEnvironmentLabel,
+  getSessionEquipmentLabel,
+  getSessionStepCategoryLabel,
+  getSessionStrokeLabel,
+  getSessionTypeLabel,
+  type SessionDraft,
+  type SessionDraftStep,
+  type SessionDraftStepCategory,
+  type SessionDraftStepDurationMode,
+  type SessionGeneratorEnvironment,
+  type SessionGeneratorPoolLength,
+  type SessionGeneratorStroke,
+} from "@/lib/session-generator-v1/shared";
+import type { WorkoutEditorRecord, WorkoutSummary } from "@/lib/workouts/shared";
+
+type Props = {
+  draft: SessionDraft;
+  savedWorkout: WorkoutEditorRecord | null;
+  recentWorkouts: WorkoutSummary[];
+  canonicalSaveReady: boolean;
+  isSaving: boolean;
+  onSave: () => void;
+  onDraftChange: (draft: SessionDraft) => void;
+  startNewDraftHref?: string | null;
+  startNewDraftLabel?: string;
+  showLoadedBanner?: boolean;
+  loadedBannerTitle?: string;
+  loadedBannerDescription?: string;
+  recentWorkoutsDescription?: string;
+  workoutHrefBuilder?: (workoutId: string) => string;
+  saveButtonTestId?: string;
+};
+
+function buildBlankStep(index: number): SessionDraftStep {
+  return {
+    id: `step-${Date.now()}-${index}`,
+    category: "main",
+    name: "Custom step",
+    stroke: "choice",
+    intensity: "moderate",
+    durationMode: "distance",
+    distanceM: 100,
+    timeMin: null,
+    targetSummary: "",
+    notes: "",
+  };
+}
+
+function parsePositiveNumber(value: string) {
+  if (!/^\d+(\.\d+)?$/.test(value)) return null;
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+export default function WorkoutEditor({
+  draft,
+  savedWorkout,
+  recentWorkouts,
+  canonicalSaveReady,
+  isSaving,
+  onSave,
+  onDraftChange,
+  startNewDraftHref = null,
+  startNewDraftLabel = "Start new draft",
+  showLoadedBanner = true,
+  loadedBannerTitle = "Accepted workout loaded.",
+  loadedBannerDescription = "Save changes below, or start a fresh draft from the prepared intake when you want a brand-new generated workout.",
+  recentWorkoutsDescription = "Open another saved session here until the dedicated workout builder route grows into the full manual builder flow.",
+  workoutHrefBuilder = (workoutId) => `/my-library/workouts/${workoutId}`,
+  saveButtonTestId = "session-generator-save",
+}: Props) {
+  const draftTotals = computeSessionDraftDerivedTotals(draft);
+
+  function updateDraft<K extends keyof SessionDraft>(key: K, value: SessionDraft[K]) {
+    onDraftChange({
+      ...draft,
+      [key]: value,
+    });
+  }
+
+  function updateDraftStep(stepId: string, updater: (step: SessionDraftStep) => SessionDraftStep) {
+    onDraftChange({
+      ...draft,
+      steps: draft.steps.map((step) => (step.id === stepId ? updater(step) : step)),
+    });
+  }
+
+  function moveStep(stepId: string, direction: -1 | 1) {
+    const index = draft.steps.findIndex((step) => step.id === stepId);
+    const nextIndex = index + direction;
+    if (index < 0 || nextIndex < 0 || nextIndex >= draft.steps.length) return;
+    const nextSteps = [...draft.steps];
+    const [step] = nextSteps.splice(index, 1);
+    nextSteps.splice(nextIndex, 0, step);
+    onDraftChange({
+      ...draft,
+      steps: nextSteps,
+    });
+  }
+
+  function addStep() {
+    onDraftChange({
+      ...draft,
+      steps: [...draft.steps, buildBlankStep(draft.steps.length + 1)],
+    });
+  }
+
+  function removeStep(stepId: string) {
+    onDraftChange({
+      ...draft,
+      steps: draft.steps.filter((step) => step.id !== stepId),
+    });
+  }
+
+  function toggleDraftStroke(stroke: SessionGeneratorStroke) {
+    const exists = draft.allowedStrokes.includes(stroke);
+    updateDraft(
+      "allowedStrokes",
+      exists
+        ? draft.allowedStrokes.filter((value) => value !== stroke)
+        : [...draft.allowedStrokes, stroke]
+    );
+  }
+
+  function toggleDraftEquipment(item: (typeof SESSION_GENERATOR_EQUIPMENT)[number]) {
+    const exists = draft.equipmentAllowlist.includes(item);
+    updateDraft(
+      "equipmentAllowlist",
+      exists
+        ? draft.equipmentAllowlist.filter((value) => value !== item)
+        : [...draft.equipmentAllowlist, item]
+    );
+  }
+
+  return (
+    <div data-testid="workout-editor-panel" className="space-y-5">
+      {showLoadedBanner && savedWorkout ? (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-blue-200 bg-blue-50/80 p-4">
+          <div>
+            <p className="text-sm font-medium text-blue-900">{loadedBannerTitle}</p>
+            <p className="mt-1 text-sm text-blue-900/90">{loadedBannerDescription}</p>
+          </div>
+          {startNewDraftHref ? (
+            <Link
+              href={startNewDraftHref}
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-4 text-sm font-medium text-blue-800 transition hover:bg-blue-50 active:bg-blue-100"
+            >
+              {startNewDraftLabel}
+            </Link>
+          ) : null}
+        </div>
+      ) : null}
+
+      {recentWorkouts.length > 0 ? (
+        <div
+          data-testid="session-generator-recent-workouts"
+          className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4"
+        >
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h3 className="text-sm font-semibold text-slate-900">Recent accepted workouts</h3>
+              <p className="mt-1 text-sm text-slate-600">{recentWorkoutsDescription}</p>
+            </div>
+          </div>
+          <div className="mt-4 grid gap-3">
+            {recentWorkouts.map((workout) => (
+              <div
+                key={workout.id}
+                className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-white/80 bg-white p-3"
+              >
+                <div>
+                  <p className="text-sm font-semibold text-slate-900">{workout.title}</p>
+                  <p className="mt-1 text-sm text-slate-600">
+                    {workout.totalDistanceM ? `${workout.totalDistanceM}m` : null}
+                    {workout.totalDistanceM && workout.estimatedDurationMin ? " · " : null}
+                    {workout.estimatedDurationMin ? `~${workout.estimatedDurationMin} min` : null}
+                    {workout.totalDistanceM || workout.estimatedDurationMin ? " · " : null}
+                    {getSessionTypeLabel(workout.sessionType)}
+                  </p>
+                </div>
+                <Link
+                  href={workoutHrefBuilder(workout.id)}
+                  data-testid={`session-generator-open-workout-${workout.id}`}
+                  className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+                >
+                  Open
+                </Link>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="rounded-2xl border border-blue-200 bg-blue-50/80 p-4">
+        <p className="text-sm text-blue-900">
+          {savedWorkout
+            ? "Canonical workout loaded: edit everything below, then save changes back into the same owner-scoped workout."
+            : "Local draft only: review and edit everything below, then accept it into the canonical workout layer when you are ready."}
+        </p>
+      </div>
+
+      {draft.warnings.length > 0 ? (
+        <div className="rounded-2xl border border-amber-200 bg-amber-50/80 p-4">
+          <ul className="space-y-2 text-sm text-amber-900">
+            {draft.warnings.map((warning) => (
+              <li key={warning}>{warning}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Status</p>
+          <p className="mt-2 text-2xl font-semibold text-slate-900">
+            {savedWorkout ? "Accepted" : "Draft"}
+          </p>
+        </div>
+        <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Session</p>
+          <p className="mt-2 text-sm font-semibold text-slate-900">
+            {buildSessionTargetSummary({
+              ...draft,
+              totalDistanceM: draftTotals.totalDistanceM ?? draft.totalDistanceM,
+              estimatedDurationMin: draftTotals.estimatedDurationMin ?? draft.estimatedDurationMin,
+            })}
+          </p>
+        </div>
+        <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Context</p>
+          <p className="mt-2 text-sm font-semibold text-slate-900">
+            {draft.goalTitle ?? draft.focusText ?? "Session-only request"}
+          </p>
+          {savedWorkout ? (
+            <p className="mt-2 text-xs text-slate-500">
+              Accepted {new Date(savedWorkout.acceptedAt).toLocaleDateString("en-GB")} · last saved{" "}
+              {new Date(savedWorkout.updatedAt).toLocaleDateString("en-GB")}
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-slate-200 bg-white p-4">
+        <h3 className="text-base font-semibold text-slate-900">Title suggestions</h3>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {draft.titleSuggestions.map((suggestion) => (
+            <button
+              key={suggestion}
+              type="button"
+              onClick={() => updateDraft("title", suggestion)}
+              className="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-sm text-slate-700 transition hover:bg-slate-100"
+            >
+              {suggestion}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
+          Draft title
+          <input
+            type="text"
+            value={draft.title}
+            onChange={(event) => updateDraft("title", event.target.value)}
+            data-testid="session-draft-title"
+            className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+          />
+        </label>
+
+        <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
+          Session type
+          <select
+            value={draft.sessionType}
+            onChange={(event) =>
+              updateDraft("sessionType", event.target.value as SessionDraft["sessionType"])
+            }
+            className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+          >
+            {SESSION_GENERATOR_SESSION_TYPES.map((value) => (
+              <option key={value} value={value}>
+                {getSessionTypeLabel(value)}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700 md:col-span-2">
+          Draft description
+          <textarea
+            value={draft.description}
+            onChange={(event) => updateDraft("description", event.target.value)}
+            data-testid="session-draft-description"
+            rows={4}
+            className="mt-2 block w-full rounded-xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+          />
+        </label>
+
+        <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4">
+          <legend className="px-1 text-sm font-semibold text-slate-900">Environment</legend>
+          <div className="mt-3 flex flex-wrap gap-3">
+            {SESSION_GENERATOR_ENVIRONMENTS.map((value) => (
+              <label key={value} className="inline-flex items-center gap-2 text-sm text-slate-700">
+                <input
+                  type="radio"
+                  name="session-draft-environment"
+                  checked={draft.environment === value}
+                  onChange={() =>
+                    onDraftChange({
+                      ...draft,
+                      environment: value as SessionGeneratorEnvironment,
+                      poolLengthM:
+                        value === "pool"
+                          ? (draft.poolLengthM ?? SESSION_GENERATOR_POOL_LENGTHS[1])
+                          : null,
+                    })
+                  }
+                />
+                {getSessionEnvironmentLabel(value)}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        {draft.environment === "pool" ? (
+          <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
+            Pool length
+            <select
+              value={draft.poolLengthM ? String(draft.poolLengthM) : ""}
+              onChange={(event) =>
+                updateDraft(
+                  "poolLengthM",
+                  (parsePositiveNumber(event.target.value) as SessionGeneratorPoolLength | null) ??
+                    null
+                )
+              }
+              className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+            >
+              {SESSION_GENERATOR_POOL_LENGTHS.map((value) => (
+                <option key={value} value={String(value)}>
+                  {formatPoolLengthLabel(value)}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
+
+        <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
+          Effort
+          <select
+            value={draft.effort}
+            onChange={(event) =>
+              updateDraft("effort", event.target.value as SessionDraft["effort"])
+            }
+            className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+          >
+            {SESSION_GENERATOR_EFFORT_PRESETS.map((value) => (
+              <option key={value} value={value}>
+                {getSessionEffortLabel(value)}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 md:col-span-2">
+          <legend className="px-1 text-sm font-semibold text-slate-900">Session strokes</legend>
+          <div className="mt-3 flex flex-wrap gap-3">
+            {SESSION_GENERATOR_STROKES.map((stroke) => (
+              <label key={stroke} className="inline-flex items-center gap-2 text-sm text-slate-700">
+                <input
+                  type="checkbox"
+                  checked={draft.allowedStrokes.includes(stroke)}
+                  onChange={() => toggleDraftStroke(stroke)}
+                />
+                {getSessionStrokeLabel(stroke)}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 md:col-span-2">
+          <legend className="px-1 text-sm font-semibold text-slate-900">Equipment</legend>
+          <div className="mt-3 flex flex-wrap gap-3">
+            {SESSION_GENERATOR_EQUIPMENT.map((item) => (
+              <label key={item} className="inline-flex items-center gap-2 text-sm text-slate-700">
+                <input
+                  type="checkbox"
+                  checked={draft.equipmentAllowlist.includes(item)}
+                  onChange={() => toggleDraftEquipment(item)}
+                />
+                {getSessionEquipmentLabel(item)}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+      </div>
+
+      <div className="rounded-2xl border border-slate-200 bg-white p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h3 className="text-base font-semibold text-slate-900">Editable draft steps</h3>
+          <button
+            type="button"
+            onClick={addStep}
+            data-testid="session-draft-add-step"
+            className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+          >
+            Add step
+          </button>
+        </div>
+
+        <div className="mt-4 space-y-4">
+          {draft.steps.map((step, index) => (
+            <article
+              key={step.id}
+              className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    Step {index + 1}
+                  </p>
+                  <p className="mt-1 text-sm font-medium text-slate-900">
+                    {getSessionStepCategoryLabel(step.category)}
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => moveStep(step.id, -1)}
+                    disabled={index === 0}
+                    className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    Move up
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => moveStep(step.id, 1)}
+                    disabled={index === draft.steps.length - 1}
+                    className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    Move down
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => removeStep(step.id)}
+                    className="inline-flex h-9 items-center justify-center rounded-xl border border-rose-200 bg-white px-3 text-sm text-rose-700 transition hover:bg-rose-50"
+                  >
+                    Remove
+                  </button>
+                </div>
+              </div>
+
+              <div className="mt-4 grid gap-4 md:grid-cols-2">
+                <label className="text-sm text-slate-700">
+                  Step name
+                  <input
+                    type="text"
+                    value={step.name}
+                    onChange={(event) =>
+                      updateDraftStep(step.id, (current) => ({
+                        ...current,
+                        name: event.target.value,
+                      }))
+                    }
+                    data-testid={`session-draft-step-name-${index}`}
+                    className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                  />
+                </label>
+
+                <label className="text-sm text-slate-700">
+                  Category
+                  <select
+                    value={step.category}
+                    onChange={(event) =>
+                      updateDraftStep(step.id, (current) => ({
+                        ...current,
+                        category: event.target.value as SessionDraftStepCategory,
+                      }))
+                    }
+                    className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                  >
+                    {SESSION_DRAFT_STEP_CATEGORIES.map((value) => (
+                      <option key={value} value={value}>
+                        {getSessionStepCategoryLabel(value)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="text-sm text-slate-700">
+                  Stroke
+                  <select
+                    value={step.stroke}
+                    onChange={(event) =>
+                      updateDraftStep(step.id, (current) => ({
+                        ...current,
+                        stroke: event.target.value as SessionDraftStep["stroke"],
+                      }))
+                    }
+                    className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                  >
+                    <option value="choice">Stroke choice</option>
+                    {SESSION_GENERATOR_STROKES.map((value) => (
+                      <option key={value} value={value}>
+                        {getSessionStrokeLabel(value)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="text-sm text-slate-700">
+                  Intensity
+                  <select
+                    value={step.intensity}
+                    onChange={(event) =>
+                      updateDraftStep(step.id, (current) => ({
+                        ...current,
+                        intensity: event.target.value as SessionDraft["effort"],
+                      }))
+                    }
+                    className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                  >
+                    {SESSION_GENERATOR_EFFORT_PRESETS.map((value) => (
+                      <option key={value} value={value}>
+                        {getSessionEffortLabel(value)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="text-sm text-slate-700">
+                  Duration mode
+                  <select
+                    value={step.durationMode}
+                    onChange={(event) =>
+                      updateDraftStep(step.id, (current) => ({
+                        ...current,
+                        durationMode: event.target.value as SessionDraftStepDurationMode,
+                        distanceM:
+                          event.target.value === "distance" ? (current.distanceM ?? 100) : null,
+                        timeMin: event.target.value === "time" ? (current.timeMin ?? 10) : null,
+                      }))
+                    }
+                    className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                  >
+                    {SESSION_DRAFT_STEP_DURATION_MODES.map((value) => (
+                      <option key={value} value={value}>
+                        {value === "distance" ? "Distance" : "Time"}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                {step.durationMode === "distance" ? (
+                  <label className="text-sm text-slate-700">
+                    Distance (m)
+                    <input
+                      type="text"
+                      inputMode="numeric"
+                      value={step.distanceM ?? ""}
+                      onChange={(event) =>
+                        updateDraftStep(step.id, (current) => ({
+                          ...current,
+                          distanceM: parsePositiveNumber(event.target.value),
+                        }))
+                      }
+                      className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                    />
+                  </label>
+                ) : (
+                  <label className="text-sm text-slate-700">
+                    Time (min)
+                    <input
+                      type="text"
+                      inputMode="numeric"
+                      value={step.timeMin ?? ""}
+                      onChange={(event) =>
+                        updateDraftStep(step.id, (current) => ({
+                          ...current,
+                          timeMin: parsePositiveNumber(event.target.value),
+                        }))
+                      }
+                      className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                    />
+                  </label>
+                )}
+
+                <label className="text-sm text-slate-700 md:col-span-2">
+                  Target summary
+                  <input
+                    type="text"
+                    value={step.targetSummary}
+                    onChange={(event) =>
+                      updateDraftStep(step.id, (current) => ({
+                        ...current,
+                        targetSummary: event.target.value,
+                      }))
+                    }
+                    className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                  />
+                </label>
+
+                <label className="text-sm text-slate-700 md:col-span-2">
+                  Notes
+                  <textarea
+                    value={step.notes}
+                    onChange={(event) =>
+                      updateDraftStep(step.id, (current) => ({
+                        ...current,
+                        notes: event.target.value,
+                      }))
+                    }
+                    rows={3}
+                    className="mt-2 block w-full rounded-xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                  />
+                </label>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+        <p className="text-sm text-slate-600">
+          {savedWorkout
+            ? "This workout is canonical now. Saving here updates the same workout instead of creating a new copy."
+            : "Review the draft carefully, then accept it into the canonical workout layer when you are happy with it."}
+        </p>
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={isSaving || !canonicalSaveReady}
+          data-testid={saveButtonTestId}
+          className="inline-flex h-11 items-center justify-center rounded-xl bg-emerald-600 px-4 text-sm font-semibold text-white transition hover:bg-emerald-500 active:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isSaving ? "Saving..." : savedWorkout ? "Save changes" : "Accept and save workout"}
+        </button>
+      </div>
+
+      <div className="overflow-hidden rounded-2xl border border-slate-200 bg-slate-950">
+        <pre
+          data-testid="session-generator-draft-preview"
+          className="max-h-[420px] overflow-auto px-4 py-4 text-xs leading-relaxed text-slate-100"
+        >
+          {JSON.stringify(
+            {
+              ...draft,
+              totalDistanceM: draftTotals.totalDistanceM ?? draft.totalDistanceM,
+              estimatedDurationMin: draftTotals.estimatedDurationMin ?? draft.estimatedDurationMin,
+            },
+            null,
+            2
+          )}
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md
+++ b/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-02-28-workout-builder-and-poolside-execution-10-10`
-- `status`: `planned`
+- `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-02-28`
 - `updated`: `2026-03-20`
@@ -13,6 +13,12 @@
 Ship a Garmin-familiar manual session builder and poolside execution experience that is fast, clear, reliable on mobile, and aligned to the canonical Garmin-ready workout contract.
 
 ## Scope
+
+- Current runtime implementation slice under this brief:
+  - introduce a dedicated authenticated canonical workout editor route for already-saved workouts,
+  - reuse the same editable workout model the AI session generator now writes into,
+  - link accepted AI workouts into that dedicated route from Generator Intake and My Library,
+  - keep manual blank-workout creation and poolside execution deferred until the dedicated builder surface is stable.
 
 - Manual workout/session authoring for user-built training sessions.
 - Editing surface for accepted single-session AI drafts after they become canonical workouts, without moving generation logic into this brief.
@@ -148,3 +154,5 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - `2026-03-20 | planning | tightened this brief into the explicit manual session builder track, added Garmin-familiar target/duration/repeat authoring requirements, and aligned swim-intensity editing to the shared threshold-based zone method | next: request owner detail later on exact builder editing ergonomics and how much compatibility guidance should be visible before export/send exists`
 - `2026-03-20 | planning | clarified that accepted AI-generated single-session drafts should hand off into this same editor after canonical save, while horizon selection and competition intent remain upstream generator concerns | next: keep later implementation focused on canonical workout editing and avoid mixing generation controls into the manual builder UI`
 - `2026-03-20 | planning | added explicit workout-level metadata editing expectations for environment, pool length, session intent, effort preset, and normalized distance/time totals so AI-authored drafts and manual workouts can truly share the same editor instead of only the same step cards | next: keep future builder implementation centered on one canonical workout form that can edit both metadata and steps`
+- `2026-03-20 | working tree | moved this brief to in-progress and narrowed the first runtime slice to a dedicated canonical workout editor route for already-accepted workouts, while manual blank-workout creation and poolside execution remain deferred | next: extract the shared workout editor out of Generator Intake, wire `/my-library/workouts/[workoutId]`, and point accepted workout links there`
+- `2026-03-20 | working tree | extracted the shared workout editor, added the dedicated `/my-library/workouts/[workoutId]` route plus My Library entrypoint, and covered generator -> builder handoff with unit + e2e validation | next: commit this slice on its own branch and rerun full repo gates from branch HEAD so PR-body/brief automation evaluates the current diff instead of falling back to the previous merge commit`

--- a/tests/e2e/my-library-generator-intake.spec.ts
+++ b/tests/e2e/my-library-generator-intake.spec.ts
@@ -28,6 +28,14 @@ async function waitForGeneratorIntakeClientReady(page: Page) {
   );
 }
 
+async function waitForWorkoutBuilderClientReady(page: Page) {
+  await expect(page.getByTestId("workout-builder-hub")).toHaveAttribute(
+    "data-client-ready",
+    "true",
+    { timeout: 15_000 }
+  );
+}
+
 test.describe("my library generator intake", () => {
   test("opens generator intake and prepares a deterministic handoff", async ({
     page,
@@ -79,7 +87,7 @@ test.describe("my library generator intake", () => {
     );
   });
 
-  test("accepts one generated session draft and reopens it in the same editor", async ({
+  test("accepts one generated session draft and reopens it in the workout builder route", async ({
     page,
   }, testInfo) => {
     runOnceOnDesktopChromium(testInfo.project.name);
@@ -139,9 +147,28 @@ test.describe("my library generator intake", () => {
     await expect(recentWorkouts).toContainText(uniqueTitle);
     await recentWorkouts.getByRole("link", { name: "Open" }).first().click();
 
-    await page.waitForURL(/\/my-library\/generator\?workout=/);
-    await waitForGeneratorIntakeClientReady(page);
-    await expect(page.getByText("Accepted workout loaded.")).toBeVisible();
+    await page.waitForURL(/\/my-library\/workouts\/[0-9a-f-]+$/);
+    await waitForWorkoutBuilderClientReady(page);
+    await expect(page.getByRole("heading", { name: "Workout builder", level: 1 })).toBeVisible();
     await expect(page.getByTestId("session-draft-title")).toHaveValue(uniqueTitle);
+
+    await page
+      .getByTestId("session-draft-description")
+      .fill("Edited in the dedicated workout builder route.");
+
+    const patchResponsePromise = page.waitForResponse(
+      (response) =>
+        /\/api\/my-library\/workouts\/[0-9a-f-]+$/.test(response.url()) &&
+        response.request().method() === "PATCH" &&
+        response.status() === 200
+    );
+
+    await page.getByTestId("workout-builder-save").click();
+    await patchResponsePromise;
+
+    await expect(page.getByText("Workout changes saved to the canonical workout.")).toBeVisible();
+    await expect(page.getByTestId("session-generator-draft-preview")).toContainText(
+      "Edited in the dedicated workout builder route."
+    );
   });
 });

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -1,0 +1,178 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import WorkoutBuilderHub from "@/components/my-library/workouts/WorkoutBuilderHub";
+import type { SessionDraft } from "@/lib/session-generator-v1/shared";
+import type {
+  WorkoutEditorRecord,
+  WorkoutLibrarySnapshot,
+  WorkoutSummary,
+} from "@/lib/workouts/shared";
+
+function buildDraft(): SessionDraft {
+  return {
+    version: 1,
+    status: "draft",
+    generatorKind: "rule_engine_v1",
+    createdAt: "2026-03-20T12:10:00.000Z",
+    sourceFingerprint: "fingerprint-1",
+    title: "Accepted threshold workout",
+    titleSuggestions: ["Accepted threshold workout"],
+    description: "Threshold session in pool mode.",
+    environment: "pool",
+    poolLengthM: 25,
+    sessionType: "threshold_css",
+    effort: "moderate",
+    sizeMode: "distance",
+    targetDistanceM: 2200,
+    targetTimeMin: null,
+    totalDistanceM: 2200,
+    estimatedDurationMin: 45,
+    basePaceSecondsPer100m: 128,
+    usedCssPaceLabel: "1:58",
+    allowedStrokes: ["freestyle"],
+    equipmentAllowlist: ["kickboard"],
+    focusText: "Breathing timing",
+    goalTitle: "Swim 1500m stronger",
+    constraintText: "Keep the first half controlled.",
+    warnings: [],
+    steps: [
+      {
+        id: "step-1",
+        category: "warmup",
+        name: "Easy warmup swim",
+        stroke: "freestyle",
+        intensity: "easy",
+        durationMode: "distance",
+        distanceM: 400,
+        timeMin: null,
+        targetSummary: "Easy swimming with relaxed breathing.",
+        notes: "Start smooth.",
+      },
+    ],
+  };
+}
+
+function buildWorkoutSummary(overrides?: Partial<WorkoutSummary>): WorkoutSummary {
+  return {
+    id: "workout-1",
+    title: "Accepted threshold workout",
+    environment: "pool",
+    poolLengthM: 25,
+    sessionType: "threshold_css",
+    effort: "moderate",
+    totalDistanceM: 2200,
+    estimatedDurationMin: 45,
+    updatedAt: "2026-03-20T12:20:00.000Z",
+    acceptedAt: "2026-03-20T12:18:00.000Z",
+    sourceKind: "ai_session_v1",
+    status: "accepted",
+    ...overrides,
+  };
+}
+
+function buildWorkoutRecord(overrides?: Partial<WorkoutEditorRecord>): WorkoutEditorRecord {
+  return {
+    id: "workout-1",
+    createdAt: "2026-03-20T12:18:00.000Z",
+    updatedAt: "2026-03-20T12:20:00.000Z",
+    acceptedAt: "2026-03-20T12:18:00.000Z",
+    sourceKind: "ai_session_v1",
+    status: "accepted",
+    draft: buildDraft(),
+    ...overrides,
+  };
+}
+
+function buildWorkoutLibrary(overrides?: Partial<WorkoutLibrarySnapshot>): WorkoutLibrarySnapshot {
+  return {
+    schemaReady: true,
+    loadError: null,
+    selectedWorkout: buildWorkoutRecord(),
+    selectedWorkoutMissing: false,
+    recentWorkouts: [buildWorkoutSummary()],
+    ...overrides,
+  };
+}
+
+describe("WorkoutBuilderHub", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("loads an accepted workout and saves canonical edits back to the same workout", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        workout: buildWorkoutRecord({
+          draft: {
+            ...buildDraft(),
+            title: "Builder edited workout",
+            description: "Edited in the dedicated builder route.",
+          },
+        }),
+        summary: buildWorkoutSummary({
+          title: "Builder edited workout",
+        }),
+      }),
+    } as Response);
+
+    render(<WorkoutBuilderHub workoutLibrary={buildWorkoutLibrary()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    fireEvent.change(screen.getByTestId("session-draft-title"), {
+      target: { value: "Builder edited workout" },
+    });
+    fireEvent.change(screen.getByTestId("session-draft-description"), {
+      target: { value: "Edited in the dedicated builder route." },
+    });
+    fireEvent.click(screen.getByTestId("workout-builder-save"));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/my-library/workouts/workout-1",
+        expect.objectContaining({
+          method: "PATCH",
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Workout changes saved to the canonical workout.")).toBeVisible();
+    });
+    expect(screen.getByTestId("session-draft-title")).toHaveValue("Builder edited workout");
+  });
+
+  it("shows recovery guidance when the requested workout is missing", () => {
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: null,
+          selectedWorkoutMissing: true,
+        })}
+      />
+    );
+
+    expect(screen.getByText("That saved workout could not be found.")).toBeVisible();
+    expect(screen.getByRole("link", { name: "Open generator" })).toHaveAttribute(
+      "href",
+      "/my-library/generator"
+    );
+    expect(screen.getByTestId("workout-builder-open-workout-workout-1")).toHaveAttribute(
+      "href",
+      "/my-library/workouts/workout-1"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a dedicated canonical workout builder route at `/my-library/workouts/[workoutId]`
- extract a shared `WorkoutEditor` so accepted AI sessions and the manual builder route use the same editable workout model
- update Generator Intake and My Library to hand accepted workouts into the builder route, with coverage for generator -> builder -> canonical save
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths changed)
- Policy version note: N/A (no policy-impacting scope detected)
- Brief link: `docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md`

## Scope

- In scope: dedicated canonical workout editing route, shared workout editor extraction, generator/My Library handoff links, targeted docs/test updates
- Out of scope: blank manual workout creation, poolside execution UX, program builder, Garmin send/export behavior
- PR size note: this diff is intentionally larger than 500 lines because it extracts the shared editor out of Generator Intake instead of duplicating a second editing surface

## Risk

- Main risk: regressions in the accepted-workout reopen/save flow between Generator Intake and the dedicated builder route
- Rollback plan: revert `2c04d7c` (`git revert 2c04d7c`) to restore the previous generator-only editing flow

## Test Evidence

- `npm run verify:pre-pr`: **PASS** on `2c04d7c`
- `npm run verify:pre-merge`: **PASS** on `2c04d7c` (`2026-03-20T22:16:15Z`, mode: `skipped` private-gate step)
- Targeted unit coverage: `npx vitest run tests/unit/session-generator-panel.test.tsx tests/unit/workout-builder-hub.test.tsx tests/unit/workouts-routes.test.ts`
- Targeted e2e coverage: `npx playwright test tests/e2e/my-library-generator-intake.spec.ts --project=desktop-chromium`
- Perf trend: repo gate recommended `tighten` after two consecutive green weekly runs; decision for this non-perf slice: `hold`, carry the tightening decision in the next AW-010/perf-focused follow-up
- CI links: use PR checks for `verify`, `CodeQL`, `size-check`, and Vercel preview jobs

- [x] `npm run lint:briefs`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] `npm run test:e2e`
- [x] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge`
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [x] Checked boxes in this PR have supporting evidence or explicit rationale
- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [x] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
