### PR TITLE
feat(workouts): add builder handoff export

### DIFF
--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -50,7 +50,10 @@ import {
 } from "@/lib/session-generator-v1/shared";
 import {
   buildWorkoutGarminReadinessReport,
+  buildWorkoutHandoffFileName,
+  buildWorkoutHandoffText,
   type WorkoutEditorRecord,
+  type WorkoutHandoffDraftState,
   type WorkoutSummary,
 } from "@/lib/workouts/shared";
 
@@ -450,8 +453,25 @@ export default function WorkoutEditor({
   );
   const [pendingRemoval, setPendingRemoval] = useState<PendingRemoval | null>(null);
   const [lastRemovedBlock, setLastRemovedBlock] = useState<LastRemovedBlock | null>(null);
+  const [handoffNotice, setHandoffNotice] = useState("");
+  const [handoffError, setHandoffError] = useState("");
   const poolLengthUsesPreset =
     typeof draft.poolLengthM === "number" && isSessionDraftPoolLengthPreset(draft.poolLengthM);
+  const handoffDraftState: WorkoutHandoffDraftState =
+    savedWorkout && !hasUnsavedChanges ? "canonical" : "local_draft";
+  const handoffText = buildWorkoutHandoffText(draft, {
+    draftState: handoffDraftState,
+  });
+  const handoffFileName = buildWorkoutHandoffFileName(draft, {
+    draftState: handoffDraftState,
+  });
+  const handoffStateLabel =
+    handoffDraftState === "canonical" ? "Canonical handoff" : "Local draft handoff";
+  const handoffStateDescription = savedWorkout
+    ? hasUnsavedChanges
+      ? "Handoff preview reflects unsaved local edits. Save first if you want the canonical workout and handoff to match."
+      : "Handoff preview matches the saved canonical workout."
+    : "Handoff preview reflects the current local draft before canonical save.";
 
   useEffect(() => {
     setPoolLengthInput(formatEditablePoolLength(draft.poolLengthM));
@@ -486,6 +506,11 @@ export default function WorkoutEditor({
     setPendingRemoval(null);
     setLastRemovedBlock(null);
   }, [savedWorkout?.id, savedWorkout?.updatedAt]);
+
+  useEffect(() => {
+    setHandoffNotice("");
+    setHandoffError("");
+  }, [handoffText, handoffDraftState, savedWorkout?.id, savedWorkout?.updatedAt]);
 
   function syncDraftSelections(nextDraft: SessionDraft) {
     const requiredStrokes = Array.from(
@@ -933,6 +958,45 @@ export default function WorkoutEditor({
 
     const parsed = parsePoolLengthInput(nextValue);
     updateDraft("poolLengthM", parsed);
+  }
+
+  async function copyWorkoutHandoff() {
+    setHandoffNotice("");
+    setHandoffError("");
+
+    try {
+      if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
+        throw new Error("Clipboard API unavailable.");
+      }
+
+      await navigator.clipboard.writeText(handoffText);
+      setHandoffNotice("Workout handoff copied.");
+    } catch {
+      setHandoffError("Could not copy the workout handoff automatically. Use the preview below.");
+    }
+  }
+
+  function downloadWorkoutHandoff() {
+    setHandoffNotice("");
+    setHandoffError("");
+
+    try {
+      const blob = new Blob([handoffText], {
+        type: "text/plain;charset=utf-8",
+      });
+      const objectUrl = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = objectUrl;
+      anchor.download = handoffFileName;
+      anchor.rel = "noopener";
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
+      setHandoffNotice(`Downloaded ${handoffFileName}.`);
+    } catch {
+      setHandoffError("Could not download the workout handoff right now.");
+    }
   }
 
   function renderStepEditorCard(
@@ -1632,6 +1696,70 @@ export default function WorkoutEditor({
             ))}
           </ul>
         ) : null}
+      </div>
+
+      <div className="rounded-2xl border border-slate-200 bg-white p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Workout handoff
+            </p>
+            <p className="mt-2 text-sm font-medium text-slate-900">
+              Copy or download the current workout as structured text for manual Garmin Connect
+              entry, coach review, or poolside notes until direct provider delivery exists.
+            </p>
+            <p
+              data-testid="workout-editor-handoff-source"
+              data-handoff-state={handoffDraftState}
+              className="mt-2 text-xs font-semibold uppercase tracking-wide text-slate-600"
+            >
+              {handoffStateLabel}
+            </p>
+            <p className="mt-1 text-sm text-slate-600">{handoffStateDescription}</p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={copyWorkoutHandoff}
+              data-testid="workout-editor-handoff-copy"
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+            >
+              Copy handoff
+            </button>
+            <button
+              type="button"
+              onClick={downloadWorkoutHandoff}
+              data-testid="workout-editor-handoff-download"
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+            >
+              Download .txt
+            </button>
+          </div>
+        </div>
+
+        {handoffNotice ? (
+          <p
+            data-testid="workout-editor-handoff-notice"
+            className="mt-3 text-sm font-medium text-emerald-700"
+          >
+            {handoffNotice}
+          </p>
+        ) : null}
+
+        {handoffError ? (
+          <p data-testid="workout-editor-handoff-error" className="mt-3 text-sm text-rose-700">
+            {handoffError}
+          </p>
+        ) : null}
+
+        <div className="mt-4 overflow-hidden rounded-2xl border border-slate-200 bg-slate-950">
+          <pre
+            data-testid="workout-editor-handoff-preview"
+            className="max-h-[320px] overflow-auto whitespace-pre-wrap px-4 py-4 text-xs leading-relaxed text-slate-100"
+          >
+            {handoffText}
+          </pre>
+        </div>
       </div>
 
       <div className="grid gap-4 md:grid-cols-3">

--- a/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md
+++ b/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md
@@ -29,6 +29,7 @@ Ship a Garmin-familiar manual session builder with truthful Garmin/export handof
   - add local duplicate actions for single steps and repeat blocks so manual authoring can branch an existing pattern without rebuilding every field by hand,
   - add contextual insert-after actions for single steps and repeat blocks so new starter scaffolds can be placed exactly where the next set belongs,
   - surface truthful Garmin/export readiness diagnostics inside the canonical builder so convenience strokes, drill metadata, and equipment metadata are reviewed before later export/send handoff,
+  - add a structured text handoff preview plus copy/download actions so the current workout can be used in manual Garmin Connect entry, coach review, or offline notes before direct provider delivery exists,
   - keep poolside execution deferred while the richer step contract continues to stabilize.
 
 - Manual workout/session authoring for user-built training sessions.
@@ -166,6 +167,7 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - Users can author send-off and CSS-based send-off style steps without learning a second advanced export-only vocabulary later.
 - If the UI exposes Garmin Connect-like labels such as `Main`, `Choice`, `IM by Round`, or `RIMO`, their internal mapping stays explicit and truthfully documented rather than implied as public Garmin provider fields.
 - Builder surfaces non-blocking Garmin/export readiness warnings whenever convenience strokes, drill metadata, or equipment metadata still need explicit downstream adapter review.
+- Builder exposes a truthful manual handoff preview that can be copied or downloaded, and it clearly marks whether the exported handoff matches the saved canonical workout or only the current local draft.
 - Threshold-based swim zone targets, when shown, use the shared published method rather than a separate builder-only zone system.
 - Poolside mode supports clean execution with minimal cognitive load.
 - Save/cancel/dirty-state behavior is deterministic.
@@ -218,3 +220,4 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - `2026-03-24 | working tree | stabilized the local Playwright merge gate for the Garmin-readiness slice: local runs now default to webpack-backed Next dev, keep Playwright artifacts out of the repo watch tree, cap local workers at \`1\`, harden contextual-notes/email-preview/mobile-screenshot flows, and standardize screenshot capture on mobile Chromium so local false negatives stop blocking builder PR closeout | next: rerun full \`verify:pre-merge\` on branch HEAD and only carry merge-ready evidence forward if the full local gate stays green`
 - `2026-03-24 | verify:pre-merge | full local \`npm run verify:pre-merge\` passed for the Garmin-readiness slice after the Playwright harness stabilization work: lint/typecheck/unit/build/perf were green, public-mode Playwright finished with \`91 passed / 263 skipped\`, and the private-gate step was correctly skipped because \`SITE_LOCK_ENABLED!=1\` in this local run | next: stage the scoped builder + test-harness files, commit on the builder branch, push, and update PR \`#285\` with current-head local merge-gate evidence`
 - `2026-03-24 | perf trend decision: hold | the successful \`verify:pre-merge\` run again recommended \`hold\` on AW-010 tightening (`runs: 1/2`, worst margin `36.5%`); decision remains \`hold\` for this Garmin-readiness + local-gate stabilization slice because it does not materially change the public perf-budget routes owned by AW-010 | next: repeat the same hold rationale in PR handoff and revisit tightening in the next perf-focused route slice`
+- `2026-03-24 | working tree | added the next builder slice: canonical workout editor now exposes a structured text handoff preview with explicit canonical-vs-local draft labeling plus copy/download actions, so users can move a workout into manual Garmin Connect entry, coach review, or offline notes without waiting for blocked provider integration; targeted unit + desktop e2e coverage are being refreshed for the new handoff contract | next: run targeted validation, then \`npm run verify:pre-pr\` once the slice is ready for PR handoff`

--- a/lib/workouts/shared.ts
+++ b/lib/workouts/shared.ts
@@ -14,8 +14,17 @@ import {
   SESSION_GENERATOR_SESSION_TYPES,
   SESSION_GENERATOR_STROKES,
   computeSessionDraftDerivedTotals,
+  buildSessionStepStructuredTargetLabel,
+  buildSessionTargetSummary,
+  formatPoolLengthLabel,
+  getSessionEffortLabel,
+  getSessionEnvironmentLabel,
+  getSessionStepCategoryLabel,
   getSessionStepDrillTypeLabel,
   getSessionStepEquipmentLabel,
+  getSessionStepStrokeLabel,
+  getSessionStepDurationModeLabel,
+  getSessionTypeLabel,
   normalizeSessionDraftPoolLength,
   type SessionDraft,
   type SessionDraftStep,
@@ -93,6 +102,8 @@ export type WorkoutGarminReadinessReport = {
   issues: WorkoutGarminReadinessIssue[];
 };
 
+export type WorkoutHandoffDraftState = "canonical" | "local_draft";
+
 export function buildWorkoutDraftChangeSignature(
   draft: SessionDraft | null | undefined
 ): string | null {
@@ -141,6 +152,142 @@ export function buildWorkoutGarminReadinessReport(
     } before you treat this workout as handoff-ready.`,
     issues,
   };
+}
+
+export function buildWorkoutHandoffFileName(
+  draft: SessionDraft | null | undefined,
+  options?: {
+    draftState?: WorkoutHandoffDraftState;
+  }
+) {
+  const title = normalizeFileNamePart(draft?.title ?? "");
+  const draftState = options?.draftState ?? "local_draft";
+  const suffix = draftState === "canonical" ? "" : "-draft";
+
+  return `freeswimming-${title || "workout"}-handoff${suffix}.txt`;
+}
+
+export function buildWorkoutHandoffText(
+  draft: SessionDraft | null | undefined,
+  options?: {
+    draftState?: WorkoutHandoffDraftState;
+  }
+) {
+  if (!draft) {
+    return "No workout draft is available yet.";
+  }
+
+  const draftState = options?.draftState ?? "local_draft";
+  const totals = computeSessionDraftDerivedTotals(draft);
+  const normalizedDraft = {
+    ...draft,
+    totalDistanceM: totals.totalDistanceM ?? draft.totalDistanceM,
+    estimatedDurationMin: totals.estimatedDurationMin ?? draft.estimatedDurationMin,
+  };
+  const readiness = buildWorkoutGarminReadinessReport(draft);
+  const stepGroups = buildWorkoutHandoffGroups(draft.steps);
+  const lines = [
+    "FreeSwimming workout handoff",
+    `Source: ${draftState === "canonical" ? "Canonical workout" : "Local draft"}`,
+    `Title: ${draft.title}`,
+    `Garmin/export readiness: ${readiness.status === "ready" ? "Ready" : "Review"}`,
+    `Readiness summary: ${readiness.summary}`,
+    "",
+    "Use this handoff for manual Garmin Connect entry, coach review, or poolside notes until direct Garmin delivery exists.",
+    "",
+    "Workout",
+    `- Session: ${buildSessionTargetSummary(normalizedDraft)}`,
+    `- Environment: ${buildWorkoutEnvironmentSummary(draft)}`,
+    `- Session type: ${getSessionTypeLabel(draft.sessionType)}`,
+    `- Effort: ${getSessionEffortLabel(draft.effort)}`,
+  ];
+
+  if (draft.goalTitle) {
+    lines.push(`- Goal: ${draft.goalTitle}`);
+  }
+
+  if (draft.focusText) {
+    lines.push(`- Focus: ${draft.focusText}`);
+  }
+
+  if (draft.constraintText) {
+    lines.push(`- Constraint: ${draft.constraintText}`);
+  }
+
+  if (draft.description) {
+    lines.push(`- Description: ${draft.description}`);
+  }
+
+  if (draft.warnings.length > 0) {
+    lines.push("", "Existing draft warnings");
+    for (const warning of draft.warnings) {
+      lines.push(`- ${warning}`);
+    }
+  }
+
+  if (readiness.issues.length > 0) {
+    lines.push("", "Review before export/send");
+    for (const issue of readiness.issues) {
+      lines.push(`- ${issue.detail}`);
+    }
+  }
+
+  lines.push("", "Steps");
+
+  stepGroups.forEach((group, groupIndex) => {
+    const groupLabel = `${groupIndex + 1}.`;
+
+    if (group.kind === "single") {
+      const entry = group.entries[0];
+      if (!entry) return;
+
+      lines.push(`${groupLabel} ${entry.step.name}`);
+      lines.push(
+        `   - ${getSessionStepCategoryLabel(entry.step.category)} · ${buildWorkoutHandoffStepSummary(
+          entry.step,
+          draft.basePaceSecondsPer100m
+        )}`
+      );
+
+      if (entry.step.targetSummary) {
+        lines.push(`   - Target notes: ${entry.step.targetSummary}`);
+      }
+
+      if (entry.step.notes) {
+        lines.push(`   - Notes: ${entry.step.notes}`);
+      }
+
+      return;
+    }
+
+    lines.push(
+      `${groupLabel} Repeat block · ${buildWorkoutHandoffRepeatSummary(
+        group.entries,
+        group.repeatCount,
+        draft.basePaceSecondsPer100m
+      )}`
+    );
+
+    group.entries.forEach((entry, repeatIndex) => {
+      lines.push(`   ${groupIndex + 1}.${repeatIndex + 1} ${entry.step.name}`);
+      lines.push(
+        `      - ${getSessionStepCategoryLabel(entry.step.category)} · ${buildWorkoutHandoffStepSummary(
+          entry.step,
+          draft.basePaceSecondsPer100m
+        )}`
+      );
+
+      if (entry.step.targetSummary) {
+        lines.push(`      - Target notes: ${entry.step.targetSummary}`);
+      }
+
+      if (entry.step.notes) {
+        lines.push(`      - Notes: ${entry.step.notes}`);
+      }
+    });
+  });
+
+  return lines.join("\n");
 }
 
 export function normalizeSessionDraftForWorkoutPersistence(
@@ -377,6 +524,211 @@ function buildWorkoutGarminReadinessIssues(
 function buildWorkoutStepReadinessLabel(step: SessionDraftStep, index: number) {
   const name = typeof step.name === "string" ? step.name.trim() : "";
   return name ? `Step ${index + 1} (${name})` : `Step ${index + 1}`;
+}
+
+type WorkoutHandoffEntry = {
+  step: SessionDraftStep;
+  index: number;
+};
+
+type WorkoutHandoffGroup =
+  | {
+      kind: "single";
+      entries: [WorkoutHandoffEntry];
+    }
+  | {
+      kind: "repeat";
+      repeatGroupId: string;
+      repeatCount: number | null;
+      entries: WorkoutHandoffEntry[];
+    };
+
+function buildWorkoutEnvironmentSummary(draft: SessionDraft) {
+  if (draft.environment !== "pool") {
+    return getSessionEnvironmentLabel(draft.environment);
+  }
+
+  const poolLength =
+    typeof draft.poolLengthM === "number" && Number.isFinite(draft.poolLengthM)
+      ? ` (${formatPoolLengthLabel(draft.poolLengthM)})`
+      : "";
+
+  return `${getSessionEnvironmentLabel(draft.environment)}${poolLength}`;
+}
+
+function buildWorkoutHandoffGroups(steps: SessionDraftStep[]): WorkoutHandoffGroup[] {
+  const groups: WorkoutHandoffGroup[] = [];
+
+  for (let index = 0; index < steps.length; index += 1) {
+    const step = steps[index];
+
+    if (!step) continue;
+
+    if (!step.repeatGroupId) {
+      groups.push({
+        kind: "single",
+        entries: [{ step, index }],
+      });
+      continue;
+    }
+
+    const entries: WorkoutHandoffEntry[] = [{ step, index }];
+    let nextIndex = index + 1;
+
+    while (nextIndex < steps.length && steps[nextIndex]?.repeatGroupId === step.repeatGroupId) {
+      const nextStep = steps[nextIndex];
+      if (!nextStep) break;
+      entries.push({ step: nextStep, index: nextIndex });
+      nextIndex += 1;
+    }
+
+    groups.push({
+      kind: "repeat",
+      repeatGroupId: step.repeatGroupId,
+      repeatCount: step.repeatCount ?? null,
+      entries,
+    });
+    index = nextIndex - 1;
+  }
+
+  return groups;
+}
+
+function buildWorkoutHandoffRepeatSummary(
+  entries: WorkoutHandoffEntry[],
+  repeatCount: number | null,
+  basePaceSecondsPer100m: number
+) {
+  if (repeatCount === null) {
+    return "repeat count not set";
+  }
+
+  let roundDistanceM = 0;
+  let roundDurationSeconds = 0;
+
+  for (const { step } of entries) {
+    if (step.durationMode === "distance" && step.distanceM) {
+      roundDistanceM += step.distanceM;
+    }
+
+    if (
+      (step.durationMode === "time" ||
+        step.durationMode === "fixed_rest" ||
+        step.durationMode === "send_off") &&
+      step.timeMin
+    ) {
+      roundDurationSeconds += getClockTotalSeconds(step.timeMin);
+    }
+
+    if (step.durationMode === "css_send_off" && typeof step.cssSendOffOffsetSeconds === "number") {
+      roundDurationSeconds += Math.max(1, basePaceSecondsPer100m + step.cssSendOffOffsetSeconds);
+    }
+  }
+
+  const parts = [`${repeatCount} rounds`];
+
+  if (roundDistanceM > 0 || roundDurationSeconds > 0) {
+    const roundParts: string[] = [];
+
+    if (roundDistanceM > 0) {
+      roundParts.push(`${roundDistanceM}m`);
+    }
+
+    if (roundDurationSeconds > 0) {
+      roundParts.push(formatClockDurationLabelFromSeconds(roundDurationSeconds));
+    }
+
+    parts.push(`${roundParts.join(" + ")} per round`);
+  }
+
+  return parts.join(" · ");
+}
+
+function buildWorkoutHandoffStepSummary(
+  step: SessionDraftStep,
+  basePaceSecondsPer100m: number
+) {
+  const structuredTarget = buildSessionStepStructuredTargetLabel(step, basePaceSecondsPer100m);
+  const contextParts = [getSessionStepStrokeLabel(step.stroke)];
+
+  if (step.drillType && step.drillType !== "none") {
+    const drillLabel = getSessionStepDrillTypeLabel(step.drillType);
+    if (!(step.stroke === "drill" && drillLabel === "Drill")) {
+      contextParts.push(drillLabel);
+    }
+  }
+
+  if (step.equipment && step.equipment !== "none") {
+    contextParts.push(getSessionStepEquipmentLabel(step.equipment));
+  }
+
+  return [
+    buildWorkoutHandoffDurationSummary(step, basePaceSecondsPer100m),
+    contextParts.join(" · "),
+    structuredTarget ?? getSessionEffortLabel(step.intensity),
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+function buildWorkoutHandoffDurationSummary(
+  step: SessionDraftStep,
+  basePaceSecondsPer100m: number
+) {
+  switch (step.durationMode) {
+    case "distance":
+      return step.distanceM ? `${step.distanceM}m` : "Distance not set";
+    case "time":
+      return step.timeMin ? formatMinutesLabel(step.timeMin) : "Time not set";
+    case "fixed_rest":
+      return step.timeMin
+        ? `Fixed rest ${formatClockDurationLabel(step.timeMin)}`
+        : "Fixed rest not set";
+    case "send_off":
+      return step.timeMin
+        ? `Send-off ${formatClockDurationLabel(step.timeMin)}`
+        : "Send-off not set";
+    case "css_send_off":
+      if (typeof step.cssSendOffOffsetSeconds !== "number") {
+        return "CSS send-off not set";
+      }
+
+      return `CSS ${step.cssSendOffOffsetSeconds > 0 ? "+" : ""}${step.cssSendOffOffsetSeconds}s send-off (${formatClockDurationLabelFromSeconds(
+        basePaceSecondsPer100m + step.cssSendOffOffsetSeconds
+      )})`;
+    case "lap_button":
+      return "Lap button press";
+    default:
+      return getSessionStepDurationModeLabel(step.durationMode);
+  }
+}
+
+function formatMinutesLabel(value: number) {
+  return `${Number.isInteger(value) ? value : value.toFixed(1).replace(/\.0$/, "")} min`;
+}
+
+function getClockTotalSeconds(valueMinutes: number | null | undefined) {
+  if (!valueMinutes || valueMinutes <= 0) return 0;
+  return Math.max(0, Math.round(valueMinutes * 60));
+}
+
+function formatClockDurationLabel(valueMinutes: number | null | undefined) {
+  return formatClockDurationLabelFromSeconds(getClockTotalSeconds(valueMinutes));
+}
+
+function formatClockDurationLabelFromSeconds(totalSeconds: number) {
+  const normalizedSeconds = Math.max(0, Math.round(totalSeconds));
+  const minutes = Math.floor(normalizedSeconds / 60);
+  const seconds = normalizedSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+function normalizeFileNamePart(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
 }
 
 function normalizeStep(

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -80,6 +80,16 @@ test.describe("my library workout builder", () => {
     await expect(page.getByTestId("workout-editor-garmin-readiness-summary")).toHaveText(
       "Ready for the planned Garmin/export handoff."
     );
+    await expect(page.getByTestId("workout-editor-handoff-source")).toHaveAttribute(
+      "data-handoff-state",
+      "canonical"
+    );
+    await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(
+      "Source: Canonical workout"
+    );
+    await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(
+      "Title: Manual pool workout"
+    );
     await expect(page.getByTestId("workout-builder-save")).toBeDisabled();
 
     await page.getByTestId("session-draft-step-remove-0").click();
@@ -157,6 +167,17 @@ test.describe("my library workout builder", () => {
     await expect(page.getByTestId("workout-editor-garmin-readiness-issue-4")).toContainText(
       "Reverse IM order (RIMO)"
     );
+    await expect(page.getByTestId("workout-editor-handoff-source")).toHaveAttribute(
+      "data-handoff-state",
+      "local_draft"
+    );
+    await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(
+      "Source: Local draft"
+    );
+    await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(uniqueTitle);
+    await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(
+      "Review before export/send"
+    );
     await expect(page.getByTestId("workout-builder-save")).toBeEnabled();
 
     const patchResponsePromise = page.waitForResponse(
@@ -180,6 +201,14 @@ test.describe("my library workout builder", () => {
       "data-readiness-status",
       "review"
     );
+    await expect(page.getByTestId("workout-editor-handoff-source")).toHaveAttribute(
+      "data-handoff-state",
+      "canonical"
+    );
+    await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(
+      "Source: Canonical workout"
+    );
+    await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(uniqueTitle);
     await expect(page.getByTestId("workout-builder-save")).toBeDisabled();
     await expect(page.getByTestId("session-draft-title")).toHaveValue(uniqueTitle);
     await expect(page.getByTestId("session-draft-pool-length-input")).toHaveValue("33.33");

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -7,6 +7,7 @@ import type {
   WorkoutLibrarySnapshot,
   WorkoutSummary,
 } from "@/lib/workouts/shared";
+import { buildWorkoutHandoffFileName } from "@/lib/workouts/shared";
 
 const navigationState = vi.hoisted(() => ({
   push: vi.fn(),
@@ -593,6 +594,96 @@ describe("WorkoutBuilderHub", () => {
 
     expect(screen.queryByTestId("session-draft-step-name-0")).not.toBeInTheDocument();
     expect(screen.getByTestId("session-draft-step-toggle-0")).toHaveTextContent("Edit step");
+  });
+
+  it("builds a truthful handoff preview and supports copy/download actions", async () => {
+    const clipboardWriteText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: clipboardWriteText,
+      },
+    });
+
+    const createUrlSpy = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:http://127.0.0.1/mock-handoff");
+    const revokeUrlSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+
+    render(<WorkoutBuilderHub workoutLibrary={buildWorkoutLibrary()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    expect(screen.getByTestId("workout-editor-handoff-source")).toHaveAttribute(
+      "data-handoff-state",
+      "canonical"
+    );
+    expect(screen.getByTestId("workout-editor-handoff-preview")).toHaveTextContent(
+      "Source: Canonical workout"
+    );
+    expect(screen.getByTestId("workout-editor-handoff-preview")).toHaveTextContent(
+      "Title: Accepted threshold workout"
+    );
+
+    fireEvent.change(screen.getByTestId("session-draft-title"), {
+      target: { value: "Local handoff workout" },
+    });
+    fireEvent.click(screen.getByTestId("session-draft-step-toggle-0"));
+    fireEvent.change(screen.getByTestId("session-draft-step-stroke-0"), {
+      target: { value: "reverse_im_order" },
+    });
+
+    expect(screen.getByTestId("workout-editor-handoff-source")).toHaveAttribute(
+      "data-handoff-state",
+      "local_draft"
+    );
+    expect(screen.getByTestId("workout-editor-handoff-preview")).toHaveTextContent(
+      "Source: Local draft"
+    );
+    expect(screen.getByTestId("workout-editor-handoff-preview")).toHaveTextContent(
+      "Title: Local handoff workout"
+    );
+    expect(screen.getByTestId("workout-editor-handoff-preview")).toHaveTextContent(
+      "Reverse IM order (RIMO)"
+    );
+
+    fireEvent.click(screen.getByTestId("workout-editor-handoff-copy"));
+
+    await waitFor(() => {
+      expect(clipboardWriteText).toHaveBeenCalledWith(
+        expect.stringContaining("Title: Local handoff workout")
+      );
+    });
+
+    expect(screen.getByTestId("workout-editor-handoff-notice")).toHaveTextContent(
+      "Workout handoff copied."
+    );
+
+    fireEvent.click(screen.getByTestId("workout-editor-handoff-download"));
+
+    await waitFor(() => {
+      expect(createUrlSpy).toHaveBeenCalledTimes(1);
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.getByTestId("workout-editor-handoff-notice")).toHaveTextContent(
+      `Downloaded ${buildWorkoutHandoffFileName(
+        {
+          ...buildDraft(),
+          title: "Local handoff workout",
+        },
+        { draftState: "local_draft" }
+      )}.`
+    );
+    expect(revokeUrlSpy).toHaveBeenCalledTimes(0);
   });
 
   it("shows recovery guidance when the requested workout is missing", () => {

--- a/tests/unit/workouts-shared.test.ts
+++ b/tests/unit/workouts-shared.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { SessionDraft } from "@/lib/session-generator-v1/shared";
-import { buildWorkoutGarminReadinessReport } from "@/lib/workouts/shared";
+import {
+  buildWorkoutGarminReadinessReport,
+  buildWorkoutHandoffFileName,
+  buildWorkoutHandoffText,
+} from "@/lib/workouts/shared";
 
 function buildDraft(): SessionDraft {
   return {
@@ -84,5 +88,79 @@ describe("workouts shared readiness", () => {
     expect(report.issues[0]?.detail).toContain("Reverse IM order (RIMO)");
     expect(report.issues[1]?.detail).toContain("Pull");
     expect(report.issues[2]?.detail).toContain("Fins");
+  });
+
+  it("builds a canonical handoff text export with workout metadata and steps", () => {
+    const draft = buildDraft();
+    const text = buildWorkoutHandoffText(draft, {
+      draftState: "canonical",
+    });
+
+    expect(buildWorkoutHandoffFileName(draft, { draftState: "canonical" })).toBe(
+      "freeswimming-garmin-readiness-draft-handoff.txt"
+    );
+    expect(text).toContain("FreeSwimming workout handoff");
+    expect(text).toContain("Source: Canonical workout");
+    expect(text).toContain("Title: Garmin readiness draft");
+    expect(text).toContain("Garmin/export readiness: Ready");
+    expect(text).toContain("Session type: Threshold / CSS");
+    expect(text).toContain("1. Warmup swim");
+    expect(text).toContain("Warmup · 400m · Freestyle · Easy");
+  });
+
+  it("builds a local-draft handoff text export with review issues", () => {
+    const draft: SessionDraft = {
+      ...buildDraft(),
+      title: "Review handoff draft",
+      steps: [
+        {
+          id: "step-1",
+          category: "main",
+          name: "Repeat review swim",
+          stroke: "im_by_round",
+          drillType: "pull",
+          equipment: "fins",
+          intensity: "moderate",
+          durationMode: "distance",
+          distanceM: 100,
+          timeMin: null,
+          targetSummary: "Truthful mapping check.",
+          notes: "Keep the export honest.",
+          repeatGroupId: "repeat-1",
+          repeatCount: 4,
+        },
+        {
+          id: "step-2",
+          category: "rest",
+          name: "Repeat review rest",
+          stroke: "choice",
+          intensity: "easy",
+          durationMode: "send_off",
+          distanceM: null,
+          timeMin: 2,
+          targetSummary: "Leave room for setup.",
+          notes: "",
+          repeatGroupId: "repeat-1",
+          repeatCount: 4,
+        },
+      ],
+    };
+
+    const text = buildWorkoutHandoffText(draft, {
+      draftState: "local_draft",
+    });
+
+    expect(buildWorkoutHandoffFileName(draft, { draftState: "local_draft" })).toBe(
+      "freeswimming-review-handoff-draft-handoff-draft.txt"
+    );
+    expect(text).toContain("Source: Local draft");
+    expect(text).toContain("Garmin/export readiness: Review");
+    expect(text).toContain("Review before export/send");
+    expect(text).toContain("IM by round");
+    expect(text).toContain("Pull");
+    expect(text).toContain("Fins");
+    expect(text).toContain("1. Repeat block · 4 rounds · 100m + 2:00 per round");
+    expect(text).toContain("1.1 Repeat review swim");
+    expect(text).toContain("1.2 Repeat review rest");
   });
 });


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-03-24T19:55:36.175Z for branch `feat/workout-builder-handoff-export` (base ref `origin/main`).
- Latest commit: `6497830` - feat(workouts): add builder handoff export.
- User-visible changes: User/admin runtime behavior may change on touched routes/components.
- Technical changes: Updated 6 file(s): `components/my-library/workouts/WorkoutEditor.tsx`, `docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md`, `lib/workouts/shared.ts`, `tests/e2e/my-library-workout-builder.spec.ts`, `tests/unit/workout-builder-hub.test.tsx`, `... and 1 more file(s)`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md`
- Scorecard target outcomes: 13 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (1); tests (3); runtime UI/routes/components (2).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (6):
  - `components/my-library/workouts/WorkoutEditor.tsx`
  - `docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md`
  - `lib/workouts/shared.ts`
  - `tests/e2e/my-library-workout-builder.spec.ts`
  - `tests/unit/workout-builder-hub.test.tsx`
  - `tests/unit/workouts-shared.test.ts`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `6497830` (`git revert 6497830`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **NOT RUN** (run locally before pushing PR updates).
- `npm run verify:pre-merge`: **PENDING** for `6497830` (required before merge to `main`).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  - No local verify log found in `artifacts/test-runs/latest`.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
