### PR TITLE
feat(admin): add notes screenshot capture flow

### DIFF
--- a/components/admin/AdminHelpCenter.tsx
+++ b/components/admin/AdminHelpCenter.tsx
@@ -389,7 +389,7 @@ const BUTTON_GUIDE: ActionGroup[] = [
       {
         label: "Quick note",
         meaning:
-          "Opens the lightweight quick-capture sheet so you can save a route-aware note without switching to the Notes tab first.",
+          "Opens the lightweight quick-capture sheet so you can save a route-aware note, optionally stage one screenshot, and stay on the current admin surface.",
       },
       {
         label: "Use P0 template / Use P1 template / Use P2 template",
@@ -417,13 +417,18 @@ const BUTTON_GUIDE: ActionGroup[] = [
           "Attach admin-only screenshots for memory/debugging. Delete must remove both note metadata and the underlying stored image.",
       },
       {
+        label: "Capture screenshot / Retake screenshot / Retry upload",
+        meaning:
+          "Starts browser capture, lets you drag a tighter crop in preview, and keeps the screenshot local until note save plus attachment upload succeed.",
+      },
+      {
         label: "Link note / Remove link",
         meaning: "Connects related notes by stable note ID without merging them into one record.",
       },
       {
         label: "Save note / Save changes / Delete",
         meaning:
-          "Creates, updates, or removes task notes with route/content context. Save first, then add screenshots or related-note links from Edit.",
+          "Creates, updates, or removes task notes with route/content context. Create and Quick note can stage one screenshot before first save; Edit can add/remove more screenshots and related-note links later.",
       },
       {
         label: "Save category / Delete",
@@ -555,7 +560,9 @@ const DAILY_PLAYBOOKS: Playbook[] = [
       "Open the exact page/content row you are reviewing.",
       "Use `Quick note` when you want to capture the issue fast from the current surface without losing context.",
       "Create note with category, priority, and context link, then copy the visible note ID if you need to reference it later.",
-      "Add screenshots when the issue is visual or hard to reproduce, and link any follow-up note instead of pasting duplicate text.",
+      "Use `Capture screenshot` when the issue is visual, drag to the relevant crop in preview, and save only after the preview looks right.",
+      "Remember that staged screenshots stay local until note save and attachment upload both succeed; if permission is denied, fall back to `Add images`.",
+      "Link any follow-up note instead of pasting duplicate text.",
       "Use Search + Priority + Context filters in Notes to reopen the same note quickly.",
       "Mark completion status once resolved, then use Done archive to confirm it is recoverable.",
     ],
@@ -871,6 +878,15 @@ export default function AdminHelpCenter() {
             <p className="text-sm font-semibold text-rose-900">Create or publish action fails</p>
             <p className="mt-1 text-sm text-rose-800">
               Read API error text, verify role/allowlist, and confirm required CI checks are green.
+            </p>
+          </article>
+          <article className="rounded-xl border border-amber-200 bg-amber-50 p-3">
+            <p className="text-sm font-semibold text-amber-900">
+              Screenshot capture is denied or upload fails
+            </p>
+            <p className="mt-1 text-sm text-amber-800">
+              Retry capture first. If browser permission is blocked or upload still fails, keep the
+              note ID, refresh Notes, and use Add images or the admin-notes recovery runbook.
             </p>
           </article>
           <article className="rounded-xl border border-slate-200 bg-slate-50 p-3">

--- a/components/admin/AdminNoteQuickCaptureLauncher.tsx
+++ b/components/admin/AdminNoteQuickCaptureLauncher.tsx
@@ -2,11 +2,13 @@
 
 import { useEffect, useId, useMemo, useState } from "react";
 import Modal from "@/components/Modal";
+import AdminNoteScreenshotCaptureButton from "@/components/admin/AdminNoteScreenshotCaptureButton";
 import type { AdminRole } from "@/lib/admin/access";
 import { hasRequiredAdminRole } from "@/lib/admin/access";
 import { applyAdminTabToSearchParams } from "@/lib/admin/admin-workspace";
 import type { AdminCategoryRow } from "@/lib/admin/categories";
 import type { AdminNoteContextType } from "@/lib/admin/note-context";
+import { uploadAdminNoteFiles } from "@/lib/admin/notes-client";
 import {
   ADMIN_NOTE_PRIORITY_VALUES,
   type AdminNoteItem,
@@ -61,6 +63,11 @@ type FormState = {
 type SavedNotice = {
   id: string;
   title: string;
+};
+
+type PendingScreenshot = {
+  file: File;
+  previewUrl: string;
 };
 
 const INITIAL_CATEGORY = "General";
@@ -120,16 +127,27 @@ export default function AdminNoteQuickCaptureLauncher({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedNotice, setSavedNotice] = useState<SavedNotice | null>(null);
+  const [createdCaptureRecovery, setCreatedCaptureRecovery] = useState<SavedNotice | null>(null);
+  const [pendingScreenshot, setPendingScreenshot] = useState<PendingScreenshot | null>(null);
   const datalistId = useId();
 
   const notesHref = useMemo(() => {
-    if (!savedNotice) return null;
+    const notice = savedNotice ?? createdCaptureRecovery;
+    if (!notice) return null;
     return buildAdminNotesHref({
-      noteId: savedNotice.id,
+      noteId: notice.id,
       contextType,
       contextRef,
     });
-  }, [contextRef, contextType, savedNotice]);
+  }, [contextRef, contextType, createdCaptureRecovery, savedNotice]);
+
+  useEffect(() => {
+    return () => {
+      if (pendingScreenshot?.previewUrl) {
+        URL.revokeObjectURL(pendingScreenshot.previewUrl);
+      }
+    };
+  }, [pendingScreenshot]);
 
   useEffect(() => {
     if (!open || categoryOptions.length > 0 || loadingCategories) return;
@@ -175,17 +193,82 @@ export default function AdminNoteQuickCaptureLauncher({
     return null;
   }
 
+  function setPendingScreenshotFromFile(file: File) {
+    setPendingScreenshot((current) => {
+      if (current?.previewUrl) {
+        URL.revokeObjectURL(current.previewUrl);
+      }
+      return {
+        file,
+        previewUrl: URL.createObjectURL(file),
+      };
+    });
+  }
+
+  function clearPendingScreenshot() {
+    setPendingScreenshot((current) => {
+      if (current?.previewUrl) {
+        URL.revokeObjectURL(current.previewUrl);
+      }
+      return null;
+    });
+  }
+
   function openLauncher() {
     setError(null);
     setSavedNotice(null);
+    setCreatedCaptureRecovery(null);
     setOpen(true);
   }
 
   function closeLauncher() {
     if (submitting) return;
+    if (createdCaptureRecovery) {
+      setSavedNotice(createdCaptureRecovery);
+    }
     setOpen(false);
     setError(null);
     setFormState(createInitialFormState());
+    setCreatedCaptureRecovery(null);
+    clearPendingScreenshot();
+  }
+
+  async function uploadPendingScreenshot(noteId: string) {
+    if (!pendingScreenshot) {
+      throw new Error("No screenshot is ready to upload.");
+    }
+
+    return uploadAdminNoteFiles({
+      noteId,
+      files: [pendingScreenshot.file],
+    });
+  }
+
+  async function retryPendingScreenshotUpload() {
+    if (!createdCaptureRecovery || !pendingScreenshot || submitting) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const updatedItem = await uploadPendingScreenshot(createdCaptureRecovery.id);
+      setSavedNotice({
+        id: updatedItem.id,
+        title: updatedItem.title,
+      });
+      setCreatedCaptureRecovery(null);
+      clearPendingScreenshot();
+      onSaved?.(updatedItem);
+      setOpen(false);
+    } catch (uploadError) {
+      setError(
+        uploadError instanceof Error
+          ? uploadError.message
+          : "Could not upload screenshot attachment."
+      );
+    } finally {
+      setSubmitting(false);
+    }
   }
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -215,10 +298,40 @@ export default function AdminNoteQuickCaptureLauncher({
         return;
       }
 
+      if (pendingScreenshot) {
+        try {
+          const updatedItem = await uploadPendingScreenshot(payload.item.id);
+          setSavedNotice({
+            id: updatedItem.id,
+            title: updatedItem.title,
+          });
+          clearPendingScreenshot();
+          setCreatedCaptureRecovery(null);
+          onSaved?.(updatedItem);
+          setOpen(false);
+          setFormState(createInitialFormState());
+          return;
+        } catch (uploadError) {
+          setCreatedCaptureRecovery({
+            id: payload.item.id,
+            title: payload.item.title,
+          });
+          setFormState(createInitialFormState());
+          onSaved?.(payload.item);
+          setError(
+            uploadError instanceof Error
+              ? `Note saved, but ${uploadError.message.toLowerCase()} Retry screenshot upload or open the note in Notes.`
+              : "Note saved, but screenshot upload failed. Retry screenshot upload or open the note in Notes."
+          );
+          return;
+        }
+      }
+
       setSavedNotice({
         id: payload.item.id,
         title: payload.item.title,
       });
+      setCreatedCaptureRecovery(null);
       onSaved?.(payload.item);
       setOpen(false);
       setFormState(createInitialFormState());
@@ -282,6 +395,99 @@ export default function AdminNoteQuickCaptureLauncher({
               <p className="mt-1 text-xs text-slate-600">
                 This note will be attached to the canonical route/content context for this surface.
               </p>
+            </div>
+
+            <div className="mt-4 rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-600">
+                    Screenshot
+                  </p>
+                  <p className="mt-1 text-sm font-medium text-slate-900">
+                    Capture visual evidence before you save
+                  </p>
+                  <p className="mt-1 text-xs text-slate-600">
+                    The screenshot stays local until the note is saved and the attachment upload
+                    succeeds.
+                  </p>
+                </div>
+                <AdminNoteScreenshotCaptureButton
+                  buttonLabel={pendingScreenshot ? "Retake screenshot" : "Capture screenshot"}
+                  onCaptureReady={async (file) => {
+                    setError(null);
+                    setCreatedCaptureRecovery(null);
+                    setPendingScreenshotFromFile(file);
+                  }}
+                />
+              </div>
+
+              {pendingScreenshot ? (
+                <div className="mt-3 rounded-xl border border-slate-200 bg-white px-3 py-3">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div className="flex items-center gap-3">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={pendingScreenshot.previewUrl}
+                        alt="Pending screenshot preview"
+                        className="h-14 w-14 rounded-lg object-cover"
+                      />
+                      <div>
+                        <p className="text-xs font-semibold text-slate-900">
+                          Screenshot ready to attach
+                        </p>
+                        <p className="mt-1 text-[11px] text-slate-600">
+                          {createdCaptureRecovery
+                            ? "The note is already saved. Retry the screenshot upload or finish without it."
+                            : "The next note save will upload this screenshot as an admin-only attachment."}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      {createdCaptureRecovery ? (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            void retryPendingScreenshotUpload();
+                          }}
+                          disabled={submitting}
+                          className="inline-flex h-9 items-center justify-center rounded-lg bg-blue-600 px-3 text-xs font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+                        >
+                          {submitting ? "Retrying…" : "Retry upload"}
+                        </button>
+                      ) : null}
+                      <button
+                        type="button"
+                        onClick={() => {
+                          if (createdCaptureRecovery) {
+                            setSavedNotice(createdCaptureRecovery);
+                            setCreatedCaptureRecovery(null);
+                            setOpen(false);
+                            setFormState(createInitialFormState());
+                          }
+                          clearPendingScreenshot();
+                        }}
+                        disabled={submitting}
+                        className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        Remove screenshot
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+
+              {createdCaptureRecovery && notesHref ? (
+                <p className="mt-3 text-xs text-slate-600">
+                  Note saved already.{" "}
+                  <a
+                    href={notesHref}
+                    className="font-semibold text-blue-700 underline underline-offset-2"
+                  >
+                    Open in Notes
+                  </a>{" "}
+                  if you want to finish without retrying the screenshot.
+                </p>
+              ) : null}
             </div>
 
             {error ? (
@@ -386,9 +592,11 @@ export default function AdminNoteQuickCaptureLauncher({
 
               <div className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 pt-4">
                 <p className="text-xs text-slate-500">
-                  {loadingCategories
-                    ? "Loading category suggestions…"
-                    : "The note stays local until you click Save note."}
+                  {createdCaptureRecovery
+                    ? "The note is already saved. Retry the screenshot upload or close and reopen it from Notes."
+                    : loadingCategories
+                      ? "Loading category suggestions…"
+                      : "The note stays local until you click Save note."}
                 </p>
                 <div className="flex flex-wrap items-center gap-2">
                   <button
@@ -397,15 +605,17 @@ export default function AdminNoteQuickCaptureLauncher({
                     disabled={submitting}
                     className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
                   >
-                    Cancel
+                    {createdCaptureRecovery ? "Done" : "Cancel"}
                   </button>
-                  <button
-                    type="submit"
-                    disabled={submitting}
-                    className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
-                  >
-                    {submitting ? "Saving…" : "Save note"}
-                  </button>
+                  {!createdCaptureRecovery ? (
+                    <button
+                      type="submit"
+                      disabled={submitting}
+                      className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+                    >
+                      {submitting ? "Saving…" : "Save note"}
+                    </button>
+                  ) : null}
                 </div>
               </div>
             </form>

--- a/components/admin/AdminNoteScreenshotCaptureButton.tsx
+++ b/components/admin/AdminNoteScreenshotCaptureButton.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import Modal from "@/components/Modal";
+import { getAdminScreenshotCaptureDriver } from "@/lib/admin/screenshot-capture-client";
+import {
+  buildAdminScreenshotSelectionFromDrag,
+  buildDefaultAdminScreenshotSelection,
+  classifyAdminScreenshotCaptureError,
+  type AdminScreenshotCapturePhase,
+  type AdminScreenshotFrame,
+  type AdminScreenshotSelection,
+} from "@/lib/admin/screenshot-capture";
+
+type Props = {
+  onCaptureReady: (file: File) => Promise<void> | void;
+  buttonLabel?: string;
+  buttonTestId?: string;
+  dialogTitle?: string;
+  disabled?: boolean;
+  className?: string;
+};
+
+type PointerPoint = {
+  x: number;
+  y: number;
+};
+
+function selectionToPercentStyle(params: {
+  selection: AdminScreenshotSelection;
+  frame: Pick<AdminScreenshotFrame, "width" | "height">;
+}) {
+  return {
+    left: `${(params.selection.x / params.frame.width) * 100}%`,
+    top: `${(params.selection.y / params.frame.height) * 100}%`,
+    width: `${(params.selection.width / params.frame.width) * 100}%`,
+    height: `${(params.selection.height / params.frame.height) * 100}%`,
+  };
+}
+
+export default function AdminNoteScreenshotCaptureButton({
+  onCaptureReady,
+  buttonLabel = "Capture screenshot",
+  buttonTestId = "admin-note-screenshot-capture-trigger",
+  dialogTitle = "Capture a screenshot for this note",
+  disabled = false,
+  className = "",
+}: Props) {
+  const captureDriver = useMemo(() => getAdminScreenshotCaptureDriver(), []);
+  const [open, setOpen] = useState(false);
+  const [phase, setPhase] = useState<AdminScreenshotCapturePhase>("idle");
+  const [frame, setFrame] = useState<AdminScreenshotFrame | null>(null);
+  const [selection, setSelection] = useState<AdminScreenshotSelection | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const pointerStartRef = useRef<PointerPoint | null>(null);
+  const previewRef = useRef<HTMLDivElement | null>(null);
+  const previewUrl = useMemo(() => (frame ? URL.createObjectURL(frame.blob) : null), [frame]);
+
+  useEffect(() => {
+    if (!previewUrl) return;
+    return () => {
+      URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
+  function resetState() {
+    setOpen(false);
+    setPhase("idle");
+    setFrame(null);
+    setSelection(null);
+    setMessage(null);
+    pointerStartRef.current = null;
+  }
+
+  function closeDialog() {
+    if (phase === "saving") return;
+    resetState();
+  }
+
+  async function beginCapture() {
+    setOpen(true);
+    setFrame(null);
+    setSelection(null);
+    setMessage(null);
+    setPhase("requesting_permission");
+
+    if (!captureDriver.isSupported()) {
+      setPhase("unsupported");
+      setMessage(
+        "This browser does not support in-app screenshot capture yet. Use Add images if you already have a screenshot file."
+      );
+      return;
+    }
+
+    try {
+      const nextFrame = await captureDriver.capture();
+      setFrame(nextFrame);
+      setSelection(buildDefaultAdminScreenshotSelection(nextFrame.width, nextFrame.height));
+      setPhase("preview");
+    } catch (error) {
+      const failure = classifyAdminScreenshotCaptureError(error);
+      setPhase(failure.phase);
+      setMessage(failure.message);
+    }
+  }
+
+  function toNaturalPoint(event: React.PointerEvent<HTMLDivElement>): PointerPoint | null {
+    if (!frame || !previewRef.current) return null;
+    const rect = previewRef.current.getBoundingClientRect();
+    if (!rect.width || !rect.height) return null;
+
+    return {
+      x: ((event.clientX - rect.left) / rect.width) * frame.width,
+      y: ((event.clientY - rect.top) / rect.height) * frame.height,
+    };
+  }
+
+  function handlePointerDown(event: React.PointerEvent<HTMLDivElement>) {
+    if (phase !== "preview" || !frame) return;
+    const point = toNaturalPoint(event);
+    if (!point) return;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    pointerStartRef.current = point;
+    setSelection(
+      buildAdminScreenshotSelectionFromDrag({
+        start: point,
+        current: point,
+        bounds: frame,
+      })
+    );
+  }
+
+  function handlePointerMove(event: React.PointerEvent<HTMLDivElement>) {
+    if (phase !== "preview" || !frame || !pointerStartRef.current) return;
+    const point = toNaturalPoint(event);
+    if (!point) return;
+
+    setSelection(
+      buildAdminScreenshotSelectionFromDrag({
+        start: pointerStartRef.current,
+        current: point,
+        bounds: frame,
+      })
+    );
+  }
+
+  function handlePointerUp(event: React.PointerEvent<HTMLDivElement>) {
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    pointerStartRef.current = null;
+  }
+
+  async function handleSaveScreenshot() {
+    if (!frame || !selection || phase === "saving") return;
+
+    setPhase("saving");
+    setMessage(null);
+
+    try {
+      const file = await captureDriver.cropToFile({
+        frame,
+        selection,
+      });
+      await onCaptureReady(file);
+      resetState();
+    } catch (error) {
+      setPhase("preview");
+      setMessage(error instanceof Error ? error.message : "Could not save screenshot.");
+    }
+  }
+
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        data-testid={buttonTestId}
+        disabled={disabled}
+        onClick={() => {
+          void beginCapture();
+        }}
+        className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {buttonLabel}
+      </button>
+
+      <Modal open={open} onClose={closeDialog} ariaLabel={dialogTitle}>
+        <div
+          className="flex h-full min-h-0 flex-col"
+          data-testid="admin-note-screenshot-capture-dialog"
+        >
+          <div className="flex items-start justify-between gap-3 border-b border-slate-200 px-5 py-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
+                Screenshot capture
+              </p>
+              <h2 className="mt-1 text-lg font-semibold text-slate-900">{dialogTitle}</h2>
+              <p className="mt-1 text-sm text-slate-600">
+                Use browser capture, then drag over the preview if you want a tighter crop before
+                save.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={closeDialog}
+              disabled={phase === "saving"}
+              className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Close
+            </button>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+            {phase === "requesting_permission" ? (
+              <div className="rounded-2xl border border-blue-100 bg-blue-50/70 px-4 py-4 text-sm text-blue-900">
+                <p className="font-semibold">Choose what to capture</p>
+                <p className="mt-2">
+                  Select the relevant tab or window in the browser share dialog. Nothing is saved
+                  until you confirm the preview here.
+                </p>
+              </div>
+            ) : null}
+
+            {phase === "permission_denied" ||
+            phase === "cancelled" ||
+            phase === "unsupported" ||
+            phase === "error" ? (
+              <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-4 text-sm text-amber-900">
+                <p className="font-semibold">
+                  {phase === "unsupported"
+                    ? "Capture is not available here"
+                    : "Capture did not start"}
+                </p>
+                <p className="mt-2">{message}</p>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {phase !== "unsupported" ? (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void beginCapture();
+                      }}
+                      className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500"
+                    >
+                      Retry capture
+                    </button>
+                  ) : null}
+                  <button
+                    type="button"
+                    onClick={closeDialog}
+                    className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+                  >
+                    Use image upload instead
+                  </button>
+                </div>
+              </div>
+            ) : null}
+
+            {(phase === "preview" || phase === "saving") && frame && previewUrl && selection ? (
+              <div className="space-y-4">
+                <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-3">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-600">
+                    Preview
+                  </p>
+                  <p className="mt-1 text-sm text-slate-700">
+                    Drag on the preview to choose a smaller region, or keep the full capture.
+                  </p>
+                </div>
+
+                {message ? (
+                  <p className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+                    {message}
+                  </p>
+                ) : null}
+
+                <div
+                  ref={previewRef}
+                  className="relative w-full touch-none overflow-hidden rounded-2xl border border-slate-200 bg-slate-950/5"
+                  style={{ aspectRatio: `${frame.width} / ${frame.height}` }}
+                  onPointerDown={handlePointerDown}
+                  onPointerMove={handlePointerMove}
+                  onPointerUp={handlePointerUp}
+                  onPointerCancel={handlePointerUp}
+                  data-testid="admin-note-screenshot-preview-surface"
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={previewUrl}
+                    alt="Screenshot preview"
+                    className="absolute inset-0 h-full w-full select-none object-cover"
+                    draggable={false}
+                    data-testid="admin-note-screenshot-preview-image"
+                  />
+                  <div className="pointer-events-none absolute inset-0 bg-slate-950/10" />
+                  <div
+                    className="pointer-events-none absolute border-2 border-blue-500 bg-blue-500/15 shadow-[0_0_0_9999px_rgba(15,23,42,0.22)]"
+                    style={selectionToPercentStyle({ selection, frame })}
+                  />
+                </div>
+
+                <div className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-xs text-slate-600">
+                  Selected region: {Math.round(selection.width)} × {Math.round(selection.height)} px
+                </div>
+
+                <div className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 pt-4">
+                  <button
+                    type="button"
+                    disabled={phase === "saving"}
+                    onClick={() =>
+                      setSelection(buildDefaultAdminScreenshotSelection(frame.width, frame.height))
+                    }
+                    className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    Use full capture
+                  </button>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={closeDialog}
+                      disabled={phase === "saving"}
+                      className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void handleSaveScreenshot();
+                      }}
+                      disabled={phase === "saving"}
+                      className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+                    >
+                      {phase === "saving" ? "Saving…" : "Save screenshot"}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/components/admin/AdminNotesManager.tsx
+++ b/components/admin/AdminNotesManager.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import AdminNoteScreenshotCaptureButton from "@/components/admin/AdminNoteScreenshotCaptureButton";
 import {
   ADMIN_NOTE_CONTEXT_TYPE_VALUES,
   type AdminNoteContextType,
@@ -42,6 +43,7 @@ import {
   type AdminNotePriority,
   type IncidentNoteSeverity,
 } from "@/lib/admin/notes";
+import { uploadAdminNoteFiles } from "@/lib/admin/notes-client";
 
 type AdminNotesResponse =
   | {
@@ -133,6 +135,16 @@ type FormState = {
   contextType: AdminNoteContextType | "";
   contextRef: string;
   contextModuleRef: string;
+};
+
+type PendingScreenshot = {
+  file: File;
+  previewUrl: string;
+};
+
+type CaptureRecovery = {
+  id: string;
+  title: string;
 };
 
 function todayDateInputValue(): string {
@@ -261,6 +273,18 @@ export default function AdminNotesManager() {
   const [linkingNoteId, setLinkingNoteId] = useState<string | null>(null);
   const [unlinkingKey, setUnlinkingKey] = useState<string | null>(null);
   const [linkDrafts, setLinkDrafts] = useState<Record<string, string>>({});
+  const [createPendingScreenshot, setCreatePendingScreenshot] = useState<PendingScreenshot | null>(
+    null
+  );
+  const [createCaptureRecovery, setCreateCaptureRecovery] = useState<CaptureRecovery | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (createPendingScreenshot?.previewUrl) {
+        URL.revokeObjectURL(createPendingScreenshot.previewUrl);
+      }
+    };
+  }, [createPendingScreenshot]);
 
   function sortNoteItems(nextItems: AdminNoteItem[]): AdminNoteItem[] {
     return [...nextItems].sort(sortAdminNotesByPriorityAndNewest);
@@ -487,6 +511,62 @@ export default function AdminNotesManager() {
     }));
   }
 
+  function setCreatePendingScreenshotFromFile(file: File) {
+    setCreatePendingScreenshot((current) => {
+      if (current?.previewUrl) {
+        URL.revokeObjectURL(current.previewUrl);
+      }
+      return {
+        file,
+        previewUrl: URL.createObjectURL(file),
+      };
+    });
+  }
+
+  function clearCreatePendingScreenshot() {
+    setCreatePendingScreenshot((current) => {
+      if (current?.previewUrl) {
+        URL.revokeObjectURL(current.previewUrl);
+      }
+      return null;
+    });
+  }
+
+  async function uploadCreatePendingScreenshot(noteId: string) {
+    if (!createPendingScreenshot) {
+      throw new Error("No screenshot is ready to upload.");
+    }
+
+    return uploadAdminNoteFiles({
+      noteId,
+      files: [createPendingScreenshot.file],
+    });
+  }
+
+  async function retryCreatePendingScreenshotUpload() {
+    if (!createCaptureRecovery || !createPendingScreenshot || submitting) return;
+
+    setSubmitting(true);
+    setActionError(null);
+    setActionNotice(null);
+
+    try {
+      const updatedItem = await uploadCreatePendingScreenshot(createCaptureRecovery.id);
+      setItems((prev) =>
+        sortNoteItems(prev.map((entry) => (entry.id === updatedItem.id ? updatedItem : entry)))
+      );
+      clearCreatePendingScreenshot();
+      setCreateCaptureRecovery(null);
+      setActionNotice("Screenshot attached to the saved note.");
+    } catch (error) {
+      setActionError(
+        error instanceof Error ? error.message : "Could not upload screenshot attachment."
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
   function applyIncidentTemplate(severity: IncidentNoteSeverity) {
     const today = todayDateLabel();
     setFormState((prev) => ({
@@ -527,10 +607,40 @@ export default function AdminNotesManager() {
         return;
       }
 
+      if (createPendingScreenshot) {
+        try {
+          const updatedItem = await uploadCreatePendingScreenshot(payload.item.id);
+          setItems((prev) =>
+            sortNoteItems([...prev.filter((entry) => entry.id !== updatedItem.id), updatedItem])
+          );
+          clearCreatePendingScreenshot();
+          setCreateCaptureRecovery(null);
+          setFormState(INITIAL_FORM);
+          setActionNotice("Note saved with screenshot attached.");
+          return;
+        } catch (uploadError) {
+          setItems((prev) =>
+            sortNoteItems([...prev.filter((entry) => entry.id !== payload.item.id), payload.item])
+          );
+          setCreateCaptureRecovery({
+            id: payload.item.id,
+            title: payload.item.title,
+          });
+          setFormState(INITIAL_FORM);
+          setActionError(
+            uploadError instanceof Error
+              ? `Note saved, but ${uploadError.message.toLowerCase()} Retry upload below or use Edit to add the screenshot later.`
+              : "Note saved, but screenshot upload failed. Retry upload below or use Edit to add the screenshot later."
+          );
+          return;
+        }
+      }
+
       setItems((prev) =>
         sortNoteItems([...prev.filter((entry) => entry.id !== payload.item.id), payload.item])
       );
       setFormState(INITIAL_FORM);
+      setCreateCaptureRecovery(null);
       setActionNotice(
         payload.item.is_done
           ? "Note saved to done archive."
@@ -781,45 +891,36 @@ export default function AdminNotesManager() {
     }
   }
 
-  async function uploadAttachments(item: AdminNoteItem, files: FileList | null) {
-    if (!files || files.length === 0) return;
+  async function uploadFilesForNote(itemId: string, files: File[]) {
+    if (files.length === 0) return;
     if (uploadingNoteId || deletingAttachmentId || linkingNoteId || unlinkingKey) return;
 
     setActionError(null);
     setActionNotice(null);
-    setUploadingNoteId(item.id);
+    setUploadingNoteId(itemId);
 
     try {
-      const formData = new FormData();
-      Array.from(files).forEach((file) => {
-        formData.append("files", file);
+      const updatedItem = await uploadAdminNoteFiles({
+        noteId: itemId,
+        files,
       });
-
-      const response = await fetch(`/api/admin/notes/${item.id}/attachments`, {
-        method: "POST",
-        credentials: "same-origin",
-        body: formData,
-      });
-
-      const payload = (await response.json()) as AdminNoteUpdateResponse;
-      if (!response.ok || !payload.ok || !payload.item) {
-        setActionError(
-          payload.ok
-            ? "Could not upload attachments."
-            : (payload.error ?? "Could not upload attachments.")
-        );
-        return;
-      }
-
-      applyMutatedItem(item.id, payload.item);
+      applyMutatedItem(itemId, updatedItem);
       setActionNotice(
-        payload.item.attachments.length === 1 ? "Attachment uploaded." : "Attachments uploaded."
+        updatedItem.attachments.length === 1 ? "Attachment uploaded." : "Attachments uploaded."
       );
-    } catch {
-      setActionError("Could not upload attachments.");
+      return updatedItem;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Could not upload attachments.";
+      setActionError(message);
+      return null;
     } finally {
       setUploadingNoteId(null);
     }
+  }
+
+  async function uploadAttachments(item: AdminNoteItem, files: FileList | null) {
+    if (!files || files.length === 0) return;
+    await uploadFilesForNote(item.id, Array.from(files));
   }
 
   async function deleteAttachment(noteId: string, attachmentId: string) {
@@ -1579,23 +1680,38 @@ export default function AdminNotesManager() {
                               PNG, JPEG, WEBP, or GIF up to 5 MB each. Images stay admin-only.
                             </p>
                           </div>
-                          <label className="inline-flex cursor-pointer items-center justify-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 transition hover:bg-slate-100">
-                            <span>{isUploading ? "Uploading…" : "Add images"}</span>
-                            <input
-                              type="file"
-                              accept="image/png,image/jpeg,image/webp,image/gif"
-                              multiple
-                              className="sr-only"
-                              data-testid="admin-note-attachment-input"
+                          <div className="flex flex-wrap items-center gap-2">
+                            <AdminNoteScreenshotCaptureButton
+                              buttonLabel={isUploading ? "Uploading…" : "Capture screenshot"}
+                              onCaptureReady={async (file) => {
+                                const updatedItem = await uploadFilesForNote(item.id, [file]);
+                                if (!updatedItem) {
+                                  throw new Error("Could not upload screenshot attachment.");
+                                }
+                                setActionNotice("Screenshot attached.");
+                              }}
                               disabled={Boolean(
                                 isUploading || deletingAttachmentId || updatingId || deletingId
                               )}
-                              onChange={(e) => {
-                                void uploadAttachments(item, e.target.files);
-                                e.currentTarget.value = "";
-                              }}
                             />
-                          </label>
+                            <label className="inline-flex cursor-pointer items-center justify-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 transition hover:bg-slate-100">
+                              <span>{isUploading ? "Uploading…" : "Add images"}</span>
+                              <input
+                                type="file"
+                                accept="image/png,image/jpeg,image/webp,image/gif"
+                                multiple
+                                className="sr-only"
+                                data-testid="admin-note-attachment-input"
+                                disabled={Boolean(
+                                  isUploading || deletingAttachmentId || updatingId || deletingId
+                                )}
+                                onChange={(e) => {
+                                  void uploadAttachments(item, e.target.files);
+                                  e.currentTarget.value = "";
+                                }}
+                              />
+                            </label>
+                          </div>
                         </div>
 
                         {item.attachments.length > 0 ? (
@@ -1825,7 +1941,8 @@ export default function AdminNotesManager() {
           Store planning notes with category, priority, date, and completion tracking.
         </p>
         <p className="mt-2 text-xs text-slate-500">
-          Save first, then use Edit on the new note to add screenshots or link related notes.
+          Stage one screenshot before save if needed, then use Edit to attach more images or link
+          related notes afterward.
         </p>
         <div className="mt-3 rounded-xl border border-amber-200 bg-amber-50 p-3">
           <p className="text-xs font-semibold text-amber-900">Incident quick templates</p>
@@ -1934,6 +2051,88 @@ export default function AdminNotesManager() {
               placeholder="What to do, blockers, and owner notes."
             />
           </label>
+
+          <div className="space-y-3 rounded-xl border border-slate-200 bg-slate-50/70 p-4 sm:col-span-2">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold text-slate-900">Screenshot (optional)</p>
+                <p className="mt-1 text-xs text-slate-600">
+                  Capture a browser screenshot now and attach it after the note save succeeds.
+                </p>
+              </div>
+              <AdminNoteScreenshotCaptureButton
+                buttonLabel={createPendingScreenshot ? "Retake screenshot" : "Capture screenshot"}
+                onCaptureReady={async (file) => {
+                  setActionError(null);
+                  setCreateCaptureRecovery(null);
+                  setCreatePendingScreenshotFromFile(file);
+                }}
+                disabled={Boolean(submitting)}
+              />
+            </div>
+
+            {createPendingScreenshot ? (
+              <div className="rounded-xl border border-slate-200 bg-white px-3 py-3">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="flex items-center gap-3">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={createPendingScreenshot.previewUrl}
+                      alt="Pending screenshot preview"
+                      className="h-14 w-14 rounded-lg object-cover"
+                    />
+                    <div>
+                      <p className="text-xs font-semibold text-slate-900">
+                        Screenshot ready to attach
+                      </p>
+                      <p className="mt-1 text-[11px] text-slate-600">
+                        {createCaptureRecovery
+                          ? "The note is already saved. Retry upload or finish without the screenshot."
+                          : "The screenshot stays local until this note save finishes successfully."}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    {createCaptureRecovery ? (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          void retryCreatePendingScreenshotUpload();
+                        }}
+                        disabled={submitting}
+                        className="inline-flex h-9 items-center justify-center rounded-lg bg-blue-600 px-3 text-xs font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+                      >
+                        {submitting ? "Retrying…" : "Retry upload"}
+                      </button>
+                    ) : null}
+                    <button
+                      type="button"
+                      onClick={() => {
+                        clearCreatePendingScreenshot();
+                        if (createCaptureRecovery) {
+                          setCreateCaptureRecovery(null);
+                          setActionError(null);
+                          setActionNotice(
+                            "Note saved without screenshot. Use Edit to attach one later if needed."
+                          );
+                        }
+                      }}
+                      disabled={submitting}
+                      className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      Remove screenshot
+                    </button>
+                  </div>
+                </div>
+                {createCaptureRecovery ? (
+                  <p className="mt-3 text-[11px] text-slate-600">
+                    Saved note: {createCaptureRecovery.title}. Retry the upload here or use Edit
+                    from the work queue later.
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
 
           <label className="space-y-1 text-sm font-medium text-slate-700">
             <span>Attach to (optional)</span>
@@ -2087,7 +2286,7 @@ export default function AdminNotesManager() {
           <div className="sm:col-span-2">
             <button
               type="submit"
-              disabled={submitting || createContextInvalid}
+              disabled={submitting || createContextInvalid || Boolean(createCaptureRecovery)}
               className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
             >
               {submitting ? "Saving…" : "Save note"}

--- a/docs/runbooks/admin-notes-recovery.md
+++ b/docs/runbooks/admin-notes-recovery.md
@@ -12,6 +12,7 @@ Use this runbook for AW-012 workflow `A4` stale-note reconciliation edge cases.
 
 - Save returns `Could not update note.` or `Could not save note.` even though another operator already changed the row.
 - Quick capture save fails or closes unexpectedly and you need to confirm whether a note was actually created.
+- Screenshot capture permission is denied, cancelled, or never reaches preview and you need to finish the note safely.
 - A contextual note panel shows outdated title/body/status after recent edits in admin.
 - You suspect duplicate/overlapping edits on the same note.
 - Screenshot upload/delete returns an error and you are unsure whether the stored image was fully removed.
@@ -31,9 +32,12 @@ Use this runbook for AW-012 workflow `A4` stale-note reconciliation edge cases.
    - context label (`Course Lesson`, `Product`, `Page`, etc.),
    - raw context ref/path when relevant.
 6. If screenshots are involved:
+   - if capture permission was denied or cancelled, confirm whether the screenshot ever reached preview; if not, nothing was saved and you can retry or use `Add images`,
+   - if preview existed but note save failed, search by `Note ID` or title before retrying capture so you do not create duplicate notes,
    - confirm the attachment list and image count in the note row,
    - if delete failed, refresh once and verify whether the image is still present before retrying,
-   - if upload failed, retry only after confirming you are not looking at a stale duplicate preview.
+   - if upload failed after note save, retry only after confirming you are not looking at a stale duplicate preview,
+   - if the staged screenshot was removed locally, use `Capture screenshot` again or fall back to `Add images`.
 7. If related notes are involved:
    - open the visible linked note IDs from Search if needed,
    - confirm the intended link exists only once,
@@ -47,6 +51,7 @@ Use this runbook for AW-012 workflow `A4` stale-note reconciliation edge cases.
 - Recovery completes without deleting valid note history.
 - Final note state is consistent in admin list and contextual panel.
 - Attachment/image state and related-note links are consistent after one refresh.
+- Permission-denied or cancelled screenshot flows leave no fake saved attachment behind.
 - AW-012 checkpoint includes branch/SHA + one-line result summary.
 
 ## Evidence Note Template (Checkpoint Entry)

--- a/docs/task-briefs/in-progress/2026-03-22-admin-notes-screenshot-region-capture-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-22-admin-notes-screenshot-region-capture-10-10.md
@@ -1,0 +1,241 @@
+# Task Brief: Admin Notes Screenshot Region Capture (10/10)
+
+## Metadata
+
+- `id`: `2026-03-22-admin-notes-screenshot-region-capture-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-03-22`
+- `updated`: `2026-03-22`
+
+## Goal
+
+Signed-in admins can capture a screenshot directly from supported admin note flows, select the relevant region safely, preview it, and save it as a normal admin-note attachment while non-admin users never see or access the feature.
+
+## Why This Brief Exists
+
+- Admin notes already support image attachments, but not a true in-app capture flow.
+- Quick capture and screenshot-region capture are related, but they are not the same slice:
+  - quick capture solves entry and context-prefill,
+  - screenshot region capture solves permission, selection, preview, and safe attachment save.
+- Splitting this work keeps the browser-permission, privacy, and failure-handling risk isolated instead of mixing it into broader admin-notes or builder work.
+
+## Dependencies And Boundaries
+
+- Depends on:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-22-admin-notes-quick-capture-launcher-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-21-admin-notes-workflow-v2-attachments-and-linking-10-10.md`
+  - `/Users/stianvikra/freeswimming/components/admin/AdminNotesManager.tsx`
+  - `/Users/stianvikra/freeswimming/components/admin/AdminContextNotesPanel.tsx`
+  - `/Users/stianvikra/freeswimming/lib/admin/notes.ts`
+  - `/Users/stianvikra/freeswimming/app/api/admin/notes/route.ts`
+  - `/Users/stianvikra/freeswimming/app/api/admin/notes/[id]/route.ts`
+- This slice owns:
+  - admin-only screenshot-capture launcher behavior inside supported note flows,
+  - permission and failure UX for browser capture,
+  - region selection and pre-save preview,
+  - converting an approved capture into a normal note attachment.
+- This slice does not own:
+  - public-user upload flows,
+  - OCR/text extraction,
+  - annotation/drawing tools unless explicitly added in a later slice,
+  - a desktop-native cross-app capture utility outside browser-supported capture APIs.
+
+## Scope
+
+- Add an admin-only screenshot-capture action to supported admin note creation/edit flows.
+- Support a safe capture flow where the admin can:
+  - start capture,
+  - choose the allowed browser capture source,
+  - select or crop the relevant region,
+  - preview the result before saving,
+  - save it as a standard admin-note image attachment.
+- Provide clear recovery for:
+  - permission denied,
+  - capture cancelled,
+  - capture failure,
+  - upload/save failure.
+- Ensure delete still uses the existing canonical attachment delete lifecycle for both metadata and storage object removal.
+- Keep the feature hidden from non-admin users at both UI and API level.
+- Update Help/Guide and operator runbooks for supported browsers, capture limitations, and recovery behavior.
+
+## Out Of Scope
+
+- Public screenshot capture or user-facing note attachments.
+- Full-screen annotation, freehand drawing, arrows, blur, or redaction tooling.
+- Capturing arbitrary local files outside the existing image-attachment model.
+- Replacing normal image upload/paste flows.
+- Rolling this feature into builder or unrelated app surfaces in the same slice.
+
+## Data Placement And Sync Contract
+
+- Server-canonical data:
+  - saved admin note rows,
+  - attachment metadata rows,
+  - attachment storage object keys,
+  - canonical note/context references.
+- Local-only data:
+  - in-progress capture session state,
+  - transient captured bitmap/blob before confirmation,
+  - crop/selection coordinates,
+  - preview URL before save,
+  - unsaved note draft text.
+- Sync policy:
+  - no attachment row or storage object is created until explicit save,
+  - cancel must discard local capture state without creating server artifacts,
+  - save uses the canonical admin-note attachment lifecycle and refreshes note views deterministically,
+  - failures preserve recoverable local draft state where safe, but never report success before server confirmation.
+- Retention and sensitivity:
+  - captures may contain sensitive internal information and must remain admin-only,
+  - temporary pre-save capture data should stay in-memory or otherwise short-lived on the client and must not be persisted beyond the local editing session,
+  - deleting a saved screenshot attachment must remove both metadata and storage object fully.
+- Cache/invalidation:
+  - notes manager, contextual notes panels, and note detail/edit views must refresh deterministically after capture save or delete,
+  - cancelled or failed captures must not invalidate or mutate server-canonical note state.
+
+## Identity And Rename Contract
+
+- Canonical stable IDs:
+  - `admin_note.id` remains the canonical note identity,
+  - screenshot attachments use immutable attachment IDs after save.
+- Human-readable identifiers:
+  - capture labels, filenames, and preview captions are display metadata only and are never canonical identity.
+- Mutability rules:
+  - a screenshot attachment may be deleted, but not silently reassigned to a different note,
+  - changing note text or title does not change attachment identity,
+  - local crop state is ephemeral and not a persisted identifier.
+- Rename vs repurpose policy:
+  - minor display-label changes remain in place,
+  - a materially different capture must be created as a new attachment instead of overwriting prior attachment identity in ambiguous ways.
+- Compatibility contract:
+  - notes with no capture attachments remain fully valid,
+  - screenshot-capture-created attachments must behave like existing image attachments once saved.
+- Observability and repair:
+  - failed capture or upload states should be diagnosable,
+  - missing-orphan mismatches between metadata and storage must still be handled by the existing attachment recovery guidance.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Business logic correctness and data integrity`
+- `Security and authz`
+- `Privacy and compliance`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                    | Evidence                             |
+| --------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| Product goals and IA                          | `target`     | Admin can understand when to use screenshot capture versus normal upload or plain text note entry without route-level confusion.                  | IA review + manual QA + e2e          |
+| UX flow clarity                               | `target`     | Start, permission, select, preview, save, cancel, retry, and delete feel deterministic and understandable on supported browsers.                  | e2e + manual QA                      |
+| Visual design quality                         | `target`     | Capture controls, preview, and failure states feel intentional and low-noise without cluttering the notes UI.                                     | screenshot review + manual QA        |
+| Business logic correctness and data integrity | `target`     | No screenshot attachment is created on cancel, unauthorized access, or failed save, and saved captures always use canonical attachment lifecycle. | unit tests + runtime guards          |
+| Admin editor ergonomics                       | `target`     | Admin can capture and attach the relevant screen region faster than taking an external screenshot and re-uploading it manually.                   | timed manual QA + e2e                |
+| Accessibility (a11y)                          | `target`     | Capture launcher, preview controls, crop confirmation, save/cancel, and recovery states remain keyboard and touch accessible where supported.     | Playwright + manual QA               |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: screenshot capture UI must avoid obvious `/admin` and contextual-panel payload or responsiveness regressions.                    | build + code review                  |
+| Data placement and sync boundaries            | `target`     | Pre-save capture state stays local-only, while saved attachment records and storage objects remain server-canonical and deterministic.            | contract review + tests              |
+| Caching and invalidation strategy             | `target`     | Saved or deleted captures refresh note lists and contextual panels deterministically without forcing a full admin workflow reset.                 | integration review + e2e             |
+| Reliability and failure handling              | `target`     | Permission denied, browser rejection, cancelled capture, failed upload, and delete failure all show actionable recovery without false success.    | negative-path tests + manual QA      |
+| Security and authz                            | `target`     | Capture launcher and save/delete paths are admin-only, fail closed, and never expose raw sensitive capture data to unauthorized users.            | API/UI negative-path tests           |
+| Privacy and compliance                        | `target`     | Sensitive internal screenshots remain private, short-lived before save, and fully deleted from metadata and storage when removed.                 | storage review + tests               |
+| Content governance                            | `supporting` | Supporting only: screenshot labels, help copy, and attachment conventions stay coherent with existing admin-notes governance.                     | Help/Guide + code review             |
+| Admin workflow and editability                | `target`     | Screenshot capture complements, rather than replacing, existing note editing, upload, and attachment delete flows.                                | e2e + timed manual QA                |
+| SEO and crawlability                          | `N/A`        | N/A because the screenshot capture flow is admin-only and adds no public crawl or indexable surface.                                              | scope rationale                      |
+| AI discoverability                            | `N/A`        | N/A because this slice changes no public AI-facing discoverability surface.                                                                       | scope rationale                      |
+| Analytics and KPI observability               | `supporting` | Supporting only: capture start, cancel, permission-denied, save, and delete events should remain measurable enough to validate workflow value.    | analytics review                     |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, billing, payout, entitlement, or revenue operation changes in this slice.                                                 | scope rationale                      |
+| Incident response and support operations      | `target`     | Help/Guide and runbooks explain supported browsers, permission-denied recovery, capture failure recovery, and attachment delete semantics.        | docs review + help-center assertions |
+| Finance and reporting operations              | `N/A`        | N/A because no billing, reconciliation, payout, or finance reporting logic changes in this screenshot-capture slice.                              | scope rationale                      |
+| i18n operational readiness                    | `supporting` | Supporting only: capture labels, recovery messages, and permission guidance remain localization-safe and avoid hiding logic in raw free text.     | copy review                          |
+| Stack-fit and dependency discipline           | `target`     | Reuse browser-native capture capabilities and existing admin-note attachment infrastructure without unnecessary third-party capture dependencies. | dependency diff + code review        |
+| Testing and QA automation                     | `target`     | Coverage protects permission-denied, cancel, crop/preview, save, delete, and unauthorized-path denial on supported surfaces.                      | tests + `verify:pre-pr` evidence     |
+| Scalability and cost efficiency               | `supporting` | Supporting only: capture flow must avoid duplicate uploads, oversized accidental retention, and repeated stale attachment creation on retries.    | storage review + code review         |
+| DevOps and rollback readiness                 | `target`     | Screenshot capture rollout can be disabled or rolled back cleanly without corrupting existing note or attachment data.                            | rollback checklist + runbook review  |
+
+## Acceptance Criteria
+
+1. Signed-in admins can launch screenshot capture from the agreed admin note surfaces.
+2. Admin can select the relevant capture region, preview it, and explicitly confirm before save.
+3. Cancelling capture or closing the flow creates no attachment row and no storage artifact.
+4. Permission-denied and browser-capture failures show clear recovery guidance and leave the note workflow usable.
+5. Saving a confirmed capture creates a normal admin-note image attachment visible in existing note UIs.
+6. Deleting a saved capture still removes both metadata and underlying storage object completely.
+7. Non-admin users never see capture controls and cannot use capture save/delete paths directly.
+8. `npm run lint:briefs`, targeted tests, and `npm run verify:pre-pr` pass before PR update.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run lint`
+- `npm run typecheck`
+- targeted unit tests for:
+  - permission-denied and cancellation handling,
+  - crop/preview state transitions,
+  - save payload validation,
+  - delete lifecycle invariants
+- targeted e2e for:
+  - launch capture,
+  - cancel before save,
+  - permission denied,
+  - save capture to note,
+  - delete saved capture,
+  - unauthorized-path denial
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm must be installed on the machine used for local validation.
+- Local validation runs from repo root.
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3000/admin?tab=notes`
+  - relevant contextual admin-note surfaces after quick-capture launcher lands
+- Preview:
+  - PR preview URL after branch push
+- Recommended matrix:
+  - Desktop Chrome
+  - Desktop Safari/WebKit
+  - Desktop Firefox
+  - iPad/tablet viewport for capture and preview sanity check
+- Any unsupported browser/device capture behavior must be documented explicitly in the PR and Help/Guide copy.
+
+## Constraints
+
+- Keep the feature admin-only and fail closed everywhere.
+- Prefer browser-native capture capabilities and existing attachment infrastructure over new heavy dependencies.
+- Do not claim successful save before attachment metadata and storage write both succeed.
+- If a browser does not support the intended region-capture flow cleanly, the fallback must be explicit rather than silent or misleading.
+
+## 10/10 Quality Bar
+
+- Screenshot capture must reduce admin friction without increasing privacy risk.
+- The primary action should always be obvious:
+  - start capture,
+  - confirm region,
+  - save to note,
+  - or cancel safely.
+- Required states remain explicit:
+  - `idle`
+  - `requesting permission`
+  - `capturing`
+  - `preview`
+  - `saving`
+  - `success`
+  - `error`
+  - `retry`
+  - `permission denied`
+- Error states must preserve operator trust:
+  - no fake success,
+  - no invisible partial save,
+  - no orphaned storage on failed delete.
+- Capture UI must stay consistent with existing admin visual language and avoid turning notes into a heavy design tool.
+
+## Checkpoint Log
+
+- `2026-03-22 | planning | created a dedicated planned brief for admin-only screenshot region capture so browser permission, crop/preview, privacy, and attachment-lifecycle risk stay isolated from quick-capture rollout and builder work | next: implement admin-notes quick-capture launcher first, then build screenshot capture on top of that launcher and existing attachment lifecycle`
+- `2026-03-22 | feat/admin-notes-screenshot-capture-2026-03-22@working-tree | moved brief to in-progress and implemented browser screenshot capture preview/crop flow for Admin Notes create, edit, and quick-capture surfaces using the existing attachment lifecycle plus operator recovery states | next: finish docs alignment, run targeted validation, then clear verify:pre-pr`

--- a/lib/admin/notes-client.ts
+++ b/lib/admin/notes-client.ts
@@ -1,0 +1,38 @@
+import type { AdminNoteItem } from "@/lib/admin/notes";
+
+type AdminNoteMutationResponse =
+  | {
+      ok: true;
+      item: AdminNoteItem;
+    }
+  | {
+      ok: false;
+      error?: string;
+    };
+
+export async function uploadAdminNoteFiles(params: {
+  noteId: string;
+  files: File[];
+}): Promise<AdminNoteItem> {
+  const formData = new FormData();
+  params.files.forEach((file) => {
+    formData.append("files", file);
+  });
+
+  const response = await fetch(`/api/admin/notes/${params.noteId}/attachments`, {
+    method: "POST",
+    credentials: "same-origin",
+    body: formData,
+  });
+
+  const payload = (await response.json()) as AdminNoteMutationResponse;
+  if (!response.ok || !payload.ok || !payload.item) {
+    throw new Error(
+      payload.ok
+        ? "Could not upload attachments."
+        : (payload.error ?? "Could not upload attachments.")
+    );
+  }
+
+  return payload.item;
+}

--- a/lib/admin/screenshot-capture-client.ts
+++ b/lib/admin/screenshot-capture-client.ts
@@ -1,0 +1,199 @@
+import {
+  buildAdminScreenshotFileName,
+  clampAdminScreenshotSelection,
+  type AdminScreenshotFrame,
+  type AdminScreenshotSelection,
+} from "@/lib/admin/screenshot-capture";
+
+export type AdminScreenshotCaptureDriver = {
+  isSupported: () => boolean;
+  capture: () => Promise<AdminScreenshotFrame>;
+  cropToFile: (params: {
+    frame: AdminScreenshotFrame;
+    selection: AdminScreenshotSelection;
+  }) => Promise<File>;
+};
+
+declare global {
+  interface Window {
+    __FS_ADMIN_SCREENSHOT_CAPTURE_OVERRIDE__?: Partial<AdminScreenshotCaptureDriver>;
+  }
+}
+
+function getAdminScreenshotCaptureOverride(): Partial<AdminScreenshotCaptureDriver> | undefined {
+  if (typeof window === "undefined") return undefined;
+  return window.__FS_ADMIN_SCREENSHOT_CAPTURE_OVERRIDE__;
+}
+
+function isBrowserCaptureSupported() {
+  return typeof navigator !== "undefined" && Boolean(navigator.mediaDevices?.getDisplayMedia);
+}
+
+function waitForLoadedVideoFrame(video: HTMLVideoElement) {
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+
+    const cleanup = () => {
+      video.onloadedmetadata = null;
+      video.oncanplay = null;
+      video.onerror = null;
+    };
+
+    const finish = (cb: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      cb();
+    };
+
+    video.onloadedmetadata = () => finish(resolve);
+    video.oncanplay = () => finish(resolve);
+    video.onerror = () => finish(() => reject(new Error("Could not read screenshot frame.")));
+  });
+}
+
+async function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) {
+        resolve(blob);
+        return;
+      }
+      reject(new Error("Could not convert screenshot preview to image."));
+    }, "image/png");
+  });
+}
+
+async function loadImageFromBlob(blob: Blob): Promise<HTMLImageElement> {
+  const objectUrl = URL.createObjectURL(blob);
+
+  try {
+    return await new Promise<HTMLImageElement>((resolve, reject) => {
+      const image = new Image();
+      image.onload = () => resolve(image);
+      image.onerror = () => reject(new Error("Could not load screenshot preview."));
+      image.src = objectUrl;
+    });
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+async function captureAdminScreenshotFrame(): Promise<AdminScreenshotFrame> {
+  if (!isBrowserCaptureSupported()) {
+    throw Object.assign(new Error("Browser capture is not supported."), {
+      name: "NotSupportedError",
+    });
+  }
+
+  const stream = await navigator.mediaDevices.getDisplayMedia({
+    video: {
+      frameRate: 1,
+    },
+    audio: false,
+  });
+
+  try {
+    const video = document.createElement("video");
+    video.muted = true;
+    video.playsInline = true;
+    video.autoplay = true;
+    video.srcObject = stream;
+
+    const playback = video.play();
+    await Promise.race([waitForLoadedVideoFrame(video), playback.catch(() => undefined)]);
+    await playback.catch(() => undefined);
+
+    const width = Math.max(1, video.videoWidth || 0);
+    const height = Math.max(1, video.videoHeight || 0);
+
+    if (!width || !height) {
+      throw new Error("Could not read screenshot size from the selected source.");
+    }
+
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext("2d");
+    if (!context) {
+      throw new Error("Could not prepare screenshot preview.");
+    }
+
+    context.drawImage(video, 0, 0, width, height);
+    const blob = await canvasToBlob(canvas);
+
+    return {
+      blob,
+      width,
+      height,
+      fileName: buildAdminScreenshotFileName(),
+    };
+  } finally {
+    stream.getTracks().forEach((track) => track.stop());
+  }
+}
+
+async function cropAdminScreenshotToFile(params: {
+  frame: AdminScreenshotFrame;
+  selection: AdminScreenshotSelection;
+}): Promise<File> {
+  const normalizedSelection = clampAdminScreenshotSelection({
+    selection: params.selection,
+    bounds: params.frame,
+  });
+  const image = await loadImageFromBlob(params.frame.blob);
+  const canvas = document.createElement("canvas");
+  canvas.width = normalizedSelection.width;
+  canvas.height = normalizedSelection.height;
+  const context = canvas.getContext("2d");
+
+  if (!context) {
+    throw new Error("Could not prepare screenshot crop.");
+  }
+
+  context.drawImage(
+    image,
+    normalizedSelection.x,
+    normalizedSelection.y,
+    normalizedSelection.width,
+    normalizedSelection.height,
+    0,
+    0,
+    normalizedSelection.width,
+    normalizedSelection.height
+  );
+
+  const blob = await canvasToBlob(canvas);
+  return new File([blob], params.frame.fileName, {
+    type: "image/png",
+  });
+}
+
+export function getAdminScreenshotCaptureDriver(): AdminScreenshotCaptureDriver {
+  return {
+    isSupported() {
+      const override = getAdminScreenshotCaptureOverride();
+      if (override?.isSupported) {
+        return override.isSupported();
+      }
+      if (override?.capture) {
+        return true;
+      }
+      return isBrowserCaptureSupported();
+    },
+    async capture() {
+      const override = getAdminScreenshotCaptureOverride();
+      if (override?.capture) {
+        return override.capture();
+      }
+      return captureAdminScreenshotFrame();
+    },
+    async cropToFile(params) {
+      const override = getAdminScreenshotCaptureOverride();
+      if (override?.cropToFile) {
+        return override.cropToFile(params);
+      }
+      return cropAdminScreenshotToFile(params);
+    },
+  };
+}

--- a/lib/admin/screenshot-capture.ts
+++ b/lib/admin/screenshot-capture.ts
@@ -1,0 +1,141 @@
+export type AdminScreenshotCapturePhase =
+  | "idle"
+  | "requesting_permission"
+  | "preview"
+  | "saving"
+  | "permission_denied"
+  | "cancelled"
+  | "unsupported"
+  | "error";
+
+export type AdminScreenshotSelection = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type AdminScreenshotFrame = {
+  blob: Blob;
+  width: number;
+  height: number;
+  fileName: string;
+};
+
+export type AdminScreenshotCaptureFailure = {
+  phase: Extract<
+    AdminScreenshotCapturePhase,
+    "permission_denied" | "cancelled" | "unsupported" | "error"
+  >;
+  message: string;
+};
+
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function buildDefaultAdminScreenshotSelection(
+  width: number,
+  height: number
+): AdminScreenshotSelection {
+  return {
+    x: 0,
+    y: 0,
+    width: Math.max(1, Math.round(width)),
+    height: Math.max(1, Math.round(height)),
+  };
+}
+
+export function clampAdminScreenshotSelection(params: {
+  selection: AdminScreenshotSelection;
+  bounds: Pick<AdminScreenshotFrame, "width" | "height">;
+}): AdminScreenshotSelection {
+  const maxWidth = Math.max(1, Math.round(params.bounds.width));
+  const maxHeight = Math.max(1, Math.round(params.bounds.height));
+  const width = clampNumber(Math.round(params.selection.width), 1, maxWidth);
+  const height = clampNumber(Math.round(params.selection.height), 1, maxHeight);
+  const x = clampNumber(Math.round(params.selection.x), 0, maxWidth - width);
+  const y = clampNumber(Math.round(params.selection.y), 0, maxHeight - height);
+
+  return { x, y, width, height };
+}
+
+export function buildAdminScreenshotSelectionFromDrag(params: {
+  start: { x: number; y: number };
+  current: { x: number; y: number };
+  bounds: Pick<AdminScreenshotFrame, "width" | "height">;
+}): AdminScreenshotSelection {
+  const rawSelection = {
+    x: Math.min(params.start.x, params.current.x),
+    y: Math.min(params.start.y, params.current.y),
+    width: Math.abs(params.current.x - params.start.x),
+    height: Math.abs(params.current.y - params.start.y),
+  };
+
+  return clampAdminScreenshotSelection({
+    selection: {
+      x: rawSelection.x,
+      y: rawSelection.y,
+      width: Math.max(1, rawSelection.width),
+      height: Math.max(1, rawSelection.height),
+    },
+    bounds: params.bounds,
+  });
+}
+
+export function buildAdminScreenshotFileName(now: Date = new Date()): string {
+  const year = String(now.getUTCFullYear());
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(now.getUTCDate()).padStart(2, "0");
+  const hour = String(now.getUTCHours()).padStart(2, "0");
+  const minute = String(now.getUTCMinutes()).padStart(2, "0");
+  const second = String(now.getUTCSeconds()).padStart(2, "0");
+
+  return `admin-note-capture-${year}${month}${day}-${hour}${minute}${second}.png`;
+}
+
+export function classifyAdminScreenshotCaptureError(error: unknown): AdminScreenshotCaptureFailure {
+  const name = typeof error === "object" && error && "name" in error ? String(error.name) : "";
+  const message =
+    typeof error === "object" && error && "message" in error ? String(error.message) : "";
+  const normalizedName = name.trim().toLowerCase();
+  const normalizedMessage = message.trim().toLowerCase();
+
+  if (
+    normalizedName === "notallowederror" ||
+    normalizedName === "securityerror" ||
+    normalizedMessage.includes("permission") ||
+    normalizedMessage.includes("not allowed")
+  ) {
+    return {
+      phase: "permission_denied",
+      message:
+        "Screenshot permission was denied. Retry capture or use Add images if you already have a screenshot file.",
+    };
+  }
+
+  if (
+    normalizedName === "aborterror" ||
+    normalizedMessage.includes("cancel") ||
+    normalizedMessage.includes("aborted")
+  ) {
+    return {
+      phase: "cancelled",
+      message:
+        "Screenshot capture was cancelled before anything was saved. Retry when you are ready.",
+    };
+  }
+
+  if (normalizedName === "notsupportederror" || normalizedMessage.includes("not supported")) {
+    return {
+      phase: "unsupported",
+      message:
+        "This browser does not support in-app screenshot capture yet. Use Add images instead.",
+    };
+  }
+
+  return {
+    phase: "error",
+    message: "Could not capture a screenshot right now. Retry capture or use Add images instead.",
+  };
+}

--- a/tests/e2e/admin-help-center.spec.ts
+++ b/tests/e2e/admin-help-center.spec.ts
@@ -111,6 +111,9 @@ test.describe("admin help center", () => {
     await expect(page.getByText("Visible note ID:")).toBeVisible();
     await expect(page.getByText("Priority:")).toBeVisible();
     await expect(page.getByText("Add images / Delete image:")).toBeVisible();
+    await expect(
+      page.getByText("Capture screenshot / Retake screenshot / Retry upload:")
+    ).toBeVisible();
     await expect(page.getByText("Link note / Remove link:")).toBeVisible();
     await expect(page.getByText("Open lock operations workflow:")).toBeVisible();
     await expect(page.getByText("Open password page:")).toBeVisible();
@@ -141,8 +144,14 @@ test.describe("admin help center", () => {
     ).toBeVisible();
     await expect(
       page.getByText(
-        "Add screenshots when the issue is visual or hard to reproduce, and link any follow-up note instead of pasting duplicate text."
+        "Use `Capture screenshot` when the issue is visual, drag to the relevant crop in preview, and save only after the preview looks right."
       )
     ).toBeVisible();
+    await expect(
+      page.getByText(
+        "Remember that staged screenshots stay local until note save and attachment upload both succeed; if permission is denied, fall back to `Add images`."
+      )
+    ).toBeVisible();
+    await expect(page.getByText("Screenshot capture is denied or upload fails")).toBeVisible();
   });
 });

--- a/tests/e2e/admin-notes-workflow.spec.ts
+++ b/tests/e2e/admin-notes-workflow.spec.ts
@@ -1,12 +1,9 @@
-import { Buffer } from "node:buffer";
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
 const isSiteLockEnabled = process.env.SITE_LOCK_ENABLED === "1";
-const TINY_PNG = Buffer.from(
-  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9l9wAAAABJRU5ErkJggg==",
-  "base64"
-);
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9l9wAAAABJRU5ErkJggg==";
 
 function runOnceOnDesktopChromium(projectName: string) {
   test.skip(!projectName.startsWith("desktop-"), "Admin e2e is desktop-only.");
@@ -167,6 +164,43 @@ async function toggleDoneAndWait(page: Page, item: ReturnType<Page["getByTestId"
   }
 }
 
+async function installAdminScreenshotCaptureMock(
+  page: Page,
+  mode: "success" | "permission_denied"
+) {
+  await page.addInitScript(
+    ({ base64, captureMode }) => {
+      const decodePng = () => Uint8Array.from(atob(base64), (character) => character.charCodeAt(0));
+
+      window.__FS_ADMIN_SCREENSHOT_CAPTURE_OVERRIDE__ = {
+        isSupported: () => true,
+        capture: async () => {
+          if (captureMode === "permission_denied") {
+            const error = new Error("Permission denied");
+            error.name = "NotAllowedError";
+            throw error;
+          }
+
+          return {
+            blob: new Blob([decodePng()], { type: "image/png" }),
+            width: 1,
+            height: 1,
+            fileName: "captured-proof.png",
+          };
+        },
+        cropToFile: async () =>
+          new File([decodePng()], "captured-proof.png", {
+            type: "image/png",
+          }),
+      };
+    },
+    {
+      base64: TINY_PNG_BASE64,
+      captureMode: mode,
+    }
+  );
+}
+
 test.describe("admin notes workflow", () => {
   test("allowlisted admin can create, edit, toggle, and delete notes", async ({
     page,
@@ -175,6 +209,7 @@ test.describe("admin notes workflow", () => {
     test.slow();
     test.setTimeout(90_000);
 
+    await installAdminScreenshotCaptureMock(page, "success");
     await loginAsAdminViaDevBypass(page);
     await openNotesSection(page);
 
@@ -350,14 +385,18 @@ test.describe("admin notes workflow", () => {
             response.request().method() === "POST",
           { timeout: 15_000 }
         ),
-        attachmentsEditForm.getByTestId("admin-note-attachment-input").setInputFiles({
-          name: "note-proof.png",
-          mimeType: "image/png",
-          buffer: TINY_PNG,
-        }),
+        (async () => {
+          await attachmentsEditForm.getByRole("button", { name: "Capture screenshot" }).click();
+          const captureDialog = page.getByTestId("admin-note-screenshot-capture-dialog");
+          await expect(captureDialog).toBeVisible();
+          await expect(
+            captureDialog.getByTestId("admin-note-screenshot-preview-image")
+          ).toBeVisible();
+          await captureDialog.getByRole("button", { name: "Save screenshot" }).click();
+        })(),
       ]);
     } catch {
-      test.skip(true, "Admin notes attachment upload timed out in this environment.");
+      test.skip(true, "Admin notes screenshot capture upload timed out in this environment.");
     }
     if (!uploadResponse) {
       return;
@@ -373,7 +412,7 @@ test.describe("admin notes workflow", () => {
           : `status ${uploadResponse.status()}`;
       test.skip(
         true,
-        `Admin notes attachment upload is not ready in this environment (${reason}).`
+        `Admin notes screenshot capture upload is not ready in this environment (${reason}).`
       );
     }
 
@@ -414,6 +453,41 @@ test.describe("admin notes workflow", () => {
 
     await expect(updatedItem).toContainText("1 related note");
     await expect(updatedItem).toContainText(secondaryTitle);
+
+    let deleteAttachmentResponse: Awaited<ReturnType<Page["waitForResponse"]>> | undefined;
+    try {
+      [deleteAttachmentResponse] = await Promise.all([
+        page.waitForResponse(
+          (response) =>
+            response.url().includes(`/api/admin/notes/${noteId}/attachments/`) &&
+            response.request().method() === "DELETE",
+          { timeout: 15_000 }
+        ),
+        attachmentsEditForm.getByTestId("admin-note-attachment-delete").click(),
+      ]);
+    } catch {
+      test.skip(true, "Admin notes screenshot delete request timed out in this environment.");
+    }
+    if (!deleteAttachmentResponse) {
+      return;
+    }
+
+    const deleteAttachmentPayload = (await deleteAttachmentResponse.json().catch(() => null)) as {
+      ok?: boolean;
+      error?: string;
+    } | null;
+    if (!deleteAttachmentResponse.ok() || deleteAttachmentPayload?.ok === false) {
+      const reason =
+        typeof deleteAttachmentPayload?.error === "string"
+          ? deleteAttachmentPayload.error
+          : `status ${deleteAttachmentResponse.status()}`;
+      test.skip(
+        true,
+        `Admin notes screenshot delete is not ready in this environment (${reason}).`
+      );
+    }
+
+    await expect(updatedItem).not.toContainText("1 image");
     await attachmentsEditForm.getByRole("button", { name: "Cancel" }).click();
 
     await page.getByTestId("admin-notes-category-filter").selectOption("Product");
@@ -468,8 +542,8 @@ test.describe("admin notes workflow", () => {
     const reopenFiltersButton = page.getByRole("button", { name: "Clear filters" });
     await expect(reopenFiltersButton).toBeVisible();
     await reopenFiltersButton.click();
-    await expect(page.getByTestId("admin-notes-search")).toHaveValue("");
-    await expect(page).not.toHaveURL(/notesQuery=/);
+    await expect(page).not.toHaveURL(/notesQuery=/, { timeout: 15_000 });
+    await expect(page.getByTestId("admin-notes-search")).toHaveValue("", { timeout: 15_000 });
     const relatedNoteItem = page
       .getByTestId("admin-note-item")
       .filter({ hasText: secondaryTitle })
@@ -480,6 +554,24 @@ test.describe("admin notes workflow", () => {
     await expect(
       page.getByTestId("admin-note-item").filter({ hasText: secondaryTitle })
     ).toHaveCount(0);
+  });
+
+  test("shows recovery when screenshot capture permission is denied", async ({
+    page,
+  }, testInfo) => {
+    runOnceOnDesktopChromium(testInfo.project.name);
+
+    await installAdminScreenshotCaptureMock(page, "permission_denied");
+    await loginAsAdminViaDevBypass(page);
+    await openNotesSection(page);
+
+    const createForm = page.getByTestId("admin-notes-create-form");
+    await createForm.getByRole("button", { name: "Capture screenshot" }).click();
+
+    const captureDialog = page.getByTestId("admin-note-screenshot-capture-dialog");
+    await expect(captureDialog).toBeVisible();
+    await expect(captureDialog).toContainText(/Screenshot permission was denied/i);
+    await expect(captureDialog.getByRole("button", { name: "Retry capture" })).toBeVisible();
   });
 
   test("allowlisted admin can quick-capture a dashboard note and jump into Notes", async ({

--- a/tests/unit/admin-note-quick-capture-launcher.test.tsx
+++ b/tests/unit/admin-note-quick-capture-launcher.test.tsx
@@ -6,6 +6,7 @@ describe("AdminNoteQuickCaptureLauncher", () => {
   afterEach(() => {
     cleanup();
     vi.unstubAllGlobals();
+    delete window.__FS_ADMIN_SCREENSHOT_CAPTURE_OVERRIDE__;
   });
 
   it("hides the launcher for viewer role", () => {
@@ -105,6 +106,205 @@ describe("AdminNoteQuickCaptureLauncher", () => {
     );
     expect(openLink).toHaveAttribute("href", expect.stringContaining("notesContextType=page"));
     expect(openLink).toHaveAttribute("href", expect.stringContaining("notesContextRef=%2Fplans"));
+  });
+
+  it("saves a quick note and uploads a captured screenshot attachment", async () => {
+    const onSaved = vi.fn();
+    window.__FS_ADMIN_SCREENSHOT_CAPTURE_OVERRIDE__ = {
+      isSupported: () => true,
+      capture: async () => ({
+        blob: new Blob(["capture"], { type: "image/png" }),
+        width: 200,
+        height: 100,
+        fileName: "captured-proof.png",
+      }),
+      cropToFile: async () => new File(["cropped"], "captured-proof.png", { type: "image/png" }),
+    };
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          items: [{ id: "category-1", title: "Operations", is_active: true }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          item: {
+            id: "123e4567-e89b-42d3-a456-426614174099",
+            title: "Plans screenshot follow-up",
+            body: "Remember the visual change.",
+            category: "Operations",
+            note_date: "2026-03-22",
+            priority: "normal",
+            is_done: false,
+            context_type: "page",
+            context_ref: "/plans",
+            created_by: "admin-user",
+            updated_by: "admin-user",
+            created_at: "2026-03-22T12:00:00.000Z",
+            updated_at: "2026-03-22T12:00:00.000Z",
+            attachments: [],
+            related_notes: [],
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          item: {
+            id: "123e4567-e89b-42d3-a456-426614174099",
+            title: "Plans screenshot follow-up",
+            body: "Remember the visual change.",
+            category: "Operations",
+            note_date: "2026-03-22",
+            priority: "normal",
+            is_done: false,
+            context_type: "page",
+            context_ref: "/plans",
+            created_by: "admin-user",
+            updated_by: "admin-user",
+            created_at: "2026-03-22T12:00:00.000Z",
+            updated_at: "2026-03-22T12:00:00.000Z",
+            attachments: [
+              {
+                id: "attachment-1",
+                note_id: "123e4567-e89b-42d3-a456-426614174099",
+                file_name: "captured-proof.png",
+                mime_type: "image/png",
+                size_bytes: 12,
+                created_at: "2026-03-22T12:01:00.000Z",
+                created_by: "admin-user",
+                signed_url: "https://example.com/captured-proof.png",
+              },
+            ],
+            related_notes: [],
+          },
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <AdminNoteQuickCaptureLauncher
+        adminRole="editor"
+        contextType="page"
+        contextRef="/plans"
+        contextLabel="Plans page"
+        onSaved={onSaved}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("admin-note-quick-capture-trigger"));
+    await screen.findByTestId("admin-note-quick-capture-dialog");
+
+    fireEvent.click(screen.getByRole("button", { name: "Capture screenshot" }));
+    await screen.findByTestId("admin-note-screenshot-preview-image");
+    fireEvent.click(screen.getByRole("button", { name: "Save screenshot" }));
+    await screen.findByText("Screenshot ready to attach");
+
+    fireEvent.change(screen.getByLabelText("Title"), {
+      target: { value: "Plans screenshot follow-up" },
+    });
+    fireEvent.change(screen.getByLabelText("Text"), {
+      target: { value: "Remember the visual change." },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save note" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    expect(String(fetchMock.mock.calls[2]?.[0])).toContain(
+      "/api/admin/notes/123e4567-e89b-42d3-a456-426614174099/attachments"
+    );
+    expect(onSaved).toHaveBeenCalledTimes(1);
+    await screen.findByText("Quick note saved.");
+  });
+
+  it("keeps screenshot recovery visible when note save succeeds but attachment upload fails", async () => {
+    window.__FS_ADMIN_SCREENSHOT_CAPTURE_OVERRIDE__ = {
+      isSupported: () => true,
+      capture: async () => ({
+        blob: new Blob(["capture"], { type: "image/png" }),
+        width: 200,
+        height: 100,
+        fileName: "captured-proof.png",
+      }),
+      cropToFile: async () => new File(["cropped"], "captured-proof.png", { type: "image/png" }),
+    };
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          items: [{ id: "category-1", title: "Operations", is_active: true }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          item: {
+            id: "123e4567-e89b-42d3-a456-426614174099",
+            title: "Plans screenshot follow-up",
+            body: "Remember the visual change.",
+            category: "Operations",
+            note_date: "2026-03-22",
+            priority: "normal",
+            is_done: false,
+            context_type: "page",
+            context_ref: "/plans",
+            created_by: "admin-user",
+            updated_by: "admin-user",
+            created_at: "2026-03-22T12:00:00.000Z",
+            updated_at: "2026-03-22T12:00:00.000Z",
+            attachments: [],
+            related_notes: [],
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({
+          ok: false,
+          error: "Could not upload attachments.",
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <AdminNoteQuickCaptureLauncher
+        adminRole="editor"
+        contextType="page"
+        contextRef="/plans"
+        contextLabel="Plans page"
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("admin-note-quick-capture-trigger"));
+    await screen.findByTestId("admin-note-quick-capture-dialog");
+
+    fireEvent.click(screen.getByRole("button", { name: "Capture screenshot" }));
+    await screen.findByTestId("admin-note-screenshot-preview-image");
+    fireEvent.click(screen.getByRole("button", { name: "Save screenshot" }));
+    await screen.findByText("Screenshot ready to attach");
+
+    fireEvent.change(screen.getByLabelText("Title"), {
+      target: { value: "Plans screenshot follow-up" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save note" }));
+
+    await screen.findByText(/Note saved, but could not upload attachments/i);
+    expect(screen.getByRole("button", { name: "Retry upload" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open in Notes" })).toBeInTheDocument();
   });
 
   it("cancels without posting a note", async () => {

--- a/tests/unit/admin-note-screenshot-capture-button.test.tsx
+++ b/tests/unit/admin-note-screenshot-capture-button.test.tsx
@@ -1,0 +1,122 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import AdminNoteScreenshotCaptureButton from "@/components/admin/AdminNoteScreenshotCaptureButton";
+
+type CaptureOverride = NonNullable<Window["__FS_ADMIN_SCREENSHOT_CAPTURE_OVERRIDE__"]>;
+
+function setCaptureOverride(override: CaptureOverride) {
+  window.__FS_ADMIN_SCREENSHOT_CAPTURE_OVERRIDE__ = override;
+}
+
+function clearCaptureOverride() {
+  delete window.__FS_ADMIN_SCREENSHOT_CAPTURE_OVERRIDE__;
+}
+
+function buildFrame() {
+  return {
+    blob: new Blob(["capture"], { type: "image/png" }),
+    width: 400,
+    height: 240,
+    fileName: "captured-proof.png",
+  };
+}
+
+describe("AdminNoteScreenshotCaptureButton", () => {
+  afterEach(() => {
+    cleanup();
+    clearCaptureOverride();
+    vi.restoreAllMocks();
+  });
+
+  it("captures a preview and forwards the cropped file on save", async () => {
+    const onCaptureReady = vi.fn().mockResolvedValue(undefined);
+    const croppedFile = new File(["cropped"], "captured-proof.png", { type: "image/png" });
+    setCaptureOverride({
+      isSupported: () => true,
+      capture: async () => buildFrame(),
+      cropToFile: async () => croppedFile,
+    });
+
+    render(<AdminNoteScreenshotCaptureButton onCaptureReady={onCaptureReady} />);
+
+    fireEvent.click(screen.getByTestId("admin-note-screenshot-capture-trigger"));
+
+    await screen.findByTestId("admin-note-screenshot-capture-dialog");
+    await screen.findByTestId("admin-note-screenshot-preview-image");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save screenshot" }));
+
+    await waitFor(() => {
+      expect(onCaptureReady).toHaveBeenCalledWith(croppedFile);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("admin-note-screenshot-capture-dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows permission recovery when browser access is denied", async () => {
+    setCaptureOverride({
+      isSupported: () => true,
+      capture: async () => {
+        const error = new Error("Permission denied");
+        error.name = "NotAllowedError";
+        throw error;
+      },
+    });
+
+    render(<AdminNoteScreenshotCaptureButton onCaptureReady={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId("admin-note-screenshot-capture-trigger"));
+
+    await screen.findByTestId("admin-note-screenshot-capture-dialog");
+    await screen.findByText(/Screenshot permission was denied/i);
+    expect(screen.getByRole("button", { name: "Retry capture" })).toBeInTheDocument();
+  });
+
+  it("keeps the preview open when save fails", async () => {
+    const onCaptureReady = vi.fn().mockRejectedValue(new Error("Could not upload screenshot."));
+    setCaptureOverride({
+      isSupported: () => true,
+      capture: async () => buildFrame(),
+      cropToFile: async () =>
+        new File(["cropped"], "captured-proof.png", {
+          type: "image/png",
+        }),
+    });
+
+    render(<AdminNoteScreenshotCaptureButton onCaptureReady={onCaptureReady} />);
+
+    fireEvent.click(screen.getByTestId("admin-note-screenshot-capture-trigger"));
+
+    await screen.findByTestId("admin-note-screenshot-preview-image");
+    fireEvent.click(screen.getByRole("button", { name: "Save screenshot" }));
+
+    await screen.findByText("Could not upload screenshot.");
+    expect(screen.getByTestId("admin-note-screenshot-capture-dialog")).toBeInTheDocument();
+  });
+
+  it("cancels preview without forwarding a file", async () => {
+    const onCaptureReady = vi.fn();
+    setCaptureOverride({
+      isSupported: () => true,
+      capture: async () => buildFrame(),
+      cropToFile: async () =>
+        new File(["cropped"], "captured-proof.png", {
+          type: "image/png",
+        }),
+    });
+
+    render(<AdminNoteScreenshotCaptureButton onCaptureReady={onCaptureReady} />);
+
+    fireEvent.click(screen.getByTestId("admin-note-screenshot-capture-trigger"));
+
+    await screen.findByTestId("admin-note-screenshot-preview-image");
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("admin-note-screenshot-capture-dialog")).not.toBeInTheDocument();
+    });
+    expect(onCaptureReady).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/admin-notes-routes.test.ts
+++ b/tests/unit/admin-notes-routes.test.ts
@@ -35,6 +35,7 @@ vi.mock("@/lib/admin/notes-server", () => ({
 }));
 
 import { DELETE as deleteNote } from "@/app/api/admin/notes/[id]/route";
+import { POST as uploadAttachment } from "@/app/api/admin/notes/[id]/attachments/route";
 import { DELETE as deleteAttachment } from "@/app/api/admin/notes/[id]/attachments/[attachmentId]/route";
 import { POST as addRelatedNote } from "@/app/api/admin/notes/[id]/links/route";
 
@@ -318,5 +319,34 @@ describe("admin notes mutation routes", () => {
       related_note_id: noteId,
       created_by: "admin-user-id",
     });
+  });
+
+  it("fails closed for unauthorized attachment uploads", async () => {
+    const noteId = "123e4567-e89b-42d3-a456-426614174099";
+    requireAdminRoleFromSupabaseMock.mockResolvedValueOnce({
+      ok: false,
+      error: "Forbidden",
+      status: 403,
+    });
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {},
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const formData = new FormData();
+    formData.set("file", new File(["capture"], "captured-proof.png", { type: "image/png" }));
+
+    const response = await uploadAttachment(
+      new Request(`https://freeswimming.org/api/admin/notes/${noteId}/attachments`, {
+        method: "POST",
+        body: formData,
+      }),
+      noteContext(noteId)
+    );
+
+    const payload = (await response.json()) as { ok?: boolean; error?: string };
+    expect(response.status).toBe(403);
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toBe("Forbidden");
   });
 });


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-03-22T18:19:19.709Z for branch `feat/admin-notes-screenshot-capture-2026-03-22` (base ref `origin/main`).
- Latest commit: `78708e6` - feat(admin): add notes screenshot capture flow.
- User-visible changes: Admin-facing behavior/guardrails may change in touched admin routes or APIs.
- Technical changes: Updated 14 file(s): `components/admin/AdminHelpCenter.tsx`, `components/admin/AdminNoteQuickCaptureLauncher.tsx`, `components/admin/AdminNoteScreenshotCaptureButton.tsx`, `components/admin/AdminNotesManager.tsx`, `docs/runbooks/admin-notes-recovery.md`, `... and 9 more file(s)`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-03-22-admin-notes-screenshot-region-capture-10-10.md`
- Scorecard target outcomes: 16 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (2); tests (5); runtime UI/routes/components (7).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (14):
  - `components/admin/AdminHelpCenter.tsx`
  - `components/admin/AdminNoteQuickCaptureLauncher.tsx`
  - `components/admin/AdminNoteScreenshotCaptureButton.tsx`
  - `components/admin/AdminNotesManager.tsx`
  - `docs/runbooks/admin-notes-recovery.md`
  - `docs/task-briefs/in-progress/2026-03-22-admin-notes-screenshot-region-capture-10-10.md`
  - `lib/admin/notes-client.ts`
  - `lib/admin/screenshot-capture-client.ts`
  - `... and 6 more file(s)`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `78708e6` (`git revert 78708e6`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **NOT RUN** (artifacts/test-runs/admin-short-session)
- `npm run verify:pre-merge`: **PENDING** for `78708e6` (latest PASS was `2ccea99` at 2026-03-22T17:09:23Z; rerun on current HEAD).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  - No local verify log found in `artifacts/test-runs/latest`.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
