### PR TITLE
feat(admin): upgrade notes core workflow

### DIFF
--- a/app/api/admin/notes/route.ts
+++ b/app/api/admin/notes/route.ts
@@ -4,7 +4,11 @@ import {
   parseAdminNoteContextInput,
   resolveAdminNoteContextLookupRefs,
 } from "@/lib/admin/note-context";
-import { parseCreateAdminNotePayload, type AdminNoteRow } from "@/lib/admin/notes";
+import {
+  parseCreateAdminNotePayload,
+  sortAdminNotesByNewest,
+  type AdminNoteRow,
+} from "@/lib/admin/notes";
 import { getAdminSchemaSetupMessage, isAdminNotesSchemaMissing } from "@/lib/admin/schema";
 import { requireAdminRoleFromSupabase } from "@/lib/admin/server";
 import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
@@ -38,19 +42,6 @@ function selectedFields() {
     created_at,
     updated_at
   `;
-}
-
-function sortAdminNotesByNewest(
-  a: { note_date: string; created_at: string },
-  b: {
-    note_date: string;
-    created_at: string;
-  }
-): number {
-  if (a.note_date !== b.note_date) {
-    return b.note_date.localeCompare(a.note_date);
-  }
-  return b.created_at.localeCompare(a.created_at);
 }
 
 export async function GET(request: Request) {

--- a/components/admin/AdminHelpCenter.tsx
+++ b/components/admin/AdminHelpCenter.tsx
@@ -16,7 +16,7 @@ type ActionGroup = {
   actions: Array<{ label: string; meaning: string }>;
 };
 
-const LAST_UPDATED = "2026-03-17";
+const LAST_UPDATED = "2026-03-21";
 
 const QUICK_ACTIONS = [
   { id: "overview", label: "Start here" },
@@ -63,8 +63,10 @@ const DASHBOARD_TABS: TabGuide[] = [
   },
   {
     name: "Notes",
-    primaryJob: "Capture internal tasks with clear context and completion status.",
-    commonRisk: "Unlinked notes lose context and slow follow-up.",
+    primaryJob:
+      "Run an internal work queue with visible note IDs, search, context filters, and done archive recovery.",
+    commonRisk:
+      "Hidden context or mixed open/done lists make the next operator pick the wrong note.",
   },
   {
     name: "Categories",
@@ -387,7 +389,17 @@ const BUTTON_GUIDE: ActionGroup[] = [
       {
         label: "Use P0 template / Use P1 template / Use P2 template",
         meaning:
-          "Prefills standardized incident structure (severity, owner, mitigation, update cadence) for operations notes.",
+          "Prefills standardized incident structure. P0 = critical outage, P1 = major degradation with workaround, P2 = low-impact bug/UX issue.",
+      },
+      {
+        label: "Open / Done archive / All + Search + Context filters",
+        meaning:
+          "Turns Notes into a work queue so operators can find the right note by ID, text, category, route, or attached content context.",
+      },
+      {
+        label: "Visible note ID",
+        meaning:
+          "Shows the stable canonical note identifier so follow-up work can reference a note without pasting the full body.",
       },
       {
         label: "Save note / Save changes / Delete",
@@ -521,8 +533,9 @@ const DAILY_PLAYBOOKS: Playbook[] = [
     title: "Capture review notes with context",
     steps: [
       "Open the exact page/content row you are reviewing.",
-      "Create note with category and context link.",
-      "Mark completion status once resolved.",
+      "Create note with category and context link, then copy the visible note ID if you need to reference it later.",
+      "Use Search + Context filters in Notes to reopen the same note quickly.",
+      "Mark completion status once resolved, then use Done archive to confirm it is recoverable.",
     ],
   },
 ];

--- a/components/admin/AdminNotesManager.tsx
+++ b/components/admin/AdminNotesManager.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  startTransition,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   ADMIN_NOTE_CONTEXT_TYPE_VALUES,
   type AdminNoteContextType,
@@ -13,10 +21,22 @@ import {
 import type { AdminCategoryRow } from "@/lib/admin/categories";
 import type { AdminContentItemRow } from "@/lib/admin/content";
 import {
+  ADMIN_INCIDENT_SEVERITY_GUIDANCE,
+  DEFAULT_ADMIN_NOTES_FILTER_STATE,
+  applyAdminNotesFilterStateToSearchParams,
+  buildAdminNoteReferenceLabel,
+  buildAdminNotesContextRefOptions,
+  buildAdminNotesCounts,
+  filterAdminNotes,
+  parseAdminNotesFilterState,
+  type AdminNotesStatusFilter,
+} from "@/lib/admin/notes-manager";
+import {
   ADMIN_INCIDENT_NOTE_CATEGORY_BY_SEVERITY,
   ADMIN_INCIDENT_NOTE_CATEGORY_OPTIONS,
   INCIDENT_NOTE_SEVERITIES,
   buildIncidentNoteBodyTemplate,
+  sortAdminNotesByNewest,
   type AdminNoteRow,
   type IncidentNoteSeverity,
 } from "@/lib/admin/notes";
@@ -187,6 +207,9 @@ function normalizeContextRef(value: string): string {
 }
 
 export default function AdminNotesManager() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const [items, setItems] = useState<AdminNoteRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -263,7 +286,7 @@ export default function AdminNotesManager() {
         return;
       }
 
-      setItems(payload.items);
+      setItems([...payload.items].sort(sortAdminNotesByNewest));
       setSchemaReady(payload.schemaReady !== false);
       setWarning(payload.warning ?? null);
 
@@ -300,20 +323,82 @@ export default function AdminNotesManager() {
     void loadNotes();
   }, [loadNotes]);
 
+  const notesFilters = useMemo(() => parseAdminNotesFilterState(searchParams), [searchParams]);
+  const deferredQuery = useDeferredValue(notesFilters.query);
+  const effectiveNotesFilters = useMemo(
+    () =>
+      deferredQuery === notesFilters.query
+        ? notesFilters
+        : { ...notesFilters, query: deferredQuery },
+    [deferredQuery, notesFilters]
+  );
+  const noteCounts = useMemo(() => buildAdminNotesCounts(items), [items]);
+
   const noteSummary = useMemo(() => {
     if (items.length === 0) return "No notes yet.";
-    const done = items.filter((item) => item.is_done).length;
-    const open = items.length - done;
-    return `${open} open · ${done} done`;
-  }, [items]);
+    return `${noteCounts.open} open · ${noteCounts.done} done archive`;
+  }, [items.length, noteCounts.done, noteCounts.open]);
 
   const suggestedCategoryOptions = useMemo(() => {
-    return [...categoryOptions, ...ADMIN_INCIDENT_NOTE_CATEGORY_OPTIONS]
+    return [
+      ...categoryOptions,
+      ...items.map((item) => item.category),
+      ...ADMIN_INCIDENT_NOTE_CATEGORY_OPTIONS,
+    ]
       .map((entry) => entry.trim())
       .filter(Boolean)
       .filter((entry, index, all) => all.indexOf(entry) === index)
       .sort((left, right) => left.localeCompare(right, "nb-NO"));
-  }, [categoryOptions]);
+  }, [categoryOptions, items]);
+
+  const contextRefOptions = useMemo(
+    () =>
+      buildAdminNotesContextRefOptions({
+        items,
+        catalog: contextCatalog,
+        contextType: notesFilters.contextType,
+      }),
+    [contextCatalog, items, notesFilters.contextType]
+  );
+
+  const filteredItems = useMemo(
+    () =>
+      filterAdminNotes({
+        items,
+        filters: effectiveNotesFilters,
+        catalog: contextCatalog,
+      }),
+    [contextCatalog, effectiveNotesFilters, items]
+  );
+
+  const hasActiveFilters =
+    notesFilters.query !== DEFAULT_ADMIN_NOTES_FILTER_STATE.query ||
+    notesFilters.status !== DEFAULT_ADMIN_NOTES_FILTER_STATE.status ||
+    notesFilters.category !== DEFAULT_ADMIN_NOTES_FILTER_STATE.category ||
+    notesFilters.contextType !== DEFAULT_ADMIN_NOTES_FILTER_STATE.contextType ||
+    notesFilters.contextRef !== DEFAULT_ADMIN_NOTES_FILTER_STATE.contextRef;
+
+  function updateNotesFilters(next: Partial<typeof notesFilters>) {
+    const nextFilters = {
+      ...notesFilters,
+      ...next,
+    };
+    if (Object.prototype.hasOwnProperty.call(next, "contextType")) {
+      nextFilters.contextRef = "";
+    }
+    if (!nextFilters.contextType) {
+      nextFilters.contextRef = "";
+    }
+
+    const nextParams = applyAdminNotesFilterStateToSearchParams(
+      new URLSearchParams(searchParams.toString()),
+      nextFilters
+    );
+    const nextHref = nextParams.toString() ? `${pathname}?${nextParams.toString()}` : pathname;
+    startTransition(() => {
+      router.replace(nextHref, { scroll: false });
+    });
+  }
 
   const createLessonOptions = useMemo(() => {
     if (formState.contextType !== "course_lesson") return [];
@@ -401,9 +486,15 @@ export default function AdminNotesManager() {
         return;
       }
 
-      setItems((prev) => [payload.item, ...prev]);
+      setItems((prev) =>
+        [...prev.filter((entry) => entry.id !== payload.item.id), payload.item].sort(
+          sortAdminNotesByNewest
+        )
+      );
       setFormState(INITIAL_FORM);
-      setActionNotice("Note saved.");
+      setActionNotice(
+        payload.item.is_done ? "Note saved to done archive." : "Note saved to open work queue."
+      );
     } catch {
       setActionError("Could not save note.");
     } finally {
@@ -485,7 +576,9 @@ export default function AdminNotesManager() {
       }
 
       setItems((prev) =>
-        prev.map((entry) => (entry.id === payload.item.id ? payload.item : entry))
+        prev
+          .map((entry) => (entry.id === payload.item.id ? payload.item : entry))
+          .sort(sortAdminNotesByNewest)
       );
       setEditingId(null);
       setEditState(null);
@@ -522,9 +615,15 @@ export default function AdminNotesManager() {
       }
 
       setItems((prev) =>
-        prev.map((entry) => (entry.id === payload.item.id ? payload.item : entry))
+        prev
+          .map((entry) => (entry.id === payload.item.id ? payload.item : entry))
+          .sort(sortAdminNotesByNewest)
       );
-      setActionNotice(payload.item.is_done ? "Note marked as done." : "Note reopened.");
+      setActionNotice(
+        payload.item.is_done
+          ? "Note marked as done and moved to done archive."
+          : "Note reopened and moved to open work queue."
+      );
     } catch {
       setActionError("Could not update note.");
     } finally {
@@ -629,8 +728,143 @@ export default function AdminNotesManager() {
         ) : null}
 
         {!loading && !error && items.length > 0 ? (
+          <div className="mt-5 space-y-4 rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold text-slate-900">Work queue filters</p>
+                <p className="mt-1 text-xs text-slate-600">
+                  Showing {filteredItems.length} of {noteCounts.all} notes.
+                </p>
+              </div>
+              {hasActiveFilters ? (
+                <button
+                  type="button"
+                  onClick={() => updateNotesFilters(DEFAULT_ADMIN_NOTES_FILTER_STATE)}
+                  className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-100"
+                >
+                  Clear filters
+                </button>
+              ) : null}
+            </div>
+
+            <div className="grid gap-3 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,0.9fr)_minmax(0,0.9fr)_minmax(0,1fr)_minmax(0,1.2fr)]">
+              <label className="space-y-1 text-sm font-medium text-slate-700">
+                <span>Search</span>
+                <input
+                  type="search"
+                  value={notesFilters.query}
+                  onChange={(e) => updateNotesFilters({ query: e.target.value })}
+                  data-testid="admin-notes-search"
+                  className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                  placeholder="Search note ID, title, text, or context"
+                />
+              </label>
+
+              <div className="space-y-1 text-sm font-medium text-slate-700">
+                <span>Status</span>
+                <div
+                  className="grid grid-cols-3 gap-2"
+                  role="group"
+                  aria-label="Notes status filter"
+                >
+                  {(["open", "done", "all"] as AdminNotesStatusFilter[]).map((status) => {
+                    const isActive = notesFilters.status === status;
+                    const count =
+                      status === "open"
+                        ? noteCounts.open
+                        : status === "done"
+                          ? noteCounts.done
+                          : noteCounts.all;
+
+                    return (
+                      <button
+                        key={status}
+                        type="button"
+                        data-testid={`admin-notes-status-${status}`}
+                        onClick={() => updateNotesFilters({ status })}
+                        className={[
+                          "inline-flex h-10 items-center justify-center rounded-xl border px-3 text-sm font-semibold transition",
+                          isActive
+                            ? "border-blue-300 bg-blue-50 text-blue-800"
+                            : "border-slate-200 bg-white text-slate-700 hover:bg-slate-100",
+                        ].join(" ")}
+                        aria-pressed={isActive}
+                      >
+                        {status === "open"
+                          ? `Open (${count})`
+                          : status === "done"
+                            ? `Done archive (${count})`
+                            : `All (${count})`}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <label className="space-y-1 text-sm font-medium text-slate-700">
+                <span>Category</span>
+                <select
+                  value={notesFilters.category}
+                  onChange={(e) => updateNotesFilters({ category: e.target.value })}
+                  data-testid="admin-notes-category-filter"
+                  className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                >
+                  <option value="">All categories</option>
+                  {suggestedCategoryOptions.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="space-y-1 text-sm font-medium text-slate-700">
+                <span>Context type</span>
+                <select
+                  value={notesFilters.contextType}
+                  onChange={(e) =>
+                    updateNotesFilters({
+                      contextType: e.target.value as AdminNoteContextType | "",
+                    })
+                  }
+                  data-testid="admin-notes-context-type-filter"
+                  className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                >
+                  <option value="">All context types</option>
+                  {CONTEXT_TYPE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="space-y-1 text-sm font-medium text-slate-700">
+                <span>Exact route/context</span>
+                <select
+                  value={notesFilters.contextRef}
+                  onChange={(e) => updateNotesFilters({ contextRef: e.target.value })}
+                  data-testid="admin-notes-context-ref-filter"
+                  className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                  disabled={contextRefOptions.length === 0}
+                >
+                  <option value="">
+                    {notesFilters.contextType ? "All selected targets" : "All routes and targets"}
+                  </option>
+                  {contextRefOptions.map((option) => (
+                    <option key={`${option.contextType}:${option.value}`} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+          </div>
+        ) : null}
+
+        {!loading && !error && items.length > 0 && filteredItems.length > 0 ? (
           <ul className="mt-5 space-y-3">
-            {items.map((item) => {
+            {filteredItems.map((item) => {
               const isUpdating = updatingId === item.id;
               const isDeleting = deletingId === item.id;
               const isEditing = editingId === item.id && editState !== null;
@@ -654,14 +888,26 @@ export default function AdminNotesManager() {
                       <p className="mt-1 text-xs text-slate-500">
                         {item.category} · {formatDateLabel(item.note_date)}
                       </p>
+                      <p
+                        className="mt-1 text-[11px] font-medium uppercase tracking-wide text-slate-500"
+                        data-testid="admin-note-id"
+                      >
+                        {buildAdminNoteReferenceLabel(item.id)}
+                      </p>
                       {item.context_type && item.context_ref ? (
-                        <p className="mt-1 text-xs font-medium text-slate-600">
-                          {resolveAdminNoteContextLabel({
-                            catalog: contextCatalog,
-                            contextType: item.context_type,
-                            contextRef: item.context_ref,
-                          })}
-                        </p>
+                        <>
+                          <p className="mt-1 text-xs font-medium text-slate-600">
+                            {resolveAdminNoteContextLabel({
+                              catalog: contextCatalog,
+                              contextType: item.context_type,
+                              contextRef: item.context_ref,
+                            })}
+                          </p>
+                          <p className="mt-1 text-[11px] text-slate-500">
+                            Context ref:{" "}
+                            <span className="font-mono text-slate-700">{item.context_ref}</span>
+                          </p>
+                        </>
                       ) : null}
                     </div>
                     <div className="flex items-center gap-2">
@@ -960,6 +1206,13 @@ export default function AdminNotesManager() {
             })}
           </ul>
         ) : null}
+
+        {!loading && !error && items.length > 0 && filteredItems.length === 0 ? (
+          <p className="mt-5 rounded-xl border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+            No notes match the current filters. Clear filters or switch to done archive to find
+            older notes.
+          </p>
+        ) : null}
       </section>
 
       <section className="rounded-2xl border border-slate-200 bg-white p-6">
@@ -973,6 +1226,19 @@ export default function AdminNotesManager() {
             Use these for runbook incidents so severity, owner, and update cadence stay
             standardized.
           </p>
+          <div className="mt-3 grid gap-2 md:grid-cols-3">
+            {INCIDENT_NOTE_SEVERITIES.map((severity) => (
+              <div
+                key={severity}
+                className="rounded-lg border border-amber-200 bg-white/80 px-3 py-2"
+              >
+                <p className="text-xs font-semibold text-amber-950">{severity}</p>
+                <p className="mt-1 text-xs text-amber-900">
+                  {ADMIN_INCIDENT_SEVERITY_GUIDANCE[severity]}
+                </p>
+              </div>
+            ))}
+          </div>
           <div className="mt-2 flex flex-wrap gap-2">
             {INCIDENT_NOTE_SEVERITIES.map((severity) => (
               <button

--- a/components/admin/AdminWorkspace.tsx
+++ b/components/admin/AdminWorkspace.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { startTransition, useMemo } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import AdminCommerceManager from "@/components/admin/AdminCommerceManager";
 import AdminContentManager from "@/components/admin/AdminContentManager";
 import AdminCategoriesManager from "@/components/admin/AdminCategoriesManager";
@@ -9,16 +10,11 @@ import AdminHelpCenter from "@/components/admin/AdminHelpCenter";
 import AdminNotesManager from "@/components/admin/AdminNotesManager";
 import AdminOperationsManager from "@/components/admin/AdminOperationsManager";
 import AdminQrLinksManager from "@/components/admin/AdminQrLinksManager";
-
-type AdminTab =
-  | "content"
-  | "qr-links"
-  | "commerce"
-  | "operations"
-  | "email-templates"
-  | "notes"
-  | "categories"
-  | "help";
+import {
+  applyAdminTabToSearchParams,
+  parseAdminTab,
+  type AdminTab,
+} from "@/lib/admin/admin-workspace";
 
 const TAB_LABELS: Array<{ id: AdminTab; label: string; subtitle: string }> = [
   {
@@ -63,24 +59,30 @@ const TAB_LABELS: Array<{ id: AdminTab; label: string; subtitle: string }> = [
   },
 ];
 
-function parseAdminTab(value: string | null): AdminTab | null {
-  if (!value) return null;
-  return TAB_LABELS.some((tab) => tab.id === value) ? (value as AdminTab) : null;
-}
-
-function resolveInitialAdminTab(): AdminTab {
-  if (typeof window === "undefined") return "content";
-  const params = new URLSearchParams(window.location.search);
-  return parseAdminTab(params.get("tab")) ?? "content";
-}
-
 export default function AdminWorkspace() {
-  const [activeTab, setActiveTab] = useState<AdminTab>(() => resolveInitialAdminTab());
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const activeTab = useMemo(
+    () => parseAdminTab(searchParams.get("tab")) ?? "content",
+    [searchParams]
+  );
 
   const activeMeta = useMemo(
     () => TAB_LABELS.find((tab) => tab.id === activeTab) ?? TAB_LABELS[0],
     [activeTab]
   );
+
+  function selectTab(tab: AdminTab) {
+    const nextParams = applyAdminTabToSearchParams(
+      new URLSearchParams(searchParams.toString()),
+      tab
+    );
+    const nextHref = nextParams.toString() ? `${pathname}?${nextParams.toString()}` : pathname;
+    startTransition(() => {
+      router.replace(nextHref, { scroll: false });
+    });
+  }
 
   return (
     <div>
@@ -91,7 +93,7 @@ export default function AdminWorkspace() {
             <button
               key={tab.id}
               type="button"
-              onClick={() => setActiveTab(tab.id)}
+              onClick={() => selectTab(tab.id)}
               data-testid={`admin-tab-${tab.id}`}
               className={[
                 "rounded-2xl border px-4 py-3 text-left transition",

--- a/docs/runbooks/admin-notes-recovery.md
+++ b/docs/runbooks/admin-notes-recovery.md
@@ -17,14 +17,17 @@ Use this runbook for AW-012 workflow `A4` stale-note reconciliation edge cases.
 ## Manual Recovery Walkthrough
 
 1. Pause edits on the current row and copy your intended final text to a temporary local note.
-2. In `/admin` -> `Notes`, click `Refresh` to reload server-canonical rows.
-3. Re-open the target note and confirm:
+2. In `/admin?tab=notes`, keep the `Notes` tab active and click `Refresh` to reload server-canonical rows.
+3. If the note is no longer visible in the default queue, switch to `Done archive` or search by the visible `Note ID`.
+4. Re-open the target note and confirm:
+   - note ID,
    - title/body/category/date,
    - completion status,
-   - context label (`Course Lesson`, `Product`, `Page`, etc.).
-4. Re-apply only the intended delta and click `Save changes`.
-5. Confirm success notice (`Note updated.`) and verify the same row in its contextual surface (`/course` or `/plans`).
-6. If update still fails, create one incident note (P1/P2) with owner + next action and link it in AW-012 checkpoint evidence.
+   - context label (`Course Lesson`, `Product`, `Page`, etc.),
+   - raw context ref/path when relevant.
+5. Re-apply only the intended delta and click `Save changes`.
+6. Confirm success notice (`Note updated.`) and verify the same row in its contextual surface (`/course` or `/plans`).
+7. If update still fails, create one incident note (P1/P2) with owner + next action and link it in AW-012 checkpoint evidence.
 
 ## Pass Criteria
 

--- a/docs/runbooks/core-flow-incident-response.md
+++ b/docs/runbooks/core-flow-incident-response.md
@@ -83,7 +83,10 @@ Add these checks when incident scope is locale-specific:
 ## Communication Contract
 
 - Open one incident note with:
+  - start in `/admin?tab=notes`,
+  - keep the note in the default `Open` queue until mitigation is complete,
   - timestamp,
+  - visible note ID,
   - taxonomy category (`Incident P0`, `Incident P1`, `Incident P2`, or `Incident Follow-up`),
   - severity,
   - owner,
@@ -114,6 +117,7 @@ Notes:
 
 - `Incident P0/P1/P2` categories should match selected severity.
 - Use `Incident Follow-up` for post-incident cleanup tasks after mitigation.
+- If the incident note is later marked done, use `Done archive` or note-ID search to recover it.
 
 ## Verification Gates Before Incident Closure
 

--- a/docs/task-briefs/in-progress/2026-03-21-admin-notes-workflow-v2-core-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-21-admin-notes-workflow-v2-core-10-10.md
@@ -1,0 +1,239 @@
+# Task Brief: Admin Notes Workflow V2 Core (10/10)
+
+## Metadata
+
+- `id`: `2026-03-21-admin-notes-workflow-v2-core-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-03-21`
+- `updated`: `2026-03-21`
+
+## Goal
+
+Admin can manage notes at scale with visible stable note IDs, search and context filters, cleaner open-vs-done workflow, explicit severity meaning, and persistent Notes-tab continuity across refresh and return flows.
+
+## Why This Brief Exists
+
+- Admin notes already have a solid foundation:
+  - create,
+  - edit,
+  - toggle done,
+  - delete,
+  - contextual attachment to content/page surfaces.
+- Real operations now need the next layer of usability:
+  - easy search,
+  - filter by route/context,
+  - done notes hidden by default,
+  - visible stable IDs for future reference in chats/workflows,
+  - persistent admin tab state on refresh,
+  - clearer incident severity meaning.
+- This should be split from attachments/linking so the core management upgrade can ship without waiting for storage/media work.
+
+## Dependencies And Boundaries
+
+- Existing foundations that remain authoritative:
+  - `/Users/stianvikra/freeswimming/components/admin/AdminNotesManager.tsx`
+  - `/Users/stianvikra/freeswimming/components/admin/AdminContextNotesPanel.tsx`
+  - `/Users/stianvikra/freeswimming/components/admin/AdminWorkspace.tsx`
+  - `/Users/stianvikra/freeswimming/lib/admin/notes.ts`
+  - `/Users/stianvikra/freeswimming/app/api/admin/notes/route.ts`
+  - `/Users/stianvikra/freeswimming/app/api/admin/notes/[id]/route.ts`
+- Existing note-context foundations that must stay compatible:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-02-19-admin-content-source-of-truth-and-dashboard-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-17-aw-013-context-aware-admin-create-notes-and-qr-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/runbooks/admin-notes-recovery.md`
+  - `/Users/stianvikra/freeswimming/docs/runbooks/core-flow-incident-response.md`
+- This slice owns core notes-manager workflow upgrades.
+- This slice does not own:
+  - image attachments,
+  - linked-notes graph,
+  - quick-capture launcher from every page,
+  - richer priority model beyond what is needed for search/filter semantics.
+
+## Scope
+
+- Make note identity visible and referenceable:
+  - show stable note ID in notes manager and detail/edit affordances,
+  - support quick search by note ID.
+- Add scalable list controls:
+  - search by title/body/ID,
+  - filter by `open` vs `done archive`,
+  - filter by category,
+  - filter by context type,
+  - filter by exact route/context reference where relevant.
+- Default notes manager to active work:
+  - open notes shown by default,
+  - done notes hidden behind explicit archive/done filter,
+  - delete remains available where policy permits.
+- Improve context visibility:
+  - page/route-linked notes show clear normalized URL/path context,
+  - filters can narrow to a specific page path or context ref.
+- Persist admin workspace tab state:
+  - switching to `Notes` updates URL state,
+  - refresh returns to `Notes`,
+  - deep links to notes filters remain possible where appropriate.
+- Clarify incident templates in-product and in Help/Guide:
+  - explain what `P0`, `P1`, and `P2` mean,
+  - keep template usage and recovery guidance aligned.
+
+## Out Of Scope
+
+- Image/file attachments.
+- Related-note linking.
+- New quick-capture launcher across all app pages.
+- Full admin dashboard redesign.
+- Replacing the current canonical note schema with a new ticketing system.
+
+## Data Placement And Sync Contract
+
+- Server-canonical data:
+  - `admin_notes` rows,
+  - note ID,
+  - category,
+  - body,
+  - done state,
+  - canonical context type/ref values.
+- Local-only data:
+  - current search query,
+  - active filter chips,
+  - active admin tab URL/query state,
+  - temporary optimistic list state and banners.
+- Sync policy:
+  - create/update/delete/toggle-done remain explicit server writes,
+  - search/filter may run server-side, client-side, or hybrid, but rendered list truth must match canonical server rows after successful mutations,
+  - URL tab state is client-owned navigation state and must not mutate note data.
+- Retention and sensitivity:
+  - done notes are hidden by default but remain recoverable through archive/done view,
+  - note IDs are safe to display to admins but must not expose note content publicly.
+- Cache/invalidation:
+  - after note mutation, current filtered list refreshes deterministically without bouncing the user back to the `Content` tab.
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - `admin_note.id` remains the only canonical stable identifier and must be visible in admin UI.
+- Human-readable identifiers:
+  - titles, category labels, and route labels are editable display metadata and not note identity.
+- Mutability rules:
+  - search/filtering and tab state must not mutate note rows,
+  - `done` remains an explicit workflow state, not an inferred status from filters.
+- Rename vs repurpose policy:
+  - normal wording updates stay on the same note row,
+  - materially different tasks should become new notes instead of silent repurpose.
+- Compatibility contract:
+  - existing contextual note references remain valid and searchable by canonical context type/ref,
+  - visible note IDs make future agent/operator reference flows possible without copying full note text.
+- Observability and repair:
+  - invalid context refs or stale page bindings must surface safe labels and remain discoverable by ID for manual cleanup.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Admin editor ergonomics`
+- `Business logic correctness and data integrity`
+- `Reliability and failure handling`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                   | Evidence                             |
+| --------------------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| Product goals and IA                          | `target`     | Admin can understand open work, done archive, context-bound notes, and note identity without scanning the entire list manually.  | IA review + manual QA + e2e          |
+| UX flow clarity                               | `target`     | Search, filter, open/done archive, and refresh-return flows are obvious and complete without dead ends.                          | e2e + manual QA                      |
+| Visual design quality                         | `target`     | Notes manager remains readable and production-ready as more controls are added, without becoming cluttered.                      | screenshot review + manual QA        |
+| Business logic correctness and data integrity | `target`     | Filtering, search, tab persistence, and visible IDs never mutate note truth and never hide recently changed canonical results.   | unit tests + runtime guards          |
+| Admin editor ergonomics                       | `target`     | An operator can find, filter, reopen, mark done, or reference the right note in seconds instead of scanning a long mixed list.   | timed manual QA + e2e                |
+| Accessibility (a11y)                          | `target`     | Search/filter controls, archive toggle, and ID/context affordances remain keyboard and screen-reader accessible.                 | Playwright + manual QA               |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: notes-manager upgrades must avoid obvious `/admin` render regressions or inefficient over-fetching.             | build + code review                  |
+| Data placement and sync boundaries            | `target`     | Note truth remains server-canonical while search/filter/tab state stays local or URL-owned and deterministic.                    | contract review + tests              |
+| Caching and invalidation strategy             | `target`     | Post-mutation list refresh respects active filters and keeps the operator in the Notes workspace instead of resetting context.   | integration review + e2e             |
+| Reliability and failure handling              | `target`     | Failed loads or mutations show actionable retry guidance without losing filter context or tab location.                          | negative-path tests + manual QA      |
+| Security and authz                            | `target`     | Notes list/search/filter/mutation endpoints remain admin-only and fail closed for unauthorized access.                           | API negative-path tests              |
+| Privacy and compliance                        | `supporting` | Supporting only: visible IDs and route context must remain admin-only and never leak note content to public routes or logs.      | route review + test assertions       |
+| Content governance                            | `target`     | Done-archive semantics, category usage, and route-context visibility remain consistent with current operational note governance. | Help/Guide + code review             |
+| Admin workflow and editability                | `target`     | Core admin note management stays fast, editable, and recoverable even as note volume grows.                                      | e2e + timed manual QA                |
+| SEO and crawlability                          | `N/A`        | N/A because admin notes are private admin-only surfaces with no public crawl/index contract.                                     | scope rationale                      |
+| AI discoverability                            | `N/A`        | N/A because this slice changes no public AI-facing discoverability surface.                                                      | scope rationale                      |
+| Analytics and KPI observability               | `supporting` | Supporting only: search/filter/done-archive actions should remain measurable enough to confirm improved operator throughput.     | analytics event review               |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, billing, entitlement, or commercial reporting logic changes in this admin notes core slice.              | scope rationale                      |
+| Incident response and support operations      | `target`     | Help/Guide and runbook content explain P0/P1/P2 meaning, archive behavior, and note lookup/recovery flow clearly.                | docs review + help-center assertions |
+| Finance and reporting operations              | `N/A`        | N/A because no billing, payout, reconciliation, or finance reporting path is changed in this admin notes workflow upgrade.       | scope rationale                      |
+| i18n operational readiness                    | `supporting` | Supporting only: severity/help copy and filter labels must remain localization-safe and enum-backed where possible.              | copy review                          |
+| Stack-fit and dependency discipline           | `target`     | Reuse the existing admin notes/API stack and avoid unnecessary dependencies for search/filter/tab persistence.                   | dependency diff + code review        |
+| Testing and QA automation                     | `target`     | Coverage protects search/filter/archive persistence, tab refresh continuity, visible IDs, and unauthorized-path safety.          | tests + `verify:pre-pr` evidence     |
+| Scalability and cost efficiency               | `supporting` | Supporting only: list controls should scale to larger note sets without brute-force client-only churn on every action.           | query review + code review           |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: core workflow changes remain easy to roll back without data migration if necessary.                             | release notes + diff review          |
+
+## Acceptance Criteria
+
+1. Every admin note shows a visible stable note ID.
+2. Admin can search notes by ID and meaningful text.
+3. Admin can filter by open/done archive, category, and route/context.
+4. Done notes are hidden by default from the main working list but remain accessible through archive/done view.
+5. Refreshing or deep-linking the admin dashboard can preserve the active `Notes` tab.
+6. P0/P1/P2 meaning is explained in-product and aligned with Help/Guide/runbooks.
+7. Existing delete and edit flows remain intact and more discoverable in filtered/archive contexts.
+8. `npm run lint:briefs`, targeted tests, and `npm run verify:pre-pr` pass before PR update.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run lint`
+- `npm run typecheck`
+- targeted unit tests for:
+  - note search/filter behavior,
+  - done-archive defaults,
+  - admin tab URL persistence,
+  - visible-ID/reference helpers
+- targeted e2e for:
+  - notes-tab refresh persistence,
+  - search and context filtering,
+  - done/archive list behavior,
+  - incident-template meaning/help visibility
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm must be installed on the machine used for local validation.
+- Local validation runs from repo root.
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3000/admin?tab=notes`
+- Preview:
+  - PR preview URL after branch push
+- Recommended matrix:
+  - Desktop Chrome
+  - Desktop Safari/WebKit
+  - Desktop Firefox
+  - iPad/tablet viewport for filter/readability sanity check
+
+## Constraints
+
+- Keep this slice focused on core notes management and continuity.
+- Do not mix media-upload work into this slice.
+- Preserve current canonical note model unless a narrowly scoped field change is required for search/filter support.
+- Avoid resetting the active admin tab after list mutations or refresh.
+
+## 10/10 Quality Bar
+
+- The operator should be able to find the right note quickly, even in a long list.
+- The Notes tab should feel like a real work queue, not a flat backlog dump.
+- Required states remain explicit:
+  - `loading`
+  - `empty`
+  - `error`
+  - `retry`
+  - `success`
+- Context and note identity must be obvious enough that future chats can reference a note by ID instead of pasting the whole body.
+- No filter or refresh behavior should silently throw the operator back into the `Content` tab.
+
+## Checkpoint Log
+
+- `2026-03-21 | verify:pre-pr passed | full gate green after hardening admin-notes workflow reload waits and explicit timeout; local verify passed with 87 e2e passed / 243 skipped, and admin notes workflow stayed green inside full desktop Chromium coverage | next: stage slice, open PR, and record a perf-trend hold in PR summary because AW-010 stretch-target tightening is outside this admin-notes scope`
+- `2026-03-21 | implementation started | moved admin notes core v2 into in-progress to ship visible note IDs, default-open work queue filters, notes-tab URL continuity, and clearer incident severity guidance before attachments/linking | next: implement notes manager filters + URL state, update Help/Guide/runbooks, and run targeted validation`
+- `2026-03-21 | planning | created admin notes core v2 brief from real operational friction: visible IDs, search/filter by route and status, done hidden by default, persistent Notes-tab state, and clearer incident severity meaning | next: implement core list/search/filter/tab continuity before taking on attachments and linked-note graph work`

--- a/lib/admin/admin-workspace.ts
+++ b/lib/admin/admin-workspace.ts
@@ -1,0 +1,33 @@
+export const ADMIN_TAB_VALUES = [
+  "content",
+  "qr-links",
+  "commerce",
+  "operations",
+  "email-templates",
+  "notes",
+  "categories",
+  "help",
+] as const;
+
+export type AdminTab = (typeof ADMIN_TAB_VALUES)[number];
+
+export const ADMIN_TAB_QUERY_KEY = "tab";
+
+export function parseAdminTab(value: string | null | undefined): AdminTab | null {
+  if (!value) return null;
+  return ADMIN_TAB_VALUES.includes(value as AdminTab) ? (value as AdminTab) : null;
+}
+
+export function applyAdminTabToSearchParams(
+  params: URLSearchParams,
+  tab: AdminTab
+): URLSearchParams {
+  const next = new URLSearchParams(params.toString());
+  if (tab === "content") {
+    next.delete(ADMIN_TAB_QUERY_KEY);
+    return next;
+  }
+
+  next.set(ADMIN_TAB_QUERY_KEY, tab);
+  return next;
+}

--- a/lib/admin/notes-manager.ts
+++ b/lib/admin/notes-manager.ts
@@ -1,0 +1,268 @@
+import {
+  resolveAdminNoteContextLabel,
+  type AdminNoteContextCatalog,
+} from "@/lib/admin/note-context-catalog";
+import {
+  ADMIN_NOTE_CONTEXT_TYPE_VALUES,
+  isAdminNoteContextType,
+  type AdminNoteContextType,
+} from "@/lib/admin/note-context";
+import type { AdminNoteRow, IncidentNoteSeverity } from "@/lib/admin/notes";
+
+type SearchParamsLike = {
+  get(name: string): string | null;
+};
+
+export const ADMIN_NOTES_STATUS_FILTER_VALUES = ["open", "done", "all"] as const;
+export type AdminNotesStatusFilter = (typeof ADMIN_NOTES_STATUS_FILTER_VALUES)[number];
+
+export type AdminNotesFilterState = {
+  query: string;
+  status: AdminNotesStatusFilter;
+  category: string;
+  contextType: AdminNoteContextType | "";
+  contextRef: string;
+};
+
+export type AdminNotesContextRefOption = {
+  value: string;
+  label: string;
+  contextType: AdminNoteContextType;
+};
+
+export const ADMIN_NOTES_QUERY_KEYS = {
+  query: "notesQuery",
+  status: "notesStatus",
+  category: "notesCategory",
+  contextType: "notesContextType",
+  contextRef: "notesContextRef",
+} as const;
+
+export const DEFAULT_ADMIN_NOTES_FILTER_STATE: AdminNotesFilterState = {
+  query: "",
+  status: "open",
+  category: "",
+  contextType: "",
+  contextRef: "",
+};
+
+export const ADMIN_INCIDENT_SEVERITY_GUIDANCE: Record<IncidentNoteSeverity, string> = {
+  P0: "Critical outage or unsafe behavior. Core actions are blocked or data is at risk.",
+  P1: "Major degradation with workaround. Core work is still possible, but unreliable.",
+  P2: "Non-critical bug or UX defect. Low operational impact and no core outage.",
+};
+
+function normalizeText(value: string | null | undefined): string {
+  if (!value) return "";
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function normalizeLowerText(value: string | null | undefined): string {
+  return normalizeText(value).toLowerCase();
+}
+
+function normalizeContextRef(value: string | null | undefined): string {
+  return normalizeLowerText(value);
+}
+
+export function parseAdminNotesStatusFilter(
+  value: string | null | undefined
+): AdminNotesStatusFilter {
+  if (!value) return DEFAULT_ADMIN_NOTES_FILTER_STATE.status;
+  return ADMIN_NOTES_STATUS_FILTER_VALUES.includes(value as AdminNotesStatusFilter)
+    ? (value as AdminNotesStatusFilter)
+    : DEFAULT_ADMIN_NOTES_FILTER_STATE.status;
+}
+
+export function parseAdminNotesFilterState(searchParams: SearchParamsLike): AdminNotesFilterState {
+  const rawContextType = normalizeLowerText(searchParams.get(ADMIN_NOTES_QUERY_KEYS.contextType));
+  const contextType = ADMIN_NOTE_CONTEXT_TYPE_VALUES.includes(
+    rawContextType as AdminNoteContextType
+  )
+    ? (rawContextType as AdminNoteContextType)
+    : "";
+
+  const contextRef = normalizeContextRef(searchParams.get(ADMIN_NOTES_QUERY_KEYS.contextRef));
+
+  return {
+    query: normalizeText(searchParams.get(ADMIN_NOTES_QUERY_KEYS.query)),
+    status: parseAdminNotesStatusFilter(searchParams.get(ADMIN_NOTES_QUERY_KEYS.status)),
+    category: normalizeText(searchParams.get(ADMIN_NOTES_QUERY_KEYS.category)),
+    contextType,
+    contextRef: contextType ? contextRef : "",
+  };
+}
+
+export function applyAdminNotesFilterStateToSearchParams(
+  params: URLSearchParams,
+  state: AdminNotesFilterState
+): URLSearchParams {
+  const next = new URLSearchParams(params.toString());
+  const normalizedQuery = normalizeText(state.query);
+  const normalizedCategory = normalizeText(state.category);
+  const normalizedContextRef = normalizeContextRef(state.contextRef);
+
+  if (normalizedQuery) {
+    next.set(ADMIN_NOTES_QUERY_KEYS.query, normalizedQuery);
+  } else {
+    next.delete(ADMIN_NOTES_QUERY_KEYS.query);
+  }
+
+  if (state.status !== DEFAULT_ADMIN_NOTES_FILTER_STATE.status) {
+    next.set(ADMIN_NOTES_QUERY_KEYS.status, state.status);
+  } else {
+    next.delete(ADMIN_NOTES_QUERY_KEYS.status);
+  }
+
+  if (normalizedCategory) {
+    next.set(ADMIN_NOTES_QUERY_KEYS.category, normalizedCategory);
+  } else {
+    next.delete(ADMIN_NOTES_QUERY_KEYS.category);
+  }
+
+  if (state.contextType) {
+    next.set(ADMIN_NOTES_QUERY_KEYS.contextType, state.contextType);
+  } else {
+    next.delete(ADMIN_NOTES_QUERY_KEYS.contextType);
+  }
+
+  if (state.contextType && normalizedContextRef) {
+    next.set(ADMIN_NOTES_QUERY_KEYS.contextRef, normalizedContextRef);
+  } else {
+    next.delete(ADMIN_NOTES_QUERY_KEYS.contextRef);
+  }
+
+  return next;
+}
+
+export function buildAdminNoteReferenceLabel(noteId: string): string {
+  return `Note ID ${noteId}`;
+}
+
+export function buildAdminNoteContextFilterLabel(params: {
+  catalog: Pick<AdminNoteContextCatalog, "labelsByContextKey">;
+  contextType: AdminNoteContextType;
+  contextRef: string;
+}): string {
+  const normalizedContextRef = normalizeContextRef(params.contextRef);
+  const contextLabel =
+    resolveAdminNoteContextLabel({
+      catalog: params.catalog,
+      contextType: params.contextType,
+      contextRef: normalizedContextRef,
+    }) ?? `${params.contextType}: ${normalizedContextRef}`;
+
+  if (contextLabel.toLowerCase().includes(normalizedContextRef)) {
+    return contextLabel;
+  }
+
+  return `${contextLabel} (${normalizedContextRef})`;
+}
+
+function buildAdminNoteSearchIndex(params: {
+  item: AdminNoteRow;
+  catalog: Pick<AdminNoteContextCatalog, "labelsByContextKey">;
+}): string {
+  const contextLabel =
+    params.item.context_type &&
+    isAdminNoteContextType(params.item.context_type) &&
+    params.item.context_ref
+      ? buildAdminNoteContextFilterLabel({
+          catalog: params.catalog,
+          contextType: params.item.context_type,
+          contextRef: params.item.context_ref,
+        })
+      : "";
+
+  return [
+    params.item.id,
+    params.item.title,
+    params.item.body,
+    params.item.category,
+    params.item.context_type,
+    params.item.context_ref,
+    contextLabel,
+  ]
+    .filter(Boolean)
+    .join("\n")
+    .toLowerCase();
+}
+
+export function buildAdminNotesCounts(items: AdminNoteRow[]): {
+  open: number;
+  done: number;
+  all: number;
+} {
+  const done = items.filter((item) => item.is_done).length;
+  return {
+    open: items.length - done,
+    done,
+    all: items.length,
+  };
+}
+
+export function filterAdminNotes(params: {
+  items: AdminNoteRow[];
+  filters: AdminNotesFilterState;
+  catalog: Pick<AdminNoteContextCatalog, "labelsByContextKey">;
+}): AdminNoteRow[] {
+  const normalizedQuery = normalizeLowerText(params.filters.query);
+  const normalizedCategory = normalizeLowerText(params.filters.category);
+  const normalizedContextRef = normalizeContextRef(params.filters.contextRef);
+
+  return params.items.filter((item) => {
+    if (params.filters.status === "open" && item.is_done) return false;
+    if (params.filters.status === "done" && !item.is_done) return false;
+
+    if (normalizedCategory && normalizeLowerText(item.category) !== normalizedCategory) {
+      return false;
+    }
+
+    if (params.filters.contextType && item.context_type !== params.filters.contextType) {
+      return false;
+    }
+
+    if (normalizedContextRef && normalizeContextRef(item.context_ref) !== normalizedContextRef) {
+      return false;
+    }
+
+    if (!normalizedQuery) return true;
+
+    return buildAdminNoteSearchIndex({
+      item,
+      catalog: params.catalog,
+    }).includes(normalizedQuery);
+  });
+}
+
+export function buildAdminNotesContextRefOptions(params: {
+  items: AdminNoteRow[];
+  catalog: Pick<AdminNoteContextCatalog, "labelsByContextKey">;
+  contextType: AdminNoteContextType | "";
+}): AdminNotesContextRefOption[] {
+  const options = new Map<string, AdminNotesContextRefOption>();
+
+  for (const item of params.items) {
+    if (!item.context_type || !item.context_ref) continue;
+    if (!isAdminNoteContextType(item.context_type)) continue;
+    if (params.contextType && item.context_type !== params.contextType) continue;
+
+    const normalizedContextRef = normalizeContextRef(item.context_ref);
+    const key = `${item.context_type}:${normalizedContextRef}`;
+    if (options.has(key)) continue;
+
+    options.set(key, {
+      value: normalizedContextRef,
+      contextType: item.context_type,
+      label: buildAdminNoteContextFilterLabel({
+        catalog: params.catalog,
+        contextType: item.context_type,
+        contextRef: normalizedContextRef,
+      }),
+    });
+  }
+
+  return [...options.values()].sort((left, right) =>
+    left.label.localeCompare(right.label, "nb-NO")
+  );
+}

--- a/lib/admin/notes.ts
+++ b/lib/admin/notes.ts
@@ -73,6 +73,16 @@ type ParseResult<T> =
 
 const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
+export function sortAdminNotesByNewest(
+  a: Pick<AdminNoteRow, "note_date" | "created_at">,
+  b: Pick<AdminNoteRow, "note_date" | "created_at">
+): number {
+  if (a.note_date !== b.note_date) {
+    return b.note_date.localeCompare(a.note_date);
+  }
+  return b.created_at.localeCompare(a.created_at);
+}
+
 function normalizeString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }

--- a/tests/e2e/admin-help-center.spec.ts
+++ b/tests/e2e/admin-help-center.spec.ts
@@ -99,6 +99,15 @@ test.describe("admin help center", () => {
     await expect(
       page.getByText("Use P0 template / Use P1 template / Use P2 template:")
     ).toBeVisible();
+    await expect(
+      page.getByText(
+        "P0 = critical outage, P1 = major degradation with workaround, P2 = low-impact bug/UX issue."
+      )
+    ).toBeVisible();
+    await expect(
+      page.getByText("Open / Done archive / All + Search + Context filters:")
+    ).toBeVisible();
+    await expect(page.getByText("Visible note ID:")).toBeVisible();
     await expect(page.getByText("Open lock operations workflow:")).toBeVisible();
     await expect(page.getByText("Open password page:")).toBeVisible();
     await expect(page.getByText("Create template:")).toBeVisible();

--- a/tests/e2e/admin-notes-workflow.spec.ts
+++ b/tests/e2e/admin-notes-workflow.spec.ts
@@ -34,18 +34,31 @@ async function loginAsAdminViaDevBypass(page: Page) {
 
 async function openNotesSection(page: Page) {
   await page.getByTestId("admin-tab-notes").click();
+  await page.waitForURL(/\/admin\?tab=notes(?:&|$)/);
   await expect(page.getByTestId("admin-active-section-label")).toHaveText("Notes");
   await expect(page.getByRole("heading", { name: "Notes" })).toBeVisible();
+  await waitForNotesSectionReady(page);
+}
 
+async function reloadNotesSection(page: Page) {
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await page.waitForURL(/\/admin\?tab=notes(?:&|$)/);
+  await expect(page.getByTestId("admin-active-section-label")).toHaveText("Notes");
+  await expect(page.getByRole("heading", { name: "Notes" })).toBeVisible();
+  await waitForNotesSectionReady(page);
+}
+
+async function waitForNotesSectionReady(page: Page) {
   const notesManager = page.getByTestId("admin-notes-manager");
   const loadingNotice = notesManager.getByText("Loading notes…");
   const errorNotice = notesManager.getByText("Could not load notes.").first();
 
-  await expect(loadingNotice).toHaveCount(0, { timeout: 20_000 });
+  await expect(notesManager).toBeVisible({ timeout: 20_000 });
+  await expect(loadingNotice).toHaveCount(0, { timeout: 45_000 });
 
   if (await errorNotice.isVisible().catch(() => false)) {
     await notesManager.getByRole("button", { name: "Retry" }).click();
-    await expect(loadingNotice).toHaveCount(0, { timeout: 20_000 });
+    await expect(loadingNotice).toHaveCount(0, { timeout: 45_000 });
   }
 
   if (await errorNotice.isVisible().catch(() => false)) {
@@ -65,6 +78,8 @@ test.describe("admin notes workflow", () => {
     page,
   }, testInfo) => {
     runOnceOnDesktopChromium(testInfo.project.name);
+    test.slow();
+    test.setTimeout(90_000);
 
     await loginAsAdminViaDevBypass(page);
     await openNotesSection(page);
@@ -121,6 +136,7 @@ test.describe("admin notes workflow", () => {
     const createPayload = (await createResponse.json().catch(() => null)) as {
       ok?: boolean;
       error?: string;
+      item?: { id?: string; context_ref?: string | null };
     } | null;
     if (!createResponse.ok() || createPayload?.ok === false) {
       const reason =
@@ -130,13 +146,24 @@ test.describe("admin notes workflow", () => {
       test.skip(true, `Admin notes create is not write-ready in this environment (${reason}).`);
     }
 
-    await expect(page.getByText("Note saved.")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText("Note saved to open work queue.")).toBeVisible({
+      timeout: 5_000,
+    });
 
     const createdItem = page.getByTestId("admin-note-item").filter({ hasText: title }).first();
     await expect(createdItem).toBeVisible({ timeout: 15_000 });
     await expect(createdItem).toContainText("Operations");
     await expect(createdItem).toContainText(body);
     await expect(createdItem).toContainText("Course Lesson:");
+    const noteIdText = await createdItem.getByTestId("admin-note-id").textContent();
+    const noteId = noteIdText?.replace("Note ID", "").trim() ?? "";
+    expect(noteId.length).toBeGreaterThan(5);
+
+    const searchInput = page.getByTestId("admin-notes-search");
+    await searchInput.fill(noteId);
+    await expect(page.getByTestId("admin-note-item")).toHaveCount(1);
+    await expect(createdItem).toBeVisible();
+    await searchInput.fill("");
 
     await createdItem.getByRole("button", { name: "Edit" }).click();
     const editForm = createdItem.getByTestId("admin-note-edit-form");
@@ -145,7 +172,6 @@ test.describe("admin notes workflow", () => {
     await editForm.getByLabel("Edit category").fill("Product");
     await editForm.getByLabel("Edit date").fill("2026-02-21");
     await editForm.getByLabel("Edit text").fill(updatedBody);
-    await editForm.getByLabel("Mark as done").check();
     await editForm.getByRole("button", { name: "Save changes" }).click();
 
     const updatedItem = page
@@ -156,13 +182,50 @@ test.describe("admin notes workflow", () => {
     await expect(updatedItem).toContainText("Product");
     await expect(updatedItem).toContainText(updatedBody);
 
+    await page.getByTestId("admin-notes-category-filter").selectOption("Product");
+    await expect(updatedItem).toBeVisible();
+    await page.getByTestId("admin-notes-category-filter").selectOption("");
+
     const doneCheckbox = updatedItem.getByRole("checkbox");
-    await expect(doneCheckbox).toBeChecked();
-    await doneCheckbox.click();
     await expect(doneCheckbox).not.toBeChecked();
+    await doneCheckbox.click();
+    await expect(page.getByText("Note marked as done and moved to done archive.")).toBeVisible();
+    await expect(page.getByTestId("admin-note-item").filter({ hasText: updatedTitle })).toHaveCount(
+      0
+    );
+
+    await page.getByTestId("admin-notes-status-done").click();
+    await expect(page).toHaveURL(/tab=notes/);
+    await expect(page).toHaveURL(/notesStatus=done/);
+
+    const archivedItem = page
+      .getByTestId("admin-note-item")
+      .filter({ hasText: updatedTitle })
+      .first();
+    await expect(archivedItem).toBeVisible({ timeout: 10_000 });
+
+    const lessonContextRef = createPayload?.item?.context_ref ?? "";
+    if (lessonContextRef) {
+      await page.getByTestId("admin-notes-context-type-filter").selectOption("course_lesson");
+      await page.getByTestId("admin-notes-context-ref-filter").selectOption(lessonContextRef);
+      await expect(archivedItem).toBeVisible();
+    }
+
+    await searchInput.fill(noteId);
+    await expect(archivedItem).toBeVisible();
+    await expect(searchInput).toHaveValue(noteId);
+
+    await reloadNotesSection(page);
+    await expect(page).toHaveURL(/notesStatus=done/);
+    await expect(page.getByTestId("admin-notes-search")).toHaveValue(noteId);
+    const reloadedArchivedItem = page
+      .getByTestId("admin-note-item")
+      .filter({ hasText: updatedTitle })
+      .first();
+    await expect(reloadedArchivedItem).toBeVisible({ timeout: 10_000 });
 
     page.once("dialog", (dialog) => dialog.accept());
-    await updatedItem.getByRole("button", { name: "Delete" }).click();
+    await reloadedArchivedItem.getByRole("button", { name: "Delete" }).click();
     await expect(page.getByTestId("admin-note-item").filter({ hasText: updatedTitle })).toHaveCount(
       0
     );

--- a/tests/unit/admin-notes-manager.test.ts
+++ b/tests/unit/admin-notes-manager.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import type { AdminNoteRow } from "@/lib/admin/notes";
+import {
+  ADMIN_NOTES_QUERY_KEYS,
+  DEFAULT_ADMIN_NOTES_FILTER_STATE,
+  applyAdminNotesFilterStateToSearchParams,
+  buildAdminNoteContextFilterLabel,
+  buildAdminNoteReferenceLabel,
+  buildAdminNotesContextRefOptions,
+  filterAdminNotes,
+  parseAdminNotesFilterState,
+} from "@/lib/admin/notes-manager";
+
+function buildNote(overrides?: Partial<AdminNoteRow>): AdminNoteRow {
+  return {
+    id: "note-1",
+    title: "Follow up note",
+    body: "Check the plans page issue.",
+    category: "Operations",
+    note_date: "2026-03-21",
+    is_done: false,
+    context_type: "page",
+    context_ref: "/plans",
+    created_by: "admin-user",
+    updated_by: "admin-user",
+    created_at: "2026-03-21T10:00:00.000Z",
+    updated_at: "2026-03-21T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const catalog = {
+  labelsByContextKey: {
+    "page:/plans": "Plans",
+    "course_lesson:kick-drills--kick-basics-support-not-speed":
+      "M3 · L1 · Kick basics support, not speed",
+  },
+};
+
+describe("admin notes manager filter state", () => {
+  it("defaults to open notes when no query params are present", () => {
+    const parsed = parseAdminNotesFilterState(new URLSearchParams());
+
+    expect(parsed).toEqual(DEFAULT_ADMIN_NOTES_FILTER_STATE);
+  });
+
+  it("writes only non-default note filter params to the URL", () => {
+    const next = applyAdminNotesFilterStateToSearchParams(new URLSearchParams("tab=notes"), {
+      query: "note-123",
+      status: "done",
+      category: "Operations",
+      contextType: "page",
+      contextRef: "/plans",
+    });
+
+    expect(next.get("tab")).toBe("notes");
+    expect(next.get(ADMIN_NOTES_QUERY_KEYS.query)).toBe("note-123");
+    expect(next.get(ADMIN_NOTES_QUERY_KEYS.status)).toBe("done");
+    expect(next.get(ADMIN_NOTES_QUERY_KEYS.category)).toBe("Operations");
+    expect(next.get(ADMIN_NOTES_QUERY_KEYS.contextType)).toBe("page");
+    expect(next.get(ADMIN_NOTES_QUERY_KEYS.contextRef)).toBe("/plans");
+  });
+});
+
+describe("admin notes manager filtering", () => {
+  const openPlansNote = buildNote();
+  const doneLessonNote = buildNote({
+    id: "note-2",
+    title: "Kick lesson follow-up",
+    body: "Adjust notes in lesson flow.",
+    category: "Content",
+    is_done: true,
+    context_type: "course_lesson",
+    context_ref: "kick-drills--kick-basics-support-not-speed",
+  });
+
+  it("searches by visible note ID and keeps done notes hidden by default", () => {
+    const filtered = filterAdminNotes({
+      items: [openPlansNote, doneLessonNote],
+      filters: {
+        query: "note-1",
+        status: "open",
+        category: "",
+        contextType: "",
+        contextRef: "",
+      },
+      catalog,
+    });
+
+    expect(filtered).toEqual([openPlansNote]);
+  });
+
+  it("filters by done archive, context type, and exact context ref", () => {
+    const filtered = filterAdminNotes({
+      items: [openPlansNote, doneLessonNote],
+      filters: {
+        query: "",
+        status: "done",
+        category: "Content",
+        contextType: "course_lesson",
+        contextRef: "kick-drills--kick-basics-support-not-speed",
+      },
+      catalog,
+    });
+
+    expect(filtered).toEqual([doneLessonNote]);
+  });
+
+  it("builds context filter labels with the raw path/ref when needed", () => {
+    expect(
+      buildAdminNoteContextFilterLabel({
+        catalog,
+        contextType: "page",
+        contextRef: "/plans",
+      })
+    ).toBe("Page: Plans (/plans)");
+  });
+
+  it("builds visible note references and context ref options", () => {
+    expect(buildAdminNoteReferenceLabel("1234-abcd")).toBe("Note ID 1234-abcd");
+
+    const options = buildAdminNotesContextRefOptions({
+      items: [openPlansNote, doneLessonNote],
+      catalog,
+      contextType: "",
+    });
+
+    expect(options.map((option) => option.label)).toEqual([
+      "Course Lesson: M3 · L1 · Kick basics support, not speed (kick-drills--kick-basics-support-not-speed)",
+      "Page: Plans (/plans)",
+    ]);
+  });
+});

--- a/tests/unit/admin-workspace-state.test.ts
+++ b/tests/unit/admin-workspace-state.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { applyAdminTabToSearchParams, parseAdminTab } from "@/lib/admin/admin-workspace";
+
+describe("admin workspace tab URL state", () => {
+  it("parses only supported admin tabs", () => {
+    expect(parseAdminTab("notes")).toBe("notes");
+    expect(parseAdminTab("content")).toBe("content");
+    expect(parseAdminTab("unknown")).toBeNull();
+    expect(parseAdminTab(null)).toBeNull();
+  });
+
+  it("writes non-default tabs and removes the default content tab", () => {
+    const notesParams = applyAdminTabToSearchParams(new URLSearchParams("foo=bar"), "notes");
+    expect(notesParams.get("foo")).toBe("bar");
+    expect(notesParams.get("tab")).toBe("notes");
+
+    const contentParams = applyAdminTabToSearchParams(notesParams, "content");
+    expect(contentParams.get("foo")).toBe("bar");
+    expect(contentParams.get("tab")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- upgrades the Admin Notes manager into a real work queue with visible note IDs, default-open filtering, search, category/context filters, and exact route/context narrowing
- persists the Admin `Notes` tab and note-filter state in the URL so refresh/deep-link flows stay on the operator's current workspace instead of snapping back to `Content`
- clarifies `P0`/`P1`/`P2` incident meanings in-product and aligns Help/Guide + recovery runbooks with the new done-archive and note-ID lookup flow
- adds focused unit and e2e coverage for filter parsing, note-ID search, archive behavior, and notes-tab refresh continuity

## Validation

- [x] `npm run lint:briefs`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] `npm run test:e2e`
- [x] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge`
- [ ] Local manual QA done on dev URL
- [ ] Vercel preview manual QA done

Automated evidence:
- `npm run verify:pre-pr` PASS on `bff83a1`
- repeat-hardening check: `PW_PORT=3118 NEXT_DIST_DIR=.next-playwright-admin-notes-core SITE_LOCK_ENABLED=0 npx playwright test tests/e2e/admin-notes-workflow.spec.ts --project=desktop-chromium --repeat-each=3` PASS
- full Playwright matrix PASS on local verify (`87 passed`, `243 skipped`)

## Risk And Rollback

- main regression risk is around admin-only notes filtering and URL-backed workspace state on `/admin`
- rollback is straightforward: revert `bff83a1`

## Perf Trend Note

- perf trend recommended `tighten` again from AW-010 baseline
- decision for this slice: `hold`
- rationale: this PR does not intentionally change route budgets or public rendering paths, so stretch-target tightening should be recorded in the next AW-010/perf-governance checkpoint instead of being coupled to admin-notes workflow work

## QA Notes

- brief: `docs/task-briefs/in-progress/2026-03-21-admin-notes-workflow-v2-core-10-10.md`
- manual Safari/iPhone and Vercel preview QA are still recommended before merge because this slice changes operator-facing admin UI
