### PR TITLE
docs(workouts): close workout export brief

### DIFF
--- a/docs/task-briefs/done/2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md
+++ b/docs/task-briefs/done/2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md
@@ -3,14 +3,14 @@
 ## Metadata
 
 - `id`: `2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-02-28`
 - `updated`: `2026-03-25`
 
 ## Goal
 
-Build export adapters so canonical workouts/programs are usable immediately (PDF/poolside) and technically ready for Garmin Training API publish mapping later.
+Build workout-level export adapters so canonical workouts are usable immediately (Garmin-ready JSON and PDF/poolside print view) and technically ready for future Garmin Training API publish mapping later.
 
 ## Dependencies And Boundaries
 
@@ -20,17 +20,20 @@ Build export adapters so canonical workouts/programs are usable immediately (PDF
   - `docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md`
 - Upstream AI-authored draft flow:
   - `docs/task-briefs/planned/2026-02-28-ai-plan-generator-json-guardrails-10-10.md`
+- Residual follow-up for program-level export:
+  - `docs/task-briefs/planned/2026-03-25-program-export-adapters-garmin-ready-pdf-followup-10-10.md`
 - Export should consume canonical workouts after they exist, regardless of whether they were authored manually or accepted from AI-generated drafts.
 - This brief is not responsible for:
   - manual builder UX,
   - AI generation behavior,
+  - program-level export bundles/PDF,
   - or live Garmin API delivery.
 
 ## Scope
 
 - Export adapter layer:
-  - canonical workout/program -> `garmin-ready` intermediate format,
-  - canonical workout/program -> printable PDF model.
+  - canonical workout -> `garmin-ready` intermediate format,
+  - canonical workout -> printable PDF model.
 - PDF export UX:
   - clear, professional layout,
   - poolside legibility,
@@ -44,6 +47,7 @@ Build export adapters so canonical workouts/programs are usable immediately (PDF
 
 - Manual workout/session/program building.
 - AI generation of workout/session/program drafts.
+- Program-level export bundles/PDF output.
 - Live Garmin push.
 - OAuth token handling.
 - Garmin Activity API completion/history ingestion.
@@ -112,7 +116,7 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 ## Acceptance Criteria
 
 - PDF export renders consistently and readable on phone print view.
-- Garmin-ready adapter produces valid mapped workout/program payloads for future Training API submission.
+- Garmin-ready adapter produces valid mapped workout payloads for future Training API submission.
 - Garmin-ready adapter preserves or explicitly rejects unsupported Garmin-documented `WorkoutIntensity`, `open`, `swim_stroke`, and lap/open-water sub-sport semantics and Garmin Connect UI swim concepts like `Main`, lap-button, fixed-rest, send-off, CSS-based pacing, `Choice`, `RIMO`, and rest/repeat workflows with actionable errors instead of silent coercion.
 - Threshold-based swim-zone targets either map deterministically into export output or fail with actionable errors.
 - Adapter rejects unsupported step combos with actionable errors.
@@ -123,8 +127,9 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 ## Validation
 
 - adapter contract tests
-- pdf rendering snapshot tests (where stable)
+- targeted workout PDF rendering checks
 - `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
 
 ## Help/Guide And Operator Training Contract
 
@@ -137,3 +142,4 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - `2026-03-22 | planning | tightened adapter expectations around observed Garmin swim-builder behavior so later export must handle or explicitly reject Garmin-documented `WorkoutIntensity`, `open`, `swim_stroke`, and lap/open-water sub-sport semantics plus Garmin Connect UI concepts like `Main`, lap-button, fixed-rest, send-off, CSS-based pacing, `Choice`, `RIMO`, and explicit rest/repeat swim sets rather than flattening them silently | next: keep adapter tests and blocked Garmin mapping matrix tied to these concrete swim-workout semantics`
 - `2026-03-24 | in-progress | moved the export-adapter brief into active implementation and narrowed the first delivery to a truthful workout-level Garmin-ready JSON adapter with builder preview/download, while PDF/program export and live Garmin partner delivery remain open | next: land deterministic adapter output, repeat-aware diagnostics, and builder verification before opening the PR`
 - `2026-03-25 | working tree | added the next export slice: the canonical workout editor now opens a dedicated print-ready workout PDF view with canonical-vs-local draft labeling, review notes, and a poolside-friendly step layout so users can use browser Print / Save PDF without adding a heavy PDF dependency; targeted unit tests, typecheck, and desktop workout-builder Playwright coverage passed green | next: run full \`npm run verify:pre-pr\`, then package commit/push/PR handoff if the repo gate stays green`
+- `2026-03-25 | merged | workout-level Garmin-ready JSON export merged earlier as \`2c4fcd8\`, workout PDF print export merged as \`e938560\`, required CI checks passed, and local \`npm run verify:pre-merge\` passed on the green PR head; lifecycle moved from \`in-progress\` to \`done\` and remaining program-level export scope was split into \`docs/task-briefs/planned/2026-03-25-program-export-adapters-garmin-ready-pdf-followup-10-10.md\` | next: implement the residual program-export slice from updated \`main\` when it outranks newer work`

--- a/docs/task-briefs/planned/2026-03-25-program-export-adapters-garmin-ready-pdf-followup-10-10.md
+++ b/docs/task-briefs/planned/2026-03-25-program-export-adapters-garmin-ready-pdf-followup-10-10.md
@@ -1,0 +1,145 @@
+# Task Brief: Program Export Adapters Garmin-Ready + PDF Follow-up (10/10)
+
+## Metadata
+
+- `id`: `2026-03-25-program-export-adapters-garmin-ready-pdf-followup-10-10`
+- `status`: `planned`
+- `owner`: `stianvikra`
+- `created`: `2026-03-25`
+- `updated`: `2026-03-25`
+
+## Goal
+
+Build the remaining program-level export adapters so canonical programs can produce truthful Garmin-ready and printable outputs without mutating canonical program or workout identity.
+
+## Dependencies And Boundaries
+
+- Workout-level export foundation already shipped in:
+  - `docs/task-briefs/done/2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md`
+- Upstream canonical workout/entity contract:
+  - `docs/task-briefs/planned/2026-02-28-workout-data-contract-and-step-engine-10-10.md`
+- Upstream program builder/calendar contract:
+  - `docs/task-briefs/planned/2026-02-28-program-builder-calendar-completion-10-10.md`
+- Blocked live Garmin provider delivery remains separate:
+  - `docs/task-briefs/blocked/2026-02-28-garmin-training-api-partner-integration-10-10.md`
+- This follow-up owns:
+  - canonical program -> `garmin-ready` intermediate bundle,
+  - canonical program -> printable PDF/print flow,
+  - deterministic program ordering/identity rules in export output.
+- This follow-up does not own:
+  - already-shipped workout-level exports except narrow shared-helper reuse,
+  - live Garmin push or OAuth,
+  - program builder authoring UX beyond export affordances,
+  - training-history ingestion.
+
+## Scope
+
+- Export adapter layer:
+  - canonical program -> `garmin-ready` intermediate format,
+  - canonical program -> printable PDF model.
+- Program export UX:
+  - clear export entry point from the canonical program surface,
+  - truthful status/source labeling,
+  - poolside/coach-readable program output.
+- Validation:
+  - preserve deterministic program ordering and nested workout identity,
+  - surface actionable diagnostics for unsupported program/export combinations,
+  - reuse workout-level export contracts where possible instead of forking rules.
+
+## Out Of Scope
+
+- Manual workout/session/program building.
+- AI generation of workout/session/program drafts.
+- Reworking already-shipped workout-level Garmin-ready or PDF exports beyond shared fixes.
+- Live Garmin push.
+- OAuth token handling.
+- Garmin Activity API completion/history ingestion.
+
+## Data Placement And Sync Contract (Required)
+
+- Server-canonical:
+  - canonical program payload remains owned by the program/data-contract slices,
+  - export job/output metadata is server-canonical only if persisted later.
+- Local-only:
+  - transient export UI state,
+  - selected output mode,
+  - local preview/download state before final export completion.
+- Sync behavior:
+  - program exports are read-only transforms from canonical program input,
+  - export must never mutate canonical program/workout identity or ordering as a side effect,
+  - retry behavior must be deterministic and must not duplicate canonical writes.
+- Invalidation:
+  - canonical program changes invalidate downstream export previews and cached adapter output.
+
+## Identity And Rename Contract
+
+- Canonical stable IDs:
+  - adapter input must resolve programs and nested workouts/steps by canonical IDs from the upstream slices.
+- Human-readable identifiers:
+  - exported program/workout labels may be presentation-friendly, but adapter correctness must not depend on mutable titles or sort labels.
+- Mutability rules:
+  - export flows are read-only against canonical entities; no export action may rewrite canonical IDs.
+- Rename vs repurpose:
+  - if source program/workout naming changes, exports should reflect new presentation text while preserving canonical entity linkage.
+- Compatibility contract:
+  - future Garmin-ready/export formats may carry external identifiers, but those must never replace FreeSwimming canonical IDs as source-of-truth.
+- Observability and repair:
+  - unsupported mappings and unresolved source IDs must fail with actionable diagnostics rather than silently coercing output.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+| Category                                      | Mapping      | Target Threshold                                                                                                             | Evidence                             |
+| --------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| Product goals and IA                          | `target`     | Program export choices and output models stay aligned with the canonical program model and future Garmin-ready direction.    | adapter contract + UX notes          |
+| UX flow clarity                               | `target`     | User can export a canonical program in <= 30 seconds with clear status, ordering, and actionable failure guidance.           | e2e/manual QA                        |
+| Visual design quality                         | `supporting` | Supporting only: program PDF/export presentation should feel consistent with the shipped workout-level export surfaces.      | PDF QA + scope rationale             |
+| Business logic correctness and data integrity | `target`     | Program export output is deterministic for the same canonical input and never mutates source program/workout identity/state. | contract tests                       |
+| Admin editor ergonomics                       | `supporting` | Supporting only: no primary admin editing workflow is introduced in this program-export slice.                               | scope rationale                      |
+| Accessibility (a11y)                          | `supporting` | Supporting only: export controls and status messaging must remain accessible on changed UI surfaces.                         | scope rationale + QA                 |
+| Performance (CWV + payloads)                  | `supporting` | Program export action stays responsive and non-blocking with no obvious route regression.                                    | perf checks                          |
+| Data placement and sync boundaries            | `target`     | Program export is explicitly read-only against canonical program state, with output metadata ownership documented.           | data contract + integration tests    |
+| Caching and invalidation strategy             | `supporting` | Supporting only: canonical program changes invalidate stale export previews deterministically.                               | cache notes + scope rationale        |
+| Reliability and failure handling              | `target`     | Unsupported or failed program exports surface retry/recover guidance without corrupting canonical data.                      | negative-path tests + e2e            |
+| Security and authz                            | `supporting` | Supporting only: protected export endpoints/downloads must remain authenticated and fail closed where required.              | auth review + scope rationale        |
+| Privacy and compliance                        | `supporting` | Supporting only: exported content must not leak unrelated sensitive account data.                                            | payload review + scope rationale     |
+| Content governance                            | `supporting` | Supporting only: canonical program governance belongs upstream, but export must honor it.                                    | linked brief + scope rationale       |
+| Admin workflow and editability                | `supporting` | Supporting only: no primary admin workflow change beyond possible later export diagnostics.                                  | scope rationale                      |
+| SEO and crawlability                          | `supporting` | Supporting only: export output is not a primary public crawl surface in this slice.                                          | scope rationale                      |
+| AI discoverability                            | `supporting` | Supporting only: adapter outputs are not the primary AI-discoverability mechanism.                                           | scope rationale                      |
+| Analytics and KPI observability               | `supporting` | Supporting only: export usage/failure events should remain available with stable canonical references.                       | event notes + scope rationale        |
+| Commerce and revenue ops                      | `supporting` | Supporting only: no direct commerce mutation, though export value proposition may support future offers.                     | scope rationale                      |
+| Incident response and support operations      | `supporting` | Supporting only: export failures need operator-readable diagnostics and support guidance.                                    | runbook note + scope rationale       |
+| Finance and reporting operations              | `supporting` | Supporting only: no finance/reporting mutation in this export-only slice.                                                    | scope rationale                      |
+| i18n operational readiness                    | `supporting` | Supporting only: exported labels/copy should remain locale-extensible later.                                                 | copy review + scope rationale        |
+| Stack-fit and dependency discipline           | `supporting` | Supporting only: prefer stack-native export patterns before adding heavy adapter dependencies.                               | dependency review                    |
+| Testing and QA automation                     | `target`     | Program adapter contract tests and key export-flow coverage pass before merge.                                               | tests + verify outputs               |
+| Scalability and cost efficiency               | `supporting` | Supporting only: export generation should avoid obvious cost spikes for repeated/download-heavy usage.                       | perf/cost notes + scope rationale    |
+| DevOps and rollback readiness                 | `target`     | Program export changes stay isolated from canonical schema writes and remain easy to disable or roll back.                   | code/test review + release checklist |
+
+## Acceptance Criteria
+
+- Program export renders consistently and readably in printable form.
+- Program export preserves deterministic nested workout ordering and canonical identity.
+- Garmin-ready program export produces truthful mapped payload structure for future Training API submission.
+- Unsupported program/export combinations fail with actionable errors instead of silent coercion.
+- Workout-level exports remain intact after program-export changes.
+- Brief is scorecard-complete and identity-safe before implementation starts.
+
+## Validation
+
+- program export adapter contract tests
+- program PDF rendering checks (where stable)
+- targeted builder/program export e2e coverage
+- `npm run lint:briefs`
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Help/Guide And Operator Training Contract
+
+- `N/A` for this follow-up unless the eventual program export UI introduces a new non-self-explanatory operator/admin workflow outside the existing user-side program surfaces.
+
+## Checkpoint Log
+
+- `2026-03-25 | planning | created residual follow-up after workout-level Garmin-ready JSON export merged as \`2c4fcd8\` and workout PDF print export merged as \`e938560\`; remaining open scope is canonical program-level export structure and printable output, while live Garmin partner delivery remains separately blocked | next: implement program export adapters from updated \`main\` without reopening the shipped workout-level export slice`


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-03-25T14:57:55.632Z for branch `docs/workout-export-closeout-2026-03-25` (base ref `origin/main`).
- Latest commit: `e548d85` - docs(workouts): close workout export brief.
- User-visible changes: No direct end-user/admin runtime behavior change; this PR improves docs/tooling/governance workflow quality.
- Technical changes: Updated 2 file(s): `docs/task-briefs/done/2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md`, `docs/task-briefs/planned/2026-03-25-program-export-adapters-garmin-ready-pdf-followup-10-10.md`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/done/2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md`
- Scorecard target outcomes: 7 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (2).
- Out of scope: Application runtime behavior, DB schema, and content payloads remain unchanged.
- Changed files (2):
  - `docs/task-briefs/done/2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md`
  - `docs/task-briefs/planned/2026-03-25-program-export-adapters-garmin-ready-pdf-followup-10-10.md`

## Risk

- Main risk: Operational/docs drift if generated scope/evidence text does not match final merged changes.
- Rollback plan: Revert `e548d85` (`git revert e548d85`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **NOT RUN** (run locally before pushing PR updates).
- `npm run verify:pre-merge`: **PENDING** for `e548d85` (required before merge to `main`).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  - No local verify log found in `artifacts/test-runs/latest`.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
