### PR TITLE
feat(workouts): add manual starter workout creation

### DIFF
--- a/app/api/my-library/workouts/route.ts
+++ b/app/api/my-library/workouts/route.ts
@@ -7,7 +7,11 @@ import {
   buildWorkoutSummary,
   WORKOUT_SELECT,
 } from "@/lib/workouts/server";
-import type { WorkoutSaveApiResponse, WorkoutSaveRequestBody } from "@/lib/workouts/shared";
+import {
+  WORKOUT_SOURCE_KINDS,
+  type WorkoutSaveApiResponse,
+  type WorkoutSaveRequestBody,
+} from "@/lib/workouts/shared";
 
 function noStoreJson(
   body: WorkoutSaveApiResponse | Record<string, unknown>,
@@ -21,6 +25,13 @@ function noStoreJson(
       "Cache-Control": "no-store",
     },
   });
+}
+
+function normalizeSourceKind(value: WorkoutSaveRequestBody["sourceKind"]) {
+  if (value && WORKOUT_SOURCE_KINDS.includes(value)) {
+    return value;
+  }
+  return "ai_session_v1";
 }
 
 export async function POST(request: Request) {
@@ -46,7 +57,11 @@ export async function POST(request: Request) {
 
   let insertPayload;
   try {
-    insertPayload = buildWorkoutInsert(user.id, body.draft ?? null);
+    insertPayload = buildWorkoutInsert(
+      user.id,
+      body.draft ?? null,
+      normalizeSourceKind(body.sourceKind)
+    );
   } catch (error) {
     return applySupabaseCookies(
       noStoreJson(

--- a/app/my-library/page.tsx
+++ b/app/my-library/page.tsx
@@ -7,6 +7,7 @@ import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { signOutFromLibrary } from "@/app/my-library/actions";
 import CheckoutButton from "@/components/my-library/CheckoutButton";
 import ContinueCourseCard from "@/components/my-library/ContinueCourseCard";
+import CreateManualWorkoutButton from "@/components/my-library/workouts/CreateManualWorkoutButton";
 import LibrarySectionTabs from "@/components/my-library/LibrarySectionTabs";
 import MyLibraryNewContentNotice from "@/components/my-library/MyLibraryNewContentNotice";
 import PortalButton from "@/components/my-library/PortalButton";
@@ -259,18 +260,22 @@ export default async function MyLibraryPage() {
                         : "Accepted AI-generated workouts will appear here for later canonical editing once you save your first session draft."}
                   </p>
                 </div>
-                <Link
-                  href={
-                    workoutLibrarySnapshot.recentWorkouts[0]
-                      ? `/my-library/workouts/${workoutLibrarySnapshot.recentWorkouts[0].id}`
-                      : "/my-library/generator"
-                  }
-                  className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700"
-                >
-                  {workoutLibrarySnapshot.recentWorkouts[0]
-                    ? "Open workout builder"
-                    : "Create first workout"}
-                </Link>
+                <div className="flex flex-wrap gap-2">
+                  {workoutLibrarySnapshot.recentWorkouts[0] ? (
+                    <Link
+                      href={`/my-library/workouts/${workoutLibrarySnapshot.recentWorkouts[0].id}`}
+                      className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+                    >
+                      Open workout builder
+                    </Link>
+                  ) : null}
+                  {workoutLibrarySnapshot.schemaReady ? (
+                    <CreateManualWorkoutButton
+                      testId="my-library-create-manual-workout"
+                      className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+                    />
+                  ) : null}
+                </div>
               </div>
             </section>
             <LibrarySectionTabs showExploreTab={sections.explore.length > 0} />

--- a/components/my-library/workouts/CreateManualWorkoutButton.tsx
+++ b/components/my-library/workouts/CreateManualWorkoutButton.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { buildManualWorkoutStarterDraft } from "@/lib/workouts/manual";
+import type { WorkoutSaveApiResponse } from "@/lib/workouts/shared";
+
+type Props = {
+  label?: string;
+  pendingLabel?: string;
+  className?: string;
+  testId?: string;
+};
+
+export default function CreateManualWorkoutButton({
+  label = "Create manual workout",
+  pendingLabel = "Creating manual workout...",
+  className = "",
+  testId = "create-manual-workout",
+}: Props) {
+  const router = useRouter();
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleCreate() {
+    setIsCreating(true);
+    setError("");
+
+    try {
+      const response = await fetch("/api/my-library/workouts", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          sourceKind: "manual",
+          draft: buildManualWorkoutStarterDraft(),
+        }),
+      });
+      const responseBody = (await response
+        .json()
+        .catch(() => null)) as WorkoutSaveApiResponse | null;
+
+      if (!response.ok || !responseBody?.ok) {
+        setError(
+          responseBody && !responseBody.ok ? responseBody.error : "Could not create workout."
+        );
+        return;
+      }
+
+      router.push(`/my-library/workouts/${responseBody.workout.id}`);
+      router.refresh();
+    } catch {
+      setError("Could not create workout.");
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        data-testid={testId}
+        onClick={handleCreate}
+        disabled={isCreating}
+        className={className}
+      >
+        {isCreating ? pendingLabel : label}
+      </button>
+      {error ? (
+        <p data-testid={`${testId}-error`} className="text-sm text-rose-700">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/components/my-library/workouts/WorkoutBuilderHub.tsx
+++ b/components/my-library/workouts/WorkoutBuilderHub.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import CreateManualWorkoutButton from "@/components/my-library/workouts/CreateManualWorkoutButton";
 import WorkoutEditor from "@/components/my-library/workouts/WorkoutEditor";
 import type {
   WorkoutEditorRecord,
@@ -99,9 +100,17 @@ export default function WorkoutBuilderHub({ workoutLibrary }: Props) {
             the fuller manual builder flow.
           </p>
         </div>
-        <p className="rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">
-          Canonical workout
-        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          {workoutLibrary.schemaReady ? (
+            <CreateManualWorkoutButton
+              testId="workout-builder-create-manual"
+              className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+            />
+          ) : null}
+          <p className="rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">
+            Canonical workout
+          </p>
+        </div>
       </div>
 
       {!workoutLibrary.schemaReady ? (
@@ -140,10 +149,16 @@ export default function WorkoutBuilderHub({ workoutLibrary }: Props) {
                 : "No canonical workout is loaded in this route."}
             </p>
             <p className="mt-2 text-sm text-amber-900/90">
-              Return to the generator when you want a brand-new AI draft, or reopen another saved
-              workout below.
+              Create a starter manual workout here, return to the generator for a brand-new AI
+              draft, or reopen another saved workout below.
             </p>
             <div className="mt-4 flex flex-wrap gap-2">
+              {workoutLibrary.schemaReady ? (
+                <CreateManualWorkoutButton
+                  testId="workout-builder-empty-create-manual"
+                  className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+                />
+              ) : null}
               <Link
                 href="/my-library/generator"
                 className="inline-flex h-10 items-center justify-center rounded-xl border border-amber-200 bg-white px-4 text-sm font-medium text-amber-900 transition hover:bg-amber-50 active:bg-amber-100"
@@ -212,7 +227,7 @@ export default function WorkoutBuilderHub({ workoutLibrary }: Props) {
             startNewDraftHref="/my-library/generator"
             startNewDraftLabel="Generate new draft"
             showLoadedBanner={false}
-            recentWorkoutsDescription="Open another saved workout here, or jump back to the generator when you want a brand-new AI draft."
+            recentWorkoutsDescription="Open another saved workout here, create a new manual workout from the header, or jump back to the generator when you want a brand-new AI draft."
             workoutHrefBuilder={(workoutId) => `/my-library/workouts/${workoutId}`}
             saveButtonTestId="workout-builder-save"
           />

--- a/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md
+++ b/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md
@@ -15,10 +15,11 @@ Ship a Garmin-familiar manual session builder and poolside execution experience 
 ## Scope
 
 - Current runtime implementation slice under this brief:
-  - introduce a dedicated authenticated canonical workout editor route for already-saved workouts,
+  - keep the dedicated authenticated canonical workout editor route for already-saved workouts,
   - reuse the same editable workout model the AI session generator now writes into,
   - link accepted AI workouts into that dedicated route from Generator Intake and My Library,
-  - keep manual blank-workout creation and poolside execution deferred until the dedicated builder surface is stable.
+  - add first-party manual blank-workout creation into the canonical builder flow with a truthful `manual` source kind and a sensible starter scaffold,
+  - keep richer Garmin-like repeat/send-off authoring and poolside execution deferred until the manual creation entrypoint is stable.
 
 - Manual workout/session authoring for user-built training sessions.
 - Editing surface for accepted single-session AI drafts after they become canonical workouts, without moving generation logic into this brief.
@@ -178,3 +179,5 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - `2026-03-20 | working tree | moved this brief to in-progress and narrowed the first runtime slice to a dedicated canonical workout editor route for already-accepted workouts, while manual blank-workout creation and poolside execution remain deferred | next: extract the shared workout editor out of Generator Intake, wire `/my-library/workouts/[workoutId]`, and point accepted workout links there`
 - `2026-03-20 | working tree | extracted the shared workout editor, added the dedicated `/my-library/workouts/[workoutId]` route plus My Library entrypoint, and covered generator -> builder handoff with unit + e2e validation | next: commit this slice on its own branch and rerun full repo gates from branch HEAD so PR-body/brief automation evaluates the current diff instead of falling back to the previous merge commit`
 - `2026-03-22 | planning | tightened the builder brief against observed Garmin swim-builder patterns and official Garmin developer docs so future manual-builder slices must treat `Add Step`, `Add Repeat`, starter scaffolds, Garmin-documented `WorkoutIntensity`, `open`, `swim_stroke`, lap/open-water context, and Garmin Connect UI concepts like `Main`, `Lap Button Press`, fixed rest, send-off, `Choice`, and `RIMO` as first-class UX with explicit mapping rather than export-only details | next: resume builder implementation with manual blank-workout creation and richer step authoring before jumping to weekly calendar planning`
+- `2026-03-22 | working tree | added the next manual-builder slice: My Library and Workout Builder can now create a canonical manual workout directly, the save API persists `source_kind = manual`, the starter draft includes a swim-friendly scaffold with explicit rest steps, and the new create flow is covered with unit + desktop e2e validation | next: run full `verify:pre-pr`, then commit/push/open the PR if the repo gate stays green`
+- `2026-03-22 | perf trend decision: hold | \`npm run verify:pre-pr\` reported two consecutive weekly green perf-budget runs and recommended tightening one stretch target step; decision is \`hold\` for this manual-builder slice because it does not change the public budget routes governed by AW-010, so the tighten choice should be recorded again in PR handoff and revisited in the next perf-focused checkpoint | next: keep builder implementation moving while carrying the AW-010 tighten/hold note forward`

--- a/lib/session-generator-v1/server.ts
+++ b/lib/session-generator-v1/server.ts
@@ -27,6 +27,7 @@ type SegmentPlan = {
   drill: number;
   kick: number;
   main: number;
+  rest: number;
   cooldown: number;
 };
 
@@ -195,12 +196,12 @@ function estimateDurationFromDistance(distanceM: number, basePaceSecondsPer100m:
 
 function buildSegmentPlan(input: SessionGeneratorInput): SegmentPlan {
   const baseByType: Record<SessionGeneratorSessionType, SegmentPlan> = {
-    recovery: { warmup: 30, drill: 0, kick: 0, main: 45, cooldown: 25 },
-    endurance: { warmup: 20, drill: 0, kick: 0, main: 60, cooldown: 20 },
-    technique: { warmup: 20, drill: 30, kick: 0, main: 30, cooldown: 20 },
-    threshold_css: { warmup: 20, drill: 0, kick: 0, main: 60, cooldown: 20 },
-    speed: { warmup: 20, drill: 10, kick: 0, main: 50, cooldown: 20 },
-    race_pace: { warmup: 20, drill: 5, kick: 0, main: 55, cooldown: 20 },
+    recovery: { warmup: 30, drill: 0, kick: 0, main: 45, rest: 0, cooldown: 25 },
+    endurance: { warmup: 20, drill: 0, kick: 0, main: 60, rest: 0, cooldown: 20 },
+    technique: { warmup: 20, drill: 30, kick: 0, main: 30, rest: 0, cooldown: 20 },
+    threshold_css: { warmup: 20, drill: 0, kick: 0, main: 60, rest: 0, cooldown: 20 },
+    speed: { warmup: 20, drill: 10, kick: 0, main: 50, rest: 0, cooldown: 20 },
+    race_pace: { warmup: 20, drill: 5, kick: 0, main: 55, rest: 0, cooldown: 20 },
   };
 
   const plan = { ...baseByType[input.sessionType] };
@@ -395,12 +396,20 @@ function allocateRoundedValues(
   plan: SegmentPlan,
   roundingUnit: number
 ): Record<SessionDraftStepCategory, number> {
-  const categories: SessionDraftStepCategory[] = ["warmup", "drill", "kick", "main", "cooldown"];
+  const categories: SessionDraftStepCategory[] = [
+    "warmup",
+    "drill",
+    "kick",
+    "main",
+    "rest",
+    "cooldown",
+  ];
   const result = {
     warmup: 0,
     drill: 0,
     kick: 0,
     main: 0,
+    rest: 0,
     cooldown: 0,
   } satisfies Record<SessionDraftStepCategory, number>;
 

--- a/lib/session-generator-v1/shared.ts
+++ b/lib/session-generator-v1/shared.ts
@@ -41,6 +41,7 @@ export const SESSION_DRAFT_STEP_CATEGORIES = [
   "drill",
   "kick",
   "main",
+  "rest",
   "cooldown",
 ] as const;
 export const SESSION_DRAFT_STEP_DURATION_MODES = ["distance", "time"] as const;
@@ -187,6 +188,7 @@ const STEP_CATEGORY_LABELS: Record<SessionDraftStepCategory, string> = {
   drill: "Drill",
   kick: "Kick",
   main: "Main",
+  rest: "Rest",
   cooldown: "Cooldown",
 };
 

--- a/lib/workouts/manual.ts
+++ b/lib/workouts/manual.ts
@@ -1,0 +1,116 @@
+import {
+  computeSessionDraftDerivedTotals,
+  type SessionDraft,
+  type SessionDraftStep,
+} from "@/lib/session-generator-v1/shared";
+
+function buildStepId(seed: string, index: number) {
+  return `manual-step-${seed}-${index + 1}`;
+}
+
+function buildStarterSteps(seed: string): SessionDraftStep[] {
+  return [
+    {
+      id: buildStepId(seed, 0),
+      category: "warmup",
+      name: "Warmup swim",
+      stroke: "freestyle",
+      intensity: "easy",
+      durationMode: "distance",
+      distanceM: 400,
+      timeMin: null,
+      targetSummary: "Easy freestyle to settle into the session.",
+      notes: "Keep the first 200m relaxed and long.",
+    },
+    {
+      id: buildStepId(seed, 1),
+      category: "rest",
+      name: "Reset rest",
+      stroke: "choice",
+      intensity: "easy",
+      durationMode: "time",
+      distanceM: null,
+      timeMin: 1,
+      targetSummary: "Easy reset before the main set.",
+      notes: "Use this as a simple fixed rest block.",
+    },
+    {
+      id: buildStepId(seed, 2),
+      category: "main",
+      name: "Main swim set",
+      stroke: "freestyle",
+      intensity: "moderate",
+      durationMode: "distance",
+      distanceM: 1000,
+      timeMin: null,
+      targetSummary: "Steady aerobic main work.",
+      notes: "Replace this with your exact set structure.",
+    },
+    {
+      id: buildStepId(seed, 3),
+      category: "rest",
+      name: "Recovery rest",
+      stroke: "choice",
+      intensity: "easy",
+      durationMode: "time",
+      distanceM: null,
+      timeMin: 1,
+      targetSummary: "Short recovery before cooldown.",
+      notes: "Adjust or remove when you refine the workout.",
+    },
+    {
+      id: buildStepId(seed, 4),
+      category: "cooldown",
+      name: "Cooldown swim",
+      stroke: "choice",
+      intensity: "easy",
+      durationMode: "distance",
+      distanceM: 200,
+      timeMin: null,
+      targetSummary: "Easy swim to finish calmer than you started.",
+      notes: "Swap stroke or distance as needed.",
+    },
+  ];
+}
+
+export function buildManualWorkoutStarterDraft(now = new Date()): SessionDraft {
+  const createdAt = now.toISOString();
+  const seed = createdAt.replace(/[^0-9]/g, "").slice(0, 14);
+  const title = "Manual pool workout";
+  const steps = buildStarterSteps(seed);
+  const baseDraft: SessionDraft = {
+    version: 1,
+    status: "draft",
+    generatorKind: "rule_engine_v1",
+    createdAt,
+    sourceFingerprint: `manual-${seed}`,
+    title,
+    titleSuggestions: [title, "Manual endurance workout"],
+    description: "Starter manual workout scaffold ready for editing in the builder.",
+    environment: "pool",
+    poolLengthM: 25,
+    sessionType: "endurance",
+    effort: "moderate",
+    sizeMode: "distance",
+    targetDistanceM: 1600,
+    targetTimeMin: null,
+    totalDistanceM: null,
+    estimatedDurationMin: null,
+    basePaceSecondsPer100m: 120,
+    usedCssPaceLabel: null,
+    allowedStrokes: ["freestyle"],
+    equipmentAllowlist: [],
+    focusText: null,
+    goalTitle: null,
+    constraintText: null,
+    warnings: [],
+    steps,
+  };
+  const totals = computeSessionDraftDerivedTotals(baseDraft);
+
+  return {
+    ...baseDraft,
+    totalDistanceM: totals.totalDistanceM,
+    estimatedDurationMin: totals.estimatedDurationMin,
+  };
+}

--- a/lib/workouts/server.ts
+++ b/lib/workouts/server.ts
@@ -52,7 +52,8 @@ export const WORKOUT_SELECT = `
 
 export function buildWorkoutInsert(
   userId: string,
-  draft: SessionDraft | null | undefined
+  draft: SessionDraft | null | undefined,
+  sourceKind: WorkoutSourceKind = "ai_session_v1"
 ): WorkoutInsert {
   const normalized = normalizeSessionDraftForWorkoutPersistence(draft);
   if (!normalized.ok) {
@@ -61,7 +62,7 @@ export function buildWorkoutInsert(
 
   return {
     user_id: userId,
-    source_kind: "ai_session_v1",
+    source_kind: sourceKind,
     status: "accepted",
     generator_kind: normalized.value.generatorKind,
     source_fingerprint: normalized.value.sourceFingerprint,

--- a/lib/workouts/shared.ts
+++ b/lib/workouts/shared.ts
@@ -48,6 +48,7 @@ export type WorkoutEditorRecord = {
 
 export type WorkoutSaveRequestBody = {
   draft?: SessionDraft | null;
+  sourceKind?: WorkoutSourceKind | null;
 };
 
 export type WorkoutSaveApiSuccess = {

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -1,0 +1,78 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+const isSiteLockEnabled = process.env.SITE_LOCK_ENABLED === "1";
+
+function runOnceOnDesktopChromium(projectName: string) {
+  test.skip(!projectName.startsWith("desktop-"), "Workout builder e2e is desktop-only.");
+  test.skip(projectName !== "desktop-chromium", "Runs once on desktop Chromium.");
+  test.skip(isSiteLockEnabled, "Skipped while private access gate is enabled.");
+}
+
+async function loginToMyLibraryViaDevBypass(page: Page) {
+  await page.goto(`/dev/login?next=${encodeURIComponent("/my-library")}`);
+  const pathAfterLogin = new URL(page.url()).pathname;
+
+  if (pathAfterLogin !== "/my-library") {
+    test.skip(true, "Dev auth bypass is not enabled in this environment.");
+  }
+
+  await expect(page.getByRole("heading", { name: "My Library" })).toBeVisible();
+}
+
+async function waitForWorkoutBuilderClientReady(page: Page) {
+  await expect(page.getByTestId("workout-builder-hub")).toHaveAttribute(
+    "data-client-ready",
+    "true",
+    { timeout: 15_000 }
+  );
+}
+
+test.describe("my library workout builder", () => {
+  test("creates a manual starter workout and saves canonical edits", async ({ page }, testInfo) => {
+    runOnceOnDesktopChromium(testInfo.project.name);
+    test.slow();
+
+    const uniqueTitle = `QA manual workout ${Date.now()}`;
+
+    await loginToMyLibraryViaDevBypass(page);
+
+    const createResponsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes("/api/my-library/workouts") &&
+        response.request().method() === "POST" &&
+        response.status() === 200
+    );
+
+    await page.getByTestId("my-library-create-manual-workout").click();
+    await createResponsePromise;
+    await page.waitForURL(/\/my-library\/workouts\/[0-9a-f-]+$/, {
+      timeout: 10_000,
+      waitUntil: "domcontentloaded",
+    });
+    await waitForWorkoutBuilderClientReady(page);
+
+    await expect(page.getByTestId("session-draft-title")).toHaveValue("Manual pool workout");
+    await expect(page.getByTestId("session-draft-step-name-0")).toHaveValue("Warmup swim");
+    await expect(page.getByTestId("session-draft-step-name-1")).toHaveValue("Reset rest");
+    await expect(page.getByTestId("session-draft-step-name-2")).toHaveValue("Main swim set");
+
+    await page.getByTestId("session-draft-add-step").click();
+    await page.getByTestId("session-draft-step-name-5").fill("QA add-on step");
+    await page.getByTestId("session-draft-title").fill(uniqueTitle);
+
+    const patchResponsePromise = page.waitForResponse(
+      (response) =>
+        /\/api\/my-library\/workouts\/[0-9a-f-]+$/.test(response.url()) &&
+        response.request().method() === "PATCH" &&
+        response.status() === 200
+    );
+
+    await page.getByTestId("workout-builder-save").click();
+    await patchResponsePromise;
+
+    await expect(page.getByText("Workout changes saved to the canonical workout.")).toBeVisible();
+    await expect(page.getByTestId("session-draft-title")).toHaveValue(uniqueTitle);
+    await expect(page.getByTestId("session-draft-step-name-5")).toHaveValue("QA add-on step");
+  });
+});

--- a/tests/unit/create-manual-workout-button.test.tsx
+++ b/tests/unit/create-manual-workout-button.test.tsx
@@ -1,0 +1,75 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import CreateManualWorkoutButton from "@/components/my-library/workouts/CreateManualWorkoutButton";
+
+const navigationState = vi.hoisted(() => ({
+  push: vi.fn(),
+  refresh: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => navigationState,
+}));
+
+describe("CreateManualWorkoutButton", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("creates a manual workout and routes into the builder", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        workout: {
+          id: "11111111-1111-4111-8111-111111111111",
+        },
+      }),
+    } as Response);
+
+    render(<CreateManualWorkoutButton />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Create manual workout" }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/my-library/workouts",
+        expect.objectContaining({
+          method: "POST",
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(navigationState.push).toHaveBeenCalledWith(
+        "/my-library/workouts/11111111-1111-4111-8111-111111111111"
+      );
+    });
+    expect(navigationState.refresh).toHaveBeenCalled();
+  });
+
+  it("shows an inline error when manual creation fails", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      json: async () => ({
+        ok: false,
+        error: "Could not create workout right now.",
+      }),
+    } as Response);
+
+    render(<CreateManualWorkoutButton />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Create manual workout" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Could not create workout right now.")).toBeVisible();
+    });
+    expect(navigationState.push).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -8,6 +8,15 @@ import type {
   WorkoutSummary,
 } from "@/lib/workouts/shared";
 
+const navigationState = vi.hoisted(() => ({
+  push: vi.fn(),
+  refresh: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => navigationState,
+}));
+
 function buildDraft(): SessionDraft {
   return {
     version: 1,
@@ -166,6 +175,7 @@ describe("WorkoutBuilderHub", () => {
     );
 
     expect(screen.getByText("That saved workout could not be found.")).toBeVisible();
+    expect(screen.getByTestId("workout-builder-empty-create-manual")).toBeVisible();
     expect(screen.getByRole("link", { name: "Open generator" })).toHaveAttribute(
       "href",
       "/my-library/generator"

--- a/tests/unit/workouts-routes.test.ts
+++ b/tests/unit/workouts-routes.test.ts
@@ -68,8 +68,9 @@ function buildWorkoutRow(overrides?: Partial<WorkoutRow>): WorkoutRow {
   };
 }
 
-function buildDraftBody() {
+function buildDraftBody(overrides?: Partial<{ sourceKind: "ai_session_v1" | "manual" }>) {
   return {
+    sourceKind: "ai_session_v1" as const,
     draft: {
       version: 1,
       status: "draft",
@@ -111,6 +112,7 @@ function buildDraftBody() {
         },
       ],
     },
+    ...overrides,
   };
 }
 
@@ -193,6 +195,53 @@ describe("workouts routes", () => {
     expect(payload.ok).toBe(true);
     expect(payload.workout.id).toBe("11111111-1111-4111-8111-111111111111");
     expect(payload.summary.title).toBe("Threshold / CSS 25m Pool draft");
+  });
+
+  it("creates manual canonical workouts when the request source kind is manual", async () => {
+    const single = vi.fn().mockResolvedValue({
+      data: buildWorkoutRow({
+        source_kind: "manual",
+        title: "Manual pool workout",
+      }),
+      error: null,
+    });
+    const select = vi.fn(() => ({ single }));
+    const insert = vi.fn(() => ({ select }));
+    const from = vi.fn().mockReturnValue({ insert });
+
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } } }),
+        },
+        from,
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await postWorkout(
+      new Request("http://127.0.0.1:3000/api/my-library/workouts", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(buildDraftBody({ sourceKind: "manual" })),
+      })
+    );
+    const payload = (await response.json()) as {
+      ok: boolean;
+      workout: { id: string };
+      summary: { title: string };
+    };
+
+    expect(response.status).toBe(200);
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source_kind: "manual",
+      })
+    );
+    expect(payload.ok).toBe(true);
+    expect(payload.summary.title).toBe("Manual pool workout");
   });
 
   it("rejects invalid workout ids before attempting update", async () => {

--- a/tests/unit/workouts-server.test.ts
+++ b/tests/unit/workouts-server.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Database } from "@/types/database";
+import { buildManualWorkoutStarterDraft } from "@/lib/workouts/manual";
 import {
   buildWorkoutEditorRecord,
   buildWorkoutInsert,
@@ -125,6 +126,16 @@ describe("workouts server", () => {
     expect(insert.total_distance_m).toBe(2200);
     expect(insert.estimated_duration_min).toBe(51);
     expect(insert.allowed_strokes).toEqual(["freestyle"]);
+  });
+
+  it("supports manual source kind and starter scaffolds", () => {
+    const starter = buildManualWorkoutStarterDraft(new Date("2026-03-22T12:00:00.000Z"));
+    const insert = buildWorkoutInsert("user-1", starter, "manual");
+
+    expect(insert.source_kind).toBe("manual");
+    expect(insert.title).toBe("Manual pool workout");
+    expect(Array.isArray(insert.steps)).toBe(true);
+    expect(starter.steps.some((step) => step.category === "rest")).toBe(true);
   });
 
   it("maps persisted workout rows back into editor and summary records", () => {


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-03-22T21:11:46.390Z for branch `feat/manual-workout-creation-2026-03-22` (base ref `origin/main`).
- Latest commit: `92a34f9` - feat(workouts): add manual starter workout creation.
- User-visible changes: User/admin runtime behavior may change on touched routes/components.
- Technical changes: Updated 15 file(s): `app/api/my-library/workouts/route.ts`, `app/my-library/page.tsx`, `components/my-library/workouts/CreateManualWorkoutButton.tsx`, `components/my-library/workouts/WorkoutBuilderHub.tsx`, `docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md`, `... and 10 more file(s)`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md`
- Scorecard target outcomes: 13 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (1); tests (5); API handlers (1); runtime UI/routes/components (8).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (15):
  - `app/api/my-library/workouts/route.ts`
  - `app/my-library/page.tsx`
  - `components/my-library/workouts/CreateManualWorkoutButton.tsx`
  - `components/my-library/workouts/WorkoutBuilderHub.tsx`
  - `docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md`
  - `lib/session-generator-v1/server.ts`
  - `lib/session-generator-v1/shared.ts`
  - `lib/workouts/manual.ts`
  - `... and 7 more file(s)`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `92a34f9` (`git revert 92a34f9`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **NOT RUN** (artifacts/test-runs/admin-short-session)
- `npm run verify:pre-merge`: **PENDING** for `92a34f9` (latest PASS was `deabfea` at 2026-03-22T20:24:30Z; rerun on current HEAD).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  - No local verify log found in `artifacts/test-runs/latest`.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
