### PR TITLE
feat(admin): add quick note capture launcher

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,5 +1,18 @@
 import AdminWorkspace from "@/components/admin/AdminWorkspace";
+import { resolveAdminRoleFromSupabase } from "@/lib/admin/server";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
 
-export default function AdminPage() {
-  return <AdminWorkspace />;
+export default async function AdminPage() {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const role = user
+    ? await resolveAdminRoleFromSupabase(supabase, user, {
+        allowlistedEmailsRaw: process.env.ADMIN_EMAIL_ALLOWLIST,
+      })
+    : null;
+
+  return <AdminWorkspace role={role} />;
 }

--- a/app/api/admin/notes/route.ts
+++ b/app/api/admin/notes/route.ts
@@ -101,6 +101,7 @@ export async function GET(request: Request) {
         return applySupabaseCookies(
           noStoreJson({
             ok: true,
+            role: gate.role,
             items: [],
             schemaReady: false,
             warning: getAdminSchemaSetupMessage("notes"),
@@ -112,6 +113,7 @@ export async function GET(request: Request) {
       return applySupabaseCookies(
         noStoreJson({
           ok: true,
+          role: gate.role,
           items: [],
           schemaReady: false,
           warning: getAdminSchemaSetupMessage("notes"),
@@ -137,6 +139,7 @@ export async function GET(request: Request) {
           return applySupabaseCookies(
             noStoreJson({
               ok: true,
+              role: gate.role,
               items: [],
               schemaReady: false,
               warning: getAdminSchemaSetupMessage("notes"),
@@ -148,6 +151,7 @@ export async function GET(request: Request) {
         return applySupabaseCookies(
           noStoreJson({
             ok: true,
+            role: gate.role,
             items: [],
             schemaReady: false,
             warning: getAdminSchemaSetupMessage("notes"),
@@ -172,6 +176,7 @@ export async function GET(request: Request) {
         return applySupabaseCookies(
           noStoreJson({
             ok: true,
+            role: gate.role,
             items: [],
             schemaReady: false,
             warning: getAdminSchemaSetupMessage("notes"),
@@ -183,6 +188,7 @@ export async function GET(request: Request) {
       return applySupabaseCookies(
         noStoreJson({
           ok: true,
+          role: gate.role,
           items: [],
           schemaReady: false,
           warning: getAdminSchemaSetupMessage("notes"),
@@ -193,6 +199,7 @@ export async function GET(request: Request) {
     return applySupabaseCookies(
       noStoreJson({
         ok: true,
+        role: gate.role,
         items: hydrated.items,
         schemaReady: true,
         warning: null,
@@ -227,6 +234,7 @@ export async function GET(request: Request) {
       return applySupabaseCookies(
         noStoreJson({
           ok: true,
+          role: gate.role,
           items: [],
           schemaReady: false,
           warning: getAdminSchemaSetupMessage("notes"),
@@ -238,6 +246,7 @@ export async function GET(request: Request) {
     return applySupabaseCookies(
       noStoreJson({
         ok: true,
+        role: gate.role,
         items: [],
         schemaReady: false,
         warning: getAdminSchemaSetupMessage("notes"),
@@ -255,6 +264,7 @@ export async function GET(request: Request) {
       return applySupabaseCookies(
         noStoreJson({
           ok: true,
+          role: gate.role,
           items: [],
           schemaReady: false,
           warning: getAdminSchemaSetupMessage("notes"),
@@ -266,6 +276,7 @@ export async function GET(request: Request) {
     return applySupabaseCookies(
       noStoreJson({
         ok: true,
+        role: gate.role,
         items: [],
         schemaReady: false,
         warning: getAdminSchemaSetupMessage("notes"),
@@ -276,6 +287,7 @@ export async function GET(request: Request) {
   return applySupabaseCookies(
     noStoreJson({
       ok: true,
+      role: gate.role,
       items: hydrated.items,
       schemaReady: true,
       warning: null,

--- a/components/admin/AdminContextNotesPanel.tsx
+++ b/components/admin/AdminContextNotesPanel.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import AdminNoteQuickCaptureLauncher from "@/components/admin/AdminNoteQuickCaptureLauncher";
+import { hasRequiredAdminRole, type AdminRole } from "@/lib/admin/access";
 import type { AdminCategoryRow } from "@/lib/admin/categories";
 import type { AdminNoteContextType } from "@/lib/admin/note-context";
 import type { AdminNoteItem } from "@/lib/admin/notes";
@@ -8,6 +10,7 @@ import type { AdminNoteItem } from "@/lib/admin/notes";
 type AdminNotesResponse =
   | {
       ok: true;
+      role: AdminRole;
       items: AdminNoteItem[];
       schemaReady?: boolean;
       warning?: string | null;
@@ -126,6 +129,7 @@ export default function AdminContextNotesPanel({
   const [expanded, setExpanded] = useState(!collapsedByDefault);
   const [loading, setLoading] = useState(false);
   const [items, setItems] = useState<AdminNoteItem[]>([]);
+  const [adminRole, setAdminRole] = useState<AdminRole | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [actionNotice, setActionNotice] = useState<string | null>(null);
@@ -169,6 +173,7 @@ export default function AdminContextNotesPanel({
 
       if (response.status === 401 || response.status === 403) {
         setAuthorized(false);
+        setAdminRole(null);
         setItems([]);
         setCategoryOptions([]);
         return;
@@ -187,6 +192,7 @@ export default function AdminContextNotesPanel({
       }
 
       setAuthorized(true);
+      setAdminRole(payload.role);
       setItems(payload.items);
       setSchemaReady(payload.schemaReady !== false);
       setWarning(payload.warning ?? null);
@@ -209,6 +215,7 @@ export default function AdminContextNotesPanel({
       }
     } catch {
       setAuthorized(true);
+      setAdminRole(null);
       setItems([]);
       setCategoryOptions([]);
       setError("Could not load context notes.");
@@ -394,6 +401,7 @@ export default function AdminContextNotesPanel({
     contextType === "course_lesson"
       ? items.filter((item) => item.context_type === "course_module").length
       : 0;
+  const canMutateNotes = Boolean(adminRole && hasRequiredAdminRole(adminRole, "editor"));
 
   return (
     <section
@@ -411,14 +419,28 @@ export default function AdminContextNotesPanel({
             {inheritedModuleCount > 0 ? ` · ${inheritedModuleCount} inherited from module` : ""}
           </p>
         </div>
-        <button
-          type="button"
-          onClick={() => setExpanded((prev) => !prev)}
-          className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-semibold text-slate-700 transition hover:bg-slate-50"
-          data-testid="admin-context-notes-toggle"
-        >
-          {expanded ? "Collapse notes" : "Show notes"}
-        </button>
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <AdminNoteQuickCaptureLauncher
+            adminRole={adminRole}
+            contextType={contextType}
+            contextRef={normalizedContextRef}
+            contextLabel={contextLabel}
+            triggerLabel="Quick note"
+            onSaved={(item) => {
+              setItems((prev) => [item, ...prev.filter((entry) => entry.id !== item.id)]);
+              setActionError(null);
+              setActionNotice("Quick note saved.");
+            }}
+          />
+          <button
+            type="button"
+            onClick={() => setExpanded((prev) => !prev)}
+            className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-semibold text-slate-700 transition hover:bg-slate-50"
+            data-testid="admin-context-notes-toggle"
+          >
+            {expanded ? "Collapse notes" : "Show notes"}
+          </button>
+        </div>
       </div>
 
       {expanded ? (
@@ -495,38 +517,42 @@ export default function AdminContextNotesPanel({
                           </p>
                         ) : null}
                       </div>
-                      <div className="flex items-center gap-2">
-                        <label className="inline-flex items-center gap-2 text-xs text-slate-700">
-                          <input
-                            type="checkbox"
-                            checked={item.is_done}
+                      {canMutateNotes ? (
+                        <div className="flex items-center gap-2">
+                          <label className="inline-flex items-center gap-2 text-xs text-slate-700">
+                            <input
+                              type="checkbox"
+                              checked={item.is_done}
+                              disabled={Boolean(updatingId || deletingId || editingId)}
+                              onChange={() => {
+                                void toggleDone(item);
+                              }}
+                              className="h-4 w-4 rounded border-slate-300 text-blue-600"
+                            />
+                            {isUpdating ? "Saving…" : "Done"}
+                          </label>
+                          <button
+                            type="button"
                             disabled={Boolean(updatingId || deletingId || editingId)}
-                            onChange={() => {
-                              void toggleDone(item);
+                            onClick={() => startEdit(item)}
+                            className="inline-flex h-8 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                          >
+                            Edit
+                          </button>
+                          <button
+                            type="button"
+                            disabled={Boolean(updatingId || deletingId)}
+                            onClick={() => {
+                              void handleDelete(item);
                             }}
-                            className="h-4 w-4 rounded border-slate-300 text-blue-600"
-                          />
-                          {isUpdating ? "Saving…" : "Done"}
-                        </label>
-                        <button
-                          type="button"
-                          disabled={Boolean(updatingId || deletingId || editingId)}
-                          onClick={() => startEdit(item)}
-                          className="inline-flex h-8 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-                        >
-                          Edit
-                        </button>
-                        <button
-                          type="button"
-                          disabled={Boolean(updatingId || deletingId)}
-                          onClick={() => {
-                            void handleDelete(item);
-                          }}
-                          className="inline-flex h-8 items-center justify-center rounded-lg border border-rose-200 bg-white px-3 text-xs font-medium text-rose-700 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
-                        >
-                          {isDeleting ? "Deleting…" : "Delete"}
-                        </button>
-                      </div>
+                            className="inline-flex h-8 items-center justify-center rounded-lg border border-rose-200 bg-white px-3 text-xs font-medium text-rose-700 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
+                          >
+                            {isDeleting ? "Deleting…" : "Delete"}
+                          </button>
+                        </div>
+                      ) : (
+                        <p className="text-xs font-medium text-slate-500">Read only</p>
+                      )}
                     </div>
 
                     {isEditing && editState ? (
@@ -628,87 +654,100 @@ export default function AdminContextNotesPanel({
             </ul>
           ) : null}
 
-          <div className="rounded-xl border border-slate-200 bg-slate-50/40 p-3">
-            <h4 className="text-sm font-semibold text-slate-900">Add note</h4>
-            <p className="mt-1 text-xs text-slate-600">
-              Save an admin reminder directly on this item.
+          {canMutateNotes ? (
+            <div className="rounded-xl border border-slate-200 bg-slate-50/40 p-3">
+              <h4 className="text-sm font-semibold text-slate-900">Add note</h4>
+              <p className="mt-1 text-xs text-slate-600">
+                Save an admin reminder directly on this item.
+              </p>
+              <form
+                className="mt-3 grid gap-3 sm:grid-cols-2"
+                onSubmit={handleCreate}
+                data-testid="admin-context-note-create-form"
+              >
+                <label className="space-y-1 text-xs font-medium text-slate-700 sm:col-span-2">
+                  <span>Title</span>
+                  <input
+                    type="text"
+                    required
+                    value={formState.title}
+                    onChange={(e) => setFormState((prev) => ({ ...prev, title: e.target.value }))}
+                    placeholder="What should be changed?"
+                    className="h-9 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                  />
+                </label>
+
+                <label className="space-y-1 text-xs font-medium text-slate-700">
+                  <span>Category</span>
+                  <input
+                    type="text"
+                    list="admin-context-note-category-options"
+                    value={formState.category}
+                    onChange={(e) =>
+                      setFormState((prev) => ({ ...prev, category: e.target.value }))
+                    }
+                    className="h-9 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                  />
+                </label>
+
+                <label className="space-y-1 text-xs font-medium text-slate-700">
+                  <span>Date</span>
+                  <input
+                    type="date"
+                    value={formState.noteDate}
+                    onChange={(e) =>
+                      setFormState((prev) => ({ ...prev, noteDate: e.target.value }))
+                    }
+                    className="h-9 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                  />
+                </label>
+
+                <label className="space-y-1 text-xs font-medium text-slate-700 sm:col-span-2">
+                  <span>Text</span>
+                  <textarea
+                    rows={3}
+                    value={formState.body}
+                    onChange={(e) => setFormState((prev) => ({ ...prev, body: e.target.value }))}
+                    placeholder="Write details you need to remember."
+                    className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
+                  />
+                </label>
+
+                <label className="inline-flex items-center gap-2 text-xs font-medium text-slate-700 sm:col-span-2">
+                  <input
+                    type="checkbox"
+                    checked={formState.isDone}
+                    onChange={(e) =>
+                      setFormState((prev) => ({ ...prev, isDone: e.target.checked }))
+                    }
+                    className="h-4 w-4 rounded border-slate-300 text-blue-600"
+                  />
+                  Mark as done
+                </label>
+
+                <div className="sm:col-span-2">
+                  <button
+                    type="submit"
+                    disabled={submitting || !schemaReady}
+                    className="inline-flex h-9 items-center justify-center rounded-lg bg-blue-600 px-3 text-xs font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+                  >
+                    {submitting ? "Saving…" : "Save note"}
+                  </button>
+                </div>
+              </form>
+
+              <datalist id="admin-context-note-category-options">
+                {categoryOptions.map((option) => (
+                  <option key={option} value={option} />
+                ))}
+              </datalist>
+            </div>
+          ) : (
+            <p className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600">
+              Viewer role can review contextual notes here, but only editors/admins can create or
+              change them.
             </p>
-            <form
-              className="mt-3 grid gap-3 sm:grid-cols-2"
-              onSubmit={handleCreate}
-              data-testid="admin-context-note-create-form"
-            >
-              <label className="space-y-1 text-xs font-medium text-slate-700 sm:col-span-2">
-                <span>Title</span>
-                <input
-                  type="text"
-                  required
-                  value={formState.title}
-                  onChange={(e) => setFormState((prev) => ({ ...prev, title: e.target.value }))}
-                  placeholder="What should be changed?"
-                  className="h-9 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-900"
-                />
-              </label>
-
-              <label className="space-y-1 text-xs font-medium text-slate-700">
-                <span>Category</span>
-                <input
-                  type="text"
-                  list="admin-context-note-category-options"
-                  value={formState.category}
-                  onChange={(e) => setFormState((prev) => ({ ...prev, category: e.target.value }))}
-                  className="h-9 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-900"
-                />
-              </label>
-
-              <label className="space-y-1 text-xs font-medium text-slate-700">
-                <span>Date</span>
-                <input
-                  type="date"
-                  value={formState.noteDate}
-                  onChange={(e) => setFormState((prev) => ({ ...prev, noteDate: e.target.value }))}
-                  className="h-9 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-900"
-                />
-              </label>
-
-              <label className="space-y-1 text-xs font-medium text-slate-700 sm:col-span-2">
-                <span>Text</span>
-                <textarea
-                  rows={3}
-                  value={formState.body}
-                  onChange={(e) => setFormState((prev) => ({ ...prev, body: e.target.value }))}
-                  placeholder="Write details you need to remember."
-                  className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
-                />
-              </label>
-
-              <label className="inline-flex items-center gap-2 text-xs font-medium text-slate-700 sm:col-span-2">
-                <input
-                  type="checkbox"
-                  checked={formState.isDone}
-                  onChange={(e) => setFormState((prev) => ({ ...prev, isDone: e.target.checked }))}
-                  className="h-4 w-4 rounded border-slate-300 text-blue-600"
-                />
-                Mark as done
-              </label>
-
-              <div className="sm:col-span-2">
-                <button
-                  type="submit"
-                  disabled={submitting || !schemaReady}
-                  className="inline-flex h-9 items-center justify-center rounded-lg bg-blue-600 px-3 text-xs font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
-                >
-                  {submitting ? "Saving…" : "Save note"}
-                </button>
-              </div>
-            </form>
-
-            <datalist id="admin-context-note-category-options">
-              {categoryOptions.map((option) => (
-                <option key={option} value={option} />
-              ))}
-            </datalist>
-          </div>
+          )}
         </div>
       ) : null}
     </section>

--- a/components/admin/AdminHelpCenter.tsx
+++ b/components/admin/AdminHelpCenter.tsx
@@ -387,6 +387,11 @@ const BUTTON_GUIDE: ActionGroup[] = [
     section: "Notes, Categories, and Commerce",
     actions: [
       {
+        label: "Quick note",
+        meaning:
+          "Opens the lightweight quick-capture sheet so you can save a route-aware note without switching to the Notes tab first.",
+      },
+      {
         label: "Use P0 template / Use P1 template / Use P2 template",
         meaning:
           "Prefills standardized incident structure. P0 = critical outage, P1 = major degradation with workaround, P2 = low-impact bug/UX issue.",
@@ -548,6 +553,7 @@ const DAILY_PLAYBOOKS: Playbook[] = [
     title: "Capture review notes with context",
     steps: [
       "Open the exact page/content row you are reviewing.",
+      "Use `Quick note` when you want to capture the issue fast from the current surface without losing context.",
       "Create note with category, priority, and context link, then copy the visible note ID if you need to reference it later.",
       "Add screenshots when the issue is visual or hard to reproduce, and link any follow-up note instead of pasting duplicate text.",
       "Use Search + Priority + Context filters in Notes to reopen the same note quickly.",

--- a/components/admin/AdminNoteQuickCaptureLauncher.tsx
+++ b/components/admin/AdminNoteQuickCaptureLauncher.tsx
@@ -1,0 +1,423 @@
+"use client";
+
+import { useEffect, useId, useMemo, useState } from "react";
+import Modal from "@/components/Modal";
+import type { AdminRole } from "@/lib/admin/access";
+import { hasRequiredAdminRole } from "@/lib/admin/access";
+import { applyAdminTabToSearchParams } from "@/lib/admin/admin-workspace";
+import type { AdminCategoryRow } from "@/lib/admin/categories";
+import type { AdminNoteContextType } from "@/lib/admin/note-context";
+import {
+  ADMIN_NOTE_PRIORITY_VALUES,
+  type AdminNoteItem,
+  type AdminNotePriority,
+} from "@/lib/admin/notes";
+import {
+  DEFAULT_ADMIN_NOTES_FILTER_STATE,
+  applyAdminNotesFilterStateToSearchParams,
+} from "@/lib/admin/notes-manager";
+
+type AdminCategoriesResponse =
+  | {
+      ok: true;
+      items: AdminCategoryRow[];
+    }
+  | {
+      ok: false;
+      error?: string;
+    };
+
+type AdminNoteCreateResponse =
+  | {
+      ok: true;
+      item: AdminNoteItem;
+    }
+  | {
+      ok: false;
+      error?: string;
+    };
+
+type Props = {
+  adminRole: AdminRole | null;
+  contextType: AdminNoteContextType;
+  contextRef: string;
+  contextLabel: string;
+  className?: string;
+  triggerLabel?: string;
+  triggerTestId?: string;
+  description?: string;
+  onSaved?: (item: AdminNoteItem) => void;
+};
+
+type FormState = {
+  title: string;
+  category: string;
+  noteDate: string;
+  priority: AdminNotePriority;
+  body: string;
+  isDone: boolean;
+};
+
+type SavedNotice = {
+  id: string;
+  title: string;
+};
+
+const INITIAL_CATEGORY = "General";
+
+function todayDateInputValue(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function createInitialFormState(): FormState {
+  return {
+    title: "",
+    category: INITIAL_CATEGORY,
+    noteDate: todayDateInputValue(),
+    priority: "normal",
+    body: "",
+    isDone: false,
+  };
+}
+
+function formatPriorityLabel(priority: AdminNotePriority): string {
+  return priority.charAt(0).toUpperCase() + priority.slice(1);
+}
+
+function buildAdminNotesHref(params: {
+  noteId: string;
+  contextType: AdminNoteContextType;
+  contextRef: string;
+}): string {
+  const withTab = applyAdminTabToSearchParams(new URLSearchParams(), "notes");
+  const withFilters = applyAdminNotesFilterStateToSearchParams(withTab, {
+    ...DEFAULT_ADMIN_NOTES_FILTER_STATE,
+    query: params.noteId,
+    contextType: params.contextType,
+    contextRef: params.contextRef,
+  });
+
+  const search = withFilters.toString();
+  return search ? `/admin?${search}` : "/admin";
+}
+
+export default function AdminNoteQuickCaptureLauncher({
+  adminRole,
+  contextType,
+  contextRef,
+  contextLabel,
+  className = "",
+  triggerLabel = "Quick note",
+  triggerTestId = "admin-note-quick-capture-trigger",
+  description = "Capture a context-aware admin note without leaving this surface.",
+  onSaved,
+}: Props) {
+  const canCreateNotes = Boolean(adminRole && hasRequiredAdminRole(adminRole, "editor"));
+  const [open, setOpen] = useState(false);
+  const [formState, setFormState] = useState<FormState>(() => createInitialFormState());
+  const [categoryOptions, setCategoryOptions] = useState<string[]>([]);
+  const [loadingCategories, setLoadingCategories] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedNotice, setSavedNotice] = useState<SavedNotice | null>(null);
+  const datalistId = useId();
+
+  const notesHref = useMemo(() => {
+    if (!savedNotice) return null;
+    return buildAdminNotesHref({
+      noteId: savedNotice.id,
+      contextType,
+      contextRef,
+    });
+  }, [contextRef, contextType, savedNotice]);
+
+  useEffect(() => {
+    if (!open || categoryOptions.length > 0 || loadingCategories) return;
+
+    let cancelled = false;
+
+    async function loadCategoryOptions() {
+      setLoadingCategories(true);
+      try {
+        const response = await fetch("/api/admin/categories/notes", {
+          method: "GET",
+          credentials: "same-origin",
+          cache: "no-store",
+        });
+        const payload = (await response.json()) as AdminCategoriesResponse;
+        if (cancelled || !response.ok || !payload.ok) {
+          return;
+        }
+
+        setCategoryOptions(
+          payload.items
+            .filter((item) => item.is_active)
+            .map((item) => item.title.trim())
+            .filter(Boolean)
+            .filter((value, index, all) => all.indexOf(value) === index)
+        );
+      } catch {
+        // fallback is safe
+      } finally {
+        if (!cancelled) {
+          setLoadingCategories(false);
+        }
+      }
+    }
+
+    void loadCategoryOptions();
+    return () => {
+      cancelled = true;
+    };
+  }, [categoryOptions.length, loadingCategories, open]);
+
+  if (!canCreateNotes) {
+    return null;
+  }
+
+  function openLauncher() {
+    setError(null);
+    setSavedNotice(null);
+    setOpen(true);
+  }
+
+  function closeLauncher() {
+    if (submitting) return;
+    setOpen(false);
+    setError(null);
+    setFormState(createInitialFormState());
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (submitting) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/admin/notes", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        credentials: "same-origin",
+        body: JSON.stringify({
+          ...formState,
+          contextType,
+          contextRef,
+        }),
+      });
+
+      const payload = (await response.json()) as AdminNoteCreateResponse;
+      if (!response.ok || !payload.ok) {
+        setError(payload.ok ? "Could not save note." : (payload.error ?? "Could not save note."));
+        return;
+      }
+
+      setSavedNotice({
+        id: payload.item.id,
+        title: payload.item.title,
+      });
+      onSaved?.(payload.item);
+      setOpen(false);
+      setFormState(createInitialFormState());
+    } catch {
+      setError("Could not save note.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        onClick={openLauncher}
+        data-testid={triggerTestId}
+        className="inline-flex h-9 items-center justify-center rounded-lg border border-blue-200 bg-blue-50 px-3 text-xs font-semibold text-blue-800 transition hover:bg-blue-100"
+      >
+        {triggerLabel}
+      </button>
+
+      {savedNotice ? (
+        <div className="mt-2 rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-900">
+          <p className="font-semibold">Quick note saved.</p>
+          <p className="mt-1">
+            {savedNotice.title}
+            {notesHref ? (
+              <>
+                {" "}
+                <a href={notesHref} className="font-semibold underline underline-offset-2">
+                  Open in Notes
+                </a>
+              </>
+            ) : null}
+          </p>
+        </div>
+      ) : null}
+
+      <Modal open={open} onClose={closeLauncher} ariaLabel="Quick note capture">
+        <div className="flex h-full min-h-0 flex-col" data-testid="admin-note-quick-capture-dialog">
+          <div className="flex items-start justify-between gap-3 border-b border-slate-200 px-5 py-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
+                Quick capture
+              </p>
+              <h2 className="mt-1 text-lg font-semibold text-slate-900">Create note fast</h2>
+              <p className="mt-1 text-sm text-slate-600">{description}</p>
+            </div>
+            <button
+              type="button"
+              onClick={closeLauncher}
+              className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+            >
+              Close
+            </button>
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+            <div className="rounded-2xl border border-blue-100 bg-blue-50/60 px-4 py-3">
+              <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Context</p>
+              <p className="mt-1 text-sm font-medium text-slate-900">{contextLabel}</p>
+              <p className="mt-1 text-xs text-slate-600">
+                This note will be attached to the canonical route/content context for this surface.
+              </p>
+            </div>
+
+            {error ? (
+              <p className="mt-4 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+                {error}
+              </p>
+            ) : null}
+
+            <form
+              className="mt-4 grid gap-3"
+              onSubmit={handleSubmit}
+              data-testid="admin-note-quick-capture-form"
+            >
+              <label className="space-y-1 text-xs font-medium text-slate-700">
+                <span>Title</span>
+                <input
+                  type="text"
+                  required
+                  autoFocus
+                  value={formState.title}
+                  onChange={(event) =>
+                    setFormState((prev) => ({ ...prev, title: event.target.value }))
+                  }
+                  placeholder="What should be changed?"
+                  className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                />
+              </label>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                <label className="space-y-1 text-xs font-medium text-slate-700">
+                  <span>Category</span>
+                  <input
+                    type="text"
+                    list={datalistId}
+                    value={formState.category}
+                    onChange={(event) =>
+                      setFormState((prev) => ({ ...prev, category: event.target.value }))
+                    }
+                    className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                  />
+                </label>
+
+                <label className="space-y-1 text-xs font-medium text-slate-700">
+                  <span>Date</span>
+                  <input
+                    type="date"
+                    value={formState.noteDate}
+                    onChange={(event) =>
+                      setFormState((prev) => ({ ...prev, noteDate: event.target.value }))
+                    }
+                    className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                  />
+                </label>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                <label className="space-y-1 text-xs font-medium text-slate-700">
+                  <span>Priority</span>
+                  <select
+                    value={formState.priority}
+                    onChange={(event) =>
+                      setFormState((prev) => ({
+                        ...prev,
+                        priority: event.target.value as AdminNotePriority,
+                      }))
+                    }
+                    className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                  >
+                    {ADMIN_NOTE_PRIORITY_VALUES.map((priority) => (
+                      <option key={priority} value={priority}>
+                        {formatPriorityLabel(priority)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="inline-flex items-center gap-2 self-end rounded-xl border border-slate-200 bg-slate-50 px-3 py-3 text-xs font-medium text-slate-700">
+                  <input
+                    type="checkbox"
+                    checked={formState.isDone}
+                    onChange={(event) =>
+                      setFormState((prev) => ({ ...prev, isDone: event.target.checked }))
+                    }
+                    className="h-4 w-4 rounded border-slate-300 text-blue-600"
+                  />
+                  Mark as done
+                </label>
+              </div>
+
+              <label className="space-y-1 text-xs font-medium text-slate-700">
+                <span>Text</span>
+                <textarea
+                  rows={5}
+                  value={formState.body}
+                  onChange={(event) =>
+                    setFormState((prev) => ({ ...prev, body: event.target.value }))
+                  }
+                  placeholder="Write the details you need to remember."
+                  className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
+                />
+              </label>
+
+              <div className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 pt-4">
+                <p className="text-xs text-slate-500">
+                  {loadingCategories
+                    ? "Loading category suggestions…"
+                    : "The note stays local until you click Save note."}
+                </p>
+                <div className="flex flex-wrap items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={closeLauncher}
+                    disabled={submitting}
+                    className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={submitting}
+                    className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+                  >
+                    {submitting ? "Saving…" : "Save note"}
+                  </button>
+                </div>
+              </div>
+            </form>
+
+            <datalist id={datalistId}>
+              {categoryOptions.map((option) => (
+                <option key={option} value={option} />
+              ))}
+            </datalist>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/components/admin/AdminWorkspace.tsx
+++ b/components/admin/AdminWorkspace.tsx
@@ -2,6 +2,7 @@
 
 import { startTransition, useMemo } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import AdminNoteQuickCaptureLauncher from "@/components/admin/AdminNoteQuickCaptureLauncher";
 import AdminCommerceManager from "@/components/admin/AdminCommerceManager";
 import AdminContentManager from "@/components/admin/AdminContentManager";
 import AdminCategoriesManager from "@/components/admin/AdminCategoriesManager";
@@ -10,6 +11,7 @@ import AdminHelpCenter from "@/components/admin/AdminHelpCenter";
 import AdminNotesManager from "@/components/admin/AdminNotesManager";
 import AdminOperationsManager from "@/components/admin/AdminOperationsManager";
 import AdminQrLinksManager from "@/components/admin/AdminQrLinksManager";
+import type { AdminRole } from "@/lib/admin/access";
 import {
   applyAdminTabToSearchParams,
   parseAdminTab,
@@ -59,7 +61,11 @@ const TAB_LABELS: Array<{ id: AdminTab; label: string; subtitle: string }> = [
   },
 ];
 
-export default function AdminWorkspace() {
+type Props = {
+  role: AdminRole | null;
+};
+
+export default function AdminWorkspace({ role }: Props) {
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -118,16 +124,29 @@ export default function AdminWorkspace() {
       </div>
 
       <div className="mt-6 rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3">
-        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-          Active section
-        </p>
-        <p
-          className="mt-1 text-sm font-semibold text-slate-900"
-          data-testid="admin-active-section-label"
-        >
-          {activeMeta.label}
-        </p>
-        <p className="mt-1 text-sm text-slate-600">{activeMeta.subtitle}</p>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Active section
+            </p>
+            <p
+              className="mt-1 text-sm font-semibold text-slate-900"
+              data-testid="admin-active-section-label"
+            >
+              {activeMeta.label}
+            </p>
+            <p className="mt-1 text-sm text-slate-600">{activeMeta.subtitle}</p>
+          </div>
+          <AdminNoteQuickCaptureLauncher
+            adminRole={role}
+            contextType="page"
+            contextRef="/admin"
+            contextLabel="Admin dashboard"
+            triggerLabel="Quick note"
+            triggerTestId="admin-workspace-quick-note-trigger"
+            description="Capture a page-level admin note from the dashboard without switching to the Notes tab first."
+          />
+        </div>
       </div>
 
       <div className="mt-6 space-y-6">

--- a/docs/runbooks/admin-notes-recovery.md
+++ b/docs/runbooks/admin-notes-recovery.md
@@ -11,6 +11,7 @@ Use this runbook for AW-012 workflow `A4` stale-note reconciliation edge cases.
 ## Triggers
 
 - Save returns `Could not update note.` or `Could not save note.` even though another operator already changed the row.
+- Quick capture save fails or closes unexpectedly and you need to confirm whether a note was actually created.
 - A contextual note panel shows outdated title/body/status after recent edits in admin.
 - You suspect duplicate/overlapping edits on the same note.
 - Screenshot upload/delete returns an error and you are unsure whether the stored image was fully removed.
@@ -19,26 +20,27 @@ Use this runbook for AW-012 workflow `A4` stale-note reconciliation edge cases.
 ## Manual Recovery Walkthrough
 
 1. Pause edits on the current row and copy your intended final text to a temporary local note.
-2. In `/admin?tab=notes`, keep the `Notes` tab active and click `Refresh` to reload server-canonical rows.
-3. If the note is no longer visible in the default queue, switch to `Done archive` or search by the visible `Note ID`.
-4. Re-open the target note and confirm:
+2. If the failure happened in `Quick note`, first search by the visible success state or intended title in `/admin?tab=notes` before retrying so you do not create duplicates.
+3. In `/admin?tab=notes`, keep the `Notes` tab active and click `Refresh` to reload server-canonical rows.
+4. If the note is no longer visible in the default queue, switch to `Done archive` or search by the visible `Note ID`.
+5. Re-open the target note and confirm:
    - note ID,
    - title/body/category/date,
    - priority,
    - completion status,
    - context label (`Course Lesson`, `Product`, `Page`, etc.),
    - raw context ref/path when relevant.
-5. If screenshots are involved:
+6. If screenshots are involved:
    - confirm the attachment list and image count in the note row,
    - if delete failed, refresh once and verify whether the image is still present before retrying,
    - if upload failed, retry only after confirming you are not looking at a stale duplicate preview.
-6. If related notes are involved:
+7. If related notes are involved:
    - open the visible linked note IDs from Search if needed,
    - confirm the intended link exists only once,
    - remove and re-add the link only if the relationship is clearly wrong.
-7. Re-apply only the intended delta and click `Save changes`.
-8. Confirm success notice (`Note updated.` or attachment/link success notice) and verify the same row in its contextual surface (`/course` or `/plans`) when relevant.
-9. If update still fails, create one incident note (P1/P2) with owner + next action and link it by note ID in AW-012 checkpoint evidence.
+8. Re-apply only the intended delta and click `Save changes`.
+9. Confirm success notice (`Note updated.` or attachment/link success notice) and verify the same row in its contextual surface (`/course` or `/plans`) when relevant.
+10. If update still fails, create one incident note (P1/P2) with owner + next action and link it by note ID in AW-012 checkpoint evidence.
 
 ## Pass Criteria
 

--- a/docs/task-briefs/in-progress/2026-03-22-admin-notes-quick-capture-launcher-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-22-admin-notes-quick-capture-launcher-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-03-22-admin-notes-quick-capture-launcher-10-10`
-- `status`: `planned`
+- `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-03-22`
 - `updated`: `2026-03-22`
@@ -136,4 +136,6 @@ Critical target categories for `10/10` claim in this brief:
 
 ## Checkpoint Log
 
+- `2026-03-22 | verify:pre-pr green | completed reusable quick-note launcher rollout for admin dashboard and contextual notes surfaces, added viewer-safe authz gating, updated Help/Guide + recovery runbook, and passed full local verify:pre-pr on branch \`fix/admin-notes-quick-capture-launcher-2026-03-22\` | next: commit, push, open PR, and run merge gate`
+- `2026-03-22 | implementation started | moved quick-capture launcher brief to in-progress, added a reusable admin quick-note launcher for dashboard/contextual surfaces, and aligned contextual notes authz so viewer sessions do not get create affordances | next: finish targeted unit/e2e coverage, update Help/Guide + recovery docs, and run lint/verify gates`
 - `2026-03-22 | planning | split quick capture out of the richer attachments/linking notes scope so launcher rollout can be implemented and tested as its own authz/navigation slice after storage-backed note enrichments land | next: finish attachments/priority/related links first, then implement launcher surfaces on a dedicated branch`

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,7 @@ const eslintConfig = defineConfig([
   globalIgnores([
     // Default ignores of eslint-config-next:
     ".next/**",
+    ".next-playwright*/**",
     ".next-playwright/**",
     ".next-playwright-lock/**",
     "out/**",

--- a/tests/e2e/admin-contextual-notes.spec.ts
+++ b/tests/e2e/admin-contextual-notes.spec.ts
@@ -183,17 +183,21 @@ test.describe("admin contextual notes", () => {
 
     const panel = page.getByTestId("admin-context-notes-panel");
     await expect(panel).toBeVisible({ timeout: 10_000 });
-    const toggle = panel.getByTestId("admin-context-notes-toggle");
-    if ((await toggle.textContent())?.includes("Show")) {
-      await toggle.click();
-    }
-
     const unique = `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
     const title = `Plans Note ${unique}`;
+    await panel.getByRole("button", { name: "Quick note" }).click();
+    const quickCaptureDialog = page.getByTestId("admin-note-quick-capture-dialog");
+    await expect(quickCaptureDialog).toBeVisible({ timeout: 10_000 });
+    await quickCaptureDialog.getByLabel("Title").fill(`Cancel ${title}`);
+    await quickCaptureDialog.getByRole("button", { name: "Cancel" }).click();
+    await expect(quickCaptureDialog).toHaveCount(0);
 
-    const createForm = panel.getByTestId("admin-context-note-create-form");
+    await panel.getByRole("button", { name: "Quick note" }).click();
+    await expect(quickCaptureDialog).toBeVisible({ timeout: 10_000 });
+    const createForm = page.getByTestId("admin-note-quick-capture-form");
     await createForm.getByLabel("Title").fill(title);
     await createForm.getByLabel("Category").fill("Content");
+    await createForm.getByLabel("Priority").selectOption("high");
     await createForm.getByLabel("Text").fill("Page-level admin note for plans.");
     let createResponse: Awaited<ReturnType<Page["waitForResponse"]>> | undefined;
     try {
@@ -224,7 +228,12 @@ test.describe("admin contextual notes", () => {
       test.skip(true, `Context notes create is not write-ready in this environment (${reason}).`);
     }
 
-    await expect(panel.getByText("Note saved.")).toBeVisible({ timeout: 5_000 });
+    await expect(panel.getByText("Quick note saved.")).toBeVisible({ timeout: 10_000 });
+
+    const toggle = panel.getByTestId("admin-context-notes-toggle");
+    if ((await toggle.textContent())?.includes("Show")) {
+      await toggle.click();
+    }
 
     const createdItem = panel
       .getByTestId("admin-context-note-item")

--- a/tests/e2e/admin-help-center.spec.ts
+++ b/tests/e2e/admin-help-center.spec.ts
@@ -104,6 +104,7 @@ test.describe("admin help center", () => {
         "P0 = critical outage, P1 = major degradation with workaround, P2 = low-impact bug/UX issue."
       )
     ).toBeVisible();
+    await expect(page.getByText("Quick note:")).toBeVisible();
     await expect(
       page.getByText("Open / Done archive / All + Search + Context filters:")
     ).toBeVisible();
@@ -128,6 +129,11 @@ test.describe("admin help center", () => {
     await expect(page.getByText("docs/runbooks/site-lock-operations.md")).toBeVisible();
     await expect(page.getByText("docs/runbooks/admin-notes-recovery.md")).toBeVisible();
     await expect(page.getByText("docs/runbooks/admin-email-template-governance.md")).toBeVisible();
+    await expect(
+      page.getByText(
+        "Use `Quick note` when you want to capture the issue fast from the current surface without losing context."
+      )
+    ).toBeVisible();
     await expect(
       page.getByText(
         "Create note with category, priority, and context link, then copy the visible note ID if you need to reference it later."

--- a/tests/e2e/admin-notes-workflow.spec.ts
+++ b/tests/e2e/admin-notes-workflow.spec.ts
@@ -250,7 +250,7 @@ test.describe("admin notes workflow", () => {
 
     await page.getByTestId("admin-notes-priority-filter").selectOption("high");
     await expect(createdItem).toBeVisible();
-    await expect(page.getByTestId("admin-note-item")).toHaveCount(1);
+    await expect(secondaryItem).toHaveCount(0);
     await page.getByTestId("admin-notes-priority-filter").selectOption("");
 
     const searchInput = page.getByTestId("admin-notes-search");
@@ -426,5 +426,71 @@ test.describe("admin notes workflow", () => {
     await expect(
       page.getByTestId("admin-note-item").filter({ hasText: secondaryTitle })
     ).toHaveCount(0);
+  });
+
+  test("allowlisted admin can quick-capture a dashboard note and jump into Notes", async ({
+    page,
+  }, testInfo) => {
+    runOnceOnDesktopChromium(testInfo.project.name);
+
+    await loginAsAdminViaDevBypass(page);
+
+    const unique = `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+    const title = `Dashboard Quick Note ${unique}`;
+
+    await page.getByTestId("admin-workspace-quick-note-trigger").click();
+    const quickCaptureDialog = page.getByTestId("admin-note-quick-capture-dialog");
+    await expect(quickCaptureDialog).toBeVisible({ timeout: 10_000 });
+    const quickCaptureForm = page.getByTestId("admin-note-quick-capture-form");
+    await quickCaptureForm.getByLabel("Title").fill(title);
+    await quickCaptureForm.getByLabel("Category").fill("Operations");
+    await quickCaptureForm.getByLabel("Priority").selectOption("high");
+    await quickCaptureForm
+      .getByLabel("Text")
+      .fill("Dashboard-level quick capture from Playwright.");
+
+    let createResponse: Awaited<ReturnType<Page["waitForResponse"]>> | undefined;
+    try {
+      [createResponse] = await Promise.all([
+        page.waitForResponse(
+          (response) =>
+            response.url().includes("/api/admin/notes") && response.request().method() === "POST",
+          { timeout: 15_000 }
+        ),
+        quickCaptureForm.getByRole("button", { name: "Save note" }).click(),
+      ]);
+    } catch {
+      test.skip(true, "Admin quick-capture request timed out in this environment.");
+    }
+    if (!createResponse) {
+      return;
+    }
+
+    const createPayload = (await createResponse.json().catch(() => null)) as {
+      ok?: boolean;
+      error?: string;
+      item?: { id?: string };
+    } | null;
+    if (!createResponse.ok() || createPayload?.ok === false) {
+      const reason =
+        typeof createPayload?.error === "string"
+          ? createPayload.error
+          : `status ${createResponse.status()}`;
+      test.skip(true, `Admin quick capture is not write-ready in this environment (${reason}).`);
+    }
+
+    await expect(page.getByText("Quick note saved.")).toBeVisible({ timeout: 10_000 });
+    await page.getByRole("link", { name: "Open in Notes" }).click();
+
+    await openNotesSection(page);
+
+    const createdItem = page.getByTestId("admin-note-item").filter({ hasText: title }).first();
+    await expect(createdItem).toBeVisible({ timeout: 15_000 });
+    await expect(createdItem).toContainText("Page:");
+    await expect(createdItem).toContainText("/admin");
+
+    page.once("dialog", (dialog) => dialog.accept());
+    await createdItem.getByRole("button", { name: "Delete" }).click();
+    await expect(page.getByTestId("admin-note-item").filter({ hasText: title })).toHaveCount(0);
   });
 });

--- a/tests/unit/admin-note-quick-capture-launcher.test.tsx
+++ b/tests/unit/admin-note-quick-capture-launcher.test.tsx
@@ -1,0 +1,143 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import AdminNoteQuickCaptureLauncher from "@/components/admin/AdminNoteQuickCaptureLauncher";
+
+describe("AdminNoteQuickCaptureLauncher", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("hides the launcher for viewer role", () => {
+    render(
+      <AdminNoteQuickCaptureLauncher
+        adminRole="viewer"
+        contextType="page"
+        contextRef="/plans"
+        contextLabel="Plans page"
+      />
+    );
+
+    expect(screen.queryByTestId("admin-note-quick-capture-trigger")).not.toBeInTheDocument();
+  });
+
+  it("saves a quick note with canonical context and exposes the notes link", async () => {
+    const onSaved = vi.fn();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          items: [{ id: "category-1", title: "Operations", is_active: true }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          item: {
+            id: "123e4567-e89b-42d3-a456-426614174099",
+            title: "Plans follow-up",
+            body: "Remember to tighten copy.",
+            category: "Operations",
+            note_date: "2026-03-22",
+            priority: "high",
+            is_done: false,
+            context_type: "page",
+            context_ref: "/plans",
+            created_by: "admin-user",
+            updated_by: "admin-user",
+            created_at: "2026-03-22T12:00:00.000Z",
+            updated_at: "2026-03-22T12:00:00.000Z",
+            attachments: [],
+            related_notes: [],
+          },
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <AdminNoteQuickCaptureLauncher
+        adminRole="editor"
+        contextType="page"
+        contextRef="/plans"
+        contextLabel="Plans page"
+        onSaved={onSaved}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("admin-note-quick-capture-trigger"));
+    await screen.findByTestId("admin-note-quick-capture-dialog");
+
+    fireEvent.change(screen.getByLabelText("Title"), {
+      target: { value: "Plans follow-up" },
+    });
+    fireEvent.change(screen.getByLabelText("Category"), {
+      target: { value: "Operations" },
+    });
+    fireEvent.change(screen.getByLabelText("Priority"), {
+      target: { value: "high" },
+    });
+    fireEvent.change(screen.getByLabelText("Text"), {
+      target: { value: "Remember to tighten copy." },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save note" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    const requestBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(requestBody.contextType).toBe("page");
+    expect(requestBody.contextRef).toBe("/plans");
+    expect(requestBody.priority).toBe("high");
+    expect(requestBody.title).toBe("Plans follow-up");
+
+    await screen.findByText("Quick note saved.");
+    expect(onSaved).toHaveBeenCalledTimes(1);
+
+    const openLink = screen.getByRole("link", { name: "Open in Notes" });
+    expect(openLink).toHaveAttribute(
+      "href",
+      expect.stringContaining("notesQuery=123e4567-e89b-42d3-a456-426614174099")
+    );
+    expect(openLink).toHaveAttribute("href", expect.stringContaining("notesContextType=page"));
+    expect(openLink).toHaveAttribute("href", expect.stringContaining("notesContextRef=%2Fplans"));
+  });
+
+  it("cancels without posting a note", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        items: [],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <AdminNoteQuickCaptureLauncher
+        adminRole="admin"
+        contextType="page"
+        contextRef="/admin"
+        contextLabel="Admin dashboard"
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("admin-note-quick-capture-trigger"));
+    await screen.findByTestId("admin-note-quick-capture-dialog");
+    fireEvent.change(screen.getByLabelText("Title"), {
+      target: { value: "Should not save" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("admin-note-quick-capture-dialog")).not.toBeInTheDocument();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/admin/categories/notes");
+  });
+});


### PR DESCRIPTION
## Summary

- Added a reusable admin-only `Quick note` launcher for fast note capture from the admin dashboard and contextual admin note surfaces.
- Prefills canonical page/context metadata, saves through the existing admin notes API, and deep-links straight into the Notes workspace after save.
- Tightened contextual notes authz so viewer-role sessions stay read-only and never see mutation affordances.
- Updated Help/Guide copy, admin recovery runbook, and unit/e2e coverage for the new flow.
- Brief link: `docs/task-briefs/in-progress/2026-03-22-admin-notes-quick-capture-launcher-10-10.md`

## Scope

- In scope: admin dashboard quick capture, contextual notes quick capture, role-aware create affordances, help/runbook updates, test coverage.
- Out of scope: screenshot-region capture, new attachment formats, user-facing My Library behavior, schema changes.
- Changed files (13):
  - `app/admin/page.tsx`
  - `app/api/admin/notes/route.ts`
  - `components/admin/AdminContextNotesPanel.tsx`
  - `components/admin/AdminHelpCenter.tsx`
  - `components/admin/AdminNoteQuickCaptureLauncher.tsx`
  - `components/admin/AdminWorkspace.tsx`
  - `docs/runbooks/admin-notes-recovery.md`
  - `docs/task-briefs/in-progress/2026-03-22-admin-notes-quick-capture-launcher-10-10.md`
  - `eslint.config.mjs`
  - `tests/e2e/admin-contextual-notes.spec.ts`
  - `tests/e2e/admin-help-center.spec.ts`
  - `tests/e2e/admin-notes-workflow.spec.ts`
  - `tests/unit/admin-note-quick-capture-launcher.test.tsx`

## Risk

- Main risk: admin note creation affordances could drift across role-gated surfaces if dashboard/context panel contracts diverge.
- Rollback plan: revert `3701b32` (`git revert 3701b32`) to restore the previous admin notes workflow.

## Test Evidence

- `npm run lint:briefs`: PASS on `3701b32`
- `npm run verify:pre-pr`: PASS on `3701b32`
- `npm run verify:pre-merge`: PASS on `3701b32`
- Key targeted coverage included:
  - `npx vitest run tests/unit/admin-note-quick-capture-launcher.test.tsx tests/unit/admin-notes-manager.test.ts`
  - `npx playwright test tests/e2e/admin-contextual-notes.spec.ts --project=desktop-chromium --workers=1`
  - `npx playwright test tests/e2e/admin-notes-workflow.spec.ts tests/e2e/my-library-athlete-profile.spec.ts --project=desktop-chromium --workers=1`
- CI checks: `verify`, `e2e-smoke`, `site-lock-smoke`, `Analyze`, `CodeQL`, `size-check`, and Vercel are green on PR #264.
- Perf trend note: baseline perf budgets stayed green with a tighten recommendation; decision for this admin slice is `hold` and carry the stretch-target tightening into AW-010 / builder tracking rather than mixing perf-target churn into this admin workflow PR.

- [x] `npm run lint:briefs`
- [x] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge`
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/264`
- [x] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
