### PR TITLE
feat(workouts): add builder removal recovery

### DIFF
--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -87,6 +87,27 @@ type StepRenderGroup =
       entries: StepRenderEntry[];
     };
 
+type PendingRemoval =
+  | {
+      kind: "step";
+      stepId: string;
+      label: string;
+      repeatGroupId: string | null;
+    }
+  | {
+      kind: "repeat";
+      repeatGroupId: string;
+      label: string;
+    };
+
+type LastRemovedBlock = {
+  kind: "step" | "repeat";
+  label: string;
+  steps: SessionDraftStep[];
+  insertIndex: number;
+  restoreOpenStepId: string | null;
+};
+
 const CUSTOM_DISTANCE_VALUE = "custom";
 
 function buildBlankStep(
@@ -213,6 +234,12 @@ function formatClockDurationLabelFromSeconds(totalSeconds: number) {
 
 function formatClockDurationLabel(valueMinutes: number | null | undefined) {
   return formatClockDurationLabelFromSeconds(getClockTotalSeconds(valueMinutes));
+}
+
+function buildStepRemovalLabel(step: SessionDraftStep, fallbackIndex: number) {
+  return (
+    step.name.trim() || `${getSessionStepCategoryLabel(step.category)} step ${fallbackIndex + 1}`
+  );
 }
 
 function buildDurationSummary(step: SessionDraftStep, basePaceSecondsPer100m: number) {
@@ -394,6 +421,8 @@ export default function WorkoutEditor({
   const [poolLengthInput, setPoolLengthInput] = useState(() =>
     formatEditablePoolLength(draft.poolLengthM)
   );
+  const [pendingRemoval, setPendingRemoval] = useState<PendingRemoval | null>(null);
+  const [lastRemovedBlock, setLastRemovedBlock] = useState<LastRemovedBlock | null>(null);
   const poolLengthUsesPreset =
     typeof draft.poolLengthM === "number" && isSessionDraftPoolLengthPreset(draft.poolLengthM);
 
@@ -406,6 +435,30 @@ export default function WorkoutEditor({
       setOpenStepId(null);
     }
   }, [draft.steps, openStepId]);
+
+  useEffect(() => {
+    if (!pendingRemoval) return;
+
+    if (
+      pendingRemoval.kind === "step" &&
+      !draft.steps.some((step) => step.id === pendingRemoval.stepId)
+    ) {
+      setPendingRemoval(null);
+      return;
+    }
+
+    if (
+      pendingRemoval.kind === "repeat" &&
+      !draft.steps.some((step) => step.repeatGroupId === pendingRemoval.repeatGroupId)
+    ) {
+      setPendingRemoval(null);
+    }
+  }, [draft.steps, pendingRemoval]);
+
+  useEffect(() => {
+    setPendingRemoval(null);
+    setLastRemovedBlock(null);
+  }, [savedWorkout?.id, savedWorkout?.updatedAt]);
 
   function syncDraftSelections(nextDraft: SessionDraft) {
     const requiredStrokes = Array.from(
@@ -481,6 +534,7 @@ export default function WorkoutEditor({
   }
 
   function addStep() {
+    setPendingRemoval(null);
     const nextStep = buildBlankStep(draft.steps.length + 1);
 
     setOpenStepId(nextStep.id);
@@ -493,6 +547,7 @@ export default function WorkoutEditor({
   }
 
   function addRepeat() {
+    setPendingRemoval(null);
     const nextSteps = buildRepeatStarterSteps(draft.steps.length + 1);
 
     setOpenStepId(nextSteps[0]?.id ?? null);
@@ -504,32 +559,124 @@ export default function WorkoutEditor({
     );
   }
 
-  function removeStep(stepId: string) {
-    if (openStepId === stepId) {
-      setOpenStepId(null);
+  function requestStepRemoval(stepId: string) {
+    const stepIndex = draft.steps.findIndex((step) => step.id === stepId);
+    if (stepIndex === -1) return;
+
+    const step = draft.steps[stepIndex];
+    setLastRemovedBlock(null);
+    setPendingRemoval({
+      kind: "step",
+      stepId,
+      label: buildStepRemovalLabel(step, stepIndex),
+      repeatGroupId: step.repeatGroupId ?? null,
+    });
+  }
+
+  function requestRepeatGroupRemoval(repeatGroupId: string) {
+    const repeatEntries = draft.steps.filter((step) => step.repeatGroupId === repeatGroupId);
+    if (repeatEntries.length === 0) return;
+
+    const repeatCount = repeatEntries[0]?.repeatCount;
+    const roundsLabel =
+      typeof repeatCount === "number" ? `${repeatCount} rounds` : "repeat count not set";
+
+    setLastRemovedBlock(null);
+    setPendingRemoval({
+      kind: "repeat",
+      repeatGroupId,
+      label: `Repeat block (${repeatEntries.length} steps, ${roundsLabel})`,
+    });
+  }
+
+  function cancelPendingRemoval() {
+    setPendingRemoval(null);
+  }
+
+  function confirmPendingRemoval() {
+    if (!pendingRemoval) return;
+
+    if (pendingRemoval.kind === "step") {
+      const removeIndex = draft.steps.findIndex((step) => step.id === pendingRemoval.stepId);
+      if (removeIndex === -1) {
+        setPendingRemoval(null);
+        return;
+      }
+
+      const removedStep = draft.steps[removeIndex];
+      const nextSteps = draft.steps.filter((step) => step.id !== pendingRemoval.stepId);
+      const removedOpenStep = openStepId === pendingRemoval.stepId;
+
+      setPendingRemoval(null);
+      setLastRemovedBlock({
+        kind: "step",
+        label: pendingRemoval.label,
+        steps: [removedStep],
+        insertIndex: removeIndex,
+        restoreOpenStepId: removedOpenStep ? removedStep.id : openStepId,
+      });
+      if (removedOpenStep) {
+        setOpenStepId(null);
+      }
+      onDraftChange(
+        syncDraftSelections({
+          ...draft,
+          steps: nextSteps,
+        })
+      );
+      return;
     }
 
+    const removedSteps = draft.steps.filter(
+      (step) => step.repeatGroupId === pendingRemoval.repeatGroupId
+    );
+    if (removedSteps.length === 0) {
+      setPendingRemoval(null);
+      return;
+    }
+
+    const insertIndex = draft.steps.findIndex(
+      (step) => step.repeatGroupId === pendingRemoval.repeatGroupId
+    );
+    const nextSteps = draft.steps.filter(
+      (step) => step.repeatGroupId !== pendingRemoval.repeatGroupId
+    );
+    const removedOpenStep = removedSteps.some((step) => step.id === openStepId);
+
+    setPendingRemoval(null);
+    setLastRemovedBlock({
+      kind: "repeat",
+      label: pendingRemoval.label,
+      steps: removedSteps,
+      insertIndex,
+      restoreOpenStepId: removedOpenStep ? (removedSteps[0]?.id ?? null) : openStepId,
+    });
+    if (removedOpenStep) {
+      setOpenStepId(null);
+    }
     onDraftChange(
       syncDraftSelections({
         ...draft,
-        steps: draft.steps.filter((step) => step.id !== stepId),
+        steps: nextSteps,
       })
     );
   }
 
-  function removeRepeatGroup(repeatGroupId: string) {
-    if (
-      draft.steps.some((step) => step.repeatGroupId === repeatGroupId && step.id === openStepId)
-    ) {
-      setOpenStepId(null);
-    }
+  function undoLastRemoval() {
+    if (!lastRemovedBlock) return;
+
+    const nextSteps = [...draft.steps];
+    const insertIndex = Math.min(Math.max(lastRemovedBlock.insertIndex, 0), nextSteps.length);
+    nextSteps.splice(insertIndex, 0, ...lastRemovedBlock.steps);
 
     onDraftChange(
       syncDraftSelections({
         ...draft,
-        steps: draft.steps.filter((step) => step.repeatGroupId !== repeatGroupId),
+        steps: nextSteps,
       })
     );
+    setOpenStepId(lastRemovedBlock.restoreOpenStepId);
+    setLastRemovedBlock(null);
   }
 
   function updateRepeatGroupCount(repeatGroupId: string, value: string) {
@@ -744,7 +891,8 @@ export default function WorkoutEditor({
             </button>
             <button
               type="button"
-              onClick={() => removeStep(step.id)}
+              onClick={() => requestStepRemoval(step.id)}
+              data-testid={`session-draft-step-remove-${index}`}
               className="inline-flex h-9 items-center justify-center rounded-xl border border-rose-200 bg-white px-3 text-sm text-rose-700 transition hover:bg-rose-50"
             >
               Remove
@@ -1513,6 +1661,71 @@ export default function WorkoutEditor({
         </div>
 
         <div className="mt-4 space-y-4">
+          {pendingRemoval ? (
+            <div
+              data-testid="workout-editor-removal-confirm"
+              className="rounded-2xl border border-amber-200 bg-amber-50/90 p-4"
+            >
+              <p className="text-sm font-medium text-amber-950">
+                Confirm removal before this builder change is applied.
+              </p>
+              <p className="mt-1 text-sm text-amber-900">
+                Remove <span className="font-semibold">{pendingRemoval.label}</span>? You can still
+                undo it locally before saving.
+              </p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={confirmPendingRemoval}
+                  data-testid="workout-editor-removal-confirm-button"
+                  className="inline-flex h-10 items-center justify-center rounded-xl bg-rose-600 px-4 text-sm font-semibold text-white transition hover:bg-rose-500 active:bg-rose-700"
+                >
+                  Remove now
+                </button>
+                <button
+                  type="button"
+                  onClick={cancelPendingRemoval}
+                  data-testid="workout-editor-removal-cancel-button"
+                  className="inline-flex h-10 items-center justify-center rounded-xl border border-amber-200 bg-white px-4 text-sm font-medium text-amber-900 transition hover:bg-amber-100 active:bg-amber-200"
+                >
+                  Keep it
+                </button>
+              </div>
+            </div>
+          ) : null}
+
+          {lastRemovedBlock ? (
+            <div
+              data-testid="workout-editor-removal-undo"
+              className="rounded-2xl border border-blue-200 bg-blue-50/90 p-4"
+            >
+              <p className="text-sm font-medium text-blue-950">
+                Removed <span className="font-semibold">{lastRemovedBlock.label}</span>.
+              </p>
+              <p className="mt-1 text-sm text-blue-900">
+                Undo restores it to the same local spot before you save this workout.
+              </p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={undoLastRemoval}
+                  data-testid="workout-editor-removal-undo-button"
+                  className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700"
+                >
+                  Undo removal
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setLastRemovedBlock(null)}
+                  data-testid="workout-editor-removal-dismiss-button"
+                  className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-4 text-sm font-medium text-blue-900 transition hover:bg-blue-100 active:bg-blue-200"
+                >
+                  Dismiss
+                </button>
+              </div>
+            </div>
+          ) : null}
+
           {stepGroups.map((group, groupIndex) =>
             group.kind === "single" ? (
               renderStepEditorCard(group.entries[0].step, group.entries[0].index, groupIndex)
@@ -1576,7 +1789,8 @@ export default function WorkoutEditor({
                     </button>
                     <button
                       type="button"
-                      onClick={() => removeRepeatGroup(group.repeatGroupId)}
+                      onClick={() => requestRepeatGroupRemoval(group.repeatGroupId)}
+                      data-testid={`session-draft-repeat-remove-${groupIndex}`}
                       className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-3 text-sm text-rose-700 transition hover:bg-rose-50"
                     >
                       Remove repeat
@@ -1622,8 +1836,12 @@ export default function WorkoutEditor({
           {savedWorkout && onResetToSaved ? (
             <button
               type="button"
-              onClick={onResetToSaved}
-              disabled={isSaving || !hasUnsavedChanges}
+              onClick={() => {
+                setPendingRemoval(null);
+                setLastRemovedBlock(null);
+                onResetToSaved();
+              }}
+              disabled={isSaving || !hasUnsavedChanges || pendingRemoval !== null}
               data-testid="workout-editor-reset"
               className="inline-flex h-11 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
             >
@@ -1632,9 +1850,16 @@ export default function WorkoutEditor({
           ) : null}
           <button
             type="button"
-            onClick={onSave}
+            onClick={() => {
+              setPendingRemoval(null);
+              setLastRemovedBlock(null);
+              onSave();
+            }}
             disabled={
-              isSaving || !canonicalSaveReady || (savedWorkout ? !hasUnsavedChanges : false)
+              isSaving ||
+              !canonicalSaveReady ||
+              pendingRemoval !== null ||
+              (savedWorkout ? !hasUnsavedChanges : false)
             }
             data-testid={saveButtonTestId}
             className="inline-flex h-11 items-center justify-center rounded-xl bg-emerald-600 px-4 text-sm font-semibold text-white transition hover:bg-emerald-500 active:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"

--- a/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md
+++ b/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md
@@ -6,7 +6,7 @@
 - `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-02-28`
-- `updated`: `2026-03-23`
+- `updated`: `2026-03-24`
 
 ## Goal
 
@@ -25,6 +25,7 @@ Ship a Garmin-familiar manual session builder and poolside execution experience 
   - add broader pool-length presets plus exact custom pool-length entry for manual pool workouts,
   - switch the always-open step forms to summary-first Garmin-familiar step cards with explicit `Edit step` / `Done` controls,
   - add deterministic canonical-editor dirty-state feedback plus a reset-to-last-saved path so builder edits are obviously local until saved,
+  - add local confirm + undo recovery for destructive step and repeat removals so builder editing stays safe before canonical save,
   - keep poolside execution deferred while the richer step contract continues to stabilize.
 
 - Manual workout/session authoring for user-built training sessions.
@@ -206,3 +207,4 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - `2026-03-24 | working tree | added deterministic dirty-state builder controls: canonical workout editor now shows when changes are unsaved, disables save when nothing changed, and exposes reset-to-last-saved recovery in both the dedicated workout route and generator handoff; targeted unit coverage and desktop builder e2e should be rerun before the next PR handoff | next: run targeted validation, then \`npm run verify:pre-pr\` once the local tree is ready for a clean builder checkpoint`
 - `2026-03-24 | working tree | full \`verify:pre-pr\` passed for the dirty-state builder slice: local gates were green end-to-end (`lint:briefs` skipped because the builder brief change is still uncommitted on branch, eslint PASS, typecheck PASS, 124/124 vitest files PASS, build PASS, perf budgets PASS, Playwright PASS with 92 passed / 262 skipped) and the focused builder flows stayed green while dirty-state, reset-to-saved, and save-disabled-when-clean behavior were added to both canonical editor entrypoints | next: stage only the scoped builder files, commit on the builder branch, push, and open/update the PR without mixing in the separate admin-notes triage docs`
 - `2026-03-24 | perf trend decision: hold | full \`verify:pre-pr\` recommended \`hold\` again after the perf-budget run (`runs: 1/2`, worst margin `36.7%`); decision remains \`hold\` for this dirty-state builder slice because it does not materially change the public perf-budget routes owned by AW-010 | next: repeat the tighten/hold rationale in the PR handoff and revisit tightening in the next perf-focused route slice`
+- `2026-03-24 | working tree | added local destructive-edit recovery to the canonical workout editor: step and repeat removals now require explicit confirmation, save/reset stay blocked while a destructive confirmation is pending, and both removal paths offer a pre-save undo restore path with targeted unit + desktop e2e coverage being refreshed | next: run targeted validation, then \`npm run verify:pre-pr\` once this slice is ready for a clean PR checkpoint`

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -75,6 +75,28 @@ test.describe("my library workout builder", () => {
     );
     await expect(page.getByTestId("workout-builder-save")).toBeDisabled();
 
+    await page.getByTestId("session-draft-step-remove-0").click();
+    await expect(page.getByTestId("workout-editor-removal-confirm")).toContainText(
+      "Remove Warmup swim?"
+    );
+    await expect(page.getByTestId("workout-builder-save")).toBeDisabled();
+    await page.getByTestId("workout-editor-removal-cancel-button").click();
+    await expect(page.getByTestId("workout-editor-removal-confirm")).toHaveCount(0);
+    await page.getByTestId("session-draft-step-remove-0").click();
+    await page.getByTestId("workout-editor-removal-confirm-button").click();
+    await expect(page.getByTestId("workout-editor-removal-undo")).toContainText(
+      "Removed Warmup swim."
+    );
+    await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
+      "Unsaved changes stay local until you save this workout."
+    );
+    await page.getByTestId("workout-editor-removal-undo-button").click();
+    await expect(page.getByTestId("workout-editor-removal-undo")).toHaveCount(0);
+    await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
+      "All builder changes are saved to the canonical workout."
+    );
+    await expect(page.getByTestId("workout-builder-save")).toBeDisabled();
+
     await page.getByTestId("session-draft-step-toggle-0").click();
     await expect(page.getByTestId("session-draft-step-name-0")).toHaveValue("Warmup swim");
     await page.getByTestId("session-draft-step-toggle-0").click();

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -327,6 +327,84 @@ describe("WorkoutBuilderHub", () => {
     );
   });
 
+  it("requires confirmation and supports undo for destructive single-step removal", async () => {
+    render(<WorkoutBuilderHub workoutLibrary={buildWorkoutLibrary()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("session-draft-step-remove-0"));
+
+    expect(screen.getByTestId("workout-editor-removal-confirm")).toHaveTextContent(
+      "Remove Easy warmup swim?"
+    );
+    expect(screen.getByTestId("workout-builder-save")).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId("workout-editor-removal-cancel-button"));
+
+    expect(screen.queryByTestId("workout-editor-removal-confirm")).not.toBeInTheDocument();
+    expect(screen.getByTestId("session-draft-step-toggle-0")).toBeVisible();
+    expect(screen.getByTestId("workout-builder-save")).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId("session-draft-step-remove-0"));
+    fireEvent.click(screen.getByTestId("workout-editor-removal-confirm-button"));
+
+    expect(screen.queryByTestId("session-draft-step-toggle-0")).not.toBeInTheDocument();
+    expect(screen.getByTestId("workout-editor-removal-undo")).toHaveTextContent(
+      "Removed Easy warmup swim."
+    );
+    expect(screen.getByTestId("workout-builder-save")).toBeEnabled();
+    expect(screen.getByTestId("workout-editor-save-state")).toHaveTextContent(
+      "Unsaved changes stay local until you save this workout."
+    );
+
+    fireEvent.click(screen.getByTestId("workout-editor-removal-undo-button"));
+
+    expect(screen.queryByTestId("workout-editor-removal-undo")).not.toBeInTheDocument();
+    expect(screen.getByTestId("session-draft-step-toggle-0")).toBeVisible();
+    expect(screen.getByTestId("workout-builder-save")).toBeDisabled();
+    expect(screen.getByTestId("workout-editor-save-state")).toHaveTextContent(
+      "All builder changes are saved to the canonical workout."
+    );
+  });
+
+  it("supports confirm and undo when removing a repeat block", async () => {
+    render(<WorkoutBuilderHub workoutLibrary={buildWorkoutLibrary()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("session-draft-add-repeat"));
+
+    expect(screen.getByTestId("session-draft-repeat-count-1")).toHaveValue("4");
+
+    fireEvent.click(screen.getByTestId("session-draft-repeat-remove-1"));
+
+    expect(screen.getByTestId("workout-editor-removal-confirm")).toHaveTextContent(
+      "Repeat block (2 steps, 4 rounds)"
+    );
+
+    fireEvent.click(screen.getByTestId("workout-editor-removal-confirm-button"));
+
+    expect(screen.queryByTestId("session-draft-repeat-count-1")).not.toBeInTheDocument();
+    expect(screen.getByTestId("workout-editor-removal-undo")).toHaveTextContent(
+      "Removed Repeat block (2 steps, 4 rounds)."
+    );
+
+    fireEvent.click(screen.getByTestId("workout-editor-removal-undo-button"));
+
+    expect(screen.queryByTestId("workout-editor-removal-undo")).not.toBeInTheDocument();
+    expect(screen.getByTestId("session-draft-repeat-count-1")).toHaveValue("4");
+  });
+
   it("keeps step cards summary-first until the user opens them for editing", async () => {
     render(<WorkoutBuilderHub workoutLibrary={buildWorkoutLibrary()} />);
 


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-03-24T08:46:32.926Z for branch `feat/workout-builder-remove-undo-guardrails` (base ref `origin/main`).
- Latest commit: `bcb45f3` - feat(workouts): add builder removal recovery.
- User-visible changes: User/admin runtime behavior may change on touched routes/components.
- Technical changes: Updated 4 file(s): `components/my-library/workouts/WorkoutEditor.tsx`, `docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md`, `tests/e2e/my-library-workout-builder.spec.ts`, `tests/unit/workout-builder-hub.test.tsx`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md`
- Scorecard target outcomes: 13 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (1); tests (2); runtime UI/routes/components (1).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (4):
  - `components/my-library/workouts/WorkoutEditor.tsx`
  - `docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md`
  - `tests/e2e/my-library-workout-builder.spec.ts`
  - `tests/unit/workout-builder-hub.test.tsx`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `bcb45f3` (`git revert bcb45f3`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **NOT RUN** (run locally before pushing PR updates).
- `npm run verify:pre-merge`: **PENDING** for `bcb45f3` (required before merge to `main`).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  - No local verify log found in `artifacts/test-runs/latest`.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
