### PR TITLE
feat(workouts): add garmin-ready json export

### DIFF
--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -49,6 +49,8 @@ import {
   type SessionGeneratorStroke,
 } from "@/lib/session-generator-v1/shared";
 import {
+  buildWorkoutGarminReadyExport,
+  buildWorkoutGarminReadyExportFileName,
   buildWorkoutGarminReadinessReport,
   buildWorkoutHandoffFileName,
   buildWorkoutHandoffText,
@@ -453,12 +455,29 @@ export default function WorkoutEditor({
   );
   const [pendingRemoval, setPendingRemoval] = useState<PendingRemoval | null>(null);
   const [lastRemovedBlock, setLastRemovedBlock] = useState<LastRemovedBlock | null>(null);
+  const [garminExportNotice, setGarminExportNotice] = useState("");
+  const [garminExportError, setGarminExportError] = useState("");
   const [handoffNotice, setHandoffNotice] = useState("");
   const [handoffError, setHandoffError] = useState("");
   const poolLengthUsesPreset =
     typeof draft.poolLengthM === "number" && isSessionDraftPoolLengthPreset(draft.poolLengthM);
   const handoffDraftState: WorkoutHandoffDraftState =
     savedWorkout && !hasUnsavedChanges ? "canonical" : "local_draft";
+  const garminReadyExport = buildWorkoutGarminReadyExport(draft, {
+    draftState: handoffDraftState,
+    workoutId: savedWorkout?.id ?? null,
+  });
+  const garminReadyExportPreview = JSON.stringify(garminReadyExport, null, 2);
+  const garminReadyExportFileName = buildWorkoutGarminReadyExportFileName(draft, {
+    draftState: handoffDraftState,
+  });
+  const garminExportStateLabel =
+    handoffDraftState === "canonical" ? "Canonical Garmin-ready export" : "Local draft Garmin-ready export";
+  const garminExportStateDescription = savedWorkout
+    ? hasUnsavedChanges
+      ? "JSON export preview reflects unsaved local edits. Save first if you want the canonical workout and export adapter output to match."
+      : "JSON export preview matches the saved canonical workout."
+    : "JSON export preview reflects the current local draft before canonical save.";
   const handoffText = buildWorkoutHandoffText(draft, {
     draftState: handoffDraftState,
   });
@@ -506,6 +525,11 @@ export default function WorkoutEditor({
     setPendingRemoval(null);
     setLastRemovedBlock(null);
   }, [savedWorkout?.id, savedWorkout?.updatedAt]);
+
+  useEffect(() => {
+    setGarminExportNotice("");
+    setGarminExportError("");
+  }, [garminReadyExportPreview, handoffDraftState, savedWorkout?.id, savedWorkout?.updatedAt]);
 
   useEffect(() => {
     setHandoffNotice("");
@@ -996,6 +1020,29 @@ export default function WorkoutEditor({
       setHandoffNotice(`Downloaded ${handoffFileName}.`);
     } catch {
       setHandoffError("Could not download the workout handoff right now.");
+    }
+  }
+
+  function downloadWorkoutGarminReadyExport() {
+    setGarminExportNotice("");
+    setGarminExportError("");
+
+    try {
+      const blob = new Blob([garminReadyExportPreview], {
+        type: "application/json;charset=utf-8",
+      });
+      const objectUrl = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = objectUrl;
+      anchor.download = garminReadyExportFileName;
+      anchor.rel = "noopener";
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
+      setGarminExportNotice(`Downloaded ${garminReadyExportFileName}.`);
+    } catch {
+      setGarminExportError("Could not download the Garmin-ready JSON right now.");
     }
   }
 
@@ -1696,6 +1743,66 @@ export default function WorkoutEditor({
             ))}
           </ul>
         ) : null}
+      </div>
+
+      <div className="rounded-2xl border border-slate-200 bg-white p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-sky-700">
+              Garmin-ready JSON
+            </p>
+            <p className="mt-2 text-sm font-medium text-slate-900">
+              Download the current workout as the truthful FreeSwimming `garmin-ready` adapter
+              output. This is not a live Garmin payload yet; it preserves current mapping warnings
+              so later provider delivery can stay explicit and deterministic.
+            </p>
+            <p
+              data-testid="workout-editor-garmin-export-source"
+              data-export-state={handoffDraftState}
+              className="mt-2 text-xs font-semibold uppercase tracking-wide text-slate-600"
+            >
+              {garminExportStateLabel}
+            </p>
+            <p className="mt-1 text-sm text-slate-600">{garminExportStateDescription}</p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={downloadWorkoutGarminReadyExport}
+              data-testid="workout-editor-garmin-export-download"
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+            >
+              Download .json
+            </button>
+          </div>
+        </div>
+
+        {garminExportNotice ? (
+          <p
+            data-testid="workout-editor-garmin-export-notice"
+            className="mt-3 text-sm font-medium text-emerald-700"
+          >
+            {garminExportNotice}
+          </p>
+        ) : null}
+
+        {garminExportError ? (
+          <p
+            data-testid="workout-editor-garmin-export-error"
+            className="mt-3 text-sm text-rose-700"
+          >
+            {garminExportError}
+          </p>
+        ) : null}
+
+        <div className="mt-4 overflow-hidden rounded-2xl border border-slate-200 bg-slate-950">
+          <pre
+            data-testid="workout-editor-garmin-export-preview"
+            className="max-h-[320px] overflow-auto whitespace-pre-wrap px-4 py-4 text-xs leading-relaxed text-slate-100"
+          >
+            {garminReadyExportPreview}
+          </pre>
+        </div>
       </div>
 
       <div className="rounded-2xl border border-slate-200 bg-white p-4">

--- a/docs/task-briefs/in-progress/2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md
+++ b/docs/task-briefs/in-progress/2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md
@@ -3,10 +3,10 @@
 ## Metadata
 
 - `id`: `2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10`
-- `status`: `planned`
+- `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-02-28`
-- `updated`: `2026-03-22`
+- `updated`: `2026-03-24`
 
 ## Goal
 
@@ -131,3 +131,4 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - `2026-03-19 | planning | clarified that export is downstream of canonical workouts from either manual builder or accepted AI-generated drafts, while live Garmin push remains a separate later slice | next: keep export adapter rules aligned with the canonical workout contract and future Garmin partner mapping`
 - `2026-03-20 | planning | expanded export scope to cover Garmin-ready workout/program mapping and threshold-based zone target handling, while keeping live send and activity-history ingestion outside this adapter brief | next: align later export adapters with the exact Training API publish model once partner docs and supported step matrix are finalized`
 - `2026-03-22 | planning | tightened adapter expectations around observed Garmin swim-builder behavior so later export must handle or explicitly reject Garmin-documented `WorkoutIntensity`, `open`, `swim_stroke`, and lap/open-water sub-sport semantics plus Garmin Connect UI concepts like `Main`, lap-button, fixed-rest, send-off, CSS-based pacing, `Choice`, `RIMO`, and explicit rest/repeat swim sets rather than flattening them silently | next: keep adapter tests and blocked Garmin mapping matrix tied to these concrete swim-workout semantics`
+- `2026-03-24 | in-progress | moved the export-adapter brief into active implementation and narrowed the first delivery to a truthful workout-level Garmin-ready JSON adapter with builder preview/download, while PDF/program export and live Garmin partner delivery remain open | next: land deterministic adapter output, repeat-aware diagnostics, and builder verification before opening the PR`

--- a/lib/workouts/shared.ts
+++ b/lib/workouts/shared.ts
@@ -24,6 +24,7 @@ import {
   getSessionStepEquipmentLabel,
   getSessionStepStrokeLabel,
   getSessionStepDurationModeLabel,
+  getSessionStepTargetModeLabel,
   getSessionTypeLabel,
   normalizeSessionDraftPoolLength,
   type SessionDraft,
@@ -104,6 +105,119 @@ export type WorkoutGarminReadinessReport = {
 
 export type WorkoutHandoffDraftState = "canonical" | "local_draft";
 
+type WorkoutGarminReadyExportLabeledValue<T extends string> = {
+  value: T;
+  label: string;
+};
+
+export type WorkoutGarminReadyExportStep = {
+  id: string;
+  position: number;
+  name: string;
+  mappingStatus: "ready" | "review";
+  reviewIssueIds: string[];
+  category: WorkoutGarminReadyExportLabeledValue<SessionDraftStep["category"]>;
+  stroke: WorkoutGarminReadyExportLabeledValue<SessionDraftStep["stroke"]>;
+  drillType:
+    | WorkoutGarminReadyExportLabeledValue<
+        Exclude<SessionDraftStep["drillType"], null | undefined>
+      >
+    | null;
+  equipment:
+    | WorkoutGarminReadyExportLabeledValue<
+        Exclude<SessionDraftStep["equipment"], null | undefined>
+      >
+    | null;
+  intensity: WorkoutGarminReadyExportLabeledValue<SessionDraftStep["intensity"]>;
+  duration: {
+    mode: SessionDraftStep["durationMode"];
+    label: string;
+    distanceM: number | null;
+    timeMin: number | null;
+    cssSendOffOffsetSeconds: number | null;
+    summary: string;
+  };
+  target: {
+    mode: NonNullable<SessionDraftStep["targetMode"]>;
+    label: string;
+    effortTarget:
+      | WorkoutGarminReadyExportLabeledValue<
+          Exclude<SessionDraftStep["effortTarget"], null | undefined>
+        >
+      | null;
+    targetPaceSecondsPer100m: number | null;
+    cssTargetOffsetSeconds: number | null;
+    structuredLabel: string | null;
+    draftSummary: string | null;
+  };
+  notes: string | null;
+  repeatGroupId: string | null;
+  repeatCount: number | null;
+};
+
+export type WorkoutGarminReadyExportBlock =
+  | {
+      kind: "single";
+      position: number;
+      mappingStatus: "ready" | "review";
+      reviewIssueIds: string[];
+      step: WorkoutGarminReadyExportStep;
+    }
+  | {
+      kind: "repeat";
+      position: number;
+      repeatGroupId: string;
+      repeatCount: number | null;
+      mappingStatus: "ready" | "review";
+      reviewIssueIds: string[];
+      roundSummary: string;
+      roundDistanceM: number | null;
+      roundDurationSeconds: number | null;
+      steps: WorkoutGarminReadyExportStep[];
+    };
+
+export type WorkoutGarminReadyExport = {
+  version: 1;
+  kind: "freeswimming_garmin_ready_workout_v1";
+  draftState: WorkoutHandoffDraftState;
+  workoutId: string | null;
+  diagnostics: {
+    status: WorkoutGarminReadinessReport["status"];
+    summary: string;
+    issueCount: number;
+    issues: WorkoutGarminReadinessIssue[];
+  };
+  workout: {
+    title: string;
+    description: string | null;
+    summary: string;
+    sourceFingerprint: string;
+    createdAt: string;
+    environment: {
+      value: SessionDraft["environment"];
+      label: string;
+      subSport: "lap_swimming" | "open_water";
+      poolLengthM: number | null;
+    };
+    sessionType: WorkoutGarminReadyExportLabeledValue<SessionDraft["sessionType"]>;
+    effort: WorkoutGarminReadyExportLabeledValue<SessionDraft["effort"]>;
+    sizeMode: SessionDraft["sizeMode"];
+    targetDistanceM: number | null;
+    targetTimeMin: number | null;
+    totalDistanceM: number | null;
+    estimatedDurationMin: number | null;
+    basePaceSecondsPer100m: number;
+    usedCssPaceLabel: string | null;
+    allowedStrokes: SessionDraft["allowedStrokes"];
+    equipmentAllowlist: SessionDraft["equipmentAllowlist"];
+    goalTitle: string | null;
+    focusText: string | null;
+    constraintText: string | null;
+    warnings: string[];
+  } | null;
+  blocks: WorkoutGarminReadyExportBlock[];
+};
+
 export function buildWorkoutDraftChangeSignature(
   draft: SessionDraft | null | undefined
 ): string | null {
@@ -165,6 +279,163 @@ export function buildWorkoutHandoffFileName(
   const suffix = draftState === "canonical" ? "" : "-draft";
 
   return `freeswimming-${title || "workout"}-handoff${suffix}.txt`;
+}
+
+export function buildWorkoutGarminReadyExportFileName(
+  draft: SessionDraft | null | undefined,
+  options?: {
+    draftState?: WorkoutHandoffDraftState;
+  }
+) {
+  const title = normalizeFileNamePart(draft?.title ?? "");
+  const draftState = options?.draftState ?? "local_draft";
+  const suffix = draftState === "canonical" ? "" : "-draft";
+
+  return `freeswimming-${title || "workout"}-garmin-ready${suffix}.json`;
+}
+
+export function buildWorkoutGarminReadyExport(
+  draft: SessionDraft | null | undefined,
+  options?: {
+    draftState?: WorkoutHandoffDraftState;
+    workoutId?: string | null;
+  }
+): WorkoutGarminReadyExport {
+  const draftState = options?.draftState ?? "local_draft";
+  const workoutId = options?.workoutId ?? null;
+  const diagnostics = buildWorkoutGarminReadinessReport(draft);
+
+  if (!draft) {
+    return {
+      version: 1,
+      kind: "freeswimming_garmin_ready_workout_v1",
+      draftState,
+      workoutId,
+      diagnostics: {
+        status: diagnostics.status,
+        summary: diagnostics.summary,
+        issueCount: diagnostics.issues.length,
+        issues: diagnostics.issues,
+      },
+      workout: null,
+      blocks: [],
+    };
+  }
+
+  const totals = computeSessionDraftDerivedTotals(draft);
+  const normalizedDraft = {
+    ...draft,
+    totalDistanceM: totals.totalDistanceM ?? draft.totalDistanceM,
+    estimatedDurationMin: totals.estimatedDurationMin ?? draft.estimatedDurationMin,
+  };
+  const issueIdsByStepId = new Map<string, string[]>();
+
+  for (const issue of diagnostics.issues) {
+    const currentIssueIds = issueIdsByStepId.get(issue.stepId) ?? [];
+    currentIssueIds.push(issue.id);
+    issueIdsByStepId.set(issue.stepId, currentIssueIds);
+  }
+
+  const blocks = buildWorkoutHandoffGroups(draft.steps).map((group, index) => {
+    if (group.kind === "single") {
+      const entry = group.entries[0];
+      const reviewIssueIds = issueIdsByStepId.get(entry?.step.id ?? "") ?? [];
+      const step = buildWorkoutGarminReadyExportStep(
+        entry.step,
+        entry.index,
+        draft.basePaceSecondsPer100m,
+        reviewIssueIds
+      );
+
+      return {
+        kind: "single" as const,
+        position: index + 1,
+        mappingStatus: reviewIssueIds.length > 0 ? ("review" as const) : ("ready" as const),
+        reviewIssueIds,
+        step,
+      };
+    }
+
+    const reviewIssueIds = group.entries.flatMap(
+      (entry) => issueIdsByStepId.get(entry.step.id) ?? []
+    );
+    const roundMetrics = buildWorkoutRepeatRoundMetrics(
+      group.entries,
+      draft.basePaceSecondsPer100m
+    );
+
+    return {
+      kind: "repeat" as const,
+      position: index + 1,
+      repeatGroupId: group.repeatGroupId,
+      repeatCount: group.repeatCount,
+      mappingStatus: reviewIssueIds.length > 0 ? ("review" as const) : ("ready" as const),
+      reviewIssueIds,
+      roundSummary: buildWorkoutHandoffRepeatSummary(
+        group.entries,
+        group.repeatCount,
+        draft.basePaceSecondsPer100m
+      ),
+      roundDistanceM: roundMetrics.roundDistanceM,
+      roundDurationSeconds: roundMetrics.roundDurationSeconds,
+      steps: group.entries.map((entry) =>
+        buildWorkoutGarminReadyExportStep(
+          entry.step,
+          entry.index,
+          draft.basePaceSecondsPer100m,
+          issueIdsByStepId.get(entry.step.id) ?? []
+        )
+      ),
+    };
+  });
+
+  return {
+    version: 1,
+    kind: "freeswimming_garmin_ready_workout_v1",
+    draftState,
+    workoutId,
+    diagnostics: {
+      status: diagnostics.status,
+      summary: diagnostics.summary,
+      issueCount: diagnostics.issues.length,
+      issues: diagnostics.issues,
+    },
+    workout: {
+      title: draft.title,
+      description: draft.description || null,
+      summary: buildSessionTargetSummary(normalizedDraft),
+      sourceFingerprint: draft.sourceFingerprint,
+      createdAt: draft.createdAt,
+      environment: {
+        value: draft.environment,
+        label: getSessionEnvironmentLabel(draft.environment),
+        subSport: draft.environment === "open_water" ? "open_water" : "lap_swimming",
+        poolLengthM: draft.poolLengthM,
+      },
+      sessionType: {
+        value: draft.sessionType,
+        label: getSessionTypeLabel(draft.sessionType),
+      },
+      effort: {
+        value: draft.effort,
+        label: getSessionEffortLabel(draft.effort),
+      },
+      sizeMode: draft.sizeMode,
+      targetDistanceM: normalizedDraft.targetDistanceM,
+      targetTimeMin: normalizedDraft.targetTimeMin,
+      totalDistanceM: normalizedDraft.totalDistanceM,
+      estimatedDurationMin: normalizedDraft.estimatedDurationMin,
+      basePaceSecondsPer100m: draft.basePaceSecondsPer100m,
+      usedCssPaceLabel: draft.usedCssPaceLabel,
+      allowedStrokes: draft.allowedStrokes,
+      equipmentAllowlist: draft.equipmentAllowlist,
+      goalTitle: draft.goalTitle,
+      focusText: draft.focusText,
+      constraintText: draft.constraintText,
+      warnings: draft.warnings,
+    },
+    blocks,
+  };
 }
 
 export function buildWorkoutHandoffText(
@@ -603,6 +874,31 @@ function buildWorkoutHandoffRepeatSummary(
     return "repeat count not set";
   }
 
+  const roundMetrics = buildWorkoutRepeatRoundMetrics(entries, basePaceSecondsPer100m);
+
+  const parts = [`${repeatCount} rounds`];
+
+  if (roundMetrics.roundDistanceM !== null || roundMetrics.roundDurationSeconds !== null) {
+    const roundParts: string[] = [];
+
+    if (roundMetrics.roundDistanceM !== null) {
+      roundParts.push(`${roundMetrics.roundDistanceM}m`);
+    }
+
+    if (roundMetrics.roundDurationSeconds !== null) {
+      roundParts.push(formatClockDurationLabelFromSeconds(roundMetrics.roundDurationSeconds));
+    }
+
+    parts.push(`${roundParts.join(" + ")} per round`);
+  }
+
+  return parts.join(" · ");
+}
+
+function buildWorkoutRepeatRoundMetrics(
+  entries: WorkoutHandoffEntry[],
+  basePaceSecondsPer100m: number
+) {
   let roundDistanceM = 0;
   let roundDurationSeconds = 0;
 
@@ -625,23 +921,79 @@ function buildWorkoutHandoffRepeatSummary(
     }
   }
 
-  const parts = [`${repeatCount} rounds`];
+  return {
+    roundDistanceM: roundDistanceM > 0 ? roundDistanceM : null,
+    roundDurationSeconds: roundDurationSeconds > 0 ? roundDurationSeconds : null,
+  };
+}
 
-  if (roundDistanceM > 0 || roundDurationSeconds > 0) {
-    const roundParts: string[] = [];
+function buildWorkoutGarminReadyExportStep(
+  step: SessionDraftStep,
+  index: number,
+  basePaceSecondsPer100m: number,
+  reviewIssueIds: string[]
+): WorkoutGarminReadyExportStep {
+  const targetMode = step.targetMode ?? "none";
+  const structuredTargetLabel = buildSessionStepStructuredTargetLabel(step, basePaceSecondsPer100m);
 
-    if (roundDistanceM > 0) {
-      roundParts.push(`${roundDistanceM}m`);
-    }
-
-    if (roundDurationSeconds > 0) {
-      roundParts.push(formatClockDurationLabelFromSeconds(roundDurationSeconds));
-    }
-
-    parts.push(`${roundParts.join(" + ")} per round`);
-  }
-
-  return parts.join(" · ");
+  return {
+    id: step.id,
+    position: index + 1,
+    name: step.name,
+    mappingStatus: reviewIssueIds.length > 0 ? "review" : "ready",
+    reviewIssueIds,
+    category: {
+      value: step.category,
+      label: getSessionStepCategoryLabel(step.category),
+    },
+    stroke: {
+      value: step.stroke,
+      label: getSessionStepStrokeLabel(step.stroke),
+    },
+    drillType:
+      step.drillType && step.drillType !== "none"
+        ? {
+            value: step.drillType,
+            label: getSessionStepDrillTypeLabel(step.drillType),
+          }
+        : null,
+    equipment:
+      step.equipment && step.equipment !== "none"
+        ? {
+            value: step.equipment,
+            label: getSessionStepEquipmentLabel(step.equipment),
+          }
+        : null,
+    intensity: {
+      value: step.intensity,
+      label: getSessionEffortLabel(step.intensity),
+    },
+    duration: {
+      mode: step.durationMode,
+      label: getSessionStepDurationModeLabel(step.durationMode),
+      distanceM: step.distanceM ?? null,
+      timeMin: step.timeMin ?? null,
+      cssSendOffOffsetSeconds: step.cssSendOffOffsetSeconds ?? null,
+      summary: buildWorkoutHandoffDurationSummary(step, basePaceSecondsPer100m),
+    },
+    target: {
+      mode: targetMode,
+      label: getSessionStepTargetModeLabel(targetMode),
+      effortTarget: step.effortTarget
+        ? {
+            value: step.effortTarget,
+            label: getSessionEffortLabel(step.effortTarget),
+          }
+        : null,
+      targetPaceSecondsPer100m: step.targetPaceSecondsPer100m ?? null,
+      cssTargetOffsetSeconds: step.cssTargetOffsetSeconds ?? null,
+      structuredLabel: structuredTargetLabel ?? null,
+      draftSummary: step.targetSummary || null,
+    },
+    notes: step.notes || null,
+    repeatGroupId: step.repeatGroupId ?? null,
+    repeatCount: step.repeatCount ?? null,
+  };
 }
 
 function buildWorkoutHandoffStepSummary(

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -90,6 +90,16 @@ test.describe("my library workout builder", () => {
     await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(
       "Title: Manual pool workout"
     );
+    await expect(page.getByTestId("workout-editor-garmin-export-source")).toHaveAttribute(
+      "data-export-state",
+      "canonical"
+    );
+    await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
+      '"kind": "freeswimming_garmin_ready_workout_v1"'
+    );
+    await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
+      '"draftState": "canonical"'
+    );
     await expect(page.getByTestId("workout-builder-save")).toBeDisabled();
 
     await page.getByTestId("session-draft-step-remove-0").click();
@@ -178,6 +188,19 @@ test.describe("my library workout builder", () => {
     await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(
       "Review before export/send"
     );
+    await expect(page.getByTestId("workout-editor-garmin-export-source")).toHaveAttribute(
+      "data-export-state",
+      "local_draft"
+    );
+    await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
+      '"draftState": "local_draft"'
+    );
+    await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
+      `"title": "${uniqueTitle}"`
+    );
+    await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
+      '"reviewIssueIds": ['
+    );
     await expect(page.getByTestId("workout-builder-save")).toBeEnabled();
 
     const patchResponsePromise = page.waitForResponse(
@@ -209,6 +232,16 @@ test.describe("my library workout builder", () => {
       "Source: Canonical workout"
     );
     await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(uniqueTitle);
+    await expect(page.getByTestId("workout-editor-garmin-export-source")).toHaveAttribute(
+      "data-export-state",
+      "canonical"
+    );
+    await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
+      '"draftState": "canonical"'
+    );
+    await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
+      `"title": "${uniqueTitle}"`
+    );
     await expect(page.getByTestId("workout-builder-save")).toBeDisabled();
     await expect(page.getByTestId("session-draft-title")).toHaveValue(uniqueTitle);
     await expect(page.getByTestId("session-draft-pool-length-input")).toHaveValue("33.33");

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -7,7 +7,10 @@ import type {
   WorkoutLibrarySnapshot,
   WorkoutSummary,
 } from "@/lib/workouts/shared";
-import { buildWorkoutHandoffFileName } from "@/lib/workouts/shared";
+import {
+  buildWorkoutGarminReadyExportFileName,
+  buildWorkoutHandoffFileName,
+} from "@/lib/workouts/shared";
 
 const navigationState = vi.hoisted(() => ({
   push: vi.fn(),
@@ -632,6 +635,16 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.getByTestId("workout-editor-handoff-preview")).toHaveTextContent(
       "Title: Accepted threshold workout"
     );
+    expect(screen.getByTestId("workout-editor-garmin-export-source")).toHaveAttribute(
+      "data-export-state",
+      "canonical"
+    );
+    expect(screen.getByTestId("workout-editor-garmin-export-preview")).toHaveTextContent(
+      '"kind": "freeswimming_garmin_ready_workout_v1"'
+    );
+    expect(screen.getByTestId("workout-editor-garmin-export-preview")).toHaveTextContent(
+      '"draftState": "canonical"'
+    );
 
     fireEvent.change(screen.getByTestId("session-draft-title"), {
       target: { value: "Local handoff workout" },
@@ -653,6 +666,19 @@ describe("WorkoutBuilderHub", () => {
     );
     expect(screen.getByTestId("workout-editor-handoff-preview")).toHaveTextContent(
       "Reverse IM order (RIMO)"
+    );
+    expect(screen.getByTestId("workout-editor-garmin-export-source")).toHaveAttribute(
+      "data-export-state",
+      "local_draft"
+    );
+    expect(screen.getByTestId("workout-editor-garmin-export-preview")).toHaveTextContent(
+      '"draftState": "local_draft"'
+    );
+    expect(screen.getByTestId("workout-editor-garmin-export-preview")).toHaveTextContent(
+      '"title": "Local handoff workout"'
+    );
+    expect(screen.getByTestId("workout-editor-garmin-export-preview")).toHaveTextContent(
+      '"reviewIssueIds": ['
     );
 
     fireEvent.click(screen.getByTestId("workout-editor-handoff-copy"));
@@ -676,6 +702,23 @@ describe("WorkoutBuilderHub", () => {
 
     expect(screen.getByTestId("workout-editor-handoff-notice")).toHaveTextContent(
       `Downloaded ${buildWorkoutHandoffFileName(
+        {
+          ...buildDraft(),
+          title: "Local handoff workout",
+        },
+        { draftState: "local_draft" }
+      )}.`
+    );
+
+    fireEvent.click(screen.getByTestId("workout-editor-garmin-export-download"));
+
+    await waitFor(() => {
+      expect(createUrlSpy).toHaveBeenCalledTimes(2);
+      expect(clickSpy).toHaveBeenCalledTimes(2);
+    });
+
+    expect(screen.getByTestId("workout-editor-garmin-export-notice")).toHaveTextContent(
+      `Downloaded ${buildWorkoutGarminReadyExportFileName(
         {
           ...buildDraft(),
           title: "Local handoff workout",

--- a/tests/unit/workouts-shared.test.ts
+++ b/tests/unit/workouts-shared.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { SessionDraft } from "@/lib/session-generator-v1/shared";
 import {
+  buildWorkoutGarminReadyExport,
+  buildWorkoutGarminReadyExportFileName,
   buildWorkoutGarminReadinessReport,
   buildWorkoutHandoffFileName,
   buildWorkoutHandoffText,
@@ -108,6 +110,74 @@ describe("workouts shared readiness", () => {
     expect(text).toContain("Warmup · 400m · Freestyle · Easy");
   });
 
+  it("builds a canonical garmin-ready export payload with deterministic workout metadata", () => {
+    const draft = buildDraft();
+    const exportPayload = buildWorkoutGarminReadyExport(draft, {
+      draftState: "canonical",
+      workoutId: "workout-1",
+    });
+
+    expect(
+      buildWorkoutGarminReadyExportFileName(draft, { draftState: "canonical" })
+    ).toBe("freeswimming-garmin-readiness-draft-garmin-ready.json");
+    expect(exportPayload).toMatchObject({
+      version: 1,
+      kind: "freeswimming_garmin_ready_workout_v1",
+      draftState: "canonical",
+      workoutId: "workout-1",
+      diagnostics: {
+        status: "ready",
+        issueCount: 0,
+      },
+      workout: {
+        title: "Garmin readiness draft",
+        summary: "400m · ~10 min · Moderate",
+        environment: {
+          value: "pool",
+          subSport: "lap_swimming",
+          poolLengthM: 25,
+        },
+        sessionType: {
+          value: "threshold_css",
+          label: "Threshold / CSS",
+        },
+        effort: {
+          value: "moderate",
+          label: "Moderate",
+        },
+      },
+    });
+    expect(exportPayload.blocks).toHaveLength(1);
+    expect(exportPayload.blocks[0]).toMatchObject({
+      kind: "single",
+      position: 1,
+      mappingStatus: "ready",
+      reviewIssueIds: [],
+      step: {
+        id: "step-1",
+        position: 1,
+        mappingStatus: "ready",
+        category: {
+          value: "warmup",
+          label: "Warmup",
+        },
+        stroke: {
+          value: "freestyle",
+          label: "Freestyle",
+        },
+        duration: {
+          mode: "distance",
+          summary: "400m",
+        },
+        target: {
+          mode: "none",
+          label: "No target",
+          draftSummary: "Easy settle-in.",
+        },
+      },
+    });
+  });
+
   it("builds a local-draft handoff text export with review issues", () => {
     const draft: SessionDraft = {
       ...buildDraft(),
@@ -162,5 +232,104 @@ describe("workouts shared readiness", () => {
     expect(text).toContain("1. Repeat block · 4 rounds · 100m + 2:00 per round");
     expect(text).toContain("1.1 Repeat review swim");
     expect(text).toContain("1.2 Repeat review rest");
+  });
+
+  it("builds a local-draft garmin-ready export payload with repeat blocks and review issue linkage", () => {
+    const draft: SessionDraft = {
+      ...buildDraft(),
+      title: "Review export draft",
+      steps: [
+        {
+          id: "step-1",
+          category: "main",
+          name: "Repeat review swim",
+          stroke: "im_by_round",
+          drillType: "pull",
+          equipment: "fins",
+          intensity: "moderate",
+          durationMode: "distance",
+          distanceM: 100,
+          timeMin: null,
+          targetSummary: "Truthful mapping check.",
+          notes: "Keep the export honest.",
+          repeatGroupId: "repeat-1",
+          repeatCount: 4,
+        },
+        {
+          id: "step-2",
+          category: "rest",
+          name: "Repeat review rest",
+          stroke: "choice",
+          intensity: "easy",
+          durationMode: "send_off",
+          distanceM: null,
+          timeMin: 2,
+          targetSummary: "Leave room for setup.",
+          notes: "",
+          repeatGroupId: "repeat-1",
+          repeatCount: 4,
+        },
+      ],
+    };
+
+    const exportPayload = buildWorkoutGarminReadyExport(draft, {
+      draftState: "local_draft",
+      workoutId: "workout-2",
+    });
+
+    expect(
+      buildWorkoutGarminReadyExportFileName(draft, { draftState: "local_draft" })
+    ).toBe("freeswimming-review-export-draft-garmin-ready-draft.json");
+    expect(exportPayload.diagnostics.status).toBe("review");
+    expect(exportPayload.diagnostics.issueCount).toBe(3);
+    expect(exportPayload.blocks).toHaveLength(1);
+    expect(exportPayload.blocks[0]).toMatchObject({
+      kind: "repeat",
+      position: 1,
+      repeatGroupId: "repeat-1",
+      repeatCount: 4,
+      mappingStatus: "review",
+      roundSummary: "4 rounds · 100m + 2:00 per round",
+      roundDistanceM: 100,
+      roundDurationSeconds: 120,
+    });
+
+    if (exportPayload.blocks[0]?.kind !== "repeat") {
+      throw new Error("Expected repeat block export.");
+    }
+
+    expect(exportPayload.blocks[0].reviewIssueIds).toEqual([
+      "step-1-im-by-round",
+      "step-1-drill-focus",
+      "step-1-equipment",
+    ]);
+    expect(exportPayload.blocks[0].steps[0]).toMatchObject({
+      id: "step-1",
+      position: 1,
+      mappingStatus: "review",
+      reviewIssueIds: ["step-1-im-by-round", "step-1-drill-focus", "step-1-equipment"],
+      stroke: {
+        value: "im_by_round",
+        label: "IM by round",
+      },
+      drillType: {
+        value: "pull",
+        label: "Pull",
+      },
+      equipment: {
+        value: "fins",
+        label: "Fins",
+      },
+    });
+    expect(exportPayload.blocks[0].steps[1]).toMatchObject({
+      id: "step-2",
+      position: 2,
+      mappingStatus: "ready",
+      reviewIssueIds: [],
+      duration: {
+        mode: "send_off",
+        summary: "Send-off 2:00",
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-03-24T21:11:04.823Z for branch `feat/workout-garmin-ready-export` (base ref `origin/main`).
- Latest commit: `a9131ad` - feat(workouts): add garmin-ready json export.
- User-visible changes: User/admin runtime behavior may change on touched routes/components.
- Technical changes: Updated 6 file(s): `components/my-library/workouts/WorkoutEditor.tsx`, `docs/task-briefs/in-progress/2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md`, `lib/workouts/shared.ts`, `tests/e2e/my-library-workout-builder.spec.ts`, `tests/unit/workout-builder-hub.test.tsx`, `... and 1 more file(s)`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md`
- Scorecard target outcomes: 7 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (1); tests (3); runtime UI/routes/components (2).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (6):
  - `components/my-library/workouts/WorkoutEditor.tsx`
  - `docs/task-briefs/in-progress/2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md`
  - `lib/workouts/shared.ts`
  - `tests/e2e/my-library-workout-builder.spec.ts`
  - `tests/unit/workout-builder-hub.test.tsx`
  - `tests/unit/workouts-shared.test.ts`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `a9131ad` (`git revert a9131ad`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **NOT RUN** (run locally before pushing PR updates).
- `npm run verify:pre-merge`: **PENDING** for `a9131ad` (required before merge to `main`).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  - No local verify log found in `artifacts/test-runs/latest`.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
