### PR TITLE
feat(admin): add notes attachments and related links

### DIFF
--- a/app/api/admin/notes/[id]/attachments/[attachmentId]/route.ts
+++ b/app/api/admin/notes/[id]/attachments/[attachmentId]/route.ts
@@ -1,0 +1,200 @@
+import { NextResponse } from "next/server";
+import { loadHydratedAdminNoteById } from "@/lib/admin/notes-server";
+import {
+  ADMIN_NOTE_ATTACHMENT_BUCKET,
+  isUuid,
+  type AdminNoteAttachmentRow,
+} from "@/lib/admin/notes";
+import { getAdminSchemaSetupMessage, isAdminNotesSchemaMissing } from "@/lib/admin/schema";
+import { requireAdminRoleFromSupabase } from "@/lib/admin/server";
+import { createAdminSupabaseClient } from "@/lib/supabase/admin";
+import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
+
+type RouteContext = {
+  params: Promise<{ id: string; attachmentId: string }>;
+};
+
+function noStoreJson(
+  body: Record<string, unknown>,
+  init?: {
+    status?: number;
+  }
+) {
+  return NextResponse.json(body, {
+    status: init?.status ?? 200,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+function selectAttachmentFields() {
+  return `
+    id,
+    note_id,
+    file_name,
+    mime_type,
+    size_bytes,
+    storage_path,
+    created_at,
+    created_by
+  `;
+}
+
+async function resolveParams(
+  context: RouteContext
+): Promise<{ noteId: string; attachmentId: string }> {
+  const params = await context.params;
+  return {
+    noteId: params.id,
+    attachmentId: params.attachmentId,
+  };
+}
+
+export async function DELETE(_request: Request, context: RouteContext) {
+  const { noteId, attachmentId } = await resolveParams(context);
+  if (!isUuid(noteId) || !isUuid(attachmentId)) {
+    return noStoreJson({ ok: false, error: "Invalid note attachment id." }, { status: 400 });
+  }
+
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+  const gate = await requireAdminRoleFromSupabase(supabase, {
+    allowlistedEmailsRaw: process.env.ADMIN_EMAIL_ALLOWLIST,
+    minimumRole: "editor",
+  });
+
+  if (!gate.ok) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: gate.error }, { status: gate.status })
+    );
+  }
+
+  const existingResult = await supabase
+    .from("admin_note_attachments")
+    .select(selectAttachmentFields())
+    .eq("id", attachmentId)
+    .eq("note_id", noteId)
+    .maybeSingle();
+
+  if (existingResult.error) {
+    if (isAdminNotesSchemaMissing(existingResult.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: getAdminSchemaSetupMessage("notes"),
+            code: "ADMIN_SCHEMA_NOT_READY",
+          },
+          { status: 503 }
+        )
+      );
+    }
+
+    console.error("[AdminNotes] Could not load attachment before delete", existingResult.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not delete attachment right now." }, { status: 500 })
+    );
+  }
+
+  if (!existingResult.data) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Attachment not found." }, { status: 404 })
+    );
+  }
+
+  const attachmentRow = existingResult.data as unknown as AdminNoteAttachmentRow;
+  const deleteResult = await supabase
+    .from("admin_note_attachments")
+    .delete()
+    .eq("id", attachmentId)
+    .eq("note_id", noteId)
+    .select(selectAttachmentFields())
+    .maybeSingle();
+
+  if (deleteResult.error) {
+    if (isAdminNotesSchemaMissing(deleteResult.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: getAdminSchemaSetupMessage("notes"),
+            code: "ADMIN_SCHEMA_NOT_READY",
+          },
+          { status: 503 }
+        )
+      );
+    }
+
+    console.error("[AdminNotes] Could not delete attachment metadata", deleteResult.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not delete attachment right now." }, { status: 500 })
+    );
+  }
+
+  const adminSupabase = createAdminSupabaseClient();
+  const storageDelete = await adminSupabase.storage
+    .from(ADMIN_NOTE_ATTACHMENT_BUCKET)
+    .remove([attachmentRow.storage_path]);
+
+  if (storageDelete.error) {
+    const restoreResult = await supabase.from("admin_note_attachments").insert({
+      ...attachmentRow,
+    });
+
+    if (restoreResult.error) {
+      console.error("[AdminNotes] Could not restore attachment metadata after storage failure", {
+        noteId,
+        attachmentId,
+        error: restoreResult.error,
+      });
+    }
+
+    console.error("[AdminNotes] Could not remove attachment from storage", {
+      noteId,
+      attachmentId,
+      error: storageDelete.error,
+    });
+    return applySupabaseCookies(
+      noStoreJson(
+        {
+          ok: false,
+          error: "Could not delete attachment right now. Refresh and retry.",
+        },
+        { status: 500 }
+      )
+    );
+  }
+
+  const refreshed = await loadHydratedAdminNoteById({
+    supabase,
+    noteId,
+  });
+
+  if (!refreshed.ok) {
+    if (isAdminNotesSchemaMissing(refreshed.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: getAdminSchemaSetupMessage("notes"),
+            code: "ADMIN_SCHEMA_NOT_READY",
+          },
+          { status: 503 }
+        )
+      );
+    }
+
+    console.error("[AdminNotes] Could not hydrate note after attachment delete", refreshed.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not delete attachment right now." }, { status: 500 })
+    );
+  }
+
+  return applySupabaseCookies(
+    noStoreJson({
+      ok: true,
+      attachmentId,
+      item: refreshed.item,
+    })
+  );
+}

--- a/app/api/admin/notes/[id]/attachments/route.ts
+++ b/app/api/admin/notes/[id]/attachments/route.ts
@@ -1,0 +1,287 @@
+import { NextResponse } from "next/server";
+import { loadHydratedAdminNoteById, selectAdminNoteFields } from "@/lib/admin/notes-server";
+import {
+  ADMIN_NOTE_ATTACHMENT_BUCKET,
+  ADMIN_NOTE_ATTACHMENT_MAX_FILES,
+  buildAdminNoteAttachmentStoragePath,
+  isUuid,
+  validateAdminNoteAttachment,
+} from "@/lib/admin/notes";
+import { getAdminSchemaSetupMessage, isAdminNotesSchemaMissing } from "@/lib/admin/schema";
+import { requireAdminRoleFromSupabase } from "@/lib/admin/server";
+import { createAdminSupabaseClient } from "@/lib/supabase/admin";
+import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+function noStoreJson(
+  body: Record<string, unknown>,
+  init?: {
+    status?: number;
+  }
+) {
+  return NextResponse.json(body, {
+    status: init?.status ?? 200,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+function selectAttachmentFields() {
+  return `
+    id,
+    note_id,
+    file_name,
+    mime_type,
+    size_bytes,
+    storage_path,
+    created_at,
+    created_by
+  `;
+}
+
+async function resolveNoteId(context: RouteContext): Promise<string> {
+  const params = await context.params;
+  return params.id;
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  const noteId = await resolveNoteId(context);
+  if (!isUuid(noteId)) {
+    return noStoreJson({ ok: false, error: "Invalid note id." }, { status: 400 });
+  }
+
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+  const gate = await requireAdminRoleFromSupabase(supabase, {
+    allowlistedEmailsRaw: process.env.ADMIN_EMAIL_ALLOWLIST,
+    minimumRole: "editor",
+  });
+
+  if (!gate.ok) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: gate.error }, { status: gate.status })
+    );
+  }
+
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.includes("multipart/form-data")) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Unsupported content type." }, { status: 415 })
+    );
+  }
+
+  const noteResult = await supabase
+    .from("admin_notes")
+    .select(selectAdminNoteFields())
+    .eq("id", noteId)
+    .maybeSingle();
+
+  if (noteResult.error) {
+    if (isAdminNotesSchemaMissing(noteResult.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: getAdminSchemaSetupMessage("notes"),
+            code: "ADMIN_SCHEMA_NOT_READY",
+          },
+          { status: 503 }
+        )
+      );
+    }
+
+    console.error("[AdminNotes] Could not load note before attachment upload", noteResult.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not upload attachments right now." }, { status: 500 })
+    );
+  }
+
+  if (!noteResult.data) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Note not found." }, { status: 404 })
+    );
+  }
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Invalid form data." }, { status: 400 })
+    );
+  }
+
+  const listedFiles = formData.getAll("files");
+  const fileEntries = listedFiles.length > 0 ? listedFiles : [formData.get("file")].filter(Boolean);
+  if (fileEntries.length === 0) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Attach at least one image." }, { status: 400 })
+    );
+  }
+
+  if (fileEntries.length > ADMIN_NOTE_ATTACHMENT_MAX_FILES) {
+    return applySupabaseCookies(
+      noStoreJson(
+        {
+          ok: false,
+          error: `Upload at most ${ADMIN_NOTE_ATTACHMENT_MAX_FILES} images at a time.`,
+        },
+        { status: 400 }
+      )
+    );
+  }
+
+  const adminSupabase = createAdminSupabaseClient();
+  const attachmentRows: Array<{
+    id: string;
+    note_id: string;
+    file_name: string;
+    mime_type: string;
+    size_bytes: number;
+    storage_path: string;
+    created_by: string;
+  }> = [];
+  const uploadedPaths: string[] = [];
+
+  for (const entry of fileEntries) {
+    if (!(entry instanceof File)) {
+      return applySupabaseCookies(
+        noStoreJson({ ok: false, error: "Attach valid image files only." }, { status: 400 })
+      );
+    }
+
+    const validated = validateAdminNoteAttachment({
+      fileName: entry.name,
+      mimeType: entry.type,
+      sizeBytes: entry.size,
+    });
+
+    if (!validated.ok) {
+      return applySupabaseCookies(
+        noStoreJson({ ok: false, error: validated.error }, { status: 400 })
+      );
+    }
+
+    const attachmentId = crypto.randomUUID();
+    const storagePath = buildAdminNoteAttachmentStoragePath({
+      noteId,
+      attachmentId,
+      fileName: validated.value.fileName,
+    });
+    const uploadResult = await adminSupabase.storage
+      .from(ADMIN_NOTE_ATTACHMENT_BUCKET)
+      .upload(storagePath, entry, {
+        contentType: validated.value.mimeType,
+        upsert: false,
+      });
+
+    if (uploadResult.error) {
+      if (uploadedPaths.length > 0) {
+        await adminSupabase.storage.from(ADMIN_NOTE_ATTACHMENT_BUCKET).remove(uploadedPaths);
+      }
+
+      console.error("[AdminNotes] Could not upload attachment", {
+        noteId,
+        fileName: validated.value.fileName,
+        error: uploadResult.error,
+      });
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: "Could not upload attachments right now. Refresh and retry.",
+          },
+          { status: 500 }
+        )
+      );
+    }
+
+    uploadedPaths.push(storagePath);
+    attachmentRows.push({
+      id: attachmentId,
+      note_id: noteId,
+      file_name: validated.value.fileName,
+      mime_type: validated.value.mimeType,
+      size_bytes: validated.value.sizeBytes,
+      storage_path: storagePath,
+      created_by: gate.user.id,
+    });
+  }
+
+  const insertResult = await supabase
+    .from("admin_note_attachments")
+    .insert(attachmentRows)
+    .select(selectAttachmentFields());
+
+  if (insertResult.error) {
+    await adminSupabase.storage.from(ADMIN_NOTE_ATTACHMENT_BUCKET).remove(uploadedPaths);
+
+    if (isAdminNotesSchemaMissing(insertResult.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: getAdminSchemaSetupMessage("notes"),
+            code: "ADMIN_SCHEMA_NOT_READY",
+          },
+          { status: 503 }
+        )
+      );
+    }
+
+    console.error("[AdminNotes] Could not save attachment metadata", insertResult.error);
+    return applySupabaseCookies(
+      noStoreJson(
+        {
+          ok: false,
+          error: "Could not save attachment metadata right now. Refresh and retry.",
+        },
+        { status: 500 }
+      )
+    );
+  }
+
+  const refreshed = await loadHydratedAdminNoteById({
+    supabase,
+    noteId,
+  });
+
+  if (!refreshed.ok) {
+    if (isAdminNotesSchemaMissing(refreshed.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: getAdminSchemaSetupMessage("notes"),
+            code: "ADMIN_SCHEMA_NOT_READY",
+          },
+          { status: 503 }
+        )
+      );
+    }
+
+    console.error("[AdminNotes] Could not hydrate note after attachment upload", refreshed.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not upload attachments right now." }, { status: 500 })
+    );
+  }
+
+  if (!refreshed.item) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Note not found." }, { status: 404 })
+    );
+  }
+
+  return applySupabaseCookies(
+    noStoreJson(
+      {
+        ok: true,
+        item: refreshed.item,
+      },
+      { status: 201 }
+    )
+  );
+}

--- a/app/api/admin/notes/[id]/links/[relatedNoteId]/route.ts
+++ b/app/api/admin/notes/[id]/links/[relatedNoteId]/route.ts
@@ -1,0 +1,127 @@
+import { NextResponse } from "next/server";
+import { loadHydratedAdminNoteById } from "@/lib/admin/notes-server";
+import { canonicalizeAdminNoteLinkPair, isUuid } from "@/lib/admin/notes";
+import { getAdminSchemaSetupMessage, isAdminNotesSchemaMissing } from "@/lib/admin/schema";
+import { requireAdminRoleFromSupabase } from "@/lib/admin/server";
+import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
+
+type RouteContext = {
+  params: Promise<{ id: string; relatedNoteId: string }>;
+};
+
+function noStoreJson(
+  body: Record<string, unknown>,
+  init?: {
+    status?: number;
+  }
+) {
+  return NextResponse.json(body, {
+    status: init?.status ?? 200,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+async function resolveParams(
+  context: RouteContext
+): Promise<{ noteId: string; relatedNoteId: string }> {
+  const params = await context.params;
+  return {
+    noteId: params.id,
+    relatedNoteId: params.relatedNoteId,
+  };
+}
+
+export async function DELETE(_request: Request, context: RouteContext) {
+  const { noteId, relatedNoteId } = await resolveParams(context);
+  if (!isUuid(noteId) || !isUuid(relatedNoteId)) {
+    return noStoreJson({ ok: false, error: "Invalid related note id." }, { status: 400 });
+  }
+
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+  const gate = await requireAdminRoleFromSupabase(supabase, {
+    allowlistedEmailsRaw: process.env.ADMIN_EMAIL_ALLOWLIST,
+    minimumRole: "editor",
+  });
+
+  if (!gate.ok) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: gate.error }, { status: gate.status })
+    );
+  }
+
+  const canonical = canonicalizeAdminNoteLinkPair(noteId, relatedNoteId);
+  if (!canonical.ok) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: canonical.error }, { status: 400 })
+    );
+  }
+
+  const deleteResult = await supabase
+    .from("admin_note_links")
+    .delete()
+    .eq("note_id", canonical.value.noteId)
+    .eq("related_note_id", canonical.value.relatedNoteId)
+    .select("note_id, related_note_id")
+    .maybeSingle();
+
+  if (deleteResult.error) {
+    if (isAdminNotesSchemaMissing(deleteResult.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: getAdminSchemaSetupMessage("notes"),
+            code: "ADMIN_SCHEMA_NOT_READY",
+          },
+          { status: 503 }
+        )
+      );
+    }
+
+    console.error("[AdminNotes] Could not remove related note link", deleteResult.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not unlink notes right now." }, { status: 500 })
+    );
+  }
+
+  if (!deleteResult.data) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Related note link not found." }, { status: 404 })
+    );
+  }
+
+  const refreshed = await loadHydratedAdminNoteById({
+    supabase,
+    noteId,
+  });
+
+  if (!refreshed.ok) {
+    if (isAdminNotesSchemaMissing(refreshed.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: getAdminSchemaSetupMessage("notes"),
+            code: "ADMIN_SCHEMA_NOT_READY",
+          },
+          { status: 503 }
+        )
+      );
+    }
+
+    console.error("[AdminNotes] Could not hydrate note after unlink", refreshed.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not unlink notes right now." }, { status: 500 })
+    );
+  }
+
+  return applySupabaseCookies(
+    noStoreJson({
+      ok: true,
+      relatedNoteId,
+      item: refreshed.item,
+    })
+  );
+}

--- a/app/api/admin/notes/[id]/links/route.ts
+++ b/app/api/admin/notes/[id]/links/route.ts
@@ -1,0 +1,190 @@
+import { NextResponse } from "next/server";
+import { loadHydratedAdminNoteById, selectAdminNoteFields } from "@/lib/admin/notes-server";
+import { canonicalizeAdminNoteLinkPair, isUuid } from "@/lib/admin/notes";
+import { getAdminSchemaSetupMessage, isAdminNotesSchemaMissing } from "@/lib/admin/schema";
+import { requireAdminRoleFromSupabase } from "@/lib/admin/server";
+import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+function noStoreJson(
+  body: Record<string, unknown>,
+  init?: {
+    status?: number;
+  }
+) {
+  return NextResponse.json(body, {
+    status: init?.status ?? 200,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+async function resolveNoteId(context: RouteContext): Promise<string> {
+  const params = await context.params;
+  return params.id;
+}
+
+function selectLinkFields() {
+  return `
+    note_id,
+    related_note_id,
+    created_at,
+    created_by
+  `;
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  const noteId = await resolveNoteId(context);
+  if (!isUuid(noteId)) {
+    return noStoreJson({ ok: false, error: "Invalid note id." }, { status: 400 });
+  }
+
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+  const gate = await requireAdminRoleFromSupabase(supabase, {
+    allowlistedEmailsRaw: process.env.ADMIN_EMAIL_ALLOWLIST,
+    minimumRole: "editor",
+  });
+
+  if (!gate.ok) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: gate.error }, { status: gate.status })
+    );
+  }
+
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Unsupported content type." }, { status: 415 })
+    );
+  }
+
+  let payload: unknown = null;
+  try {
+    payload = await request.json();
+  } catch {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Invalid JSON." }, { status: 400 })
+    );
+  }
+
+  const relatedNoteId =
+    payload && typeof payload === "object" && "relatedNoteId" in payload
+      ? (payload as { relatedNoteId?: unknown }).relatedNoteId
+      : null;
+
+  const canonical = canonicalizeAdminNoteLinkPair(
+    noteId,
+    typeof relatedNoteId === "string" ? relatedNoteId : ""
+  );
+  if (!canonical.ok) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: canonical.error }, { status: 400 })
+    );
+  }
+
+  const notesResult = await supabase
+    .from("admin_notes")
+    .select(selectAdminNoteFields())
+    .in("id", [canonical.value.noteId, canonical.value.relatedNoteId]);
+
+  if (notesResult.error) {
+    if (isAdminNotesSchemaMissing(notesResult.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: getAdminSchemaSetupMessage("notes"),
+            code: "ADMIN_SCHEMA_NOT_READY",
+          },
+          { status: 503 }
+        )
+      );
+    }
+
+    console.error("[AdminNotes] Could not validate related note ids", notesResult.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not link notes right now." }, { status: 500 })
+    );
+  }
+
+  if ((notesResult.data ?? []).length !== 2) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Related note not found." }, { status: 404 })
+    );
+  }
+
+  const insertResult = await supabase
+    .from("admin_note_links")
+    .insert({
+      note_id: canonical.value.noteId,
+      related_note_id: canonical.value.relatedNoteId,
+      created_by: gate.user.id,
+    })
+    .select(selectLinkFields())
+    .maybeSingle();
+
+  if (insertResult.error && insertResult.error.code !== "23505") {
+    if (isAdminNotesSchemaMissing(insertResult.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: getAdminSchemaSetupMessage("notes"),
+            code: "ADMIN_SCHEMA_NOT_READY",
+          },
+          { status: 503 }
+        )
+      );
+    }
+
+    console.error("[AdminNotes] Could not insert related note link", insertResult.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not link notes right now." }, { status: 500 })
+    );
+  }
+
+  const refreshed = await loadHydratedAdminNoteById({
+    supabase,
+    noteId,
+  });
+
+  if (!refreshed.ok) {
+    if (isAdminNotesSchemaMissing(refreshed.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: getAdminSchemaSetupMessage("notes"),
+            code: "ADMIN_SCHEMA_NOT_READY",
+          },
+          { status: 503 }
+        )
+      );
+    }
+
+    console.error("[AdminNotes] Could not hydrate note after linking", refreshed.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not link notes right now." }, { status: 500 })
+    );
+  }
+
+  if (!refreshed.item) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Note not found." }, { status: 404 })
+    );
+  }
+
+  return applySupabaseCookies(
+    noStoreJson(
+      {
+        ok: true,
+        item: refreshed.item,
+      },
+      { status: 201 }
+    )
+  );
+}

--- a/app/api/admin/notes/[id]/route.ts
+++ b/app/api/admin/notes/[id]/route.ts
@@ -1,10 +1,16 @@
 import { NextResponse } from "next/server";
-import { parseUpdateAdminNotePayload } from "@/lib/admin/notes";
+import { hydrateAdminNoteRows, selectAdminNoteFields } from "@/lib/admin/notes-server";
+import {
+  ADMIN_NOTE_ATTACHMENT_BUCKET,
+  isUuid,
+  parseUpdateAdminNotePayload,
+  type AdminNoteAttachmentRow,
+  type AdminNoteRow,
+} from "@/lib/admin/notes";
 import { getAdminSchemaSetupMessage, isAdminNotesSchemaMissing } from "@/lib/admin/schema";
 import { requireAdminRoleFromSupabase } from "@/lib/admin/server";
+import { createAdminSupabaseClient } from "@/lib/supabase/admin";
 import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
-
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 type RouteContext = {
   params: Promise<{ id: string }>;
@@ -24,25 +30,17 @@ function noStoreJson(
   });
 }
 
-function selectedFields() {
+function selectAttachmentMutationFields() {
   return `
     id,
-    title,
-    body,
-    category,
-    note_date,
-    is_done,
-    context_type,
-    context_ref,
-    created_by,
-    updated_by,
+    note_id,
+    file_name,
+    mime_type,
+    size_bytes,
+    storage_path,
     created_at,
-    updated_at
+    created_by
   `;
-}
-
-function isUuid(value: string): boolean {
-  return UUID_REGEX.test(value);
 }
 
 async function resolveNoteId(context: RouteContext): Promise<string> {
@@ -96,13 +94,14 @@ export async function PATCH(request: Request, context: RouteContext) {
       ...(parsed.value.body !== undefined ? { body: parsed.value.body } : {}),
       ...(parsed.value.category !== undefined ? { category: parsed.value.category } : {}),
       ...(parsed.value.noteDate !== undefined ? { note_date: parsed.value.noteDate } : {}),
+      ...(parsed.value.priority !== undefined ? { priority: parsed.value.priority } : {}),
       ...(parsed.value.isDone !== undefined ? { is_done: parsed.value.isDone } : {}),
       ...(parsed.value.contextType !== undefined ? { context_type: parsed.value.contextType } : {}),
       ...(parsed.value.contextRef !== undefined ? { context_ref: parsed.value.contextRef } : {}),
       updated_by: gate.user.id,
     })
     .eq("id", noteId)
-    .select(selectedFields())
+    .select(selectAdminNoteFields())
     .maybeSingle();
 
   if (updateResult.error) {
@@ -131,10 +130,35 @@ export async function PATCH(request: Request, context: RouteContext) {
     );
   }
 
+  const hydrated = await hydrateAdminNoteRows({
+    supabase,
+    rows: [updateResult.data as unknown as AdminNoteRow],
+  });
+
+  if (!hydrated.ok) {
+    if (isAdminNotesSchemaMissing(hydrated.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: getAdminSchemaSetupMessage("notes"),
+            code: "ADMIN_SCHEMA_NOT_READY",
+          },
+          { status: 503 }
+        )
+      );
+    }
+
+    console.error("[AdminNotes] Could not hydrate updated note", hydrated.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not update note right now." }, { status: 500 })
+    );
+  }
+
   return applySupabaseCookies(
     noStoreJson({
       ok: true,
-      item: updateResult.data,
+      item: hydrated.items[0],
     })
   );
 }
@@ -155,6 +179,100 @@ export async function DELETE(_request: Request, context: RouteContext) {
     return applySupabaseCookies(
       noStoreJson({ ok: false, error: gate.error }, { status: gate.status })
     );
+  }
+
+  const attachmentsResult = await supabase
+    .from("admin_note_attachments")
+    .select(selectAttachmentMutationFields())
+    .eq("note_id", noteId)
+    .order("created_at", { ascending: true });
+
+  if (attachmentsResult.error) {
+    if (isAdminNotesSchemaMissing(attachmentsResult.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: getAdminSchemaSetupMessage("notes"),
+            code: "ADMIN_SCHEMA_NOT_READY",
+          },
+          { status: 503 }
+        )
+      );
+    }
+
+    console.error("[AdminNotes] Could not load note attachments", attachmentsResult.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not delete note right now." }, { status: 500 })
+    );
+  }
+
+  const attachmentRows = (attachmentsResult.data ?? []) as unknown as AdminNoteAttachmentRow[];
+
+  if (attachmentRows.length > 0) {
+    const deleteAttachmentsResult = await supabase
+      .from("admin_note_attachments")
+      .delete()
+      .eq("note_id", noteId)
+      .select(selectAttachmentMutationFields());
+
+    if (deleteAttachmentsResult.error) {
+      if (isAdminNotesSchemaMissing(deleteAttachmentsResult.error)) {
+        return applySupabaseCookies(
+          noStoreJson(
+            {
+              ok: false,
+              error: getAdminSchemaSetupMessage("notes"),
+              code: "ADMIN_SCHEMA_NOT_READY",
+            },
+            { status: 503 }
+          )
+        );
+      }
+
+      console.error(
+        "[AdminNotes] Could not delete note attachments",
+        deleteAttachmentsResult.error
+      );
+      return applySupabaseCookies(
+        noStoreJson({ ok: false, error: "Could not delete note right now." }, { status: 500 })
+      );
+    }
+
+    const adminSupabase = createAdminSupabaseClient();
+    const storageDelete = await adminSupabase.storage
+      .from(ADMIN_NOTE_ATTACHMENT_BUCKET)
+      .remove(attachmentRows.map((row) => row.storage_path));
+
+    if (storageDelete.error) {
+      const restoreResult = await supabase
+        .from("admin_note_attachments")
+        .insert(attachmentRows.map((row) => ({ ...row })));
+
+      if (restoreResult.error) {
+        console.error("[AdminNotes] Could not restore attachment metadata after storage failure", {
+          noteId,
+          attachmentIds: attachmentRows.map((row) => row.id),
+          error: restoreResult.error,
+        });
+      }
+
+      console.error("[AdminNotes] Could not remove note attachments from storage", {
+        noteId,
+        attachmentIds: attachmentRows.map((row) => row.id),
+        error: storageDelete.error,
+      });
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error:
+              "Could not delete note attachments right now. Refresh and retry so storage cleanup stays complete.",
+          },
+          { status: 500 }
+        )
+      );
+    }
   }
 
   const deleteResult = await supabase
@@ -180,7 +298,16 @@ export async function DELETE(_request: Request, context: RouteContext) {
 
     console.error("[AdminNotes] Could not delete note", deleteResult.error);
     return applySupabaseCookies(
-      noStoreJson({ ok: false, error: "Could not delete note right now." }, { status: 500 })
+      noStoreJson(
+        {
+          ok: false,
+          error:
+            attachmentRows.length > 0
+              ? "Attachments were removed, but the note could not be deleted. Refresh and retry delete."
+              : "Could not delete note right now.",
+        },
+        { status: 500 }
+      )
     );
   }
 

--- a/app/api/admin/notes/route.ts
+++ b/app/api/admin/notes/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { hydrateAdminNoteRows, selectAdminNoteFields } from "@/lib/admin/notes-server";
 import {
   deriveCourseModuleRefFromLessonRef,
   parseAdminNoteContextInput,
@@ -25,23 +26,6 @@ function noStoreJson(
       "Cache-Control": "no-store",
     },
   });
-}
-
-function selectedFields() {
-  return `
-    id,
-    title,
-    body,
-    category,
-    note_date,
-    is_done,
-    context_type,
-    context_ref,
-    created_by,
-    updated_by,
-    created_at,
-    updated_at
-  `;
 }
 
 export async function GET(request: Request) {
@@ -104,7 +88,7 @@ export async function GET(request: Request) {
 
     const lessonResult = await supabase
       .from("admin_notes")
-      .select(selectedFields())
+      .select(selectAdminNoteFields())
       .eq("context_type", "course_lesson")
       .in("context_ref", lessonLookupRefs)
       .order("note_date", { ascending: false })
@@ -140,7 +124,7 @@ export async function GET(request: Request) {
     if (moduleLookupRefs.length > 0) {
       const moduleResult = await supabase
         .from("admin_notes")
-        .select(selectedFields())
+        .select(selectAdminNoteFields())
         .eq("context_type", "course_module")
         .in("context_ref", moduleLookupRefs)
         .order("note_date", { ascending: false })
@@ -178,18 +162,45 @@ export async function GET(request: Request) {
     const deduped = Array.from(new Map(merged.map((item) => [item.id, item])).values()).sort(
       sortAdminNotesByNewest
     );
+    const hydrated = await hydrateAdminNoteRows({
+      supabase,
+      rows: deduped,
+    });
+
+    if (!hydrated.ok) {
+      if (isAdminNotesSchemaMissing(hydrated.error)) {
+        return applySupabaseCookies(
+          noStoreJson({
+            ok: true,
+            items: [],
+            schemaReady: false,
+            warning: getAdminSchemaSetupMessage("notes"),
+          })
+        );
+      }
+
+      console.error("[AdminNotes] Could not hydrate notes", hydrated.error);
+      return applySupabaseCookies(
+        noStoreJson({
+          ok: true,
+          items: [],
+          schemaReady: false,
+          warning: getAdminSchemaSetupMessage("notes"),
+        })
+      );
+    }
 
     return applySupabaseCookies(
       noStoreJson({
         ok: true,
-        items: deduped,
+        items: hydrated.items,
         schemaReady: true,
         warning: null,
       })
     );
   }
 
-  let query = supabase.from("admin_notes").select(selectedFields());
+  let query = supabase.from("admin_notes").select(selectAdminNoteFields());
 
   if (contextFilter.value) {
     const lookupRefs = resolveAdminNoteContextLookupRefs({
@@ -234,10 +245,38 @@ export async function GET(request: Request) {
     );
   }
 
+  const hydrated = await hydrateAdminNoteRows({
+    supabase,
+    rows: (result.data ?? []) as unknown as AdminNoteRow[],
+  });
+
+  if (!hydrated.ok) {
+    if (isAdminNotesSchemaMissing(hydrated.error)) {
+      return applySupabaseCookies(
+        noStoreJson({
+          ok: true,
+          items: [],
+          schemaReady: false,
+          warning: getAdminSchemaSetupMessage("notes"),
+        })
+      );
+    }
+
+    console.error("[AdminNotes] Could not hydrate notes", hydrated.error);
+    return applySupabaseCookies(
+      noStoreJson({
+        ok: true,
+        items: [],
+        schemaReady: false,
+        warning: getAdminSchemaSetupMessage("notes"),
+      })
+    );
+  }
+
   return applySupabaseCookies(
     noStoreJson({
       ok: true,
-      items: result.data ?? [],
+      items: hydrated.items,
       schemaReady: true,
       warning: null,
     })
@@ -285,13 +324,14 @@ export async function POST(request: Request) {
       body: parsed.value.body,
       category: parsed.value.category,
       note_date: parsed.value.noteDate,
+      priority: parsed.value.priority,
       is_done: parsed.value.isDone,
       context_type: parsed.value.contextType,
       context_ref: parsed.value.contextRef,
       created_by: gate.user.id,
       updated_by: gate.user.id,
     })
-    .select(selectedFields())
+    .select(selectAdminNoteFields())
     .single();
 
   if (insertResult.error || !insertResult.data) {
@@ -314,11 +354,36 @@ export async function POST(request: Request) {
     );
   }
 
+  const hydrated = await hydrateAdminNoteRows({
+    supabase,
+    rows: [insertResult.data as unknown as AdminNoteRow],
+  });
+
+  if (!hydrated.ok) {
+    if (isAdminNotesSchemaMissing(hydrated.error)) {
+      return applySupabaseCookies(
+        noStoreJson(
+          {
+            ok: false,
+            error: getAdminSchemaSetupMessage("notes"),
+            code: "ADMIN_SCHEMA_NOT_READY",
+          },
+          { status: 503 }
+        )
+      );
+    }
+
+    console.error("[AdminNotes] Could not hydrate created note", hydrated.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not save note right now." }, { status: 500 })
+    );
+  }
+
   return applySupabaseCookies(
     noStoreJson(
       {
         ok: true,
-        item: insertResult.data,
+        item: hydrated.items[0],
       },
       { status: 201 }
     )

--- a/components/admin/AdminContextNotesPanel.tsx
+++ b/components/admin/AdminContextNotesPanel.tsx
@@ -3,12 +3,12 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { AdminCategoryRow } from "@/lib/admin/categories";
 import type { AdminNoteContextType } from "@/lib/admin/note-context";
-import type { AdminNoteRow } from "@/lib/admin/notes";
+import type { AdminNoteItem } from "@/lib/admin/notes";
 
 type AdminNotesResponse =
   | {
       ok: true;
-      items: AdminNoteRow[];
+      items: AdminNoteItem[];
       schemaReady?: boolean;
       warning?: string | null;
     }
@@ -20,7 +20,7 @@ type AdminNotesResponse =
 type AdminNoteCreateResponse =
   | {
       ok: true;
-      item: AdminNoteRow;
+      item: AdminNoteItem;
     }
   | {
       ok: false;
@@ -30,7 +30,7 @@ type AdminNoteCreateResponse =
 type AdminNoteUpdateResponse =
   | {
       ok: true;
-      item: AdminNoteRow;
+      item: AdminNoteItem;
     }
   | {
       ok: false;
@@ -98,7 +98,7 @@ function formatDateLabel(value: string): string {
   }).format(date);
 }
 
-function toFormState(note: AdminNoteRow): FormState {
+function toFormState(note: AdminNoteItem): FormState {
   return {
     title: note.title,
     body: note.body,
@@ -125,7 +125,7 @@ export default function AdminContextNotesPanel({
   const [authorized, setAuthorized] = useState<boolean | null>(null);
   const [expanded, setExpanded] = useState(!collapsedByDefault);
   const [loading, setLoading] = useState(false);
-  const [items, setItems] = useState<AdminNoteRow[]>([]);
+  const [items, setItems] = useState<AdminNoteItem[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [actionNotice, setActionNotice] = useState<string | null>(null);
@@ -222,7 +222,7 @@ export default function AdminContextNotesPanel({
     void loadNotes();
   }, [loadNotes]);
 
-  function startEdit(item: AdminNoteRow) {
+  function startEdit(item: AdminNoteItem) {
     if (updatingId || deletingId) return;
     setActionError(null);
     setActionNotice(null);
@@ -318,7 +318,7 @@ export default function AdminContextNotesPanel({
     }
   }
 
-  async function toggleDone(item: AdminNoteRow) {
+  async function toggleDone(item: AdminNoteItem) {
     if (updatingId || deletingId || editingId) return;
     setActionError(null);
     setActionNotice(null);
@@ -351,7 +351,7 @@ export default function AdminContextNotesPanel({
     }
   }
 
-  async function handleDelete(item: AdminNoteRow) {
+  async function handleDelete(item: AdminNoteItem) {
     if (updatingId || deletingId) return;
     const confirmed = window.confirm(`Delete note "${item.title}"?`);
     if (!confirmed) return;

--- a/components/admin/AdminHelpCenter.tsx
+++ b/components/admin/AdminHelpCenter.tsx
@@ -16,7 +16,7 @@ type ActionGroup = {
   actions: Array<{ label: string; meaning: string }>;
 };
 
-const LAST_UPDATED = "2026-03-21";
+const LAST_UPDATED = "2026-03-22";
 
 const QUICK_ACTIONS = [
   { id: "overview", label: "Start here" },
@@ -64,9 +64,9 @@ const DASHBOARD_TABS: TabGuide[] = [
   {
     name: "Notes",
     primaryJob:
-      "Run an internal work queue with visible note IDs, search, context filters, and done archive recovery.",
+      "Run an internal work queue with visible note IDs, priority, screenshots, related-note links, context filters, and done archive recovery.",
     commonRisk:
-      "Hidden context or mixed open/done lists make the next operator pick the wrong note.",
+      "Hidden context, missing screenshots, or mixed open/done queues make the next operator pick the wrong note.",
   },
   {
     name: "Categories",
@@ -394,7 +394,7 @@ const BUTTON_GUIDE: ActionGroup[] = [
       {
         label: "Open / Done archive / All + Search + Context filters",
         meaning:
-          "Turns Notes into a work queue so operators can find the right note by ID, text, category, route, or attached content context.",
+          "Turns Notes into a work queue so operators can find the right note by ID, text, category, priority, route, or attached content context.",
       },
       {
         label: "Visible note ID",
@@ -402,8 +402,23 @@ const BUTTON_GUIDE: ActionGroup[] = [
           "Shows the stable canonical note identifier so follow-up work can reference a note without pasting the full body.",
       },
       {
+        label: "Priority",
+        meaning:
+          "Marks urgency separately from category. Urgent/high notes should surface first in the work queue.",
+      },
+      {
+        label: "Add images / Delete image",
+        meaning:
+          "Attach admin-only screenshots for memory/debugging. Delete must remove both note metadata and the underlying stored image.",
+      },
+      {
+        label: "Link note / Remove link",
+        meaning: "Connects related notes by stable note ID without merging them into one record.",
+      },
+      {
         label: "Save note / Save changes / Delete",
-        meaning: "Creates, updates, or removes task notes with route/content context.",
+        meaning:
+          "Creates, updates, or removes task notes with route/content context. Save first, then add screenshots or related-note links from Edit.",
       },
       {
         label: "Save category / Delete",
@@ -533,8 +548,9 @@ const DAILY_PLAYBOOKS: Playbook[] = [
     title: "Capture review notes with context",
     steps: [
       "Open the exact page/content row you are reviewing.",
-      "Create note with category and context link, then copy the visible note ID if you need to reference it later.",
-      "Use Search + Context filters in Notes to reopen the same note quickly.",
+      "Create note with category, priority, and context link, then copy the visible note ID if you need to reference it later.",
+      "Add screenshots when the issue is visual or hard to reproduce, and link any follow-up note instead of pasting duplicate text.",
+      "Use Search + Priority + Context filters in Notes to reopen the same note quickly.",
       "Mark completion status once resolved, then use Done archive to confirm it is recoverable.",
     ],
   },

--- a/components/admin/AdminNotesManager.tsx
+++ b/components/admin/AdminNotesManager.tsx
@@ -34,17 +34,19 @@ import {
 import {
   ADMIN_INCIDENT_NOTE_CATEGORY_BY_SEVERITY,
   ADMIN_INCIDENT_NOTE_CATEGORY_OPTIONS,
+  ADMIN_NOTE_PRIORITY_VALUES,
   INCIDENT_NOTE_SEVERITIES,
   buildIncidentNoteBodyTemplate,
-  sortAdminNotesByNewest,
-  type AdminNoteRow,
+  sortAdminNotesByPriorityAndNewest,
+  type AdminNoteItem,
+  type AdminNotePriority,
   type IncidentNoteSeverity,
 } from "@/lib/admin/notes";
 
 type AdminNotesResponse =
   | {
       ok: true;
-      items: AdminNoteRow[];
+      items: AdminNoteItem[];
       schemaReady?: boolean;
       warning?: string | null;
     }
@@ -56,7 +58,7 @@ type AdminNotesResponse =
 type AdminNoteCreateResponse =
   | {
       ok: true;
-      item: AdminNoteRow;
+      item: AdminNoteItem;
     }
   | {
       ok: false;
@@ -66,7 +68,7 @@ type AdminNoteCreateResponse =
 type AdminNoteUpdateResponse =
   | {
       ok: true;
-      item: AdminNoteRow;
+      item: AdminNoteItem | null;
     }
   | {
       ok: false;
@@ -125,6 +127,7 @@ type FormState = {
   title: string;
   category: string;
   noteDate: string;
+  priority: AdminNotePriority;
   body: string;
   isDone: boolean;
   contextType: AdminNoteContextType | "";
@@ -148,6 +151,7 @@ const INITIAL_FORM: FormState = {
   title: "",
   category: "General",
   noteDate: todayDateInputValue(),
+  priority: "normal",
   body: "",
   isDone: false,
   contextType: "",
@@ -179,11 +183,12 @@ function formatDateLabel(value: string): string {
   }).format(date);
 }
 
-function toFormState(note: AdminNoteRow): FormState {
+function toFormState(note: AdminNoteItem): FormState {
   return {
     title: note.title,
     category: note.category,
     noteDate: note.note_date,
+    priority: note.priority,
     body: note.body,
     isDone: note.is_done,
     contextType:
@@ -194,6 +199,31 @@ function toFormState(note: AdminNoteRow): FormState {
     contextRef: note.context_ref ?? "",
     contextModuleRef: "",
   };
+}
+
+function formatPriorityLabel(priority: AdminNotePriority): string {
+  return priority.charAt(0).toUpperCase() + priority.slice(1);
+}
+
+function priorityBadgeClasses(priority: AdminNotePriority): string {
+  switch (priority) {
+    case "urgent":
+      return "border-rose-200 bg-rose-50 text-rose-700";
+    case "high":
+      return "border-amber-200 bg-amber-50 text-amber-800";
+    case "normal":
+      return "border-blue-200 bg-blue-50 text-blue-700";
+    case "low":
+    default:
+      return "border-slate-200 bg-slate-100 text-slate-700";
+  }
+}
+
+function formatAttachmentSize(sizeBytes: number): string {
+  if (sizeBytes < 1024) return `${sizeBytes} B`;
+  const sizeKb = sizeBytes / 1024;
+  if (sizeKb < 1024) return `${sizeKb.toFixed(1)} KB`;
+  return `${(sizeKb / 1024).toFixed(1)} MB`;
 }
 
 function hasPartialContextSelection(contextType: string, contextRef: string): boolean {
@@ -210,7 +240,7 @@ export default function AdminNotesManager() {
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [items, setItems] = useState<AdminNoteRow[]>([]);
+  const [items, setItems] = useState<AdminNoteItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [warning, setWarning] = useState<string | null>(null);
@@ -226,6 +256,15 @@ export default function AdminNotesManager() {
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editState, setEditState] = useState<FormState | null>(null);
+  const [uploadingNoteId, setUploadingNoteId] = useState<string | null>(null);
+  const [deletingAttachmentId, setDeletingAttachmentId] = useState<string | null>(null);
+  const [linkingNoteId, setLinkingNoteId] = useState<string | null>(null);
+  const [unlinkingKey, setUnlinkingKey] = useState<string | null>(null);
+  const [linkDrafts, setLinkDrafts] = useState<Record<string, string>>({});
+
+  function sortNoteItems(nextItems: AdminNoteItem[]): AdminNoteItem[] {
+    return [...nextItems].sort(sortAdminNotesByPriorityAndNewest);
+  }
 
   const loadContextCatalog = useCallback(async () => {
     try {
@@ -286,7 +325,7 @@ export default function AdminNotesManager() {
         return;
       }
 
-      setItems([...payload.items].sort(sortAdminNotesByNewest));
+      setItems(sortNoteItems(payload.items));
       setSchemaReady(payload.schemaReady !== false);
       setWarning(payload.warning ?? null);
 
@@ -375,6 +414,7 @@ export default function AdminNotesManager() {
     notesFilters.query !== DEFAULT_ADMIN_NOTES_FILTER_STATE.query ||
     notesFilters.status !== DEFAULT_ADMIN_NOTES_FILTER_STATE.status ||
     notesFilters.category !== DEFAULT_ADMIN_NOTES_FILTER_STATE.category ||
+    notesFilters.priority !== DEFAULT_ADMIN_NOTES_FILTER_STATE.priority ||
     notesFilters.contextType !== DEFAULT_ADMIN_NOTES_FILTER_STATE.contextType ||
     notesFilters.contextRef !== DEFAULT_ADMIN_NOTES_FILTER_STATE.contextRef;
 
@@ -453,6 +493,7 @@ export default function AdminNotesManager() {
       ...prev,
       title: prev.title || `Incident ${severity} - ${today}`,
       category: ADMIN_INCIDENT_NOTE_CATEGORY_BY_SEVERITY[severity],
+      priority: severity === "P0" ? "urgent" : severity === "P1" ? "high" : "normal",
       body: buildIncidentNoteBodyTemplate(severity),
       noteDate: todayDateInputValue(),
       isDone: false,
@@ -487,13 +528,13 @@ export default function AdminNotesManager() {
       }
 
       setItems((prev) =>
-        [...prev.filter((entry) => entry.id !== payload.item.id), payload.item].sort(
-          sortAdminNotesByNewest
-        )
+        sortNoteItems([...prev.filter((entry) => entry.id !== payload.item.id), payload.item])
       );
       setFormState(INITIAL_FORM);
       setActionNotice(
-        payload.item.is_done ? "Note saved to done archive." : "Note saved to open work queue."
+        payload.item.is_done
+          ? "Note saved to done archive."
+          : "Note saved to open work queue. Use Edit to add images or related notes."
       );
     } catch {
       setActionError("Could not save note.");
@@ -502,8 +543,16 @@ export default function AdminNotesManager() {
     }
   }
 
-  function startEdit(item: AdminNoteRow) {
-    if (updatingId || deletingId) return;
+  function startEdit(item: AdminNoteItem) {
+    if (
+      updatingId ||
+      deletingId ||
+      uploadingNoteId ||
+      deletingAttachmentId ||
+      linkingNoteId ||
+      unlinkingKey
+    )
+      return;
     setActionError(null);
     setActionNotice(null);
     const nextState = toFormState(item);
@@ -516,7 +565,15 @@ export default function AdminNotesManager() {
   }
 
   function cancelEdit() {
-    if (updatingId || deletingId) return;
+    if (
+      updatingId ||
+      deletingId ||
+      uploadingNoteId ||
+      deletingAttachmentId ||
+      linkingNoteId ||
+      unlinkingKey
+    )
+      return;
     setEditingId(null);
     setEditState(null);
   }
@@ -551,7 +608,15 @@ export default function AdminNotesManager() {
 
   async function saveEdit(itemId: string) {
     if (!editState) return;
-    if (updatingId || deletingId) return;
+    if (
+      updatingId ||
+      deletingId ||
+      uploadingNoteId ||
+      deletingAttachmentId ||
+      linkingNoteId ||
+      unlinkingKey
+    )
+      return;
 
     setActionError(null);
     setActionNotice(null);
@@ -575,10 +640,15 @@ export default function AdminNotesManager() {
         return;
       }
 
+      if (!payload.item) {
+        setActionError("Could not update note.");
+        return;
+      }
+
+      const nextItem = payload.item;
+
       setItems((prev) =>
-        prev
-          .map((entry) => (entry.id === payload.item.id ? payload.item : entry))
-          .sort(sortAdminNotesByNewest)
+        sortNoteItems(prev.map((entry) => (entry.id === nextItem.id ? nextItem : entry)))
       );
       setEditingId(null);
       setEditState(null);
@@ -590,8 +660,17 @@ export default function AdminNotesManager() {
     }
   }
 
-  async function toggleDone(item: AdminNoteRow) {
-    if (updatingId || deletingId || editingId) return;
+  async function toggleDone(item: AdminNoteItem) {
+    if (
+      updatingId ||
+      deletingId ||
+      editingId ||
+      uploadingNoteId ||
+      deletingAttachmentId ||
+      linkingNoteId ||
+      unlinkingKey
+    )
+      return;
     setActionError(null);
     setActionNotice(null);
     setUpdatingId(item.id);
@@ -614,13 +693,18 @@ export default function AdminNotesManager() {
         return;
       }
 
+      if (!payload.item) {
+        setActionError("Could not update note.");
+        return;
+      }
+
+      const nextItem = payload.item;
+
       setItems((prev) =>
-        prev
-          .map((entry) => (entry.id === payload.item.id ? payload.item : entry))
-          .sort(sortAdminNotesByNewest)
+        sortNoteItems(prev.map((entry) => (entry.id === nextItem.id ? nextItem : entry)))
       );
       setActionNotice(
-        payload.item.is_done
+        nextItem.is_done
           ? "Note marked as done and moved to done archive."
           : "Note reopened and moved to open work queue."
       );
@@ -631,8 +715,16 @@ export default function AdminNotesManager() {
     }
   }
 
-  async function handleDelete(item: AdminNoteRow) {
-    if (updatingId || deletingId) return;
+  async function handleDelete(item: AdminNoteItem) {
+    if (
+      updatingId ||
+      deletingId ||
+      uploadingNoteId ||
+      deletingAttachmentId ||
+      linkingNoteId ||
+      unlinkingKey
+    )
+      return;
     const confirmed = window.confirm(`Delete note \"${item.title}\"?`);
     if (!confirmed) return;
 
@@ -664,6 +756,159 @@ export default function AdminNotesManager() {
       setActionError("Could not delete note.");
     } finally {
       setDeletingId(null);
+    }
+  }
+
+  function applyMutatedItem(itemId: string, nextItem: AdminNoteItem | null) {
+    setItems((prev) =>
+      nextItem
+        ? sortNoteItems(prev.map((entry) => (entry.id === itemId ? nextItem : entry)))
+        : prev.filter((entry) => entry.id !== itemId)
+    );
+
+    if (!nextItem && editingId === itemId) {
+      setEditingId(null);
+      setEditState(null);
+    }
+  }
+
+  async function uploadAttachments(item: AdminNoteItem, files: FileList | null) {
+    if (!files || files.length === 0) return;
+    if (uploadingNoteId || deletingAttachmentId || linkingNoteId || unlinkingKey) return;
+
+    setActionError(null);
+    setActionNotice(null);
+    setUploadingNoteId(item.id);
+
+    try {
+      const formData = new FormData();
+      Array.from(files).forEach((file) => {
+        formData.append("files", file);
+      });
+
+      const response = await fetch(`/api/admin/notes/${item.id}/attachments`, {
+        method: "POST",
+        credentials: "same-origin",
+        body: formData,
+      });
+
+      const payload = (await response.json()) as AdminNoteUpdateResponse;
+      if (!response.ok || !payload.ok || !payload.item) {
+        setActionError(
+          payload.ok
+            ? "Could not upload attachments."
+            : (payload.error ?? "Could not upload attachments.")
+        );
+        return;
+      }
+
+      applyMutatedItem(item.id, payload.item);
+      setActionNotice(
+        payload.item.attachments.length === 1 ? "Attachment uploaded." : "Attachments uploaded."
+      );
+    } catch {
+      setActionError("Could not upload attachments.");
+    } finally {
+      setUploadingNoteId(null);
+    }
+  }
+
+  async function deleteAttachment(noteId: string, attachmentId: string) {
+    if (uploadingNoteId || deletingAttachmentId || linkingNoteId || unlinkingKey) return;
+
+    setActionError(null);
+    setActionNotice(null);
+    setDeletingAttachmentId(attachmentId);
+
+    try {
+      const response = await fetch(`/api/admin/notes/${noteId}/attachments/${attachmentId}`, {
+        method: "DELETE",
+        credentials: "same-origin",
+      });
+
+      const payload = (await response.json()) as AdminNoteUpdateResponse;
+      if (!response.ok || !payload.ok) {
+        setActionError(
+          payload.ok
+            ? "Could not delete attachment."
+            : (payload.error ?? "Could not delete attachment.")
+        );
+        return;
+      }
+
+      applyMutatedItem(noteId, payload.item);
+      setActionNotice("Attachment deleted.");
+    } catch {
+      setActionError("Could not delete attachment.");
+    } finally {
+      setDeletingAttachmentId(null);
+    }
+  }
+
+  async function addRelatedNote(noteId: string) {
+    const relatedNoteId = (linkDrafts[noteId] ?? "").trim();
+    if (!relatedNoteId) return;
+    if (uploadingNoteId || deletingAttachmentId || linkingNoteId || unlinkingKey) return;
+
+    setActionError(null);
+    setActionNotice(null);
+    setLinkingNoteId(noteId);
+
+    try {
+      const response = await fetch(`/api/admin/notes/${noteId}/links`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        credentials: "same-origin",
+        body: JSON.stringify({ relatedNoteId }),
+      });
+
+      const payload = (await response.json()) as AdminNoteUpdateResponse;
+      if (!response.ok || !payload.ok || !payload.item) {
+        setActionError(
+          payload.ok ? "Could not link note." : (payload.error ?? "Could not link note.")
+        );
+        return;
+      }
+
+      applyMutatedItem(noteId, payload.item);
+      setLinkDrafts((prev) => ({ ...prev, [noteId]: "" }));
+      setActionNotice("Related note linked.");
+    } catch {
+      setActionError("Could not link note.");
+    } finally {
+      setLinkingNoteId(null);
+    }
+  }
+
+  async function removeRelatedNote(noteId: string, relatedNoteId: string) {
+    if (uploadingNoteId || deletingAttachmentId || linkingNoteId || unlinkingKey) return;
+
+    setActionError(null);
+    setActionNotice(null);
+    setUnlinkingKey(`${noteId}:${relatedNoteId}`);
+
+    try {
+      const response = await fetch(`/api/admin/notes/${noteId}/links/${relatedNoteId}`, {
+        method: "DELETE",
+        credentials: "same-origin",
+      });
+
+      const payload = (await response.json()) as AdminNoteUpdateResponse;
+      if (!response.ok || !payload.ok) {
+        setActionError(
+          payload.ok ? "Could not unlink note." : (payload.error ?? "Could not unlink note.")
+        );
+        return;
+      }
+
+      applyMutatedItem(noteId, payload.item);
+      setActionNotice("Related note removed.");
+    } catch {
+      setActionError("Could not unlink note.");
+    } finally {
+      setUnlinkingKey(null);
     }
   }
 
@@ -747,7 +992,7 @@ export default function AdminNotesManager() {
               ) : null}
             </div>
 
-            <div className="grid gap-3 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,0.9fr)_minmax(0,0.9fr)_minmax(0,1fr)_minmax(0,1.2fr)]">
+            <div className="grid gap-3 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,0.9fr)_minmax(0,0.9fr)_minmax(0,0.9fr)_minmax(0,1fr)_minmax(0,1.2fr)]">
               <label className="space-y-1 text-sm font-medium text-slate-700">
                 <span>Search</span>
                 <input
@@ -756,7 +1001,7 @@ export default function AdminNotesManager() {
                   onChange={(e) => updateNotesFilters({ query: e.target.value })}
                   data-testid="admin-notes-search"
                   className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
-                  placeholder="Search note ID, title, text, or context"
+                  placeholder="Search note ID, title, text, attachment, or context"
                 />
               </label>
 
@@ -819,6 +1064,27 @@ export default function AdminNotesManager() {
               </label>
 
               <label className="space-y-1 text-sm font-medium text-slate-700">
+                <span>Priority</span>
+                <select
+                  value={notesFilters.priority}
+                  onChange={(e) =>
+                    updateNotesFilters({
+                      priority: e.target.value as AdminNotePriority | "",
+                    })
+                  }
+                  data-testid="admin-notes-priority-filter"
+                  className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                >
+                  <option value="">All priorities</option>
+                  {ADMIN_NOTE_PRIORITY_VALUES.map((priority) => (
+                    <option key={priority} value={priority}>
+                      {formatPriorityLabel(priority)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="space-y-1 text-sm font-medium text-slate-700">
                 <span>Context type</span>
                 <select
                   value={notesFilters.contextType}
@@ -868,9 +1134,17 @@ export default function AdminNotesManager() {
               const isUpdating = updatingId === item.id;
               const isDeleting = deletingId === item.id;
               const isEditing = editingId === item.id && editState !== null;
+              const isUploading = uploadingNoteId === item.id;
+              const isLinking = linkingNoteId === item.id;
               const editContextInvalid = isEditing
                 ? hasPartialContextSelection(editState.contextType, editState.contextRef)
                 : false;
+              const linkableNotes = items
+                .filter((entry) => entry.id !== item.id)
+                .filter(
+                  (entry) => !item.related_notes.some((relatedNote) => relatedNote.id === entry.id)
+                )
+                .sort(sortAdminNotesByPriorityAndNewest);
               return (
                 <li
                   key={item.id}
@@ -888,6 +1162,28 @@ export default function AdminNotesManager() {
                       <p className="mt-1 text-xs text-slate-500">
                         {item.category} · {formatDateLabel(item.note_date)}
                       </p>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        <span
+                          className={[
+                            "inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-semibold",
+                            priorityBadgeClasses(item.priority),
+                          ].join(" ")}
+                        >
+                          {formatPriorityLabel(item.priority)}
+                        </span>
+                        {item.attachments.length > 0 ? (
+                          <span className="inline-flex items-center rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] font-medium text-slate-700">
+                            {item.attachments.length} image
+                            {item.attachments.length === 1 ? "" : "s"}
+                          </span>
+                        ) : null}
+                        {item.related_notes.length > 0 ? (
+                          <span className="inline-flex items-center rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] font-medium text-slate-700">
+                            {item.related_notes.length} related note
+                            {item.related_notes.length === 1 ? "" : "s"}
+                          </span>
+                        ) : null}
+                      </div>
                       <p
                         className="mt-1 text-[11px] font-medium uppercase tracking-wide text-slate-500"
                         data-testid="admin-note-id"
@@ -915,7 +1211,15 @@ export default function AdminNotesManager() {
                         <input
                           type="checkbox"
                           checked={item.is_done}
-                          disabled={Boolean(updatingId || deletingId || editingId)}
+                          disabled={Boolean(
+                            updatingId ||
+                            deletingId ||
+                            editingId ||
+                            uploadingNoteId ||
+                            deletingAttachmentId ||
+                            linkingNoteId ||
+                            unlinkingKey
+                          )}
                           onChange={() => {
                             void toggleDone(item);
                           }}
@@ -925,7 +1229,15 @@ export default function AdminNotesManager() {
                       </label>
                       <button
                         type="button"
-                        disabled={Boolean(updatingId || deletingId || editingId)}
+                        disabled={Boolean(
+                          updatingId ||
+                          deletingId ||
+                          editingId ||
+                          uploadingNoteId ||
+                          deletingAttachmentId ||
+                          linkingNoteId ||
+                          unlinkingKey
+                        )}
                         onClick={() => {
                           startEdit(item);
                         }}
@@ -935,7 +1247,14 @@ export default function AdminNotesManager() {
                       </button>
                       <button
                         type="button"
-                        disabled={Boolean(updatingId || deletingId)}
+                        disabled={Boolean(
+                          updatingId ||
+                          deletingId ||
+                          uploadingNoteId ||
+                          deletingAttachmentId ||
+                          linkingNoteId ||
+                          unlinkingKey
+                        )}
                         onClick={() => {
                           void handleDelete(item);
                         }}
@@ -945,6 +1264,64 @@ export default function AdminNotesManager() {
                       </button>
                     </div>
                   </div>
+
+                  {!isEditing && item.body ? (
+                    <p className="mt-3 whitespace-pre-wrap text-sm text-slate-700">{item.body}</p>
+                  ) : null}
+
+                  {!isEditing && item.attachments.length > 0 ? (
+                    <div className="mt-3 space-y-2 rounded-lg border border-slate-200 bg-white/80 p-3">
+                      <p className="text-xs font-semibold text-slate-700">Images / screenshots</p>
+                      <div className="flex flex-wrap gap-3">
+                        {item.attachments.map((attachment) => (
+                          <a
+                            key={attachment.id}
+                            href={attachment.signed_url ?? undefined}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="group flex w-32 flex-col gap-2 rounded-lg border border-slate-200 bg-slate-50 p-2"
+                          >
+                            {attachment.signed_url ? (
+                              // eslint-disable-next-line @next/next/no-img-element
+                              <img
+                                src={attachment.signed_url}
+                                alt={attachment.file_name}
+                                className="h-20 w-full rounded-md object-cover"
+                              />
+                            ) : (
+                              <div className="flex h-20 w-full items-center justify-center rounded-md bg-slate-200 text-[11px] font-medium text-slate-600">
+                                Preview unavailable
+                              </div>
+                            )}
+                            <div className="space-y-1">
+                              <p className="truncate text-[11px] font-medium text-slate-700">
+                                {attachment.file_name}
+                              </p>
+                              <p className="text-[10px] text-slate-500">
+                                {formatAttachmentSize(attachment.size_bytes)}
+                              </p>
+                            </div>
+                          </a>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {!isEditing && item.related_notes.length > 0 ? (
+                    <div className="mt-3 space-y-2 rounded-lg border border-slate-200 bg-white/80 p-3">
+                      <p className="text-xs font-semibold text-slate-700">Related notes</p>
+                      <div className="flex flex-wrap gap-2">
+                        {item.related_notes.map((relatedNote) => (
+                          <span
+                            key={relatedNote.id}
+                            className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-[11px] text-slate-700"
+                          >
+                            {relatedNote.title} · {buildAdminNoteReferenceLabel(relatedNote.id)}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
 
                   {isEditing && editState ? (
                     <form
@@ -992,6 +1369,26 @@ export default function AdminNotesManager() {
                           }}
                           className="h-9 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-900"
                         />
+                      </label>
+
+                      <label className="space-y-1 text-xs font-medium text-slate-700">
+                        <span>Priority</span>
+                        <select
+                          value={editState.priority}
+                          onChange={(e) => {
+                            setEditField((prev) => ({
+                              ...prev,
+                              priority: e.target.value as AdminNotePriority,
+                            }));
+                          }}
+                          className="h-9 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                        >
+                          {ADMIN_NOTE_PRIORITY_VALUES.map((priority) => (
+                            <option key={priority} value={priority}>
+                              {formatPriorityLabel(priority)}
+                            </option>
+                          ))}
+                        </select>
                       </label>
 
                       <label className="space-y-1 text-xs font-medium text-slate-700 sm:col-span-2">
@@ -1163,6 +1560,191 @@ export default function AdminNotesManager() {
                         ) : null}
                       </label>
 
+                      <div className="space-y-2 rounded-lg border border-slate-200 bg-slate-50/70 p-3 sm:col-span-2">
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <div>
+                            <p className="text-xs font-semibold text-slate-900">
+                              Images / screenshots
+                            </p>
+                            <p className="mt-1 text-[11px] text-slate-600">
+                              PNG, JPEG, WEBP, or GIF up to 5 MB each. Images stay admin-only.
+                            </p>
+                          </div>
+                          <label className="inline-flex cursor-pointer items-center justify-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 transition hover:bg-slate-100">
+                            <span>{isUploading ? "Uploading…" : "Add images"}</span>
+                            <input
+                              type="file"
+                              accept="image/png,image/jpeg,image/webp,image/gif"
+                              multiple
+                              className="sr-only"
+                              data-testid="admin-note-attachment-input"
+                              disabled={Boolean(
+                                isUploading || deletingAttachmentId || updatingId || deletingId
+                              )}
+                              onChange={(e) => {
+                                void uploadAttachments(item, e.target.files);
+                                e.currentTarget.value = "";
+                              }}
+                            />
+                          </label>
+                        </div>
+
+                        {item.attachments.length > 0 ? (
+                          <ul className="space-y-2">
+                            {item.attachments.map((attachment) => {
+                              const isDeletingAttachment = deletingAttachmentId === attachment.id;
+                              return (
+                                <li
+                                  key={attachment.id}
+                                  className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-slate-200 bg-white px-3 py-2"
+                                >
+                                  <div className="flex min-w-0 items-center gap-3">
+                                    {attachment.signed_url ? (
+                                      // eslint-disable-next-line @next/next/no-img-element
+                                      <img
+                                        src={attachment.signed_url}
+                                        alt={attachment.file_name}
+                                        className="h-12 w-12 rounded-md object-cover"
+                                      />
+                                    ) : (
+                                      <div className="flex h-12 w-12 items-center justify-center rounded-md bg-slate-200 text-[10px] font-medium text-slate-600">
+                                        No preview
+                                      </div>
+                                    )}
+                                    <div className="min-w-0">
+                                      <p className="truncate text-xs font-medium text-slate-700">
+                                        {attachment.file_name}
+                                      </p>
+                                      <p className="text-[11px] text-slate-500">
+                                        {formatAttachmentSize(attachment.size_bytes)}
+                                      </p>
+                                    </div>
+                                  </div>
+                                  <div className="flex items-center gap-2">
+                                    {attachment.signed_url ? (
+                                      <a
+                                        href={attachment.signed_url}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className="inline-flex h-8 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50"
+                                      >
+                                        Open
+                                      </a>
+                                    ) : null}
+                                    <button
+                                      type="button"
+                                      data-testid="admin-note-attachment-delete"
+                                      disabled={Boolean(
+                                        isDeletingAttachment ||
+                                        isUploading ||
+                                        updatingId ||
+                                        deletingId
+                                      )}
+                                      onClick={() => {
+                                        void deleteAttachment(item.id, attachment.id);
+                                      }}
+                                      className="inline-flex h-8 items-center justify-center rounded-lg border border-rose-200 bg-white px-3 text-xs font-medium text-rose-700 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
+                                    >
+                                      {isDeletingAttachment ? "Deleting…" : "Delete image"}
+                                    </button>
+                                  </div>
+                                </li>
+                              );
+                            })}
+                          </ul>
+                        ) : (
+                          <p className="text-[11px] text-slate-600">No screenshots attached yet.</p>
+                        )}
+                      </div>
+
+                      <div className="space-y-2 rounded-lg border border-slate-200 bg-slate-50/70 p-3 sm:col-span-2">
+                        <div>
+                          <p className="text-xs font-semibold text-slate-900">Related notes</p>
+                          <p className="mt-1 text-[11px] text-slate-600">
+                            Connect follow-up notes without merging their identities.
+                          </p>
+                        </div>
+
+                        {item.related_notes.length > 0 ? (
+                          <ul className="space-y-2">
+                            {item.related_notes.map((relatedNote) => {
+                              const currentUnlinkKey = `${item.id}:${relatedNote.id}`;
+                              const isUnlinking = unlinkingKey === currentUnlinkKey;
+                              return (
+                                <li
+                                  key={relatedNote.id}
+                                  className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2"
+                                >
+                                  <div>
+                                    <p className="text-xs font-medium text-slate-700">
+                                      {relatedNote.title}
+                                    </p>
+                                    <p className="text-[11px] text-slate-500">
+                                      {formatPriorityLabel(relatedNote.priority)} ·{" "}
+                                      {buildAdminNoteReferenceLabel(relatedNote.id)}
+                                    </p>
+                                  </div>
+                                  <button
+                                    type="button"
+                                    data-testid="admin-note-related-delete"
+                                    disabled={Boolean(
+                                      isUnlinking || isLinking || updatingId || deletingId
+                                    )}
+                                    onClick={() => {
+                                      void removeRelatedNote(item.id, relatedNote.id);
+                                    }}
+                                    className="inline-flex h-8 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                                  >
+                                    {isUnlinking ? "Removing…" : "Remove link"}
+                                  </button>
+                                </li>
+                              );
+                            })}
+                          </ul>
+                        ) : (
+                          <p className="text-[11px] text-slate-600">No related notes linked yet.</p>
+                        )}
+
+                        <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+                          <select
+                            value={linkDrafts[item.id] ?? ""}
+                            onChange={(e) => {
+                              setLinkDrafts((prev) => ({
+                                ...prev,
+                                [item.id]: e.target.value,
+                              }));
+                            }}
+                            data-testid="admin-note-related-select"
+                            className="h-9 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                          >
+                            <option value="">Choose note to link</option>
+                            {linkableNotes.map((linkableNote) => (
+                              <option key={linkableNote.id} value={linkableNote.id}>
+                                {formatPriorityLabel(linkableNote.priority)} · {linkableNote.title}{" "}
+                                · {buildAdminNoteReferenceLabel(linkableNote.id)}
+                              </option>
+                            ))}
+                          </select>
+                          <button
+                            type="button"
+                            data-testid="admin-note-related-add"
+                            disabled={Boolean(
+                              !linkDrafts[item.id] ||
+                              isLinking ||
+                              unlinkingKey ||
+                              updatingId ||
+                              deletingId
+                            )}
+                            onClick={() => {
+                              void addRelatedNote(item.id);
+                            }}
+                            className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                          >
+                            {isLinking ? "Linking…" : "Link note"}
+                          </button>
+                        </div>
+                      </div>
+
                       <label className="inline-flex items-center gap-2 text-xs font-medium text-slate-700 sm:col-span-2">
                         <input
                           type="checkbox"
@@ -1179,7 +1761,15 @@ export default function AdminNotesManager() {
                         <button
                           type="submit"
                           className="inline-flex h-8 items-center justify-center rounded-lg bg-blue-600 px-3 text-xs font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
-                          disabled={Boolean(updatingId || deletingId || editContextInvalid)}
+                          disabled={Boolean(
+                            updatingId ||
+                            deletingId ||
+                            editContextInvalid ||
+                            uploadingNoteId ||
+                            deletingAttachmentId ||
+                            linkingNoteId ||
+                            unlinkingKey
+                          )}
                         >
                           {isUpdating ? "Saving…" : "Save changes"}
                         </button>
@@ -1187,7 +1777,14 @@ export default function AdminNotesManager() {
                           type="button"
                           className="inline-flex h-8 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
                           onClick={cancelEdit}
-                          disabled={Boolean(updatingId || deletingId)}
+                          disabled={Boolean(
+                            updatingId ||
+                            deletingId ||
+                            uploadingNoteId ||
+                            deletingAttachmentId ||
+                            linkingNoteId ||
+                            unlinkingKey
+                          )}
                         >
                           Cancel
                         </button>
@@ -1198,8 +1795,6 @@ export default function AdminNotesManager() {
                         </p>
                       ) : null}
                     </form>
-                  ) : item.body ? (
-                    <p className="mt-3 whitespace-pre-wrap text-sm text-slate-700">{item.body}</p>
                   ) : null}
                 </li>
               );
@@ -1218,7 +1813,10 @@ export default function AdminNotesManager() {
       <section className="rounded-2xl border border-slate-200 bg-white p-6">
         <h2 className="text-lg font-semibold text-slate-900">Create note</h2>
         <p className="mt-2 text-sm text-slate-600">
-          Store planning notes with category, date, and completion tracking.
+          Store planning notes with category, priority, date, and completion tracking.
+        </p>
+        <p className="mt-2 text-xs text-slate-500">
+          Save first, then use Edit on the new note to add screenshots or link related notes.
         </p>
         <div className="mt-3 rounded-xl border border-amber-200 bg-amber-50 p-3">
           <p className="text-xs font-semibold text-amber-900">Incident quick templates</p>
@@ -1295,6 +1893,26 @@ export default function AdminNotesManager() {
               onChange={(e) => setFormState((prev) => ({ ...prev, noteDate: e.target.value }))}
               className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
             />
+          </label>
+
+          <label className="space-y-1 text-sm font-medium text-slate-700">
+            <span>Priority</span>
+            <select
+              value={formState.priority}
+              onChange={(e) =>
+                setFormState((prev) => ({
+                  ...prev,
+                  priority: e.target.value as AdminNotePriority,
+                }))
+              }
+              className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+            >
+              {ADMIN_NOTE_PRIORITY_VALUES.map((priority) => (
+                <option key={priority} value={priority}>
+                  {formatPriorityLabel(priority)}
+                </option>
+              ))}
+            </select>
           </label>
 
           <label className="space-y-1 text-sm font-medium text-slate-700 sm:col-span-2">

--- a/docs/runbooks/admin-notes-recovery.md
+++ b/docs/runbooks/admin-notes-recovery.md
@@ -13,6 +13,8 @@ Use this runbook for AW-012 workflow `A4` stale-note reconciliation edge cases.
 - Save returns `Could not update note.` or `Could not save note.` even though another operator already changed the row.
 - A contextual note panel shows outdated title/body/status after recent edits in admin.
 - You suspect duplicate/overlapping edits on the same note.
+- Screenshot upload/delete returns an error and you are unsure whether the stored image was fully removed.
+- Related-note link/unlink returns an error and you need to confirm whether the link actually exists.
 
 ## Manual Recovery Walkthrough
 
@@ -22,17 +24,27 @@ Use this runbook for AW-012 workflow `A4` stale-note reconciliation edge cases.
 4. Re-open the target note and confirm:
    - note ID,
    - title/body/category/date,
+   - priority,
    - completion status,
    - context label (`Course Lesson`, `Product`, `Page`, etc.),
    - raw context ref/path when relevant.
-5. Re-apply only the intended delta and click `Save changes`.
-6. Confirm success notice (`Note updated.`) and verify the same row in its contextual surface (`/course` or `/plans`).
-7. If update still fails, create one incident note (P1/P2) with owner + next action and link it in AW-012 checkpoint evidence.
+5. If screenshots are involved:
+   - confirm the attachment list and image count in the note row,
+   - if delete failed, refresh once and verify whether the image is still present before retrying,
+   - if upload failed, retry only after confirming you are not looking at a stale duplicate preview.
+6. If related notes are involved:
+   - open the visible linked note IDs from Search if needed,
+   - confirm the intended link exists only once,
+   - remove and re-add the link only if the relationship is clearly wrong.
+7. Re-apply only the intended delta and click `Save changes`.
+8. Confirm success notice (`Note updated.` or attachment/link success notice) and verify the same row in its contextual surface (`/course` or `/plans`) when relevant.
+9. If update still fails, create one incident note (P1/P2) with owner + next action and link it by note ID in AW-012 checkpoint evidence.
 
 ## Pass Criteria
 
 - Recovery completes without deleting valid note history.
 - Final note state is consistent in admin list and contextual panel.
+- Attachment/image state and related-note links are consistent after one refresh.
 - AW-012 checkpoint includes branch/SHA + one-line result summary.
 
 ## Evidence Note Template (Checkpoint Entry)

--- a/docs/task-briefs/in-progress/2026-03-21-admin-notes-workflow-v2-attachments-and-linking-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-21-admin-notes-workflow-v2-attachments-and-linking-10-10.md
@@ -1,0 +1,224 @@
+# Task Brief: Admin Notes Workflow V2 Attachments And Linking (10/10)
+
+## Metadata
+
+- `id`: `2026-03-21-admin-notes-workflow-v2-attachments-and-linking-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-03-21`
+- `updated`: `2026-03-22`
+
+## Goal
+
+Admin notes can hold screenshot/image attachments, explicit priority, and related-note links with deletion that removes attachment data completely and safely.
+
+## Why This Brief Exists
+
+- Core admin notes already support text and context.
+- The next real operational needs are richer:
+  - screenshots for memory and debugging,
+  - linked notes for follow-up chains,
+  - explicit priority independent of incident category,
+  - linked notes for follow-up chains.
+- This scope is materially larger and riskier than core search/filter notes work because it introduces:
+  - storage,
+  - deletion lifecycle,
+  - richer note relationships,
+  - stronger data-integrity requirements than the core queue/filter slice.
+- Quick capture from across the app is intentionally split into a later follow-up so storage/linking can ship without touching multiple app surfaces in the same PR.
+
+## Dependencies And Boundaries
+
+- Upstream foundations that must remain authoritative:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-21-admin-notes-workflow-v2-core-10-10.md`
+  - `/Users/stianvikra/freeswimming/components/admin/AdminNotesManager.tsx`
+  - `/Users/stianvikra/freeswimming/components/admin/AdminContextNotesPanel.tsx`
+  - `/Users/stianvikra/freeswimming/lib/admin/notes.ts`
+  - `/Users/stianvikra/freeswimming/app/api/admin/notes/route.ts`
+  - `/Users/stianvikra/freeswimming/app/api/admin/notes/[id]/route.ts`
+- Existing contextual-note/edit-surface foundations to reuse:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-17-aw-013-context-aware-admin-create-notes-and-qr-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/runbooks/admin-notes-recovery.md`
+- Recommended direction locked unless owner overrides:
+  - image attachments are admin-only,
+  - attachment delete must remove both the DB reference and underlying storage object,
+  - note priority remains separate from incident severity/category,
+  - related notes are explicit links by canonical note ID.
+- This slice does not replace the note system with a full issue tracker.
+
+## Scope
+
+- Add admin-note image attachments:
+  - upload screenshots/images to a controlled admin-only storage path,
+  - show attachment previews or metadata in notes UI,
+  - allow deletion from create/edit contexts,
+  - deleting a note with attachments must also delete the attachment records and storage objects.
+- Add note priority field:
+  - recommended values: `low`, `normal`, `high`, `urgent`,
+  - usable in list sorting/filtering and visible in note detail.
+- Add related-note linking:
+  - link a note to one or more other note IDs,
+  - show related notes with safe titles/IDs,
+  - avoid circular/confusing duplicates where practical through validation.
+- Extend filters where needed so attachments/priority/linked-note state are discoverable from the notes manager.
+
+## Out Of Scope
+
+- General public user uploads.
+- Arbitrary file-type attachments beyond approved image types in this slice.
+- Full comment-thread system inside admin notes.
+- Replacing current content/page context catalog model.
+- App-wide quick-capture launcher and route-surface rollout.
+
+## Data Placement And Sync Contract
+
+- Server-canonical data:
+  - note rows,
+  - attachment metadata rows,
+  - attachment storage object keys,
+  - note priority,
+  - related-note link rows,
+  - canonical route/context refs.
+- Local-only data:
+  - in-progress upload state,
+  - temporary preview URLs,
+  - unsaved note draft text.
+- Sync policy:
+  - uploads happen only on explicit admin action,
+  - attachment and related-note records become canonical only after server confirmation,
+  - delete must remove DB link and storage object before success is reported,
+- Retention and sensitivity:
+  - screenshots may contain sensitive internal information and must remain admin-only,
+  - deleted attachments must be fully removed from both metadata and storage, not only hidden in UI.
+- Cache/invalidation:
+  - notes lists, note detail views, contextual panels, and quick-capture entrypoints refresh deterministically after attachment/link/priority mutations.
+
+## Identity And Rename Contract
+
+- Canonical stable IDs:
+  - `admin_note.id` remains canonical for notes,
+  - each attachment gets its own immutable canonical attachment ID,
+  - related-note links reference canonical note IDs only.
+- Human-readable identifiers:
+  - note titles and attachment filenames are display metadata and not canonical identity.
+- Mutability rules:
+  - priority is a semantic field and changes only through explicit admin action,
+  - related-note links must not rewrite or merge note identity,
+  - deleting an attachment must not silently leave an orphaned storage object.
+- Rename vs repurpose policy:
+  - editing note wording or priority remains in-place,
+  - materially different operational concerns should create new note rows and optionally link them.
+- Compatibility contract:
+  - older notes with no attachments, no priority, or no related links remain fully valid.
+- Observability and repair:
+  - orphaned attachment records, missing storage objects, and broken related-note links must be detectable and repairable with deterministic admin guidance.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `Business logic correctness and data integrity`
+- `Admin editor ergonomics`
+- `Security and authz`
+- `Privacy and compliance`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                      | Evidence                             |
+| --------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| Product goals and IA                          | `target`     | Admin can understand attachment, priority, and related-note behavior without confusing them with core note identity or done/archive state.          | IA review + manual QA + e2e          |
+| UX flow clarity                               | `target`     | Admin can attach screenshots, set priority, link related notes, and save without dead ends or hidden partial states.                                | e2e + manual QA                      |
+| Visual design quality                         | `target`     | Added attachment and linking controls remain readable and intentional instead of turning notes UI into clutter.                                     | screenshot review + manual QA        |
+| Business logic correctness and data integrity | `target`     | Attachment lifecycle, priority updates, and related-note links are deterministic, canonical, and leave no orphaned metadata.                        | unit tests + runtime guards          |
+| Admin editor ergonomics                       | `target`     | Admin can capture and revisit richer operational notes with screenshots, explicit priority, and related-note trace without confusing note identity. | timed manual QA + e2e                |
+| Accessibility (a11y)                          | `target`     | Upload controls, launcher actions, priority selectors, and related-note affordances remain keyboard/touch accessible.                               | Playwright + manual QA               |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: attachments and launcher UI must avoid obvious `/admin` or route-level regressions and excessive client weight.                    | build + code review                  |
+| Data placement and sync boundaries            | `target`     | Notes, attachment metadata, and related-note links are server-canonical while upload previews remain local-only.                                    | contract review + tests              |
+| Caching and invalidation strategy             | `target`     | Note detail, contextual panels, and manager lists refresh deterministically after upload, delete, link, unlink, and priority changes.               | integration review + e2e             |
+| Reliability and failure handling              | `target`     | Partial upload/delete failures show actionable recovery guidance and never claim full delete while storage objects still exist.                     | negative-path tests + manual QA      |
+| Security and authz                            | `target`     | Attachments and richer note mutations remain admin-only, fail closed, and do not expose raw storage paths or uploads to public users.               | API/storage negative-path tests      |
+| Privacy and compliance                        | `target`     | Internal screenshots stay private, are deleted fully when requested, and are never leaked into public routes, logs, or exports.                     | storage review + tests               |
+| Content governance                            | `supporting` | Supporting only: priority/link semantics must remain coherent with existing note categories and operational conventions.                            | Help/Guide + code review             |
+| Admin workflow and editability                | `target`     | Rich-note editing remains fast, recoverable, and clear even when screenshots, priority, and related links are added to the same note.               | e2e + timed manual QA                |
+| SEO and crawlability                          | `N/A`        | N/A because attachments and admin note enrichments are private admin-only workflows with no public crawl/index contract.                            | scope rationale                      |
+| AI discoverability                            | `N/A`        | N/A because this slice changes no public AI-facing discoverability surface.                                                                         | scope rationale                      |
+| Analytics and KPI observability               | `supporting` | Supporting only: upload, delete, priority, and launcher actions should remain measurable enough to evaluate real operational value.                 | analytics event review               |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, billing, payout, or commercial reporting path changes in this admin notes enhancement slice.                                | scope rationale                      |
+| Incident response and support operations      | `target`     | Runbooks and Help/Guide explain screenshot handling, delete semantics, launcher recovery, and richer note triage behavior.                          | docs review + help-center assertions |
+| Finance and reporting operations              | `N/A`        | N/A because no billing, reconciliation, payout, or finance reporting logic is changed by note attachments/linking work.                             | scope rationale                      |
+| i18n operational readiness                    | `supporting` | Supporting only: priority labels and richer note copy must remain localization-safe and not encode logic in free text alone.                        | copy review                          |
+| Stack-fit and dependency discipline           | `target`     | Reuse existing admin/storage patterns and avoid unnecessary third-party upload or issue-tracker dependencies.                                       | dependency diff + code review        |
+| Testing and QA automation                     | `target`     | Coverage protects upload/delete lifecycle, orphan cleanup, related-note link safety, priority behavior, and quick-capture authz.                    | tests + `verify:pre-pr` evidence     |
+| Scalability and cost efficiency               | `supporting` | Supporting only: attachment storage and quick-capture flows must avoid runaway storage retention and duplicate note/link churn.                     | storage review + code review         |
+| DevOps and rollback readiness                 | `target`     | Storage-backed note enrichments include safe cleanup, repair guidance, and rollback strategy for attachment-enabled deployments.                    | rollback checklist + runbook review  |
+
+## Acceptance Criteria
+
+1. Admin can attach one or more approved images/screenshots to a note.
+2. Deleting an attachment removes both the note metadata reference and the underlying storage object.
+3. Deleting a note with attachments removes attachment records and storage objects fully.
+4. Admin can assign and edit explicit priority without conflating it with incident category/severity.
+5. Admin can link related notes by canonical note ID and revisit those links later.
+6. Non-admin users never see attachment data.
+7. `npm run lint:briefs`, targeted tests, and `npm run verify:pre-pr` pass before PR update.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run lint`
+- `npm run typecheck`
+- targeted unit tests for:
+  - attachment payload validation,
+  - priority normalization,
+  - related-note link invariants,
+  - delete lifecycle/orphan cleanup
+- targeted e2e for:
+  - screenshot upload/delete,
+  - note delete with attachments,
+  - related-note linking flow,
+  - unauthorized-path denial
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm must be installed on the machine used for local validation.
+- Local validation runs from repo root.
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3000/admin?tab=notes`
+- Preview:
+  - PR preview URL after branch push
+- Recommended matrix:
+  - Desktop Chrome
+  - Desktop Safari/WebKit
+  - Desktop Firefox
+  - iPad/tablet viewport for upload and launcher sanity check
+
+## Constraints
+
+- Keep upload scope to approved image formats first.
+- Delete must mean real delete, not UI hide-only behavior.
+- Preserve current admin note foundations and avoid turning this slice into a general-purpose ticketing system.
+
+## 10/10 Quality Bar
+
+- Richer notes must improve operational memory, not create clutter or hidden risk.
+- The operator should trust delete semantics completely.
+- Required states remain explicit:
+  - `loading`
+  - `empty`
+  - `error`
+  - `retry`
+  - `success`
+  - upload pending
+- Attachments and links must never make note identity ambiguous.
+
+## Checkpoint Log
+
+- `2026-03-22 | scope split | moved attachments/linking brief into in-progress and explicitly split app-wide quick capture into a follow-up slice so storage lifecycle, priority, and related-note integrity can ship first without broad route-surface risk | next: implement schema + API + UI foundations for attachments, priority, and related-note links`
+- `2026-03-22 | implementation + verify | implemented attachment storage/delete lifecycle, priority, related-note linking, hydration, help/runbook updates, and authz negative-path coverage; local npm run verify:pre-pr passed | perf-budget trend recommended tighten, decision: hold for this slice because it does not change public core-route perf targets, and revisit tightening in the next AW-010 performance checkpoint/PR summary | next: run final diff review, commit, push, and open/update PR`
+- `2026-03-21 | planning | created separate advanced admin notes brief for screenshots, related-note links, explicit priority, and app-wide admin quick capture so storage-backed lifecycle risk does not block core notes search/filter continuity work | next: ship admin notes core first, then implement attachment/linking/launcher work with full delete-lifecycle coverage`

--- a/docs/task-briefs/planned/2026-03-22-admin-notes-quick-capture-launcher-10-10.md
+++ b/docs/task-briefs/planned/2026-03-22-admin-notes-quick-capture-launcher-10-10.md
@@ -1,0 +1,139 @@
+# Task Brief: Admin Notes Quick Capture Launcher (10/10)
+
+## Metadata
+
+- `id`: `2026-03-22-admin-notes-quick-capture-launcher-10-10`
+- `status`: `planned`
+- `owner`: `stianvikra`
+- `created`: `2026-03-22`
+- `updated`: `2026-03-22`
+
+## Goal
+
+Signed-in admins can capture a new admin note quickly from key app surfaces with canonical route/context prefilled, while non-admin users never see the launcher.
+
+## Why This Brief Exists
+
+- The richer admin-notes slice for attachments/priority/related links is already large enough on its own.
+- Quick capture is a different kind of work:
+  - touches multiple app surfaces,
+  - depends on clean admin-only visibility rules,
+  - changes navigation and workflow entrypoints more than the notes data model itself.
+- Splitting it keeps storage/data-integrity work separate from launcher/surface rollout risk.
+
+## Dependencies And Boundaries
+
+- Depends on:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-21-admin-notes-workflow-v2-core-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-03-21-admin-notes-workflow-v2-attachments-and-linking-10-10.md`
+  - `/Users/stianvikra/freeswimming/components/admin/AdminContextNotesPanel.tsx`
+  - `/Users/stianvikra/freeswimming/components/admin/AdminNotesManager.tsx`
+- This slice owns:
+  - launcher visibility,
+  - route/context prefill behavior,
+  - lightweight capture UX from in-app surfaces.
+- This slice does not own:
+  - storage-backed attachment lifecycle,
+  - note priority data model,
+  - related-note linking schema.
+
+## Scope
+
+- Add an admin-only quick-capture launcher on key routes:
+  - `/admin`
+  - `/plans`
+  - selected content/edit surfaces already using contextual admin tooling
+- Launcher opens a lightweight note-create flow with canonical route/context prefilled.
+- Saving routes the new note into the existing notes workflow without losing operator context.
+- Non-admin users never see launcher affordances or launcher payloads.
+- Help/Guide and runbooks explain launcher behavior and recovery path.
+
+## Out Of Scope
+
+- Public-user note capture.
+- Broad site-wide floating-toolbar redesign.
+- Replacing contextual notes panels that already exist where they are sufficient.
+- Attachment upload logic, priority semantics, and related-note link lifecycle.
+
+## Data Placement And Sync Contract
+
+- Server-canonical data:
+  - saved note row,
+  - canonical context type/ref values.
+- Local-only data:
+  - launcher open/closed state,
+  - unsaved draft text,
+  - route-prefill preview before explicit save.
+- Sync policy:
+  - prefill remains local until explicit save,
+  - save uses the canonical admin-notes API,
+  - cancelling capture must not create or mutate any server note row.
+
+## Identity And Rename Contract
+
+- Canonical identity remains `admin_note.id`.
+- Route labels and launcher captions are display metadata only.
+- Quick capture must never invent free-text context refs when a canonical route/context ref exists.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Admin editor ergonomics`
+- `Security and authz`
+- `Reliability and failure handling`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                     | Evidence                             |
+| --------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| Product goals and IA                          | `target`     | Admin can discover quick capture from key routes without confusing it with public UI or the full notes workspace.                  | IA review + manual QA + e2e          |
+| UX flow clarity                               | `target`     | Opening, prefilling, saving, cancelling, and returning from quick capture feel obvious and deterministic on supported surfaces.    | e2e + manual QA                      |
+| Visual design quality                         | `target`     | Launcher and sheet/modal affordances feel intentional and low-noise on both desktop and tablet/mobile layouts.                     | screenshot review + manual QA        |
+| Business logic correctness and data integrity | `target`     | Launcher save uses canonical context refs and never creates stray notes on cancel or authz failure.                                | unit tests + runtime guards          |
+| Admin editor ergonomics                       | `target`     | Admin can create a context-aware note without re-finding the notes tab or manually re-entering route context.                      | timed manual QA + e2e                |
+| Accessibility (a11y)                          | `target`     | Launcher trigger, focus handling, and save/cancel actions remain keyboard and touch accessible.                                    | Playwright + manual QA               |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: launcher UI must avoid obvious route-level regressions or unnecessary client payload growth.                      | build + code review                  |
+| Data placement and sync boundaries            | `target`     | Prefill state is local-only until save, while saved note context remains server-canonical and consistent with notes APIs.          | contract review + tests              |
+| Caching and invalidation strategy             | `target`     | Saved notes refresh relevant contextual panels/work queues deterministically without forcing the admin out of the current surface. | integration review + e2e             |
+| Reliability and failure handling              | `target`     | Failed save or authz checks show actionable guidance and preserve the draft when appropriate.                                      | negative-path tests + manual QA      |
+| Security and authz                            | `target`     | Non-admin users never see the launcher, and direct launcher/save paths fail closed for unauthorized access.                        | API/UI negative-path tests           |
+| Privacy and compliance                        | `target`     | Launcher-prefilled route context remains admin-only and is never leaked into public UI.                                            | route review + test assertions       |
+| Content governance                            | `supporting` | Supporting only: launcher copy and context labels stay consistent with existing notes governance and route taxonomy.               | Help/Guide + code review             |
+| Admin workflow and editability                | `target`     | Quick capture complements, rather than replaces, the full notes manager and contextual notes panels.                               | e2e + manual QA                      |
+| SEO and crawlability                          | `N/A`        | N/A because the launcher is admin-only and adds no public crawl/index surface.                                                     | scope rationale                      |
+| AI discoverability                            | `N/A`        | N/A because this slice changes no public AI-facing discoverability surface.                                                        | scope rationale                      |
+| Analytics and KPI observability               | `supporting` | Supporting only: launcher open/save/cancel events should remain measurable enough to confirm workflow value.                       | analytics review                     |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, billing, payout, or revenue workflow changes in this launcher slice.                                       | scope rationale                      |
+| Incident response and support operations      | `target`     | Help/Guide and runbooks explain where quick capture appears, what it prefills, and how to recover if a save fails.                 | docs review + help-center assertions |
+| Finance and reporting operations              | `N/A`        | N/A because no billing, reconciliation, payout, or finance reporting logic changes in this slice.                                  | scope rationale                      |
+| i18n operational readiness                    | `supporting` | Supporting only: launcher labels and prefill copy remain localization-safe and do not hide logic inside free text.                 | copy review                          |
+| Stack-fit and dependency discipline           | `target`     | Reuse existing admin auth, notes APIs, and contextual panels without introducing unnecessary launcher dependencies.                | dependency diff + code review        |
+| Testing and QA automation                     | `target`     | Coverage protects launcher visibility, route/context prefill, cancel/save behavior, and unauthorized-path denial.                  | tests + `verify:pre-pr` evidence     |
+| Scalability and cost efficiency               | `supporting` | Supporting only: launcher rollout should avoid duplicate entrypoints and accidental note spam from repeated prefills.              | workflow review + code review        |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: launcher rollout can be rolled back cleanly without touching existing saved note data.                            | rollback note + diff review          |
+
+## Acceptance Criteria
+
+1. Signed-in admins can open quick capture from the agreed key surfaces.
+2. Route/context is prefilled canonically without manual re-entry on supported surfaces.
+3. Cancelling quick capture creates no note and leaves no server drift.
+4. Saving quick capture writes a normal admin note that appears in the existing notes workflow.
+5. Non-admin users never see launcher controls or launcher-only data.
+6. `npm run lint:briefs`, targeted tests, and `npm run verify:pre-pr` pass before PR update.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run lint`
+- `npm run typecheck`
+- targeted unit tests for launcher visibility and route/context prefill
+- targeted e2e for open, cancel, save, and unauthorized-path denial
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Checkpoint Log
+
+- `2026-03-22 | planning | split quick capture out of the richer attachments/linking notes scope so launcher rollout can be implemented and tested as its own authz/navigation slice after storage-backed note enrichments land | next: finish attachments/priority/related links first, then implement launcher surfaces on a dedicated branch`

--- a/lib/admin/notes-manager.ts
+++ b/lib/admin/notes-manager.ts
@@ -7,7 +7,12 @@ import {
   isAdminNoteContextType,
   type AdminNoteContextType,
 } from "@/lib/admin/note-context";
-import type { AdminNoteRow, IncidentNoteSeverity } from "@/lib/admin/notes";
+import {
+  isAdminNotePriority,
+  type AdminNoteItem,
+  type AdminNotePriority,
+  type IncidentNoteSeverity,
+} from "@/lib/admin/notes";
 
 type SearchParamsLike = {
   get(name: string): string | null;
@@ -20,6 +25,7 @@ export type AdminNotesFilterState = {
   query: string;
   status: AdminNotesStatusFilter;
   category: string;
+  priority: AdminNotePriority | "";
   contextType: AdminNoteContextType | "";
   contextRef: string;
 };
@@ -34,6 +40,7 @@ export const ADMIN_NOTES_QUERY_KEYS = {
   query: "notesQuery",
   status: "notesStatus",
   category: "notesCategory",
+  priority: "notesPriority",
   contextType: "notesContextType",
   contextRef: "notesContextRef",
 } as const;
@@ -42,6 +49,7 @@ export const DEFAULT_ADMIN_NOTES_FILTER_STATE: AdminNotesFilterState = {
   query: "",
   status: "open",
   category: "",
+  priority: "",
   contextType: "",
   contextRef: "",
 };
@@ -81,6 +89,8 @@ export function parseAdminNotesFilterState(searchParams: SearchParamsLike): Admi
   )
     ? (rawContextType as AdminNoteContextType)
     : "";
+  const rawPriority = normalizeLowerText(searchParams.get(ADMIN_NOTES_QUERY_KEYS.priority));
+  const priority = isAdminNotePriority(rawPriority) ? rawPriority : "";
 
   const contextRef = normalizeContextRef(searchParams.get(ADMIN_NOTES_QUERY_KEYS.contextRef));
 
@@ -88,6 +98,7 @@ export function parseAdminNotesFilterState(searchParams: SearchParamsLike): Admi
     query: normalizeText(searchParams.get(ADMIN_NOTES_QUERY_KEYS.query)),
     status: parseAdminNotesStatusFilter(searchParams.get(ADMIN_NOTES_QUERY_KEYS.status)),
     category: normalizeText(searchParams.get(ADMIN_NOTES_QUERY_KEYS.category)),
+    priority,
     contextType,
     contextRef: contextType ? contextRef : "",
   };
@@ -101,6 +112,7 @@ export function applyAdminNotesFilterStateToSearchParams(
   const normalizedQuery = normalizeText(state.query);
   const normalizedCategory = normalizeText(state.category);
   const normalizedContextRef = normalizeContextRef(state.contextRef);
+  const normalizedPriority = normalizeLowerText(state.priority);
 
   if (normalizedQuery) {
     next.set(ADMIN_NOTES_QUERY_KEYS.query, normalizedQuery);
@@ -118,6 +130,12 @@ export function applyAdminNotesFilterStateToSearchParams(
     next.set(ADMIN_NOTES_QUERY_KEYS.category, normalizedCategory);
   } else {
     next.delete(ADMIN_NOTES_QUERY_KEYS.category);
+  }
+
+  if (normalizedPriority) {
+    next.set(ADMIN_NOTES_QUERY_KEYS.priority, normalizedPriority);
+  } else {
+    next.delete(ADMIN_NOTES_QUERY_KEYS.priority);
   }
 
   if (state.contextType) {
@@ -160,7 +178,7 @@ export function buildAdminNoteContextFilterLabel(params: {
 }
 
 function buildAdminNoteSearchIndex(params: {
-  item: AdminNoteRow;
+  item: AdminNoteItem;
   catalog: Pick<AdminNoteContextCatalog, "labelsByContextKey">;
 }): string {
   const contextLabel =
@@ -179,16 +197,19 @@ function buildAdminNoteSearchIndex(params: {
     params.item.title,
     params.item.body,
     params.item.category,
+    params.item.priority,
     params.item.context_type,
     params.item.context_ref,
     contextLabel,
+    ...params.item.attachments.map((attachment) => attachment.file_name),
+    ...params.item.related_notes.flatMap((note) => [note.id, note.title]),
   ]
     .filter(Boolean)
     .join("\n")
     .toLowerCase();
 }
 
-export function buildAdminNotesCounts(items: AdminNoteRow[]): {
+export function buildAdminNotesCounts(items: AdminNoteItem[]): {
   open: number;
   done: number;
   all: number;
@@ -202,10 +223,10 @@ export function buildAdminNotesCounts(items: AdminNoteRow[]): {
 }
 
 export function filterAdminNotes(params: {
-  items: AdminNoteRow[];
+  items: AdminNoteItem[];
   filters: AdminNotesFilterState;
   catalog: Pick<AdminNoteContextCatalog, "labelsByContextKey">;
-}): AdminNoteRow[] {
+}): AdminNoteItem[] {
   const normalizedQuery = normalizeLowerText(params.filters.query);
   const normalizedCategory = normalizeLowerText(params.filters.category);
   const normalizedContextRef = normalizeContextRef(params.filters.contextRef);
@@ -215,6 +236,10 @@ export function filterAdminNotes(params: {
     if (params.filters.status === "done" && !item.is_done) return false;
 
     if (normalizedCategory && normalizeLowerText(item.category) !== normalizedCategory) {
+      return false;
+    }
+
+    if (params.filters.priority && item.priority !== params.filters.priority) {
       return false;
     }
 
@@ -236,7 +261,7 @@ export function filterAdminNotes(params: {
 }
 
 export function buildAdminNotesContextRefOptions(params: {
-  items: AdminNoteRow[];
+  items: AdminNoteItem[];
   catalog: Pick<AdminNoteContextCatalog, "labelsByContextKey">;
   contextType: AdminNoteContextType | "";
 }): AdminNotesContextRefOption[] {

--- a/lib/admin/notes-server.ts
+++ b/lib/admin/notes-server.ts
@@ -1,0 +1,257 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createAdminSupabaseClient } from "@/lib/supabase/admin";
+import type { Database } from "@/types/database";
+import {
+  ADMIN_NOTE_ATTACHMENT_BUCKET,
+  buildAdminNoteLinkedSummary,
+  compareAdminNotePriority,
+  type AdminNoteAttachment,
+  type AdminNoteAttachmentRow,
+  type AdminNoteItem,
+  type AdminNoteLinkRow,
+  type AdminNoteRow,
+} from "@/lib/admin/notes";
+
+type PostgrestLikeError = {
+  code?: string | null;
+  message?: string | null;
+  details?: string | null;
+  hint?: string | null;
+};
+
+type HydrateAdminNotesResult =
+  | {
+      ok: true;
+      items: AdminNoteItem[];
+    }
+  | {
+      ok: false;
+      error: PostgrestLikeError;
+    };
+
+export function selectAdminNoteFields() {
+  return `
+    id,
+    title,
+    body,
+    category,
+    priority,
+    note_date,
+    is_done,
+    context_type,
+    context_ref,
+    created_by,
+    updated_by,
+    created_at,
+    updated_at
+  `;
+}
+
+function selectAdminNoteAttachmentFields() {
+  return `
+    id,
+    note_id,
+    file_name,
+    mime_type,
+    size_bytes,
+    storage_path,
+    created_at,
+    created_by
+  `;
+}
+
+function selectAdminNoteLinkFields() {
+  return `
+    note_id,
+    related_note_id,
+    created_at,
+    created_by
+  `;
+}
+
+function sortLinkedNotes(
+  left: AdminNoteItem["related_notes"][number],
+  right: AdminNoteItem["related_notes"][number]
+) {
+  if (left.priority !== right.priority) {
+    return compareAdminNotePriority(left.priority, right.priority);
+  }
+
+  if (left.note_date !== right.note_date) {
+    return right.note_date.localeCompare(left.note_date);
+  }
+
+  return right.id.localeCompare(left.id);
+}
+
+async function buildAttachmentPayload(
+  rows: AdminNoteAttachmentRow[]
+): Promise<AdminNoteAttachment[]> {
+  if (rows.length === 0) return [];
+
+  const adminSupabase = createAdminSupabaseClient();
+
+  return Promise.all(
+    rows.map(async (row) => {
+      const signed = await adminSupabase.storage
+        .from(ADMIN_NOTE_ATTACHMENT_BUCKET)
+        .createSignedUrl(row.storage_path, 60 * 60);
+
+      if (signed.error) {
+        console.error("[AdminNotes] Could not sign attachment URL", {
+          attachmentId: row.id,
+          noteId: row.note_id,
+          error: signed.error,
+        });
+      }
+
+      return {
+        id: row.id,
+        note_id: row.note_id,
+        file_name: row.file_name,
+        mime_type: row.mime_type,
+        size_bytes: row.size_bytes,
+        created_at: row.created_at,
+        created_by: row.created_by,
+        signed_url: signed.data?.signedUrl ?? null,
+      };
+    })
+  );
+}
+
+export async function hydrateAdminNoteRows(params: {
+  supabase: SupabaseClient<Database>;
+  rows: AdminNoteRow[];
+}): Promise<HydrateAdminNotesResult> {
+  if (params.rows.length === 0) {
+    return { ok: true, items: [] };
+  }
+
+  const noteIds = params.rows.map((row) => row.id);
+
+  const attachmentsResult = await params.supabase
+    .from("admin_note_attachments")
+    .select(selectAdminNoteAttachmentFields())
+    .in("note_id", noteIds)
+    .order("created_at", { ascending: true });
+
+  if (attachmentsResult.error) {
+    return { ok: false, error: attachmentsResult.error };
+  }
+
+  const idsCsv = noteIds.join(",");
+  const linksResult = await params.supabase
+    .from("admin_note_links")
+    .select(selectAdminNoteLinkFields())
+    .or(`note_id.in.(${idsCsv}),related_note_id.in.(${idsCsv})`)
+    .order("created_at", { ascending: true });
+
+  if (linksResult.error) {
+    return { ok: false, error: linksResult.error };
+  }
+
+  const linkRows = (linksResult.data ?? []) as unknown as AdminNoteLinkRow[];
+  const relatedNoteIds = new Set<string>();
+  for (const link of linkRows) {
+    relatedNoteIds.add(link.note_id);
+    relatedNoteIds.add(link.related_note_id);
+  }
+
+  const missingRelatedIds = [...relatedNoteIds].filter((id) => !noteIds.includes(id));
+  let relatedLookupRows: AdminNoteRow[] = [];
+  if (missingRelatedIds.length > 0) {
+    const relatedNotesResult = await params.supabase
+      .from("admin_notes")
+      .select(selectAdminNoteFields())
+      .in("id", missingRelatedIds);
+
+    if (relatedNotesResult.error) {
+      return { ok: false, error: relatedNotesResult.error };
+    }
+
+    relatedLookupRows = (relatedNotesResult.data ?? []) as unknown as AdminNoteRow[];
+  }
+
+  const noteLookup = new Map<string, AdminNoteRow>(
+    [...params.rows, ...relatedLookupRows].map((row) => [row.id, row])
+  );
+
+  const attachmentRows = (attachmentsResult.data ?? []) as unknown as AdminNoteAttachmentRow[];
+  const attachmentPayload = await buildAttachmentPayload(attachmentRows);
+  const attachmentsByNoteId = new Map<string, AdminNoteAttachment[]>();
+  for (const attachment of attachmentPayload) {
+    const bucket = attachmentsByNoteId.get(attachment.note_id) ?? [];
+    bucket.push(attachment);
+    attachmentsByNoteId.set(attachment.note_id, bucket);
+  }
+
+  const relatedByNoteId = new Map<string, AdminNoteItem["related_notes"]>();
+  for (const link of linkRows) {
+    const left = noteLookup.get(link.note_id);
+    const right = noteLookup.get(link.related_note_id);
+    if (!left || !right) continue;
+
+    const leftBucket = relatedByNoteId.get(left.id) ?? [];
+    if (!leftBucket.some((entry) => entry.id === right.id)) {
+      leftBucket.push(buildAdminNoteLinkedSummary(right));
+      relatedByNoteId.set(left.id, leftBucket);
+    }
+
+    const rightBucket = relatedByNoteId.get(right.id) ?? [];
+    if (!rightBucket.some((entry) => entry.id === left.id)) {
+      rightBucket.push(buildAdminNoteLinkedSummary(left));
+      relatedByNoteId.set(right.id, rightBucket);
+    }
+  }
+
+  return {
+    ok: true,
+    items: params.rows.map((row) => ({
+      ...row,
+      attachments: attachmentsByNoteId.get(row.id) ?? [],
+      related_notes: [...(relatedByNoteId.get(row.id) ?? [])].sort(sortLinkedNotes),
+    })),
+  };
+}
+
+export async function loadHydratedAdminNoteById(params: {
+  supabase: SupabaseClient<Database>;
+  noteId: string;
+}): Promise<
+  | {
+      ok: true;
+      item: AdminNoteItem | null;
+    }
+  | {
+      ok: false;
+      error: PostgrestLikeError;
+    }
+> {
+  const result = await params.supabase
+    .from("admin_notes")
+    .select(selectAdminNoteFields())
+    .eq("id", params.noteId)
+    .maybeSingle();
+
+  if (result.error) {
+    return { ok: false, error: result.error };
+  }
+
+  if (!result.data) {
+    return { ok: true, item: null };
+  }
+
+  const hydrated = await hydrateAdminNoteRows({
+    supabase: params.supabase,
+    rows: [result.data as unknown as AdminNoteRow],
+  });
+
+  if (!hydrated.ok) {
+    return hydrated;
+  }
+
+  return {
+    ok: true,
+    item: hydrated.items[0] ?? null,
+  };
+}

--- a/lib/admin/notes.ts
+++ b/lib/admin/notes.ts
@@ -6,9 +6,37 @@ import {
 } from "@/lib/admin/note-context";
 
 export type AdminNoteRow = Database["public"]["Tables"]["admin_notes"]["Row"];
+export type AdminNoteAttachmentRow = Database["public"]["Tables"]["admin_note_attachments"]["Row"];
+export type AdminNoteLinkRow = Database["public"]["Tables"]["admin_note_links"]["Row"];
 
 export const INCIDENT_NOTE_SEVERITIES = ["P0", "P1", "P2"] as const;
 export type IncidentNoteSeverity = (typeof INCIDENT_NOTE_SEVERITIES)[number];
+export const ADMIN_NOTE_PRIORITY_VALUES = ["low", "normal", "high", "urgent"] as const;
+export type AdminNotePriority = (typeof ADMIN_NOTE_PRIORITY_VALUES)[number];
+export const ADMIN_NOTE_ATTACHMENT_BUCKET = "admin-note-attachments";
+export const ADMIN_NOTE_ATTACHMENT_MAX_BYTES = 5 * 1024 * 1024;
+export const ADMIN_NOTE_ATTACHMENT_MAX_FILES = 6;
+export const ADMIN_NOTE_ALLOWED_ATTACHMENT_MIME_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+] as const;
+export type AdminNoteAttachmentMimeType = (typeof ADMIN_NOTE_ALLOWED_ATTACHMENT_MIME_TYPES)[number];
+
+export type AdminNoteAttachment = Omit<AdminNoteAttachmentRow, "storage_path"> & {
+  signed_url: string | null;
+};
+
+export type AdminNoteLinkedSummary = Pick<
+  AdminNoteRow,
+  "id" | "title" | "category" | "note_date" | "is_done" | "priority"
+>;
+
+export type AdminNoteItem = AdminNoteRow & {
+  attachments: AdminNoteAttachment[];
+  related_notes: AdminNoteLinkedSummary[];
+};
 
 export const ADMIN_INCIDENT_NOTE_CATEGORY_BY_SEVERITY: Record<IncidentNoteSeverity, string> = {
   P0: "Incident P0",
@@ -26,6 +54,7 @@ export type CreateAdminNotePayload = {
   body?: unknown;
   category?: unknown;
   noteDate?: unknown;
+  priority?: unknown;
   isDone?: unknown;
   contextType?: unknown;
   contextRef?: unknown;
@@ -36,6 +65,7 @@ export type UpdateAdminNotePayload = {
   body?: unknown;
   category?: unknown;
   noteDate?: unknown;
+  priority?: unknown;
   isDone?: unknown;
   contextType?: unknown;
   contextRef?: unknown;
@@ -46,6 +76,7 @@ type CreateAdminNoteNormalized = {
   body: string;
   category: string;
   noteDate: string;
+  priority: AdminNotePriority;
   isDone: boolean;
   contextType: AdminNoteContext["contextType"] | null;
   contextRef: string | null;
@@ -56,6 +87,7 @@ type UpdateAdminNoteNormalized = {
   body?: string;
   category?: string;
   noteDate?: string;
+  priority?: AdminNotePriority;
   isDone?: boolean;
   contextType?: AdminNoteContext["contextType"] | null;
   contextRef?: string | null;
@@ -72,6 +104,7 @@ type ParseResult<T> =
     };
 
 const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export function sortAdminNotesByNewest(
   a: Pick<AdminNoteRow, "note_date" | "created_at">,
@@ -83,6 +116,17 @@ export function sortAdminNotesByNewest(
   return b.created_at.localeCompare(a.created_at);
 }
 
+export function sortAdminNotesByPriorityAndNewest(
+  a: Pick<AdminNoteRow, "priority" | "note_date" | "created_at">,
+  b: Pick<AdminNoteRow, "priority" | "note_date" | "created_at">
+): number {
+  if (a.priority !== b.priority) {
+    return compareAdminNotePriority(a.priority, b.priority);
+  }
+
+  return sortAdminNotesByNewest(a, b);
+}
+
 function normalizeString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
@@ -90,6 +134,36 @@ function normalizeString(value: unknown): string {
 function normalizeCategory(raw: string): string {
   const collapsed = raw.replace(/\s+/g, " ").trim();
   return collapsed.length > 0 ? collapsed : "General";
+}
+
+export function normalizeAdminNotePriority(value: unknown): AdminNotePriority | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return ADMIN_NOTE_PRIORITY_VALUES.includes(normalized as AdminNotePriority)
+    ? (normalized as AdminNotePriority)
+    : null;
+}
+
+export function isAdminNotePriority(value: string | null | undefined): value is AdminNotePriority {
+  return Boolean(value && ADMIN_NOTE_PRIORITY_VALUES.includes(value as AdminNotePriority));
+}
+
+export function compareAdminNotePriority(
+  left: AdminNotePriority,
+  right: AdminNotePriority
+): number {
+  const rank = {
+    urgent: 4,
+    high: 3,
+    normal: 2,
+    low: 1,
+  } satisfies Record<AdminNotePriority, number>;
+
+  return rank[right] - rank[left];
+}
+
+export function isUuid(value: string): boolean {
+  return UUID_REGEX.test(value);
 }
 
 function normalizeDateInput(raw: unknown): string | null {
@@ -119,6 +193,98 @@ export function buildIncidentNoteBodyTemplate(severity: IncidentNoteSeverity): s
   ].join("\n");
 }
 
+export function buildAdminNoteLinkedSummary(
+  note: Pick<AdminNoteRow, "id" | "title" | "category" | "note_date" | "is_done" | "priority">
+): AdminNoteLinkedSummary {
+  return {
+    id: note.id,
+    title: note.title,
+    category: note.category,
+    note_date: note.note_date,
+    is_done: note.is_done,
+    priority: note.priority,
+  };
+}
+
+export function canonicalizeAdminNoteLinkPair(
+  noteId: string,
+  relatedNoteId: string
+): ParseResult<{ noteId: string; relatedNoteId: string }> {
+  const left = noteId.trim().toLowerCase();
+  const right = relatedNoteId.trim().toLowerCase();
+
+  if (!isUuid(left) || !isUuid(right)) {
+    return { ok: false, error: "Note links require valid note IDs." };
+  }
+
+  if (left === right) {
+    return { ok: false, error: "A note cannot be linked to itself." };
+  }
+
+  return left < right
+    ? { ok: true, value: { noteId: left, relatedNoteId: right } }
+    : { ok: true, value: { noteId: right, relatedNoteId: left } };
+}
+
+function sanitizeAttachmentFileName(fileName: string): string {
+  const baseName = fileName
+    .normalize("NFKD")
+    .replace(/[^\x00-\x7F]/g, "")
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 80);
+
+  return baseName || "attachment";
+}
+
+export function validateAdminNoteAttachment(params: {
+  fileName: string;
+  mimeType: string;
+  sizeBytes: number;
+}): ParseResult<{
+  fileName: string;
+  mimeType: AdminNoteAttachmentMimeType;
+  sizeBytes: number;
+}> {
+  const fileName = sanitizeAttachmentFileName(params.fileName);
+  const mimeType = params.mimeType.trim().toLowerCase();
+  const sizeBytes = Number.isFinite(params.sizeBytes) ? Math.trunc(params.sizeBytes) : 0;
+
+  if (!ADMIN_NOTE_ALLOWED_ATTACHMENT_MIME_TYPES.includes(mimeType as AdminNoteAttachmentMimeType)) {
+    return { ok: false, error: "Only PNG, JPEG, WEBP, and GIF images are allowed." };
+  }
+
+  if (sizeBytes <= 0) {
+    return { ok: false, error: "Attachment file is empty." };
+  }
+
+  if (sizeBytes > ADMIN_NOTE_ATTACHMENT_MAX_BYTES) {
+    return {
+      ok: false,
+      error: `Attachments must be ${Math.round(ADMIN_NOTE_ATTACHMENT_MAX_BYTES / (1024 * 1024))} MB or smaller.`,
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      fileName,
+      mimeType: mimeType as AdminNoteAttachmentMimeType,
+      sizeBytes,
+    },
+  };
+}
+
+export function buildAdminNoteAttachmentStoragePath(params: {
+  noteId: string;
+  attachmentId: string;
+  fileName: string;
+}): string {
+  const safeFileName = sanitizeAttachmentFileName(params.fileName);
+  return `notes/${params.noteId}/${params.attachmentId}-${safeFileName}`;
+}
+
 function hasOwn(payload: Record<string, unknown>, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(payload, key);
 }
@@ -142,6 +308,7 @@ export function parseCreateAdminNotePayload(
   }
 
   const noteDate = normalizeDateInput(payload.noteDate) ?? todayIsoDate();
+  const priority = normalizeAdminNotePriority(payload.priority) ?? "normal";
   const isDone = payload.isDone === true;
   const context = parseAdminNoteContextInput({
     contextType: payload.contextType,
@@ -159,6 +326,7 @@ export function parseCreateAdminNotePayload(
       body,
       category,
       noteDate,
+      priority,
       isDone,
       contextType: canonicalContext?.contextType ?? null,
       contextRef: canonicalContext?.contextRef ?? null,
@@ -206,6 +374,15 @@ export function parseUpdateAdminNotePayload(
       return { ok: false, error: "Date must use YYYY-MM-DD format." };
     }
     value.noteDate = noteDate;
+    changed += 1;
+  }
+
+  if (hasOwn(source, "priority")) {
+    const priority = normalizeAdminNotePriority(payload.priority);
+    if (!priority) {
+      return { ok: false, error: "Priority must be low, normal, high, or urgent." };
+    }
+    value.priority = priority;
     changed += 1;
   }
 

--- a/lib/admin/schema.ts
+++ b/lib/admin/schema.ts
@@ -71,7 +71,12 @@ export function isAdminNotesSchemaMissing(error: PostgrestLikeError | null | und
   const blob = buildErrorBlob(error);
   if (hasSetupBlockedCode(error) || includesAnyMarker(blob, SETUP_BLOCKED_MARKERS)) return true;
 
-  return includesAnyMarker(blob, ["admin_notes"]);
+  return includesAnyMarker(blob, [
+    "admin_notes",
+    "admin_note_attachments",
+    "admin_note_links",
+    "admin-note-attachments",
+  ]);
 }
 
 export function isAdminCommerceSchemaMissing(

--- a/supabase/migrations/20260322074548_admin_note_attachments_priority_links.sql
+++ b/supabase/migrations/20260322074548_admin_note_attachments_priority_links.sql
@@ -1,0 +1,149 @@
+-- Admin notes v2 enrichments: explicit priority, image attachments, and canonical related-note links.
+
+alter table public.admin_notes
+  add column if not exists priority text not null default 'normal';
+
+alter table public.admin_notes
+  drop constraint if exists admin_notes_priority_check;
+
+alter table public.admin_notes
+  add constraint admin_notes_priority_check
+  check (priority in ('low', 'normal', 'high', 'urgent'));
+
+create index if not exists admin_notes_priority_idx
+  on public.admin_notes (priority, is_done, note_date desc, created_at desc);
+
+create table if not exists public.admin_note_attachments (
+  id uuid primary key default gen_random_uuid(),
+  note_id uuid not null references public.admin_notes (id) on delete cascade,
+  file_name text not null,
+  mime_type text not null,
+  size_bytes integer not null check (size_bytes > 0),
+  storage_path text not null unique,
+  created_by uuid references auth.users (id) on delete set null,
+  created_at timestamptz not null default timezone('utc', now()),
+  constraint admin_note_attachments_mime_type_check
+    check (mime_type in ('image/png', 'image/jpeg', 'image/webp', 'image/gif'))
+);
+
+create index if not exists admin_note_attachments_note_idx
+  on public.admin_note_attachments (note_id, created_at asc);
+
+grant select, insert, update, delete on public.admin_note_attachments to authenticated;
+
+alter table public.admin_note_attachments enable row level security;
+
+drop policy if exists admin_note_attachments_select_roles on public.admin_note_attachments;
+create policy admin_note_attachments_select_roles
+on public.admin_note_attachments
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.id = auth.uid()
+      and profile.role in ('admin', 'editor', 'viewer')
+  )
+);
+
+drop policy if exists admin_note_attachments_insert_roles on public.admin_note_attachments;
+create policy admin_note_attachments_insert_roles
+on public.admin_note_attachments
+for insert
+to authenticated
+with check (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.id = auth.uid()
+      and profile.role in ('admin', 'editor')
+  )
+);
+
+drop policy if exists admin_note_attachments_delete_roles on public.admin_note_attachments;
+create policy admin_note_attachments_delete_roles
+on public.admin_note_attachments
+for delete
+to authenticated
+using (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.id = auth.uid()
+      and profile.role in ('admin', 'editor')
+  )
+);
+
+create table if not exists public.admin_note_links (
+  note_id uuid not null references public.admin_notes (id) on delete cascade,
+  related_note_id uuid not null references public.admin_notes (id) on delete cascade,
+  created_by uuid references auth.users (id) on delete set null,
+  created_at timestamptz not null default timezone('utc', now()),
+  primary key (note_id, related_note_id),
+  constraint admin_note_links_not_self check (note_id <> related_note_id),
+  constraint admin_note_links_canonical_order check (note_id < related_note_id)
+);
+
+create index if not exists admin_note_links_related_idx
+  on public.admin_note_links (related_note_id, created_at asc);
+
+grant select, insert, delete on public.admin_note_links to authenticated;
+
+alter table public.admin_note_links enable row level security;
+
+drop policy if exists admin_note_links_select_roles on public.admin_note_links;
+create policy admin_note_links_select_roles
+on public.admin_note_links
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.id = auth.uid()
+      and profile.role in ('admin', 'editor', 'viewer')
+  )
+);
+
+drop policy if exists admin_note_links_insert_roles on public.admin_note_links;
+create policy admin_note_links_insert_roles
+on public.admin_note_links
+for insert
+to authenticated
+with check (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.id = auth.uid()
+      and profile.role in ('admin', 'editor')
+  )
+);
+
+drop policy if exists admin_note_links_delete_roles on public.admin_note_links;
+create policy admin_note_links_delete_roles
+on public.admin_note_links
+for delete
+to authenticated
+using (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.id = auth.uid()
+      and profile.role in ('admin', 'editor')
+  )
+);
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'admin-note-attachments',
+  'admin-note-attachments',
+  false,
+  5242880,
+  array['image/png', 'image/jpeg', 'image/webp', 'image/gif']
+)
+on conflict (id) do update
+set
+  public = excluded.public,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;

--- a/tests/e2e/admin-help-center.spec.ts
+++ b/tests/e2e/admin-help-center.spec.ts
@@ -108,6 +108,9 @@ test.describe("admin help center", () => {
       page.getByText("Open / Done archive / All + Search + Context filters:")
     ).toBeVisible();
     await expect(page.getByText("Visible note ID:")).toBeVisible();
+    await expect(page.getByText("Priority:")).toBeVisible();
+    await expect(page.getByText("Add images / Delete image:")).toBeVisible();
+    await expect(page.getByText("Link note / Remove link:")).toBeVisible();
     await expect(page.getByText("Open lock operations workflow:")).toBeVisible();
     await expect(page.getByText("Open password page:")).toBeVisible();
     await expect(page.getByText("Create template:")).toBeVisible();
@@ -125,5 +128,15 @@ test.describe("admin help center", () => {
     await expect(page.getByText("docs/runbooks/site-lock-operations.md")).toBeVisible();
     await expect(page.getByText("docs/runbooks/admin-notes-recovery.md")).toBeVisible();
     await expect(page.getByText("docs/runbooks/admin-email-template-governance.md")).toBeVisible();
+    await expect(
+      page.getByText(
+        "Create note with category, priority, and context link, then copy the visible note ID if you need to reference it later."
+      )
+    ).toBeVisible();
+    await expect(
+      page.getByText(
+        "Add screenshots when the issue is visual or hard to reproduce, and link any follow-up note instead of pasting duplicate text."
+      )
+    ).toBeVisible();
   });
 });

--- a/tests/e2e/admin-notes-workflow.spec.ts
+++ b/tests/e2e/admin-notes-workflow.spec.ts
@@ -1,7 +1,12 @@
+import { Buffer } from "node:buffer";
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
 const isSiteLockEnabled = process.env.SITE_LOCK_ENABLED === "1";
+const TINY_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9l9wAAAABJRU5ErkJggg==",
+  "base64"
+);
 
 function runOnceOnDesktopChromium(projectName: string) {
   test.skip(!projectName.startsWith("desktop-"), "Admin e2e is desktop-only.");
@@ -86,6 +91,7 @@ test.describe("admin notes workflow", () => {
 
     const unique = `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
     const title = `E2E Note ${unique}`;
+    const secondaryTitle = `E2E Related Note ${unique}`;
     const updatedTitle = `E2E Note Updated ${unique}`;
     const body = "Initial note body from Playwright.";
     const updatedBody = "Updated note body from Playwright.";
@@ -96,6 +102,7 @@ test.describe("admin notes workflow", () => {
     await createForm.getByLabel("Title").fill(title);
     await createForm.getByLabel("Category").fill("Operations");
     await createForm.locator('input[type="date"]').fill("2026-02-20");
+    await createForm.getByLabel("Priority").selectOption("high");
     await createForm.getByLabel("Text").fill(body);
     await createForm.getByTestId("admin-note-create-context-type").selectOption("course_lesson");
     const modulePicker = createForm.getByTestId("admin-note-create-context-lesson-module");
@@ -154,10 +161,62 @@ test.describe("admin notes workflow", () => {
     await expect(createdItem).toBeVisible({ timeout: 15_000 });
     await expect(createdItem).toContainText("Operations");
     await expect(createdItem).toContainText(body);
+    await expect(createdItem).toContainText("High");
     await expect(createdItem).toContainText("Course Lesson:");
     const noteIdText = await createdItem.getByTestId("admin-note-id").textContent();
     const noteId = noteIdText?.replace("Note ID", "").trim() ?? "";
     expect(noteId.length).toBeGreaterThan(5);
+
+    await createForm.getByLabel("Title").fill(secondaryTitle);
+    await createForm.getByLabel("Category").fill("Operations");
+    await createForm.getByLabel("Priority").selectOption("low");
+    await createForm.getByLabel("Text").fill("Secondary note used for related-link flow.");
+    await createForm.getByTestId("admin-note-create-context-type").selectOption("");
+    let secondaryCreateResponse: Awaited<ReturnType<Page["waitForResponse"]>> | undefined;
+    try {
+      [secondaryCreateResponse] = await Promise.all([
+        page.waitForResponse(
+          (response) =>
+            response.url().includes("/api/admin/notes") && response.request().method() === "POST",
+          { timeout: 15_000 }
+        ),
+        createForm.getByRole("button", { name: "Save note" }).click(),
+      ]);
+    } catch {
+      test.skip(true, "Admin notes secondary create request timed out in this environment.");
+    }
+    if (!secondaryCreateResponse) {
+      return;
+    }
+
+    const secondaryPayload = (await secondaryCreateResponse.json().catch(() => null)) as {
+      ok?: boolean;
+      error?: string;
+    } | null;
+    if (!secondaryCreateResponse.ok() || secondaryPayload?.ok === false) {
+      const reason =
+        typeof secondaryPayload?.error === "string"
+          ? secondaryPayload.error
+          : `status ${secondaryCreateResponse.status()}`;
+      test.skip(
+        true,
+        `Admin notes secondary create is not write-ready in this environment (${reason}).`
+      );
+    }
+
+    const secondaryItem = page
+      .getByTestId("admin-note-item")
+      .filter({ hasText: secondaryTitle })
+      .first();
+    await expect(secondaryItem).toBeVisible({ timeout: 10_000 });
+    const secondaryNoteIdText = await secondaryItem.getByTestId("admin-note-id").textContent();
+    const secondaryNoteId = secondaryNoteIdText?.replace("Note ID", "").trim() ?? "";
+    expect(secondaryNoteId.length).toBeGreaterThan(5);
+
+    await page.getByTestId("admin-notes-priority-filter").selectOption("high");
+    await expect(createdItem).toBeVisible();
+    await expect(page.getByTestId("admin-note-item")).toHaveCount(1);
+    await page.getByTestId("admin-notes-priority-filter").selectOption("");
 
     const searchInput = page.getByTestId("admin-notes-search");
     await searchInput.fill(noteId);
@@ -171,6 +230,7 @@ test.describe("admin notes workflow", () => {
     await editForm.getByLabel("Edit title").fill(updatedTitle);
     await editForm.getByLabel("Edit category").fill("Product");
     await editForm.getByLabel("Edit date").fill("2026-02-21");
+    await editForm.getByLabel("Priority").selectOption("urgent");
     await editForm.getByLabel("Edit text").fill(updatedBody);
     await editForm.getByRole("button", { name: "Save changes" }).click();
 
@@ -181,6 +241,84 @@ test.describe("admin notes workflow", () => {
     await expect(updatedItem).toBeVisible({ timeout: 10_000 });
     await expect(updatedItem).toContainText("Product");
     await expect(updatedItem).toContainText(updatedBody);
+    await expect(updatedItem).toContainText("Urgent");
+
+    await updatedItem.getByRole("button", { name: "Edit" }).click();
+    const attachmentsEditForm = updatedItem.getByTestId("admin-note-edit-form");
+    let uploadResponse: Awaited<ReturnType<Page["waitForResponse"]>> | undefined;
+    try {
+      [uploadResponse] = await Promise.all([
+        page.waitForResponse(
+          (response) =>
+            response.url().includes(`/api/admin/notes/${noteId}/attachments`) &&
+            response.request().method() === "POST",
+          { timeout: 15_000 }
+        ),
+        attachmentsEditForm.getByTestId("admin-note-attachment-input").setInputFiles({
+          name: "note-proof.png",
+          mimeType: "image/png",
+          buffer: TINY_PNG,
+        }),
+      ]);
+    } catch {
+      test.skip(true, "Admin notes attachment upload timed out in this environment.");
+    }
+    if (!uploadResponse) {
+      return;
+    }
+    const uploadPayload = (await uploadResponse.json().catch(() => null)) as {
+      ok?: boolean;
+      error?: string;
+    } | null;
+    if (!uploadResponse.ok() || uploadPayload?.ok === false) {
+      const reason =
+        typeof uploadPayload?.error === "string"
+          ? uploadPayload.error
+          : `status ${uploadResponse.status()}`;
+      test.skip(
+        true,
+        `Admin notes attachment upload is not ready in this environment (${reason}).`
+      );
+    }
+
+    await expect(updatedItem).toContainText("1 image");
+
+    await attachmentsEditForm
+      .getByTestId("admin-note-related-select")
+      .selectOption(secondaryNoteId);
+    let linkResponse: Awaited<ReturnType<Page["waitForResponse"]>> | undefined;
+    try {
+      [linkResponse] = await Promise.all([
+        page.waitForResponse(
+          (response) =>
+            response.url().includes(`/api/admin/notes/${noteId}/links`) &&
+            response.request().method() === "POST",
+          { timeout: 15_000 }
+        ),
+        attachmentsEditForm.getByTestId("admin-note-related-add").click(),
+      ]);
+    } catch {
+      test.skip(true, "Admin notes related-link request timed out in this environment.");
+    }
+    if (!linkResponse) {
+      return;
+    }
+
+    const linkPayload = (await linkResponse.json().catch(() => null)) as {
+      ok?: boolean;
+      error?: string;
+    } | null;
+    if (!linkResponse.ok() || linkPayload?.ok === false) {
+      const reason =
+        typeof linkPayload?.error === "string"
+          ? linkPayload.error
+          : `status ${linkResponse.status()}`;
+      test.skip(true, `Admin notes related-link is not ready in this environment (${reason}).`);
+    }
+
+    await expect(updatedItem).toContainText("1 related note");
+    await expect(updatedItem).toContainText(secondaryTitle);
+    await attachmentsEditForm.getByRole("button", { name: "Cancel" }).click();
 
     await page.getByTestId("admin-notes-category-filter").selectOption("Product");
     await expect(updatedItem).toBeVisible();
@@ -229,5 +367,17 @@ test.describe("admin notes workflow", () => {
     await expect(page.getByTestId("admin-note-item").filter({ hasText: updatedTitle })).toHaveCount(
       0
     );
+
+    await page.getByTestId("admin-notes-status-all").click();
+    const relatedNoteItem = page
+      .getByTestId("admin-note-item")
+      .filter({ hasText: secondaryTitle })
+      .first();
+    await expect(relatedNoteItem).toBeVisible({ timeout: 10_000 });
+    page.once("dialog", (dialog) => dialog.accept());
+    await relatedNoteItem.getByRole("button", { name: "Delete" }).click();
+    await expect(
+      page.getByTestId("admin-note-item").filter({ hasText: secondaryTitle })
+    ).toHaveCount(0);
   });
 });

--- a/tests/e2e/api-security-negative-paths.spec.ts
+++ b/tests/e2e/api-security-negative-paths.spec.ts
@@ -321,6 +321,25 @@ test.describe("api security negative paths", () => {
     await expectUnauthorizedNoLeakWithTransientRetry(() =>
       request.delete(`/api/admin/notes/${dummyUuid}`)
     );
+    await expectUnauthorizedNoLeakWithTransientRetry(() =>
+      request.post(`/api/admin/notes/${dummyUuid}/attachments`)
+    );
+    await expectUnauthorizedNoLeakWithTransientRetry(() =>
+      request.delete(`/api/admin/notes/${dummyUuid}/attachments/${dummyUuid}`)
+    );
+    await expectUnauthorizedNoLeakWithTransientRetry(() =>
+      request.post(`/api/admin/notes/${dummyUuid}/links`, {
+        headers: {
+          "content-type": "application/json",
+        },
+        data: JSON.stringify({
+          relatedNoteId: dummyUuid,
+        }),
+      })
+    );
+    await expectUnauthorizedNoLeakWithTransientRetry(() =>
+      request.delete(`/api/admin/notes/${dummyUuid}/links/${dummyUuid}`)
+    );
 
     await expectUnauthorizedNoLeakWithTransientRetry(() =>
       request.get("/api/admin/categories/notes")

--- a/tests/unit/admin-notes-manager.test.ts
+++ b/tests/unit/admin-notes-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { AdminNoteRow } from "@/lib/admin/notes";
+import type { AdminNoteItem } from "@/lib/admin/notes";
 import {
   ADMIN_NOTES_QUERY_KEYS,
   DEFAULT_ADMIN_NOTES_FILTER_STATE,
@@ -11,13 +11,14 @@ import {
   parseAdminNotesFilterState,
 } from "@/lib/admin/notes-manager";
 
-function buildNote(overrides?: Partial<AdminNoteRow>): AdminNoteRow {
+function buildNote(overrides?: Partial<AdminNoteItem>): AdminNoteItem {
   return {
     id: "note-1",
     title: "Follow up note",
     body: "Check the plans page issue.",
     category: "Operations",
     note_date: "2026-03-21",
+    priority: "normal",
     is_done: false,
     context_type: "page",
     context_ref: "/plans",
@@ -25,6 +26,8 @@ function buildNote(overrides?: Partial<AdminNoteRow>): AdminNoteRow {
     updated_by: "admin-user",
     created_at: "2026-03-21T10:00:00.000Z",
     updated_at: "2026-03-21T10:00:00.000Z",
+    attachments: [],
+    related_notes: [],
     ...overrides,
   };
 }
@@ -49,6 +52,7 @@ describe("admin notes manager filter state", () => {
       query: "note-123",
       status: "done",
       category: "Operations",
+      priority: "high",
       contextType: "page",
       contextRef: "/plans",
     });
@@ -57,6 +61,7 @@ describe("admin notes manager filter state", () => {
     expect(next.get(ADMIN_NOTES_QUERY_KEYS.query)).toBe("note-123");
     expect(next.get(ADMIN_NOTES_QUERY_KEYS.status)).toBe("done");
     expect(next.get(ADMIN_NOTES_QUERY_KEYS.category)).toBe("Operations");
+    expect(next.get(ADMIN_NOTES_QUERY_KEYS.priority)).toBe("high");
     expect(next.get(ADMIN_NOTES_QUERY_KEYS.contextType)).toBe("page");
     expect(next.get(ADMIN_NOTES_QUERY_KEYS.contextRef)).toBe("/plans");
   });
@@ -81,6 +86,7 @@ describe("admin notes manager filtering", () => {
         query: "note-1",
         status: "open",
         category: "",
+        priority: "",
         contextType: "",
         contextRef: "",
       },
@@ -97,6 +103,7 @@ describe("admin notes manager filtering", () => {
         query: "",
         status: "done",
         category: "Content",
+        priority: "",
         contextType: "course_lesson",
         contextRef: "kick-drills--kick-basics-support-not-speed",
       },
@@ -129,5 +136,49 @@ describe("admin notes manager filtering", () => {
       "Course Lesson: M3 · L1 · Kick basics support, not speed (kick-drills--kick-basics-support-not-speed)",
       "Page: Plans (/plans)",
     ]);
+  });
+
+  it("filters by priority and searches attachment + related note metadata", () => {
+    const withAttachment = buildNote({
+      id: "note-3",
+      priority: "urgent",
+      attachments: [
+        {
+          id: "attachment-1",
+          note_id: "note-3",
+          file_name: "checkout-error.png",
+          mime_type: "image/png",
+          size_bytes: 1024,
+          created_at: "2026-03-21T10:05:00.000Z",
+          created_by: "admin-user",
+          signed_url: "https://example.com/checkout-error.png",
+        },
+      ],
+      related_notes: [
+        {
+          id: "note-4",
+          title: "Billing follow-up",
+          category: "Commerce",
+          note_date: "2026-03-20",
+          is_done: false,
+          priority: "high",
+        },
+      ],
+    });
+
+    const filtered = filterAdminNotes({
+      items: [openPlansNote, withAttachment],
+      filters: {
+        query: "checkout-error",
+        status: "open",
+        category: "",
+        priority: "urgent",
+        contextType: "",
+        contextRef: "",
+      },
+      catalog,
+    });
+
+    expect(filtered).toEqual([withAttachment]);
   });
 });

--- a/tests/unit/admin-notes-routes.test.ts
+++ b/tests/unit/admin-notes-routes.test.ts
@@ -1,0 +1,322 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  createRouteHandlerSupabaseClientMock,
+  requireAdminRoleFromSupabaseMock,
+  createAdminSupabaseClientMock,
+  hydrateAdminNoteRowsMock,
+  loadHydratedAdminNoteByIdMock,
+  selectAdminNoteFieldsMock,
+} = vi.hoisted(() => ({
+  createRouteHandlerSupabaseClientMock: vi.fn(),
+  requireAdminRoleFromSupabaseMock: vi.fn(),
+  createAdminSupabaseClientMock: vi.fn(),
+  hydrateAdminNoteRowsMock: vi.fn(),
+  loadHydratedAdminNoteByIdMock: vi.fn(),
+  selectAdminNoteFieldsMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/route-handler", () => ({
+  createRouteHandlerSupabaseClient: createRouteHandlerSupabaseClientMock,
+}));
+
+vi.mock("@/lib/admin/server", () => ({
+  requireAdminRoleFromSupabase: requireAdminRoleFromSupabaseMock,
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminSupabaseClient: createAdminSupabaseClientMock,
+}));
+
+vi.mock("@/lib/admin/notes-server", () => ({
+  hydrateAdminNoteRows: hydrateAdminNoteRowsMock,
+  loadHydratedAdminNoteById: loadHydratedAdminNoteByIdMock,
+  selectAdminNoteFields: selectAdminNoteFieldsMock,
+}));
+
+import { DELETE as deleteNote } from "@/app/api/admin/notes/[id]/route";
+import { DELETE as deleteAttachment } from "@/app/api/admin/notes/[id]/attachments/[attachmentId]/route";
+import { POST as addRelatedNote } from "@/app/api/admin/notes/[id]/links/route";
+
+function applyResponseCookiesIdentity<T>(response: T): T {
+  return response;
+}
+
+function noteContext(id: string) {
+  return {
+    params: Promise.resolve({ id }),
+  };
+}
+
+function attachmentContext(id: string, attachmentId: string) {
+  return {
+    params: Promise.resolve({ id, attachmentId }),
+  };
+}
+
+function linkContext(id: string) {
+  return {
+    params: Promise.resolve({ id }),
+  };
+}
+
+function buildSelectEqOrder(result: unknown) {
+  const order = vi.fn().mockResolvedValue(result);
+  const eq = vi.fn().mockReturnValue({ order });
+  const select = vi.fn().mockReturnValue({ eq });
+  return { select, eq, order };
+}
+
+function buildSelectTwoEqMaybeSingle(result: unknown) {
+  const maybeSingle = vi.fn().mockResolvedValue(result);
+  const eqSecond = vi.fn().mockReturnValue({ maybeSingle });
+  const eqFirst = vi.fn().mockReturnValue({ eq: eqSecond });
+  const select = vi.fn().mockReturnValue({ eq: eqFirst });
+  return { select, eqFirst, eqSecond, maybeSingle };
+}
+
+function buildDeleteEqSelect(result: unknown) {
+  const select = vi.fn().mockResolvedValue(result);
+  const eq = vi.fn().mockReturnValue({ select });
+  const del = vi.fn().mockReturnValue({ eq });
+  return { del, eq, select };
+}
+
+function buildDeleteTwoEqSelectMaybeSingle(result: unknown) {
+  const maybeSingle = vi.fn().mockResolvedValue(result);
+  const select = vi.fn().mockReturnValue({ maybeSingle });
+  const eqSecond = vi.fn().mockReturnValue({ select });
+  const eqFirst = vi.fn().mockReturnValue({ eq: eqSecond });
+  const del = vi.fn().mockReturnValue({ eq: eqFirst });
+  return { del, eqFirst, eqSecond, select, maybeSingle };
+}
+
+function buildDeleteEqSelectMaybeSingle(result: unknown) {
+  const maybeSingle = vi.fn().mockResolvedValue(result);
+  const select = vi.fn().mockReturnValue({ maybeSingle });
+  const eq = vi.fn().mockReturnValue({ select });
+  const del = vi.fn().mockReturnValue({ eq });
+  return { del, eq, select, maybeSingle };
+}
+
+function buildSelectIn(result: unknown) {
+  const inMock = vi.fn().mockResolvedValue(result);
+  const select = vi.fn().mockReturnValue({ in: inMock });
+  return { select, inMock };
+}
+
+describe("admin notes mutation routes", () => {
+  beforeEach(() => {
+    requireAdminRoleFromSupabaseMock.mockResolvedValue({
+      ok: true,
+      user: { id: "admin-user-id" },
+      role: "admin",
+    });
+    selectAdminNoteFieldsMock.mockReturnValue("id,title");
+    hydrateAdminNoteRowsMock.mockResolvedValue({
+      ok: true,
+      items: [],
+    });
+    loadHydratedAdminNoteByIdMock.mockResolvedValue({
+      ok: true,
+      item: {
+        id: "123e4567-e89b-42d3-a456-426614174099",
+        title: "Hydrated note",
+        body: "",
+        category: "Operations",
+        note_date: "2026-03-22",
+        priority: "high",
+        is_done: false,
+        context_type: null,
+        context_ref: null,
+        created_by: "admin-user-id",
+        updated_by: "admin-user-id",
+        created_at: "2026-03-22T09:00:00.000Z",
+        updated_at: "2026-03-22T09:00:00.000Z",
+        attachments: [],
+        related_notes: [],
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes note attachments from storage before reporting note delete success", async () => {
+    const noteId = "123e4567-e89b-42d3-a456-426614174099";
+    const attachmentRow = {
+      id: "123e4567-e89b-42d3-a456-426614174011",
+      note_id: noteId,
+      file_name: "incident.png",
+      mime_type: "image/png",
+      size_bytes: 1024,
+      storage_path: "notes/path/incident.png",
+      created_at: "2026-03-22T09:00:00.000Z",
+      created_by: "admin-user-id",
+    };
+
+    const attachmentsSelect = buildSelectEqOrder({
+      data: [attachmentRow],
+      error: null,
+    });
+    const attachmentsDelete = buildDeleteEqSelect({
+      data: [attachmentRow],
+      error: null,
+    });
+    const noteDelete = buildDeleteEqSelectMaybeSingle({
+      data: { id: noteId },
+      error: null,
+    });
+
+    const supabase = {
+      from: vi
+        .fn()
+        .mockImplementationOnce(() => ({ select: attachmentsSelect.select }))
+        .mockImplementationOnce(() => ({ delete: attachmentsDelete.del }))
+        .mockImplementationOnce(() => ({ delete: noteDelete.del })),
+    };
+
+    const removeMock = vi.fn().mockResolvedValue({ data: [], error: null });
+    createAdminSupabaseClientMock.mockReturnValue({
+      storage: {
+        from: vi.fn().mockReturnValue({ remove: removeMock }),
+      },
+    });
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase,
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await deleteNote(
+      new Request(`https://freeswimming.org/api/admin/notes/${noteId}`, {
+        method: "DELETE",
+      }),
+      noteContext(noteId)
+    );
+
+    const payload = (await response.json()) as { ok?: boolean; id?: string };
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(payload.id).toBe(noteId);
+    expect(removeMock).toHaveBeenCalledWith([attachmentRow.storage_path]);
+  });
+
+  it("restores attachment metadata if storage delete fails", async () => {
+    const noteId = "123e4567-e89b-42d3-a456-426614174099";
+    const attachmentId = "123e4567-e89b-42d3-a456-426614174011";
+    const attachmentRow = {
+      id: attachmentId,
+      note_id: noteId,
+      file_name: "incident.png",
+      mime_type: "image/png",
+      size_bytes: 1024,
+      storage_path: "notes/path/incident.png",
+      created_at: "2026-03-22T09:00:00.000Z",
+      created_by: "admin-user-id",
+    };
+
+    const existingAttachment = buildSelectTwoEqMaybeSingle({
+      data: attachmentRow,
+      error: null,
+    });
+    const deleteAttachmentMetadata = buildDeleteTwoEqSelectMaybeSingle({
+      data: attachmentRow,
+      error: null,
+    });
+    const restoreInsert = vi.fn().mockResolvedValue({ error: null });
+
+    const supabase = {
+      from: vi
+        .fn()
+        .mockImplementationOnce(() => ({ select: existingAttachment.select }))
+        .mockImplementationOnce(() => ({ delete: deleteAttachmentMetadata.del }))
+        .mockImplementationOnce(() => ({ insert: restoreInsert })),
+    };
+
+    createAdminSupabaseClientMock.mockReturnValue({
+      storage: {
+        from: vi.fn().mockReturnValue({
+          remove: vi.fn().mockResolvedValue({
+            data: null,
+            error: { message: "bucket unavailable" },
+          }),
+        }),
+      },
+    });
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase,
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await deleteAttachment(
+      new Request(
+        `https://freeswimming.org/api/admin/notes/${noteId}/attachments/${attachmentId}`,
+        {
+          method: "DELETE",
+        }
+      ),
+      attachmentContext(noteId, attachmentId)
+    );
+
+    const payload = (await response.json()) as { ok?: boolean; error?: string };
+    expect(response.status).toBe(500);
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toContain("Could not delete attachment");
+    expect(restoreInsert).toHaveBeenCalledWith(attachmentRow);
+  });
+
+  it("canonicalizes link insert order before saving related note pairs", async () => {
+    const noteId = "123e4567-e89b-42d3-a456-426614174099";
+    const relatedNoteId = "123e4567-e89b-42d3-a456-426614174001";
+    const notesLookup = buildSelectIn({
+      data: [{ id: noteId }, { id: relatedNoteId }],
+      error: null,
+    });
+    const insertLink = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        maybeSingle: vi.fn().mockResolvedValue({
+          data: {
+            note_id: relatedNoteId,
+            related_note_id: noteId,
+            created_at: "2026-03-22T09:00:00.000Z",
+            created_by: "admin-user-id",
+          },
+          error: null,
+        }),
+      }),
+    });
+
+    const supabase = {
+      from: vi
+        .fn()
+        .mockImplementationOnce(() => ({ select: notesLookup.select }))
+        .mockImplementationOnce(() => ({ insert: insertLink })),
+    };
+
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase,
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await addRelatedNote(
+      new Request(`https://freeswimming.org/api/admin/notes/${noteId}/links`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ relatedNoteId }),
+      }),
+      linkContext(noteId)
+    );
+
+    const payload = (await response.json()) as { ok?: boolean; item?: { id?: string } };
+    expect(response.status).toBe(201);
+    expect(payload.ok).toBe(true);
+    expect(insertLink).toHaveBeenCalledWith({
+      note_id: relatedNoteId,
+      related_note_id: noteId,
+      created_by: "admin-user-id",
+    });
+  });
+});

--- a/tests/unit/admin-notes.test.ts
+++ b/tests/unit/admin-notes.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   ADMIN_INCIDENT_NOTE_CATEGORY_BY_SEVERITY,
+  buildAdminNoteAttachmentStoragePath,
   buildIncidentNoteBodyTemplate,
+  canonicalizeAdminNoteLinkPair,
   parseCreateAdminNotePayload,
   parseUpdateAdminNotePayload,
+  validateAdminNoteAttachment,
 } from "@/lib/admin/notes";
 
 describe("parseCreateAdminNotePayload", () => {
@@ -24,6 +27,7 @@ describe("parseCreateAdminNotePayload", () => {
     expect(parsed.value.title).toBe("Follow up Stripe webhook");
     expect(parsed.value.category).toBe("Commerce");
     expect(parsed.value.noteDate).toBe("2026-02-20");
+    expect(parsed.value.priority).toBe("normal");
     expect(parsed.value.contextType).toBe("course_lesson");
     expect(parsed.value.contextRef).toBe("kick-drills--kick-basics-support-not-speed");
   });
@@ -51,6 +55,7 @@ describe("parseUpdateAdminNotePayload", () => {
     const parsed = parseUpdateAdminNotePayload({
       isDone: true,
       category: "Product",
+      priority: "urgent",
     });
 
     expect(parsed.ok).toBe(true);
@@ -58,6 +63,7 @@ describe("parseUpdateAdminNotePayload", () => {
 
     expect(parsed.value.isDone).toBe(true);
     expect(parsed.value.category).toBe("Product");
+    expect(parsed.value.priority).toBe("urgent");
   });
 
   it("allows context update", () => {
@@ -96,6 +102,62 @@ describe("parseUpdateAdminNotePayload", () => {
   it("rejects unknown/empty updates", () => {
     const parsed = parseUpdateAdminNotePayload({});
     expect(parsed.ok).toBe(false);
+  });
+});
+
+describe("admin note attachment validation", () => {
+  it("accepts allowed image types and builds storage paths", () => {
+    const validated = validateAdminNoteAttachment({
+      fileName: "Checkout error 1.png",
+      mimeType: "image/png",
+      sizeBytes: 2048,
+    });
+
+    expect(validated.ok).toBe(true);
+    if (!validated.ok) return;
+
+    expect(validated.value.fileName).toBe("Checkout-error-1.png");
+    expect(
+      buildAdminNoteAttachmentStoragePath({
+        noteId: "123e4567-e89b-42d3-a456-426614174000",
+        attachmentId: "123e4567-e89b-42d3-a456-426614174001",
+        fileName: validated.value.fileName,
+      })
+    ).toContain("Checkout-error-1.png");
+  });
+
+  it("rejects unsupported types", () => {
+    const validated = validateAdminNoteAttachment({
+      fileName: "malware.svg",
+      mimeType: "image/svg+xml",
+      sizeBytes: 1024,
+    });
+
+    expect(validated.ok).toBe(false);
+  });
+});
+
+describe("admin note link canonicalization", () => {
+  it("sorts note ids into a canonical pair", () => {
+    const canonical = canonicalizeAdminNoteLinkPair(
+      "123e4567-e89b-42d3-a456-426614174099",
+      "123e4567-e89b-42d3-a456-426614174001"
+    );
+
+    expect(canonical.ok).toBe(true);
+    if (!canonical.ok) return;
+
+    expect(canonical.value.noteId).toBe("123e4567-e89b-42d3-a456-426614174001");
+    expect(canonical.value.relatedNoteId).toBe("123e4567-e89b-42d3-a456-426614174099");
+  });
+
+  it("rejects self-links", () => {
+    const canonical = canonicalizeAdminNoteLinkPair(
+      "123e4567-e89b-42d3-a456-426614174001",
+      "123e4567-e89b-42d3-a456-426614174001"
+    );
+
+    expect(canonical.ok).toBe(false);
   });
 });
 

--- a/types/database.ts
+++ b/types/database.ts
@@ -657,6 +657,7 @@ export type Database = {
           id: string;
           is_done: boolean;
           note_date: string;
+          priority: "low" | "normal" | "high" | "urgent";
           title: string;
           updated_at: string;
           updated_by: string | null;
@@ -671,6 +672,7 @@ export type Database = {
           id?: string;
           is_done?: boolean;
           note_date?: string;
+          priority?: "low" | "normal" | "high" | "urgent";
           title: string;
           updated_at?: string;
           updated_by?: string | null;
@@ -685,11 +687,89 @@ export type Database = {
           id?: string;
           is_done?: boolean;
           note_date?: string;
+          priority?: "low" | "normal" | "high" | "urgent";
           title?: string;
           updated_at?: string;
           updated_by?: string | null;
         };
         Relationships: [];
+      };
+      admin_note_attachments: {
+        Row: {
+          created_at: string;
+          created_by: string | null;
+          file_name: string;
+          id: string;
+          mime_type: string;
+          note_id: string;
+          size_bytes: number;
+          storage_path: string;
+        };
+        Insert: {
+          created_at?: string;
+          created_by?: string | null;
+          file_name: string;
+          id?: string;
+          mime_type: string;
+          note_id: string;
+          size_bytes: number;
+          storage_path: string;
+        };
+        Update: {
+          created_at?: string;
+          created_by?: string | null;
+          file_name?: string;
+          id?: string;
+          mime_type?: string;
+          note_id?: string;
+          size_bytes?: number;
+          storage_path?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "admin_note_attachments_note_id_fkey";
+            columns: ["note_id"];
+            isOneToOne: false;
+            referencedRelation: "admin_notes";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      admin_note_links: {
+        Row: {
+          created_at: string;
+          created_by: string | null;
+          note_id: string;
+          related_note_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          created_by?: string | null;
+          note_id: string;
+          related_note_id: string;
+        };
+        Update: {
+          created_at?: string;
+          created_by?: string | null;
+          note_id?: string;
+          related_note_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "admin_note_links_note_id_fkey";
+            columns: ["note_id"];
+            isOneToOne: false;
+            referencedRelation: "admin_notes";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "admin_note_links_related_note_id_fkey";
+            columns: ["related_note_id"];
+            isOneToOne: false;
+            referencedRelation: "admin_notes";
+            referencedColumns: ["id"];
+          },
+        ];
       };
       admin_runtime_flags: {
         Row: {


### PR DESCRIPTION
## Summary

- add admin-note image attachments with real storage-backed upload/delete lifecycle
- add explicit note priority and related-note linking across the admin notes manager and contextual notes surfaces
- hydrate notes with signed attachment URLs, related note summaries, stronger delete recovery, and updated help/runbook guidance
- split app-wide quick capture into a dedicated follow-up brief so this PR stays focused on storage, integrity, and richer note editing

## Scope

- In scope:
  - admin note API and schema changes for attachments, priority, and related links
  - admin notes UI updates for richer editing, filtering, sorting, and discoverability
  - help/runbook updates for screenshot handling, delete semantics, and richer note triage
  - unit and e2e coverage for mutation lifecycle and unauthorized-path denial
- Out of scope:
  - app-wide admin quick-capture launcher rollout
  - non-image attachments
  - public-user uploads or issue-tracker style threading

## Risk

- Main risk: attachment delete/upload edge cases could leave confusing operator state if metadata and storage drift apart
- Mitigation: upload rollback, storage-delete rollback, runtime guards, authz negative-path coverage, and help/runbook recovery guidance
- Rollback plan: revert `2637a81` to restore the previous notes workflow

## Test Evidence

- `npm run verify:pre-pr`: PASS on `2637a81`
- `npm run verify:pre-merge`: pending on current HEAD
- Additional targeted validation completed during implementation:
  - `npx eslint` on changed admin-notes files and tests
  - `npm run typecheck -- --pretty false`
  - `npx vitest run tests/unit/admin-notes.test.ts tests/unit/admin-notes-manager.test.ts tests/unit/admin-notes-routes.test.ts`
  - `npx playwright test tests/e2e/api-security-negative-paths.spec.ts --project=desktop-chromium`
- Perf budget trend: recommendation was `tighten`; decision for this slice is `hold` because it does not change public core-route perf targets. Revisit tightening in the next AW-010 performance checkpoint/PR summary.

- [x] `npm run lint:briefs`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] `npm run test:e2e`
- [x] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Docs And Briefs

- brief in progress: `docs/task-briefs/in-progress/2026-03-21-admin-notes-workflow-v2-attachments-and-linking-10-10.md`
- planned follow-up: `docs/task-briefs/planned/2026-03-22-admin-notes-quick-capture-launcher-10-10.md`
- updated docs:
  - `docs/runbooks/admin-notes-recovery.md`
  - `components/admin/AdminHelpCenter.tsx`

## Checklist

- [x] Acceptance criteria are met for this slice
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added

## Owner Merge Step

- [ ] Required checks are green
- [ ] `npm run verify:pre-merge` passes on current HEAD
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner
