### PR TITLE
feat(programs): add canonical program shell foundation

### DIFF
--- a/app/api/my-library/programs/[programId]/route.ts
+++ b/app/api/my-library/programs/[programId]/route.ts
@@ -1,0 +1,126 @@
+import { NextResponse } from "next/server";
+import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
+import { isProgramSchemaMissing } from "@/lib/programs/schema";
+import {
+  buildProgramEditorRecord,
+  buildProgramSummary,
+  buildProgramUpdate,
+  PROGRAM_SELECT,
+  validateProgramWorkoutOwnership,
+} from "@/lib/programs/server";
+import type { ProgramSaveApiResponse, ProgramSaveRequestBody } from "@/lib/programs/shared";
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function noStoreJson(
+  body: ProgramSaveApiResponse | Record<string, unknown>,
+  init?: {
+    status?: number;
+  }
+) {
+  return NextResponse.json(body, {
+    status: init?.status ?? 200,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export async function PATCH(
+  request: Request,
+  context: {
+    params: Promise<{
+      programId: string;
+    }>;
+  }
+) {
+  const { programId } = await context.params;
+
+  if (!UUID_PATTERN.test(programId)) {
+    return noStoreJson({ ok: false, error: "Program not found." }, { status: 404 });
+  }
+
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Unauthorized." }, { status: 401 })
+    );
+  }
+
+  let body: ProgramSaveRequestBody;
+  try {
+    body = (await request.json()) as ProgramSaveRequestBody;
+  } catch {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Invalid JSON body." }, { status: 400 })
+    );
+  }
+
+  const ownershipValidation = await validateProgramWorkoutOwnership(supabase, user.id, body);
+  if (!ownershipValidation.ok) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: ownershipValidation.error }, { status: 400 })
+    );
+  }
+
+  let updatePayload;
+  try {
+    updatePayload = buildProgramUpdate(body);
+  } catch (error) {
+    return applySupabaseCookies(
+      noStoreJson(
+        {
+          ok: false,
+          error: error instanceof Error ? error.message : "Could not save program right now.",
+        },
+        { status: 400 }
+      )
+    );
+  }
+
+  const result = await supabase
+    .from("programs")
+    .update(updatePayload)
+    .eq("user_id", user.id)
+    .eq("id", programId)
+    .select(PROGRAM_SELECT)
+    .maybeSingle();
+
+  if (isProgramSchemaMissing(result.error)) {
+    return applySupabaseCookies(
+      noStoreJson(
+        {
+          ok: false,
+          error: "Canonical program save is still syncing in this environment.",
+        },
+        { status: 503 }
+      )
+    );
+  }
+
+  if (result.error) {
+    console.error("[ProgramsApi] Could not save canonical program", result.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not save program right now." }, { status: 500 })
+    );
+  }
+
+  if (!result.data) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Program not found." }, { status: 404 })
+    );
+  }
+
+  const program = buildProgramEditorRecord(result.data);
+  return applySupabaseCookies(
+    noStoreJson({
+      ok: true,
+      program,
+      summary: buildProgramSummary(result.data),
+    })
+  );
+}

--- a/app/api/my-library/programs/route.ts
+++ b/app/api/my-library/programs/route.ts
@@ -1,0 +1,116 @@
+import { NextResponse } from "next/server";
+import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
+import { isProgramSchemaMissing } from "@/lib/programs/schema";
+import {
+  buildProgramEditorRecord,
+  buildProgramInsert,
+  buildProgramSummary,
+  PROGRAM_SELECT,
+  validateProgramWorkoutOwnership,
+} from "@/lib/programs/server";
+import {
+  buildManualProgramStarterState,
+  type ProgramSaveApiResponse,
+  type ProgramSaveRequestBody,
+} from "@/lib/programs/shared";
+
+function noStoreJson(
+  body: ProgramSaveApiResponse | Record<string, unknown>,
+  init?: {
+    status?: number;
+  }
+) {
+  return NextResponse.json(body, {
+    status: init?.status ?? 200,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export async function POST(request: Request) {
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Unauthorized." }, { status: 401 })
+    );
+  }
+
+  let body: ProgramSaveRequestBody | null = null;
+  try {
+    body = (await request.json()) as ProgramSaveRequestBody;
+  } catch {
+    body = null;
+  }
+
+  const starter = buildManualProgramStarterState();
+  const hydratedBody: ProgramSaveRequestBody = {
+    title: body?.title ?? starter.title,
+    weeks: body?.weeks ?? starter.weeks,
+    sourceKind: "manual",
+  };
+
+  const ownershipValidation = await validateProgramWorkoutOwnership(
+    supabase,
+    user.id,
+    hydratedBody
+  );
+  if (!ownershipValidation.ok) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: ownershipValidation.error }, { status: 400 })
+    );
+  }
+
+  let insertPayload;
+  try {
+    insertPayload = buildProgramInsert(user.id, hydratedBody, "manual");
+  } catch (error) {
+    return applySupabaseCookies(
+      noStoreJson(
+        {
+          ok: false,
+          error: error instanceof Error ? error.message : "Could not create program right now.",
+        },
+        { status: 400 }
+      )
+    );
+  }
+
+  const result = await supabase
+    .from("programs")
+    .insert(insertPayload)
+    .select(PROGRAM_SELECT)
+    .single();
+
+  if (isProgramSchemaMissing(result.error)) {
+    return applySupabaseCookies(
+      noStoreJson(
+        {
+          ok: false,
+          error: "Canonical program save is still syncing in this environment.",
+        },
+        { status: 503 }
+      )
+    );
+  }
+
+  if (result.error) {
+    console.error("[ProgramsApi] Could not create canonical program", result.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not create program right now." }, { status: 500 })
+    );
+  }
+
+  const program = buildProgramEditorRecord(result.data);
+  return applySupabaseCookies(
+    noStoreJson({
+      ok: true,
+      program,
+      summary: buildProgramSummary(result.data),
+    })
+  );
+}

--- a/app/my-library/page.tsx
+++ b/app/my-library/page.tsx
@@ -8,6 +8,7 @@ import { signOutFromLibrary } from "@/app/my-library/actions";
 import CheckoutButton from "@/components/my-library/CheckoutButton";
 import ContinueCourseCard from "@/components/my-library/ContinueCourseCard";
 import CreateManualWorkoutButton from "@/components/my-library/workouts/CreateManualWorkoutButton";
+import CreateManualProgramButton from "@/components/my-library/programs/CreateManualProgramButton";
 import LibrarySectionTabs from "@/components/my-library/LibrarySectionTabs";
 import MyLibraryNewContentNotice from "@/components/my-library/MyLibraryNewContentNotice";
 import PortalButton from "@/components/my-library/PortalButton";
@@ -19,6 +20,7 @@ import { createAdminSupabaseClient } from "@/lib/supabase/admin";
 import { loadAthleteProfileSnapshot } from "@/lib/athlete-profile/server";
 import { attachGuestEntitlementsByEmail } from "@/lib/commerce/entitlements";
 import { loadTrainingContextSnapshot } from "@/lib/training-context/server";
+import { loadProgramLibrarySnapshot } from "@/lib/programs/server";
 import { loadWorkoutLibrarySnapshot } from "@/lib/workouts/server";
 
 export const dynamic = "force-dynamic";
@@ -85,12 +87,17 @@ export default async function MyLibraryPage() {
     console.error("[MyLibrary] Could not load active goal count", activeGoalCountError);
   }
 
-  const [trainingContextSnapshot, athleteProfileSnapshot, workoutLibrarySnapshot] =
-    await Promise.all([
-      loadTrainingContextSnapshot(supabase, user.id),
-      loadAthleteProfileSnapshot(supabase, user.id),
-      loadWorkoutLibrarySnapshot(supabase, user.id, null),
-    ]);
+  const [
+    trainingContextSnapshot,
+    athleteProfileSnapshot,
+    workoutLibrarySnapshot,
+    programLibrarySnapshot,
+  ] = await Promise.all([
+    loadTrainingContextSnapshot(supabase, user.id),
+    loadAthleteProfileSnapshot(supabase, user.id),
+    loadWorkoutLibrarySnapshot(supabase, user.id, null),
+    loadProgramLibrarySnapshot(supabase, user.id, null),
+  ]);
 
   const claimQuery = new URLSearchParams({ next: "/my-library" });
   if (user.email) {
@@ -178,6 +185,42 @@ export default async function MyLibraryPage() {
                 >
                   Open training setup
                 </Link>
+              </div>
+            </section>
+            <section className="rounded-2xl border border-slate-200 bg-white p-5">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-lg font-semibold text-slate-900">Program shell</h2>
+                  <p className="mt-2 text-sm text-slate-600">
+                    {!programLibrarySnapshot.schemaReady
+                      ? "This canonical program layer is still syncing in this environment."
+                      : programLibrarySnapshot.recentPrograms[0]
+                        ? [
+                            programLibrarySnapshot.recentPrograms[0].title,
+                            `${programLibrarySnapshot.recentPrograms[0].weekCount} week${programLibrarySnapshot.recentPrograms[0].weekCount === 1 ? "" : "s"}`,
+                            `${programLibrarySnapshot.recentPrograms[0].assignmentCount} scheduled workout${programLibrarySnapshot.recentPrograms[0].assignmentCount === 1 ? "" : "s"}`,
+                          ]
+                            .filter(Boolean)
+                            .join(" · ")
+                        : "Create your first saved program shell and place accepted workouts into week/day slots before richer planner and export slices arrive."}
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {programLibrarySnapshot.recentPrograms[0] ? (
+                    <Link
+                      href={`/my-library/programs/${programLibrarySnapshot.recentPrograms[0].id}`}
+                      className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+                    >
+                      Open program shell
+                    </Link>
+                  ) : null}
+                  {programLibrarySnapshot.schemaReady ? (
+                    <CreateManualProgramButton
+                      testId="my-library-create-manual-program"
+                      className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+                    />
+                  ) : null}
+                </div>
               </div>
             </section>
             <section className="rounded-2xl border border-slate-200 bg-white p-5">

--- a/app/my-library/programs/[programId]/page.tsx
+++ b/app/my-library/programs/[programId]/page.tsx
@@ -1,0 +1,70 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import SiteChrome from "@/components/SiteChrome";
+import ProgramBuilderHub from "@/components/my-library/programs/ProgramBuilderHub";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { loadProgramLibrarySnapshot } from "@/lib/programs/server";
+
+export const dynamic = "force-dynamic";
+
+type Params = Promise<{
+  programId: string;
+}>;
+
+type Props = {
+  params: Params;
+};
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export default async function ProgramBuilderPage({ params }: Props) {
+  const { programId } = await params;
+
+  if (!UUID_PATTERN.test(programId)) {
+    notFound();
+  }
+
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(`/auth/sign-in?next=${encodeURIComponent(`/my-library/programs/${programId}`)}`);
+  }
+
+  const programLibrary = await loadProgramLibrarySnapshot(supabase, user.id, programId);
+
+  return (
+    <SiteChrome>
+      <section className="mx-auto min-h-screen w-full max-w-[1120px] px-6 pb-20 pt-28">
+        <div className="rounded-3xl border border-blue-100 bg-white/95 p-8 shadow-[0_16px_60px_rgba(24,58,107,0.14)]">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
+                My Library
+              </p>
+              <h1 className="mt-2 text-3xl font-bold text-slate-900">Program shell</h1>
+              <p className="mt-2 max-w-[68ch] text-sm text-slate-600">
+                Open one saved program in its own route, place accepted workouts into week/day
+                slots, and keep the canonical program ready for later planner and export slices.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Link
+                href="/my-library"
+                className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+              >
+                Back to My Library
+              </Link>
+            </div>
+          </div>
+
+          <div className="mt-8">
+            <ProgramBuilderHub programLibrary={programLibrary} />
+          </div>
+        </div>
+      </section>
+    </SiteChrome>
+  );
+}

--- a/components/my-library/programs/CreateManualProgramButton.tsx
+++ b/components/my-library/programs/CreateManualProgramButton.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { ProgramSaveApiResponse } from "@/lib/programs/shared";
+
+type Props = {
+  label?: string;
+  pendingLabel?: string;
+  className?: string;
+  testId?: string;
+};
+
+export default function CreateManualProgramButton({
+  label = "Create program shell",
+  pendingLabel = "Creating program shell...",
+  className = "",
+  testId = "create-manual-program",
+}: Props) {
+  const router = useRouter();
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleCreate() {
+    setIsCreating(true);
+    setError("");
+
+    try {
+      const response = await fetch("/api/my-library/programs", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      });
+      const responseBody = (await response
+        .json()
+        .catch(() => null)) as ProgramSaveApiResponse | null;
+
+      if (!response.ok || !responseBody?.ok) {
+        setError(
+          responseBody && !responseBody.ok ? responseBody.error : "Could not create program."
+        );
+        return;
+      }
+
+      router.push(`/my-library/programs/${responseBody.program.id}`);
+      router.refresh();
+    } catch {
+      setError("Could not create program.");
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        data-testid={testId}
+        onClick={handleCreate}
+        disabled={isCreating}
+        className={className}
+      >
+        {isCreating ? pendingLabel : label}
+      </button>
+      {error ? (
+        <p data-testid={`${testId}-error`} className="text-sm text-rose-700">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/components/my-library/programs/ProgramBuilderHub.tsx
+++ b/components/my-library/programs/ProgramBuilderHub.tsx
@@ -1,0 +1,556 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import CreateManualProgramButton from "@/components/my-library/programs/CreateManualProgramButton";
+import {
+  PROGRAM_WEEKDAY_LABELS,
+  buildProgramWeekdayGroups,
+  createProgramEntityId,
+  haveProgramDraftChanges,
+  type ProgramAssignment,
+  type ProgramEditorRecord,
+  type ProgramLibrarySnapshot,
+  type ProgramSaveApiResponse,
+  type ProgramSummary,
+} from "@/lib/programs/shared";
+
+type Props = {
+  programLibrary: ProgramLibrarySnapshot;
+};
+
+function upsertRecentProgramSummary(current: ProgramSummary[], next: ProgramSummary) {
+  const existing = current.filter((summary) => summary.id !== next.id);
+  return [next, ...existing].slice(0, 6);
+}
+
+function reindexAssignments(assignments: ProgramAssignment[]) {
+  return PROGRAM_WEEKDAY_LABELS.flatMap((_, dayIndex) =>
+    assignments
+      .filter((assignment) => assignment.dayIndex === dayIndex)
+      .sort((left, right) => left.position - right.position)
+      .map((assignment, position) => ({
+        ...assignment,
+        position,
+      }))
+  );
+}
+
+export default function ProgramBuilderHub({ programLibrary }: Props) {
+  const [savedProgram, setSavedProgram] = useState<ProgramEditorRecord | null>(
+    programLibrary.selectedProgram
+  );
+  const [draftTitle, setDraftTitle] = useState(programLibrary.selectedProgram?.title ?? "");
+  const [draftWeeks, setDraftWeeks] = useState(programLibrary.selectedProgram?.weeks ?? []);
+  const [recentPrograms, setRecentPrograms] = useState(programLibrary.recentPrograms);
+  const [availableWorkouts, setAvailableWorkouts] = useState(programLibrary.availableWorkouts);
+  const [missingWorkoutIds, setMissingWorkoutIds] = useState(programLibrary.missingWorkoutIds);
+  const [pickerSelections, setPickerSelections] = useState<Record<string, string>>({});
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [clientReady, setClientReady] = useState(false);
+  const hasUnsavedChanges = haveProgramDraftChanges(
+    savedProgram ? { title: draftTitle, weeks: draftWeeks } : null,
+    savedProgram ? { title: savedProgram.title, weeks: savedProgram.weeks } : null
+  );
+
+  useEffect(() => {
+    setClientReady(true);
+  }, []);
+
+  useEffect(() => {
+    setSavedProgram(programLibrary.selectedProgram);
+    setDraftTitle(programLibrary.selectedProgram?.title ?? "");
+    setDraftWeeks(programLibrary.selectedProgram?.weeks ?? []);
+    setRecentPrograms(programLibrary.recentPrograms);
+    setAvailableWorkouts(programLibrary.availableWorkouts);
+    setMissingWorkoutIds(programLibrary.missingWorkoutIds);
+    setPickerSelections({});
+    setError("");
+    setSuccess("");
+  }, [programLibrary]);
+
+  const workoutLookup = useMemo(
+    () => new Map(availableWorkouts.map((workout) => [workout.id, workout])),
+    [availableWorkouts]
+  );
+
+  async function saveProgram() {
+    if (!savedProgram) return;
+
+    setIsSaving(true);
+    setError("");
+    setSuccess("");
+
+    try {
+      const response = await fetch(`/api/my-library/programs/${savedProgram.id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          title: draftTitle,
+          weeks: draftWeeks,
+        }),
+      });
+      const responseBody = (await response
+        .json()
+        .catch(() => null)) as ProgramSaveApiResponse | null;
+      const responseError =
+        responseBody && !responseBody.ok ? responseBody.error : "Could not save program right now.";
+
+      if (!response.ok || !responseBody?.ok) {
+        setError(responseError);
+        return;
+      }
+
+      setSavedProgram(responseBody.program);
+      setDraftTitle(responseBody.program.title);
+      setDraftWeeks(responseBody.program.weeks);
+      setRecentPrograms((current) => upsertRecentProgramSummary(current, responseBody.summary));
+      setSuccess("Program changes saved to the canonical program.");
+    } catch {
+      setError("Could not save program right now.");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  function resetDraftToSavedProgram() {
+    if (!savedProgram) return;
+
+    setDraftTitle(savedProgram.title);
+    setDraftWeeks(savedProgram.weeks);
+    setPickerSelections({});
+    setError("");
+    setSuccess("Unsaved program changes were reset to the last saved program.");
+  }
+
+  function setWeekAssignments(
+    weekId: string,
+    updater: (assignments: ProgramAssignment[]) => ProgramAssignment[]
+  ) {
+    setDraftWeeks((current) =>
+      current.map((week) =>
+        week.id === weekId
+          ? {
+              ...week,
+              assignments: reindexAssignments(updater(week.assignments)),
+            }
+          : week
+      )
+    );
+    setSuccess("");
+    setError("");
+  }
+
+  function addAssignment(weekId: string, dayIndex: number) {
+    const pickerKey = `${weekId}-${dayIndex}`;
+    const workoutId = pickerSelections[pickerKey];
+    if (!workoutId) return;
+
+    setWeekAssignments(weekId, (assignments) => {
+      const nextPosition = assignments.filter(
+        (assignment) => assignment.dayIndex === dayIndex
+      ).length;
+      return [
+        ...assignments,
+        {
+          id: createProgramEntityId(),
+          workoutId,
+          dayIndex,
+          position: nextPosition,
+        },
+      ];
+    });
+    setPickerSelections((current) => ({
+      ...current,
+      [pickerKey]: "",
+    }));
+  }
+
+  function removeAssignment(weekId: string, assignmentId: string) {
+    setWeekAssignments(weekId, (assignments) =>
+      assignments.filter((assignment) => assignment.id !== assignmentId)
+    );
+  }
+
+  function moveAssignmentDay(weekId: string, assignmentId: string, nextDayIndex: number) {
+    setWeekAssignments(weekId, (assignments) =>
+      assignments.map((assignment) =>
+        assignment.id === assignmentId ? { ...assignment, dayIndex: nextDayIndex } : assignment
+      )
+    );
+  }
+
+  function moveAssignmentPosition(weekId: string, assignmentId: string, direction: -1 | 1) {
+    setWeekAssignments(weekId, (assignments) => {
+      const target = assignments.find((assignment) => assignment.id === assignmentId);
+      if (!target) return assignments;
+
+      const dayAssignments = assignments
+        .filter((assignment) => assignment.dayIndex === target.dayIndex)
+        .sort((left, right) => left.position - right.position);
+      const targetIndex = dayAssignments.findIndex((assignment) => assignment.id === assignmentId);
+      const swapIndex = targetIndex + direction;
+
+      if (targetIndex < 0 || swapIndex < 0 || swapIndex >= dayAssignments.length) {
+        return assignments;
+      }
+
+      const nextDayAssignments = [...dayAssignments];
+      [nextDayAssignments[targetIndex], nextDayAssignments[swapIndex]] = [
+        nextDayAssignments[swapIndex],
+        nextDayAssignments[targetIndex],
+      ];
+
+      const otherAssignments = assignments.filter(
+        (assignment) => assignment.dayIndex !== target.dayIndex
+      );
+      return [...otherAssignments, ...nextDayAssignments];
+    });
+  }
+
+  return (
+    <section
+      data-testid="program-builder-hub"
+      data-client-ready={clientReady ? "true" : "false"}
+      className="rounded-2xl border border-slate-200 bg-white p-5"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Program shell</h2>
+          <p className="mt-2 max-w-[66ch] text-sm text-slate-600">
+            Save a canonical program shell, place accepted workouts into week/day slots, and keep
+            one shared program surface ready for later planner and export work.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {programLibrary.schemaReady ? (
+            <CreateManualProgramButton
+              testId="program-builder-create-manual"
+              className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+            />
+          ) : null}
+          <p className="rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">
+            Canonical program
+          </p>
+        </div>
+      </div>
+
+      {!programLibrary.schemaReady ? (
+        <div className="mt-5 rounded-2xl border border-amber-200 bg-amber-50/80 p-4">
+          <p className="text-sm text-amber-900">
+            Canonical program save is still syncing in this environment. Come back once the programs
+            table is live to build saved program shells here.
+          </p>
+        </div>
+      ) : null}
+
+      {programLibrary.loadError ? (
+        <div className="mt-5 rounded-2xl border border-rose-200 bg-rose-50/80 p-4">
+          <p className="text-sm text-rose-900">{programLibrary.loadError}</p>
+        </div>
+      ) : null}
+
+      {missingWorkoutIds.length > 0 ? (
+        <div className="mt-5 rounded-2xl border border-amber-200 bg-amber-50/80 p-4">
+          <p className="text-sm text-amber-900">
+            {missingWorkoutIds.length === 1
+              ? "One scheduled workout could not be loaded for this account."
+              : `${missingWorkoutIds.length} scheduled workouts could not be loaded for this account.`}
+          </p>
+        </div>
+      ) : null}
+
+      {error ? (
+        <div className="mt-5 rounded-2xl border border-rose-200 bg-rose-50/80 p-4">
+          <p className="text-sm text-rose-900">{error}</p>
+        </div>
+      ) : null}
+
+      {success ? (
+        <div className="mt-5 rounded-2xl border border-emerald-200 bg-emerald-50/80 p-4">
+          <p className="text-sm text-emerald-900">{success}</p>
+        </div>
+      ) : null}
+
+      {!savedProgram ? (
+        <div className="mt-6 space-y-5">
+          <div className="rounded-2xl border border-amber-200 bg-amber-50/80 p-4">
+            <p className="text-sm font-medium text-amber-900">
+              {programLibrary.selectedProgramMissing
+                ? "That saved program could not be found."
+                : "No canonical program is loaded in this route."}
+            </p>
+            <p className="mt-2 text-sm text-amber-900/90">
+              Create a starter program here, return to My Library, or reopen another saved program
+              below.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              {programLibrary.schemaReady ? (
+                <CreateManualProgramButton
+                  testId="program-builder-empty-create-manual"
+                  className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+                />
+              ) : null}
+              <Link
+                href="/my-library"
+                className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+              >
+                Back to My Library
+              </Link>
+            </div>
+          </div>
+
+          {recentPrograms.length > 0 ? (
+            <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+              <h3 className="text-sm font-semibold text-slate-900">Recent saved programs</h3>
+              <p className="mt-1 text-sm text-slate-600">
+                Reopen another canonical program shell directly in this route.
+              </p>
+              <div className="mt-4 grid gap-3">
+                {recentPrograms.map((program) => (
+                  <div
+                    key={program.id}
+                    className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-white/80 bg-white p-3"
+                  >
+                    <div>
+                      <p className="text-sm font-semibold text-slate-900">{program.title}</p>
+                      <p className="mt-1 text-sm text-slate-600">
+                        {program.weekCount} week{program.weekCount === 1 ? "" : "s"} ·{" "}
+                        {program.assignmentCount} scheduled workout
+                        {program.assignmentCount === 1 ? "" : "s"}
+                      </p>
+                    </div>
+                    <Link
+                      href={`/my-library/programs/${program.id}`}
+                      data-testid={`program-builder-open-program-${program.id}`}
+                      className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+                    >
+                      Open
+                    </Link>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {savedProgram ? (
+        <div className="mt-6 space-y-6">
+          <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="max-w-[48rem]">
+                <label
+                  htmlFor="program-draft-title"
+                  className="text-xs font-semibold uppercase tracking-wide text-slate-500"
+                >
+                  Program title
+                </label>
+                <input
+                  id="program-draft-title"
+                  data-testid="program-draft-title"
+                  type="text"
+                  value={draftTitle}
+                  onChange={(event) => {
+                    setDraftTitle(event.target.value);
+                    setSuccess("");
+                  }}
+                  className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm outline-none transition focus:border-blue-400 focus:ring-2 focus:ring-blue-200"
+                />
+                <p data-testid="program-editor-save-state" className="mt-3 text-sm text-slate-600">
+                  {hasUnsavedChanges
+                    ? "Unsaved changes stay local until you save this program."
+                    : "All program changes are saved to the canonical program."}
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  data-testid="program-editor-reset"
+                  onClick={resetDraftToSavedProgram}
+                  disabled={!hasUnsavedChanges || isSaving}
+                  className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Reset
+                </button>
+                <button
+                  type="button"
+                  data-testid="program-builder-save"
+                  onClick={saveProgram}
+                  disabled={!hasUnsavedChanges || isSaving}
+                  className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+                >
+                  {isSaving ? "Saving..." : "Save program"}
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {draftWeeks.map((week, weekIndex) => {
+            const days = buildProgramWeekdayGroups(week);
+            return (
+              <section
+                key={week.id}
+                data-testid={`program-week-${weekIndex}`}
+                className="rounded-2xl border border-slate-200 bg-white p-4"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <h3 className="text-base font-semibold text-slate-900">{week.label}</h3>
+                    <p className="mt-1 text-sm text-slate-600">
+                      Place accepted workouts into day slots. This first program slice keeps the
+                      shell simple and canonical.
+                    </p>
+                  </div>
+                  <p className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600">
+                    {week.assignments.length} scheduled
+                  </p>
+                </div>
+
+                <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-7">
+                  {PROGRAM_WEEKDAY_LABELS.map((dayLabel, dayIndex) => {
+                    const pickerKey = `${week.id}-${dayIndex}`;
+                    const dayAssignments = days[dayIndex];
+
+                    return (
+                      <div
+                        key={dayLabel}
+                        className="rounded-2xl border border-slate-200 bg-slate-50/70 p-3"
+                      >
+                        <p className="text-sm font-semibold text-slate-900">{dayLabel}</p>
+                        <div className="mt-3 flex flex-col gap-2">
+                          <select
+                            data-testid={`program-day-picker-week-${weekIndex}-day-${dayIndex}`}
+                            value={pickerSelections[pickerKey] ?? ""}
+                            onChange={(event) =>
+                              setPickerSelections((current) => ({
+                                ...current,
+                                [pickerKey]: event.target.value,
+                              }))
+                            }
+                            className="rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900"
+                          >
+                            <option value="">Choose workout</option>
+                            {availableWorkouts.map((workout) => (
+                              <option key={workout.id} value={workout.id}>
+                                {workout.title}
+                              </option>
+                            ))}
+                          </select>
+                          <button
+                            type="button"
+                            data-testid={`program-day-add-week-${weekIndex}-day-${dayIndex}`}
+                            onClick={() => addAssignment(week.id, dayIndex)}
+                            disabled={!pickerSelections[pickerKey]}
+                            className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm font-medium text-blue-700 transition hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-60"
+                          >
+                            Add workout
+                          </button>
+                        </div>
+
+                        {dayAssignments.length === 0 ? (
+                          <p className="mt-3 text-sm text-slate-500">No workout scheduled.</p>
+                        ) : (
+                          <div className="mt-3 space-y-2">
+                            {dayAssignments.map((assignment, assignmentIndex) => {
+                              const workout = workoutLookup.get(assignment.workoutId);
+                              return (
+                                <div
+                                  key={assignment.id}
+                                  className="rounded-xl border border-white bg-white p-3 shadow-sm"
+                                >
+                                  <p className="text-sm font-medium text-slate-900">
+                                    {workout?.title ?? "Missing workout reference"}
+                                  </p>
+                                  <p className="mt-1 text-xs text-slate-500">
+                                    {workout
+                                      ? [
+                                          workout.totalDistanceM
+                                            ? `${workout.totalDistanceM}m`
+                                            : null,
+                                          workout.estimatedDurationMin
+                                            ? `~${workout.estimatedDurationMin} min`
+                                            : null,
+                                        ]
+                                          .filter(Boolean)
+                                          .join(" · ")
+                                      : assignment.workoutId}
+                                  </p>
+
+                                  <div className="mt-3 space-y-2">
+                                    <label className="block text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                      Move to day
+                                    </label>
+                                    <select
+                                      data-testid={`program-assignment-day-${assignment.id}`}
+                                      value={String(assignment.dayIndex)}
+                                      onChange={(event) =>
+                                        moveAssignmentDay(
+                                          week.id,
+                                          assignment.id,
+                                          Number(event.target.value)
+                                        )
+                                      }
+                                      className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900"
+                                    >
+                                      {PROGRAM_WEEKDAY_LABELS.map((label, optionDayIndex) => (
+                                        <option key={label} value={optionDayIndex}>
+                                          {label}
+                                        </option>
+                                      ))}
+                                    </select>
+                                  </div>
+
+                                  <div className="mt-3 flex flex-wrap gap-2">
+                                    <button
+                                      type="button"
+                                      data-testid={`program-assignment-up-${assignment.id}`}
+                                      disabled={assignmentIndex === 0}
+                                      onClick={() =>
+                                        moveAssignmentPosition(week.id, assignment.id, -1)
+                                      }
+                                      className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                                    >
+                                      Move up
+                                    </button>
+                                    <button
+                                      type="button"
+                                      data-testid={`program-assignment-down-${assignment.id}`}
+                                      disabled={assignmentIndex === dayAssignments.length - 1}
+                                      onClick={() =>
+                                        moveAssignmentPosition(week.id, assignment.id, 1)
+                                      }
+                                      className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                                    >
+                                      Move down
+                                    </button>
+                                    <button
+                                      type="button"
+                                      data-testid={`program-assignment-remove-${assignment.id}`}
+                                      onClick={() => removeAssignment(week.id, assignment.id)}
+                                      className="inline-flex h-9 items-center justify-center rounded-lg border border-rose-200 bg-white px-3 text-sm text-rose-700 transition hover:bg-rose-50"
+                                    >
+                                      Remove
+                                    </button>
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/docs/task-briefs/blocked/2026-03-25-program-export-adapters-garmin-ready-pdf-followup-10-10.md
+++ b/docs/task-briefs/blocked/2026-03-25-program-export-adapters-garmin-ready-pdf-followup-10-10.md
@@ -26,6 +26,8 @@ Build the remaining program-level export adapters so canonical programs can prod
   - `docs/task-briefs/planned/2026-02-28-workout-data-contract-and-step-engine-10-10.md`
 - Upstream program builder/calendar contract:
   - `docs/task-briefs/planned/2026-02-28-program-builder-calendar-completion-10-10.md`
+- Immediate unblocking foundation:
+  - `docs/task-briefs/in-progress/2026-03-25-canonical-program-foundation-and-library-shell-10-10.md`
 - Blocked live Garmin provider delivery remains separate:
   - `docs/task-briefs/blocked/2026-02-28-garmin-training-api-partner-integration-10-10.md`
 - This follow-up owns:
@@ -150,3 +152,4 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 
 - `2026-03-25 | planning | created residual follow-up after workout-level Garmin-ready JSON export merged as \`2c4fcd8\` and workout PDF print export merged as \`e938560\`; remaining open scope is canonical program-level export structure and printable output, while live Garmin partner delivery remains separately blocked | next: implement program export adapters from updated \`main\` without reopening the shipped workout-level export slice`
 - `2026-03-25 | blocked | reconfirmed before implementation that program generation still shows \`session-generator-program-deferred\` in the UI, the session-draft API returns \`Program generation stays deferred\`, and the repo still has no canonical \`/api/my-library/programs\` surface or program editor/model to export from | next: unblock via the upstream program-builder/calendar completion track or a smaller canonical-program foundation slice before reopening program export`
+- `2026-03-25 | blocked | after blocker PR #292 merged as \`6047d26\`, created the narrower upstream brief \`docs/task-briefs/in-progress/2026-03-25-canonical-program-foundation-and-library-shell-10-10.md\` so export can stay blocked truthfully on missing canonical program entities while implementation resumes on the smallest shared foundation instead of the full planner scope | next: reopen this export brief only after the canonical foundation ships and a real program surface exists`

--- a/docs/task-briefs/in-progress/2026-03-25-canonical-program-foundation-and-library-shell-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-25-canonical-program-foundation-and-library-shell-10-10.md
@@ -1,0 +1,171 @@
+# Task Brief: Canonical Program Foundation And Library Shell (10/10)
+
+## Metadata
+
+- `id`: `2026-03-25-canonical-program-foundation-and-library-shell-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-03-25`
+- `updated`: `2026-03-25`
+
+## Goal
+
+Introduce a canonical user-owned program entity, persistence model, and minimal My Library program shell so later planner, AI save, and export work all target one identity-safe program surface.
+
+## Why This Brief Exists
+
+- The program export follow-up is truthfully blocked because the repo still had no canonical `program` entity, `/api/my-library/programs` surface, or editable program route.
+- The existing manual planner brief is intentionally broader than the smallest safe unblocking step; it also owns later completion/history handoff and richer planner UX.
+- The repo already has canonical workouts, so the next smallest useful slice is to persist programs as first-class entities that reference those workouts instead of inventing parallel export-only or AI-only shapes.
+- This brief creates the minimum stable program foundation that later planner, export, and AI acceptance slices can share without forking identity, storage, or schedule semantics.
+
+## Dependencies And Boundaries
+
+- Upstream canonical workout foundation already exists in code and remains the source of truth for referenced workout payloads.
+- Broader downstream planner/completion scope remains in:
+  - `docs/task-briefs/planned/2026-02-28-program-builder-calendar-completion-10-10.md`
+- Downstream export work remains blocked in:
+  - `docs/task-briefs/blocked/2026-03-25-program-export-adapters-garmin-ready-pdf-followup-10-10.md`
+- AI generation guardrails remain separate in:
+  - `docs/task-briefs/planned/2026-02-28-ai-plan-generator-json-guardrails-10-10.md`
+- This brief owns:
+  - canonical persisted `program` rows with stable nested week and assignment identities inside the stored `weeks` payload,
+  - user-owned read/write API surface for program shells,
+  - minimal My Library route/UI to create, open, title, and schedule referenced workouts into weeks/days,
+  - invariant enforcement for stable identity and workout references.
+- This brief does not own:
+  - AI-authored multi-week plan generation,
+  - planner completion/cancel/history truth,
+  - rich weekly metrics/adherence summaries,
+  - Garmin-ready or PDF export output,
+  - marketing `/programs` page redesign.
+
+## Scope
+
+- Persistence and schema:
+  - canonical `programs` table with stable program identity and user ownership,
+  - atomic `weeks` JSON payload with immutable week + assignment IDs,
+  - update-safe save contract that avoids partial multi-table writes in this first slice.
+- Program server contract:
+  - typed shared program models for editor + summary payloads,
+  - loader/normalizer utilities,
+  - deterministic validation for week/day placement, referenced workouts, and ordering.
+- Protected user API:
+  - create manual starter program shell,
+  - load selected program,
+  - save title/week/day assignment edits for the authenticated owner.
+- My Library user surfaces:
+  - program entry point on `/my-library`,
+  - dedicated `/my-library/programs/[programId]` route,
+  - minimal editor shell to title a program and assign existing canonical workouts into week/day cells.
+
+## Out Of Scope
+
+- AI program generation UX or save flows.
+- Completion, cancellation, comments, adherence, or retrospective training-history state.
+- Program summary analytics beyond the minimum required to render the shell safely.
+- Export buttons, Garmin-ready payloads, printable PDF flows, or provider delivery.
+- Public marketing/waitlist changes on `/programs`.
+
+## Data Placement And Sync Contract (Required)
+
+- Server-canonical:
+  - canonical `program` rows,
+  - nested week/assignment objects inside the stored `weeks` payload,
+  - assignment ordering, day placement, and referenced `workout_id` values,
+  - persisted program title and metadata needed to reopen the same shell later.
+- Local-only:
+  - unsaved editor draft mutations before explicit save,
+  - temporary workout picker/query state,
+  - optimistic UI state for non-destructive assignment edits.
+- Sync behavior:
+  - server remains source of truth for persisted program structure,
+  - save endpoints must validate referenced workouts belong to the same authenticated owner,
+  - optimistic updates are allowed only when they can be deterministically rolled back from canonical response,
+  - stale or conflicting writes must fail with explicit recoverable guidance rather than silently reordering/mutating canonical assignments.
+- Retention and sensitivity:
+  - program records are user-owned training planning data and must delete with the owning account,
+  - no unrelated profile/goals/history/comment payloads should be embedded into program rows.
+- Cache/invalidation:
+  - any program mutation invalidates recent-program summaries and the selected program route,
+  - any deleted or missing referenced workout must surface an explicit invalid-reference state rather than being silently dropped.
+
+## Identity And Rename Contract
+
+- Canonical stable IDs:
+  - `program.id` plus nested `week.id` and `assignment.id` values are immutable canonical identifiers used across persistence, planner, export, and future AI acceptance flows.
+- Human-readable identifiers:
+  - program title is editable presentation text,
+  - week labels and day placement are presentation/scheduling metadata and must never be treated as identity.
+- Mutability rules:
+  - moving an assignment between week/day positions or reordering within a day must preserve the same `assignment.id`,
+  - renaming a program must preserve the same `program.id`,
+  - changing the referenced `workout_id` on an assignment is allowed only when the assignment still represents the same scheduled slot rather than a historical completed record.
+- Rename vs repurpose:
+  - retitling or rescheduling within the same plan is an in-place edit,
+  - materially replacing an entire training plan should create a new `program` entity instead of overwriting one plan into a different one.
+- Compatibility contract:
+  - later export, planner, and AI save flows must resolve program structures by canonical IDs and may not infer identity from titles, week numbers, or workout names,
+  - legacy absence of canonical programs is handled by empty-state/create flow rather than aliasing the public `/programs` page.
+- Observability and repair:
+  - unresolved referenced workouts, duplicate day-order collisions, and orphaned week/assignment reads must be detected deterministically and surfaced in logs plus user-facing recovery copy.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+| Category                                      | Mapping      | Target Threshold                                                                                                                                   | Evidence                             |
+| --------------------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| Product goals and IA                          | `target`     | Signed-in users can create/open one canonical program shell from My Library and understand that workouts are being scheduled into a saved program. | e2e journey + UI copy review         |
+| UX flow clarity                               | `target`     | User can create a starter program and place at least one saved workout into a week/day slot in <= 3 minutes without documentation.                 | timed manual QA + e2e                |
+| Visual design quality                         | `supporting` | Supporting only: the program shell should match existing My Library/workout-builder language without introducing a new visual system.              | UI QA + scope rationale              |
+| Business logic correctness and data integrity | `target`     | No duplicate/orphan week or assignment identities after retries/reorders; assignment references always point to owner-visible workouts.            | unit/integration invariants          |
+| Admin editor ergonomics                       | `supporting` | Supporting only: this slice changes end-user My Library flows, not primary admin editing surfaces.                                                 | scope rationale                      |
+| Accessibility (a11y)                          | `target`     | Keyboard users can create/open a program shell, assign workouts, and save edits with no critical accessibility violations on changed routes.       | e2e a11y + manual keyboard QA        |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: changed My Library routes should stay within existing route budgets with no obvious payload regression.                           | build/perf review + scope rationale  |
+| Data placement and sync boundaries            | `target`     | Program local-vs-server ownership, conflict behavior, and invalidation rules are explicit and reflected in code/tests.                             | brief contract + integration tests   |
+| Caching and invalidation strategy             | `target`     | Recent-program summaries and selected program route refresh deterministically after save with no stale assignment ordering.                        | integration tests + cache review     |
+| Reliability and failure handling              | `target`     | Missing schema, invalid workout references, and save failures surface actionable recovery without dead-end editor states.                          | negative-path tests + e2e            |
+| Security and authz                            | `target`     | Unauthorized reads/writes fail closed (`401/403`), and cross-user workout/program references are rejected without mutating data.                   | API negative-path tests              |
+| Privacy and compliance                        | `supporting` | Supporting only: program payloads should not leak unrelated notes/history/profile details beyond explicit workout references.                      | payload review + scope rationale     |
+| Content governance                            | `supporting` | Supporting only: canonical workout content remains upstream; this slice preserves references to it.                                                | linked brief + scope rationale       |
+| Admin workflow and editability                | `supporting` | Supporting only: no primary admin workflow change ships in this program foundation slice.                                                          | scope rationale                      |
+| SEO and crawlability                          | `supporting` | Supporting only: authenticated My Library program routes are not public crawl targets.                                                             | scope rationale                      |
+| AI discoverability                            | `supporting` | Supporting only: this slice creates canonical storage for future AI flows but does not publish public AI-discoverable content.                     | scope rationale                      |
+| Analytics and KPI observability               | `supporting` | Supporting only: create/open/save events should remain traceable with canonical program IDs where product already emits library telemetry.         | event review + scope rationale       |
+| Commerce and revenue ops                      | `supporting` | Supporting only: no checkout or entitlement logic changes in this slice.                                                                           | scope rationale                      |
+| Incident response and support operations      | `supporting` | Supporting only: support-visible diagnostics and recovery copy should exist for invalid/missing program references and schema-sync states.         | error contract + scope rationale     |
+| Finance and reporting operations              | `supporting` | Supporting only: no finance/reporting mutation is introduced by canonical program storage.                                                         | scope rationale                      |
+| i18n operational readiness                    | `supporting` | Supporting only: new user-facing labels/copy must remain locale-extensible and avoid hard-coded identity semantics.                                | copy review + scope rationale        |
+| Stack-fit and dependency discipline           | `target`     | Reuse current Next.js/Supabase/TypeScript/test stack and existing workout-library patterns without new dependencies.                               | package diff + architecture review   |
+| Testing and QA automation                     | `target`     | Program server/shared invariants, API negative paths, and one create/open/save user journey are covered in unit+e2e before merge.                  | test matrix + verify outputs         |
+| Scalability and cost efficiency               | `supporting` | Supporting only: program load/save should avoid duplicate queries and unnecessary nested rewrites for small shells.                                | code review + scope rationale        |
+| DevOps and rollback readiness                 | `target`     | Program foundation can be rolled back via isolated schema/API/UI changes without corrupting workouts or export codepaths.                          | migration review + release checklist |
+
+## Acceptance Criteria
+
+- Signed-in users can create a canonical starter program from My Library.
+- Users can reopen a saved program on `/my-library/programs/[programId]`.
+- Users can assign at least one existing canonical workout into a saved week/day slot and persist that assignment.
+- Canonical program, week, and assignment IDs stay stable across rename and reorder/reschedule edits.
+- Unauthorized or cross-user program/workout mutations fail closed without partial writes.
+- Missing schema or invalid referenced workouts show actionable recovery copy instead of empty success states.
+- This foundation leaves planner completion/history and export explicitly for downstream briefs instead of inventing parallel temporary contracts.
+
+## Validation
+
+- `npm run lint:briefs`
+- targeted unit/integration tests for program shared/server/api invariants
+- targeted e2e for create/open/save program shell flow
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Help/Guide And Operator Training Contract
+
+- `N/A` for admin/operator docs because this slice changes user-owned My Library flows only.
+- The shipped UI must still use self-explanatory empty/error/recovery copy; if non-obvious recovery behavior is added, update the relevant My Library/help copy in the same PR.
+
+## Checkpoint Log
+
+- `2026-03-25 | planning | created this narrower upstream slice after PR #292 merged and confirmed that program export is blocked by missing canonical program entity/API/editor surfaces, while the broader planner brief remains intentionally larger than the minimum unblocking step | next: implement schema + API + minimal My Library program shell from updated main without reopening export or completion scope`
+- `2026-03-25 | in-progress | started implementation on branch \`feat/program-foundation-2026-03-25\`, chose one canonical \`programs\` row with stable nested week/assignment IDs inside \`weeks\` JSON so saves stay atomic in the existing Supabase stack, and landed initial schema/shared/API/My Library shell plus targeted program unit coverage green | next: run broader validation, then open PR once \`verify:pre-pr\` is green`

--- a/docs/task-briefs/planned/2026-02-28-program-builder-calendar-completion-10-10.md
+++ b/docs/task-briefs/planned/2026-02-28-program-builder-calendar-completion-10-10.md
@@ -6,7 +6,7 @@
 - `status`: `planned`
 - `owner`: `stianvikra`
 - `created`: `2026-02-28`
-- `updated`: `2026-03-20`
+- `updated`: `2026-03-25`
 
 ## Goal
 
@@ -22,6 +22,9 @@ Enable users to manually turn workouts into clear weekly programs with determini
 - AI-generated session/program creation belongs to a separate generator brief and must not be conflated with this manual planner flow.
 - Accepted AI-generated plans across supported fixed-duration, date-range, and competition-date horizons should still hand off into one editable planner surface after canonical save.
 - Canonical training-history state, manual done/cancel/comments, and Garmin-completed reconciliation belong to a separate history brief and must not be hidden inside planner-only flags.
+- The initial canonical program entity/API/editor foundation is intentionally split into:
+  - `docs/task-briefs/in-progress/2026-03-25-canonical-program-foundation-and-library-shell-10-10.md`
+    so this broader brief can stay focused on richer planner UX, summaries, and completion/history handoff instead of re-owning base persistence.
 
 ## Scope
 
@@ -46,6 +49,7 @@ Enable users to manually turn workouts into clear weekly programs with determini
 - External activity imports.
 - Garmin partner sync.
 - Canonical training-history detail, manual completion/cancel comments, and retrospective evaluation logic.
+- Canonical program persistence bootstrapping that is now owned by the narrower `2026-03-25-canonical-program-foundation-and-library-shell-10-10` brief.
 
 ## Data Placement And Sync Contract (Required)
 
@@ -140,3 +144,4 @@ Reference: `docs/quality/platform-10-10-scorecard.md`
 - `2026-03-19 | planning | clarified product direction that this brief owns manual program building from user-authored workouts, while AI goal-based session/program generation stays in a separate generator brief | next: request owner detail later on how AI-generated plans should hand off into editable builder/program flows`
 - `2026-03-20 | planning | narrowed this brief to the manual program builder and planner-status track, and moved canonical done/cancel/comments/history ownership into a separate training-history brief so scheduling truth and outcome truth stay cleanly separated | next: keep planner UI aligned to canonical history state instead of adding planner-local completion flags`
 - `2026-03-20 | planning | clarified that accepted AI-generated plans across supported fixed-duration, date-range, and competition-date horizons should still converge into this same editable planner after canonical save, while horizon selection and competition intent remain upstream generator concerns | next: keep later planner implementation compatible with AI-authored plan metadata without turning this brief into a generation brief`
+- `2026-03-25 | planning | split the minimal canonical program entity/API/editor bootstrap into the narrower \`docs/task-briefs/in-progress/2026-03-25-canonical-program-foundation-and-library-shell-10-10.md\` so this brief can stay focused on richer planner calendar UX, summaries, and completion/history handoff after the base program surface exists | next: layer planner-specific UX and status behavior on top of the canonical foundation instead of recreating persistence contracts here`

--- a/lib/programs/schema.ts
+++ b/lib/programs/schema.ts
@@ -1,0 +1,30 @@
+type PostgrestLikeError = {
+  code?: string | null;
+  message?: string | null;
+  details?: string | null;
+  hint?: string | null;
+};
+
+function isSchemaMissing(error: PostgrestLikeError | null | undefined, markers: string[]): boolean {
+  if (!error) return false;
+
+  if (
+    error.code === "42P01" ||
+    error.code === "42703" ||
+    error.code === "PGRST204" ||
+    error.code === "PGRST205"
+  ) {
+    return true;
+  }
+
+  if (typeof error.code === "string" && error.code.length > 0) {
+    return false;
+  }
+
+  const blob = `${error.message ?? ""} ${error.details ?? ""} ${error.hint ?? ""}`.toLowerCase();
+  return markers.some((marker) => blob.includes(marker));
+}
+
+export function isProgramSchemaMissing(error: PostgrestLikeError | null | undefined): boolean {
+  return isSchemaMissing(error, ["programs", "source_kind", "weeks"]);
+}

--- a/lib/programs/server.ts
+++ b/lib/programs/server.ts
@@ -1,0 +1,307 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { isProgramSchemaMissing } from "@/lib/programs/schema";
+import {
+  buildManualProgramStarterState,
+  countProgramAssignments,
+  normalizeProgramForPersistence,
+  programWeeksToJson,
+  type ProgramEditorRecord,
+  type ProgramLibrarySnapshot,
+  type ProgramSaveRequestBody,
+  type ProgramSourceKind,
+  type ProgramStatus,
+  type ProgramSummary,
+} from "@/lib/programs/shared";
+import { isWorkoutSchemaMissing } from "@/lib/workouts/schema";
+import { buildWorkoutSummary } from "@/lib/workouts/server";
+import type { WorkoutSummary } from "@/lib/workouts/shared";
+import type { Database } from "@/types/database";
+
+type TypedSupabaseClient = SupabaseClient<Database>;
+type ProgramRow = Database["public"]["Tables"]["programs"]["Row"];
+type ProgramInsert = Database["public"]["Tables"]["programs"]["Insert"];
+type ProgramUpdate = Database["public"]["Tables"]["programs"]["Update"];
+type WorkoutRow = Database["public"]["Tables"]["workouts"]["Row"];
+
+const WORKOUT_SUMMARY_SELECT = `
+  id,
+  source_kind,
+  status,
+  title,
+  environment,
+  pool_length_m,
+  session_type,
+  effort,
+  total_distance_m,
+  estimated_duration_min,
+  accepted_at,
+  updated_at
+`;
+
+export const PROGRAM_SELECT = `
+  id,
+  user_id,
+  source_kind,
+  status,
+  title,
+  weeks,
+  created_at,
+  updated_at
+`;
+
+export function buildProgramInsert(
+  userId: string,
+  body: ProgramSaveRequestBody | null | undefined,
+  sourceKind: ProgramSourceKind = "manual"
+): ProgramInsert {
+  const starter = buildManualProgramStarterState();
+  const normalized = normalizeProgramForPersistence({
+    title: body?.title ?? starter.title,
+    weeks: body?.weeks ?? starter.weeks,
+  });
+
+  if (!normalized.ok) {
+    throw new Error(normalized.error);
+  }
+
+  return {
+    user_id: userId,
+    source_kind: sourceKind,
+    status: "draft",
+    title: normalized.value.title,
+    weeks: programWeeksToJson(normalized.value.weeks),
+  };
+}
+
+export function buildProgramUpdate(body: ProgramSaveRequestBody | null | undefined): ProgramUpdate {
+  const normalized = normalizeProgramForPersistence(body);
+  if (!normalized.ok) {
+    throw new Error(normalized.error);
+  }
+
+  return {
+    title: normalized.value.title,
+    weeks: programWeeksToJson(normalized.value.weeks),
+  };
+}
+
+export function buildProgramEditorRecord(row: ProgramRow): ProgramEditorRecord {
+  const normalized = normalizeProgramForPersistence({
+    title: row.title,
+    weeks: Array.isArray(row.weeks) ? (row.weeks as ProgramEditorRecord["weeks"]) : null,
+  });
+
+  if (!normalized.ok) {
+    throw new Error(`Stored program ${row.id} is invalid: ${normalized.error}`);
+  }
+
+  return {
+    id: row.id,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    sourceKind: row.source_kind as ProgramSourceKind,
+    status: row.status as ProgramStatus,
+    title: normalized.value.title,
+    weeks: normalized.value.weeks,
+  };
+}
+
+export function buildProgramSummary(row: ProgramRow): ProgramSummary {
+  const editor = buildProgramEditorRecord(row);
+  return {
+    id: row.id,
+    title: editor.title,
+    weekCount: editor.weeks.length,
+    assignmentCount: countProgramAssignments(editor.weeks),
+    updatedAt: row.updated_at,
+    sourceKind: row.source_kind as ProgramSourceKind,
+    status: row.status as ProgramStatus,
+  };
+}
+
+export async function validateProgramWorkoutOwnership(
+  supabase: TypedSupabaseClient,
+  userId: string,
+  input: ProgramSaveRequestBody | null | undefined
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const normalized = normalizeProgramForPersistence(input);
+  if (!normalized.ok) {
+    return normalized;
+  }
+
+  const workoutIds = Array.from(
+    new Set(
+      normalized.value.weeks.flatMap((week) =>
+        week.assignments.map((assignment) => assignment.workoutId)
+      )
+    )
+  );
+
+  if (workoutIds.length === 0) {
+    return { ok: true };
+  }
+
+  const result = await supabase
+    .from("workouts")
+    .select("id")
+    .eq("user_id", userId)
+    .in("id", workoutIds);
+
+  if (isWorkoutSchemaMissing(result.error)) {
+    return {
+      ok: false,
+      error: "Canonical workout save is still syncing in this environment.",
+    };
+  }
+
+  if (result.error) {
+    console.error("[Programs] Could not validate referenced workouts", result.error);
+    return { ok: false, error: "Could not validate scheduled workouts right now." };
+  }
+
+  const ownedWorkoutIds = new Set((result.data ?? []).map((row) => row.id));
+  const missingWorkoutIds = workoutIds.filter((id) => !ownedWorkoutIds.has(id));
+  if (missingWorkoutIds.length > 0) {
+    return {
+      ok: false,
+      error:
+        missingWorkoutIds.length === 1
+          ? "One scheduled workout could not be found for this account."
+          : `${missingWorkoutIds.length} scheduled workouts could not be found for this account.`,
+    };
+  }
+
+  return { ok: true };
+}
+
+export async function loadProgramLibrarySnapshot(
+  supabase: TypedSupabaseClient,
+  userId: string,
+  selectedProgramId: string | null
+): Promise<ProgramLibrarySnapshot> {
+  const [recentProgramsResult, selectedProgramResult, recentWorkoutsResult] = await Promise.all([
+    supabase
+      .from("programs")
+      .select(PROGRAM_SELECT)
+      .eq("user_id", userId)
+      .order("updated_at", { ascending: false })
+      .limit(6),
+    selectedProgramId
+      ? supabase
+          .from("programs")
+          .select(PROGRAM_SELECT)
+          .eq("user_id", userId)
+          .eq("id", selectedProgramId)
+          .maybeSingle()
+      : Promise.resolve({ data: null, error: null }),
+    supabase
+      .from("workouts")
+      .select(WORKOUT_SUMMARY_SELECT)
+      .eq("user_id", userId)
+      .order("updated_at", { ascending: false })
+      .limit(12),
+  ]);
+
+  if (
+    isProgramSchemaMissing(recentProgramsResult.error) ||
+    isProgramSchemaMissing(selectedProgramResult.error)
+  ) {
+    return {
+      schemaReady: false,
+      loadError: null,
+      selectedProgram: null,
+      selectedProgramMissing: false,
+      recentPrograms: [],
+      availableWorkouts: [],
+      missingWorkoutIds: [],
+    };
+  }
+
+  const recentWorkouts =
+    isWorkoutSchemaMissing(recentWorkoutsResult.error) || recentWorkoutsResult.error
+      ? []
+      : (recentWorkoutsResult.data ?? []).map((row) => buildWorkoutSummary(row as WorkoutRow));
+
+  if (recentProgramsResult.error) {
+    console.error("[Programs] Could not load program summaries", recentProgramsResult.error);
+    return {
+      schemaReady: true,
+      loadError: "Could not load saved programs right now.",
+      selectedProgram: null,
+      selectedProgramMissing: false,
+      recentPrograms: [],
+      availableWorkouts: recentWorkouts,
+      missingWorkoutIds: [],
+    };
+  }
+
+  if (selectedProgramResult.error) {
+    console.error("[Programs] Could not load selected program", selectedProgramResult.error);
+    return {
+      schemaReady: true,
+      loadError: "Could not open that saved program right now.",
+      selectedProgram: null,
+      selectedProgramMissing: false,
+      recentPrograms: recentProgramsResult.data.map(buildProgramSummary),
+      availableWorkouts: recentWorkouts,
+      missingWorkoutIds: [],
+    };
+  }
+
+  try {
+    const selectedProgram = selectedProgramResult.data
+      ? buildProgramEditorRecord(selectedProgramResult.data)
+      : null;
+    const recentPrograms = recentProgramsResult.data.map(buildProgramSummary);
+    const referencedWorkoutIds = Array.from(
+      new Set(
+        selectedProgram?.weeks.flatMap((week) =>
+          week.assignments.map((assignment) => assignment.workoutId)
+        ) ?? []
+      )
+    );
+    const knownWorkoutIds = new Set(recentWorkouts.map((workout) => workout.id));
+    const missingFromRecent = referencedWorkoutIds.filter((id) => !knownWorkoutIds.has(id));
+
+    let referencedWorkouts: WorkoutSummary[] = [];
+    if (missingFromRecent.length > 0) {
+      const result = await supabase
+        .from("workouts")
+        .select(WORKOUT_SUMMARY_SELECT)
+        .eq("user_id", userId)
+        .in("id", missingFromRecent);
+
+      if (!result.error) {
+        referencedWorkouts = (result.data ?? []).map((row) =>
+          buildWorkoutSummary(row as WorkoutRow)
+        );
+      }
+    }
+
+    const availableWorkoutMap = new Map<string, WorkoutSummary>();
+    for (const workout of [...recentWorkouts, ...referencedWorkouts]) {
+      availableWorkoutMap.set(workout.id, workout);
+    }
+
+    return {
+      schemaReady: true,
+      loadError: null,
+      selectedProgram,
+      selectedProgramMissing: Boolean(selectedProgramId && !selectedProgramResult.data),
+      recentPrograms,
+      availableWorkouts: Array.from(availableWorkoutMap.values()),
+      missingWorkoutIds: referencedWorkoutIds.filter((id) => !availableWorkoutMap.has(id)),
+    };
+  } catch (error) {
+    console.error("[Programs] Stored program payload is invalid", error);
+    return {
+      schemaReady: true,
+      loadError: "A saved program could not be opened because its stored data is invalid.",
+      selectedProgram: null,
+      selectedProgramMissing: false,
+      recentPrograms: [],
+      availableWorkouts: recentWorkouts,
+      missingWorkoutIds: [],
+    };
+  }
+}

--- a/lib/programs/shared.ts
+++ b/lib/programs/shared.ts
@@ -1,0 +1,284 @@
+import type { Json } from "@/types/database";
+import type { WorkoutSummary } from "@/lib/workouts/shared";
+
+export const PROGRAM_SOURCE_KINDS = ["manual"] as const;
+export const PROGRAM_STATUSES = ["draft"] as const;
+export const PROGRAM_WEEKDAY_LABELS = [
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+] as const;
+
+export const PROGRAM_MAX_WEEKS = 24;
+export const PROGRAM_MAX_ASSIGNMENTS = 84;
+
+export type ProgramSourceKind = (typeof PROGRAM_SOURCE_KINDS)[number];
+export type ProgramStatus = (typeof PROGRAM_STATUSES)[number];
+
+export type ProgramAssignment = {
+  id: string;
+  workoutId: string;
+  dayIndex: number;
+  position: number;
+};
+
+export type ProgramWeek = {
+  id: string;
+  label: string;
+  assignments: ProgramAssignment[];
+};
+
+export type ProgramEditorRecord = {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  sourceKind: ProgramSourceKind;
+  status: ProgramStatus;
+  title: string;
+  weeks: ProgramWeek[];
+};
+
+export type ProgramSummary = {
+  id: string;
+  title: string;
+  weekCount: number;
+  assignmentCount: number;
+  updatedAt: string;
+  sourceKind: ProgramSourceKind;
+  status: ProgramStatus;
+};
+
+export type ProgramLibrarySnapshot = {
+  schemaReady: boolean;
+  loadError: string | null;
+  selectedProgram: ProgramEditorRecord | null;
+  selectedProgramMissing: boolean;
+  recentPrograms: ProgramSummary[];
+  availableWorkouts: WorkoutSummary[];
+  missingWorkoutIds: string[];
+};
+
+export type ProgramSaveRequestBody = {
+  title?: string | null;
+  weeks?: ProgramWeek[] | null;
+  sourceKind?: ProgramSourceKind | null;
+};
+
+export type ProgramSaveApiSuccess = {
+  ok: true;
+  program: ProgramEditorRecord;
+  summary: ProgramSummary;
+};
+
+export type ProgramSaveApiError = {
+  ok: false;
+  error: string;
+};
+
+export type ProgramSaveApiResponse = ProgramSaveApiSuccess | ProgramSaveApiError;
+
+export function createProgramEntityId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return `program-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+}
+
+export function buildManualProgramStarterState(now = new Date()): {
+  title: string;
+  weeks: ProgramWeek[];
+} {
+  void now;
+
+  return {
+    title: "New program",
+    weeks: [
+      {
+        id: createProgramEntityId(),
+        label: "Week 1",
+        assignments: [],
+      },
+    ],
+  };
+}
+
+export function buildProgramDraftChangeSignature(
+  draft: Pick<ProgramEditorRecord, "title" | "weeks"> | null | undefined
+): string | null {
+  if (!draft) return null;
+  return JSON.stringify(draft);
+}
+
+export function haveProgramDraftChanges(
+  currentDraft: Pick<ProgramEditorRecord, "title" | "weeks"> | null | undefined,
+  savedDraft: Pick<ProgramEditorRecord, "title" | "weeks"> | null | undefined
+): boolean {
+  const currentSignature = buildProgramDraftChangeSignature(currentDraft);
+  const savedSignature = buildProgramDraftChangeSignature(savedDraft);
+
+  if (currentSignature === null && savedSignature === null) return false;
+  if (currentSignature === null || savedSignature === null) return true;
+
+  return currentSignature !== savedSignature;
+}
+
+export function countProgramAssignments(weeks: ProgramWeek[] | null | undefined) {
+  if (!Array.isArray(weeks)) return 0;
+  return weeks.reduce(
+    (total, week) => total + (Array.isArray(week.assignments) ? week.assignments.length : 0),
+    0
+  );
+}
+
+export function buildProgramWeekdayGroups(week: ProgramWeek) {
+  return PROGRAM_WEEKDAY_LABELS.map((_, dayIndex) =>
+    week.assignments
+      .filter((assignment) => assignment.dayIndex === dayIndex)
+      .sort((left, right) => left.position - right.position)
+  );
+}
+
+export function normalizeProgramForPersistence(
+  input:
+    | {
+        title?: string | null;
+        weeks?: ProgramWeek[] | null;
+      }
+    | null
+    | undefined
+): { ok: true; value: { title: string; weeks: ProgramWeek[] } } | { ok: false; error: string } {
+  if (!input) {
+    return { ok: false, error: "Create and review a program shell before saving it." };
+  }
+
+  const title = normalizeRequiredText(input.title, 120);
+  if (!title) {
+    return { ok: false, error: "Add a program title before saving." };
+  }
+
+  if (!Array.isArray(input.weeks) || input.weeks.length === 0) {
+    return { ok: false, error: "Add at least one program week before saving." };
+  }
+
+  if (input.weeks.length > PROGRAM_MAX_WEEKS) {
+    return {
+      ok: false,
+      error: `This first canonical slice supports up to ${PROGRAM_MAX_WEEKS} program weeks.`,
+    };
+  }
+
+  const seenWeekIds = new Set<string>();
+  const seenAssignmentIds = new Set<string>();
+  const normalizedWeeks: ProgramWeek[] = [];
+  let assignmentCount = 0;
+
+  for (const [weekIndex, rawWeek] of input.weeks.entries()) {
+    const weekId = normalizeRequiredText(rawWeek?.id, 120);
+    if (!weekId) {
+      return { ok: false, error: `Week ${weekIndex + 1} is missing a stable id.` };
+    }
+    if (seenWeekIds.has(weekId)) {
+      return { ok: false, error: `Week ${weekIndex + 1} is duplicated in this program.` };
+    }
+    seenWeekIds.add(weekId);
+
+    const label = normalizeRequiredText(rawWeek?.label, 80) ?? `Week ${weekIndex + 1}`;
+    const rawAssignments = Array.isArray(rawWeek?.assignments) ? rawWeek.assignments : [];
+    const normalizedAssignments: ProgramAssignment[] = [];
+
+    for (const rawAssignment of rawAssignments) {
+      assignmentCount += 1;
+      if (assignmentCount > PROGRAM_MAX_ASSIGNMENTS) {
+        return {
+          ok: false,
+          error: `This first canonical slice supports up to ${PROGRAM_MAX_ASSIGNMENTS} scheduled workouts per program.`,
+        };
+      }
+
+      const assignmentId = normalizeRequiredText(rawAssignment?.id, 120);
+      if (!assignmentId) {
+        return {
+          ok: false,
+          error: `${label} includes a scheduled workout without a stable assignment id.`,
+        };
+      }
+      if (seenAssignmentIds.has(assignmentId)) {
+        return {
+          ok: false,
+          error: `${label} includes a duplicated assignment id.`,
+        };
+      }
+      seenAssignmentIds.add(assignmentId);
+
+      const workoutId = normalizeRequiredText(rawAssignment?.workoutId, 120);
+      if (!workoutId) {
+        return { ok: false, error: `${label} includes a scheduled workout with no workout id.` };
+      }
+
+      const dayIndex = normalizeInteger(rawAssignment?.dayIndex);
+      if (dayIndex == null || dayIndex < 0 || dayIndex >= PROGRAM_WEEKDAY_LABELS.length) {
+        return { ok: false, error: `${label} includes a scheduled workout on an invalid day.` };
+      }
+
+      const position = normalizeInteger(rawAssignment?.position);
+      if (position == null || position < 0) {
+        return {
+          ok: false,
+          error: `${label} includes a scheduled workout with invalid day ordering.`,
+        };
+      }
+
+      normalizedAssignments.push({
+        id: assignmentId,
+        workoutId,
+        dayIndex,
+        position,
+      });
+    }
+
+    const groupedByDay = PROGRAM_WEEKDAY_LABELS.map((_, dayIndex) =>
+      normalizedAssignments
+        .filter((assignment) => assignment.dayIndex === dayIndex)
+        .sort((left, right) => left.position - right.position || left.id.localeCompare(right.id))
+        .map((assignment, position) => ({
+          ...assignment,
+          position,
+        }))
+    );
+
+    normalizedWeeks.push({
+      id: weekId,
+      label,
+      assignments: groupedByDay.flat(),
+    });
+  }
+
+  return {
+    ok: true,
+    value: {
+      title,
+      weeks: normalizedWeeks,
+    },
+  };
+}
+
+export function programWeeksToJson(weeks: ProgramWeek[]): Json {
+  return weeks as unknown as Json;
+}
+
+function normalizeRequiredText(value: string | null | undefined, maxLength: number) {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  if (normalized.length === 0 || normalized.length > maxLength) return null;
+  return normalized;
+}
+
+function normalizeInteger(value: number | null | undefined) {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return Math.trunc(value);
+}

--- a/supabase/migrations/20260325170500_programs_foundation_and_library_shell.sql
+++ b/supabase/migrations/20260325170500_programs_foundation_and_library_shell.sql
@@ -1,0 +1,65 @@
+-- Canonical program foundation for user-owned program shells.
+-- Stores stable week + assignment identities inside one canonical program row
+-- so save operations remain atomic in this first program slice.
+
+create table if not exists public.programs (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  source_kind text not null check (source_kind in ('manual')),
+  status text not null check (status in ('draft')),
+  title text not null,
+  weeks jsonb not null,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint programs_title_check
+    check (char_length(btrim(title)) between 1 and 120),
+  constraint programs_weeks_array_check
+    check (jsonb_typeof(weeks) = 'array'),
+  constraint programs_weeks_non_empty_check
+    check (jsonb_array_length(weeks) between 1 and 24)
+);
+
+create index if not exists programs_user_updated_idx
+  on public.programs (user_id, updated_at desc);
+
+create index if not exists programs_user_source_updated_idx
+  on public.programs (user_id, source_kind, updated_at desc);
+
+drop trigger if exists programs_set_updated_at on public.programs;
+create trigger programs_set_updated_at
+before update on public.programs
+for each row
+execute function public.set_updated_at();
+
+grant select, insert, update, delete on public.programs to authenticated;
+
+alter table public.programs enable row level security;
+
+drop policy if exists programs_select_own on public.programs;
+create policy programs_select_own
+on public.programs
+for select
+to authenticated
+using (auth.uid() = user_id);
+
+drop policy if exists programs_insert_own on public.programs;
+create policy programs_insert_own
+on public.programs
+for insert
+to authenticated
+with check (auth.uid() = user_id);
+
+drop policy if exists programs_update_own on public.programs;
+create policy programs_update_own
+on public.programs
+for update
+to authenticated
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+drop policy if exists programs_delete_own on public.programs;
+create policy programs_delete_own
+on public.programs
+for delete
+to authenticated
+using (auth.uid() = user_id);

--- a/tests/unit/create-manual-program-button.test.tsx
+++ b/tests/unit/create-manual-program-button.test.tsx
@@ -1,0 +1,75 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import CreateManualProgramButton from "@/components/my-library/programs/CreateManualProgramButton";
+
+const navigationState = vi.hoisted(() => ({
+  push: vi.fn(),
+  refresh: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => navigationState,
+}));
+
+describe("CreateManualProgramButton", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("creates a manual program and routes into the builder", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        program: {
+          id: "11111111-1111-4111-8111-111111111111",
+        },
+      }),
+    } as Response);
+
+    render(<CreateManualProgramButton />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Create program shell" }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/my-library/programs",
+        expect.objectContaining({
+          method: "POST",
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(navigationState.push).toHaveBeenCalledWith(
+        "/my-library/programs/11111111-1111-4111-8111-111111111111"
+      );
+    });
+    expect(navigationState.refresh).toHaveBeenCalled();
+  });
+
+  it("shows an inline error when manual creation fails", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      json: async () => ({
+        ok: false,
+        error: "Could not create program right now.",
+      }),
+    } as Response);
+
+    render(<CreateManualProgramButton />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Create program shell" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Could not create program right now.")).toBeVisible();
+    });
+    expect(navigationState.push).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/program-builder-hub.test.tsx
+++ b/tests/unit/program-builder-hub.test.tsx
@@ -1,0 +1,174 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ProgramBuilderHub from "@/components/my-library/programs/ProgramBuilderHub";
+import type {
+  ProgramEditorRecord,
+  ProgramLibrarySnapshot,
+  ProgramSummary,
+} from "@/lib/programs/shared";
+import type { WorkoutSummary } from "@/lib/workouts/shared";
+
+const navigationState = vi.hoisted(() => ({
+  push: vi.fn(),
+  refresh: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => navigationState,
+}));
+
+function buildWorkoutSummary(overrides?: Partial<WorkoutSummary>): WorkoutSummary {
+  return {
+    id: "workout-1",
+    title: "Threshold builder workout",
+    environment: "pool",
+    poolLengthM: 25,
+    sessionType: "threshold_css",
+    effort: "moderate",
+    totalDistanceM: 2200,
+    estimatedDurationMin: 45,
+    updatedAt: "2026-03-25T12:10:00.000Z",
+    acceptedAt: "2026-03-25T12:05:00.000Z",
+    sourceKind: "manual",
+    status: "accepted",
+    ...overrides,
+  };
+}
+
+function buildProgramRecord(overrides?: Partial<ProgramEditorRecord>): ProgramEditorRecord {
+  return {
+    id: "program-1",
+    createdAt: "2026-03-25T12:00:00.000Z",
+    updatedAt: "2026-03-25T12:05:00.000Z",
+    sourceKind: "manual",
+    status: "draft",
+    title: "Manual race prep shell",
+    weeks: [
+      {
+        id: "week-1",
+        label: "Week 1",
+        assignments: [],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function buildProgramSummary(overrides?: Partial<ProgramSummary>): ProgramSummary {
+  return {
+    id: "program-1",
+    title: "Manual race prep shell",
+    weekCount: 1,
+    assignmentCount: 0,
+    updatedAt: "2026-03-25T12:05:00.000Z",
+    sourceKind: "manual",
+    status: "draft",
+    ...overrides,
+  };
+}
+
+function buildProgramLibrary(overrides?: Partial<ProgramLibrarySnapshot>): ProgramLibrarySnapshot {
+  return {
+    schemaReady: true,
+    loadError: null,
+    selectedProgram: buildProgramRecord(),
+    selectedProgramMissing: false,
+    recentPrograms: [buildProgramSummary()],
+    availableWorkouts: [buildWorkoutSummary()],
+    missingWorkoutIds: [],
+    ...overrides,
+  };
+}
+
+describe("ProgramBuilderHub", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("adds a scheduled workout and saves canonical program edits", async () => {
+    vi.mocked(fetch).mockImplementation(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        title: string;
+        weeks: ProgramEditorRecord["weeks"];
+      };
+
+      return {
+        ok: true,
+        json: async () => ({
+          ok: true,
+          program: buildProgramRecord({
+            title: body.title,
+            weeks: body.weeks,
+          }),
+          summary: buildProgramSummary({
+            title: body.title,
+            assignmentCount: body.weeks[0]?.assignments.length ?? 0,
+          }),
+        }),
+      } as Response;
+    });
+
+    render(<ProgramBuilderHub programLibrary={buildProgramLibrary()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("program-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    expect(screen.getByTestId("program-editor-save-state")).toHaveTextContent(
+      "All program changes are saved to the canonical program."
+    );
+    expect(screen.getByTestId("program-builder-save")).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId("program-draft-title"), {
+      target: { value: "Builder edited program" },
+    });
+    fireEvent.change(screen.getByTestId("program-day-picker-week-0-day-0"), {
+      target: { value: "workout-1" },
+    });
+    fireEvent.click(screen.getByTestId("program-day-add-week-0-day-0"));
+
+    expect(screen.getByRole("button", { name: "Remove" })).toBeVisible();
+    expect(screen.getByTestId("program-editor-save-state")).toHaveTextContent(
+      "Unsaved changes stay local until you save this program."
+    );
+    expect(screen.getByTestId("program-builder-save")).toBeEnabled();
+
+    fireEvent.click(screen.getByTestId("program-builder-save"));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/my-library/programs/program-1",
+        expect.objectContaining({
+          method: "PATCH",
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Program changes saved to the canonical program.")).toBeVisible();
+    });
+
+    const fetchBody = JSON.parse(String(vi.mocked(fetch).mock.calls[0]?.[1]?.body ?? "{}")) as {
+      title: string;
+      weeks: ProgramEditorRecord["weeks"];
+    };
+
+    expect(fetchBody.title).toBe("Builder edited program");
+    expect(fetchBody.weeks[0]?.assignments).toHaveLength(1);
+    expect(fetchBody.weeks[0]?.assignments[0]).toMatchObject({
+      workoutId: "workout-1",
+      dayIndex: 0,
+      position: 0,
+    });
+    expect(screen.getByTestId("program-builder-save")).toBeDisabled();
+  });
+});

--- a/tests/unit/programs-routes.test.ts
+++ b/tests/unit/programs-routes.test.ts
@@ -1,0 +1,344 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createRouteHandlerSupabaseClientMock } = vi.hoisted(() => ({
+  createRouteHandlerSupabaseClientMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/route-handler", () => ({
+  createRouteHandlerSupabaseClient: createRouteHandlerSupabaseClientMock,
+}));
+
+import { PATCH as patchProgram } from "@/app/api/my-library/programs/[programId]/route";
+import { POST as postProgram } from "@/app/api/my-library/programs/route";
+import type { ProgramSaveRequestBody } from "@/lib/programs/shared";
+import type { Database } from "@/types/database";
+
+type ProgramRow = Database["public"]["Tables"]["programs"]["Row"];
+
+function applyResponseCookiesIdentity<T>(response: T): T {
+  return response;
+}
+
+function buildProgramRow(overrides?: Partial<ProgramRow>): ProgramRow {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    user_id: "user-1",
+    source_kind: "manual",
+    status: "draft",
+    title: "Manual race prep shell",
+    weeks: [
+      {
+        id: "week-1",
+        label: "Week 1",
+        assignments: [
+          {
+            id: "assignment-1",
+            workoutId: "workout-1",
+            dayIndex: 0,
+            position: 0,
+          },
+        ],
+      },
+    ],
+    created_at: "2026-03-25T12:00:00.000Z",
+    updated_at: "2026-03-25T12:05:00.000Z",
+    ...overrides,
+  };
+}
+
+function buildProgramBody(overrides?: Partial<ProgramSaveRequestBody>): ProgramSaveRequestBody {
+  return {
+    title: "Manual race prep shell",
+    weeks: [
+      {
+        id: "week-1",
+        label: "Week 1",
+        assignments: [
+          {
+            id: "assignment-1",
+            workoutId: "workout-1",
+            dayIndex: 0,
+            position: 0,
+          },
+        ],
+      },
+    ],
+    sourceKind: "manual",
+    ...overrides,
+  };
+}
+
+describe("programs routes", () => {
+  beforeEach(() => {
+    createRouteHandlerSupabaseClientMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fails closed for unauthenticated canonical program save", async () => {
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+        },
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await postProgram(
+      new Request("http://127.0.0.1:3000/api/my-library/programs", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      })
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("creates canonical programs for the authenticated owner", async () => {
+    const single = vi.fn().mockResolvedValue({
+      data: buildProgramRow({ weeks: [{ id: "week-1", label: "Week 1", assignments: [] }] }),
+      error: null,
+    });
+    const selectPrograms = vi.fn(() => ({ single }));
+    const insert = vi.fn(() => ({ select: selectPrograms }));
+    const selectWorkouts = vi.fn().mockResolvedValue({
+      data: [],
+      error: null,
+    });
+    const workoutsFrom = vi.fn(() => ({ select: selectWorkouts }));
+    const programsFrom = vi.fn(() => ({ insert }));
+    const from = vi.fn((table: string) => {
+      if (table === "workouts") {
+        return workoutsFrom();
+      }
+      if (table === "programs") {
+        return programsFrom();
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } } }),
+        },
+        from,
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await postProgram(
+      new Request("http://127.0.0.1:3000/api/my-library/programs", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      })
+    );
+    const payload = (await response.json()) as {
+      ok: boolean;
+      program: { id: string };
+      summary: { title: string };
+    };
+
+    expect(response.status).toBe(200);
+    expect(from).toHaveBeenCalledWith("programs");
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: "user-1",
+        source_kind: "manual",
+        status: "draft",
+        title: "New program",
+      })
+    );
+    expect(payload.ok).toBe(true);
+    expect(payload.program.id).toBe("11111111-1111-4111-8111-111111111111");
+    expect(payload.summary.title).toBe("Manual race prep shell");
+  });
+
+  it("rejects scheduled workouts that do not belong to the authenticated owner", async () => {
+    const selectWorkouts = vi.fn().mockResolvedValue({
+      data: [{ id: "workout-1" }],
+      error: null,
+    });
+    const inClause = vi.fn(() => Promise.resolve({ data: [{ id: "workout-1" }], error: null }));
+    const eqUser = vi.fn(() => ({ in: inClause }));
+    const from = vi.fn((table: string) => {
+      if (table === "workouts") {
+        return {
+          select: selectWorkouts,
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+    selectWorkouts.mockImplementation(() => ({ eq: eqUser }));
+
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } } }),
+        },
+        from,
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await patchProgram(
+      new Request(
+        "http://127.0.0.1:3000/api/my-library/programs/11111111-1111-4111-8111-111111111111",
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(
+            buildProgramBody({
+              weeks: [
+                {
+                  id: "week-1",
+                  label: "Week 1",
+                  assignments: [
+                    {
+                      id: "assignment-1",
+                      workoutId: "workout-1",
+                      dayIndex: 0,
+                      position: 0,
+                    },
+                    {
+                      id: "assignment-2",
+                      workoutId: "missing-workout",
+                      dayIndex: 1,
+                      position: 0,
+                    },
+                  ],
+                },
+              ],
+            })
+          ),
+        }
+      ),
+      {
+        params: Promise.resolve({
+          programId: "11111111-1111-4111-8111-111111111111",
+        }),
+      }
+    );
+
+    const payload = (await response.json()) as { ok: boolean; error: string };
+
+    expect(response.status).toBe(400);
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toContain("scheduled workout");
+  });
+
+  it("saves canonical program edits for the authenticated owner", async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: buildProgramRow({
+        title: "Updated manual race prep shell",
+        weeks: [
+          {
+            id: "week-1",
+            label: "Week 1",
+            assignments: [
+              {
+                id: "assignment-1",
+                workoutId: "workout-1",
+                dayIndex: 2,
+                position: 0,
+              },
+            ],
+          },
+        ],
+      }),
+      error: null,
+    });
+    const selectPrograms = vi.fn(() => ({ maybeSingle }));
+    const eqProgramId = vi.fn(() => ({ select: selectPrograms }));
+    const eqUserPrograms = vi.fn(() => ({ eq: eqProgramId }));
+    const update = vi.fn(() => ({ eq: eqUserPrograms }));
+
+    const inClause = vi.fn().mockResolvedValue({
+      data: [{ id: "workout-1" }],
+      error: null,
+    });
+    const eqUserWorkouts = vi.fn(() => ({ in: inClause }));
+    const selectWorkouts = vi.fn(() => ({ eq: eqUserWorkouts }));
+    const from = vi.fn((table: string) => {
+      if (table === "programs") {
+        return { update };
+      }
+      if (table === "workouts") {
+        return { select: selectWorkouts };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } } }),
+        },
+        from,
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await patchProgram(
+      new Request(
+        "http://127.0.0.1:3000/api/my-library/programs/11111111-1111-4111-8111-111111111111",
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(
+            buildProgramBody({
+              title: "Updated manual race prep shell",
+              weeks: [
+                {
+                  id: "week-1",
+                  label: "Week 1",
+                  assignments: [
+                    {
+                      id: "assignment-1",
+                      workoutId: "workout-1",
+                      dayIndex: 2,
+                      position: 0,
+                    },
+                  ],
+                },
+              ],
+            })
+          ),
+        }
+      ),
+      {
+        params: Promise.resolve({
+          programId: "11111111-1111-4111-8111-111111111111",
+        }),
+      }
+    );
+    const payload = (await response.json()) as {
+      ok: boolean;
+      program: { title: string };
+      summary: { assignmentCount: number };
+    };
+
+    expect(response.status).toBe(200);
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Updated manual race prep shell",
+      })
+    );
+    expect(payload.ok).toBe(true);
+    expect(payload.program.title).toBe("Updated manual race prep shell");
+    expect(payload.summary.assignmentCount).toBe(1);
+  });
+});

--- a/tests/unit/programs-shared.test.ts
+++ b/tests/unit/programs-shared.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildManualProgramStarterState,
+  countProgramAssignments,
+  normalizeProgramForPersistence,
+} from "@/lib/programs/shared";
+
+describe("programs shared", () => {
+  it("builds a canonical starter program shell", () => {
+    const starter = buildManualProgramStarterState();
+
+    expect(starter.title).toBe("New program");
+    expect(starter.weeks).toHaveLength(1);
+    expect(starter.weeks[0]?.label).toBe("Week 1");
+    expect(starter.weeks[0]?.assignments).toEqual([]);
+  });
+
+  it("normalizes assignment ordering within each day", () => {
+    const normalized = normalizeProgramForPersistence({
+      title: "Race prep shell",
+      weeks: [
+        {
+          id: "week-1",
+          label: "Week 1",
+          assignments: [
+            { id: "a-2", workoutId: "workout-2", dayIndex: 0, position: 3 },
+            { id: "a-1", workoutId: "workout-1", dayIndex: 0, position: 0 },
+            { id: "a-3", workoutId: "workout-3", dayIndex: 2, position: 7 },
+          ],
+        },
+      ],
+    });
+
+    expect(normalized.ok).toBe(true);
+    if (!normalized.ok) return;
+
+    expect(normalized.value.weeks[0]?.assignments).toEqual([
+      { id: "a-1", workoutId: "workout-1", dayIndex: 0, position: 0 },
+      { id: "a-2", workoutId: "workout-2", dayIndex: 0, position: 1 },
+      { id: "a-3", workoutId: "workout-3", dayIndex: 2, position: 0 },
+    ]);
+    expect(countProgramAssignments(normalized.value.weeks)).toBe(3);
+  });
+
+  it("rejects duplicate assignment ids", () => {
+    const normalized = normalizeProgramForPersistence({
+      title: "Race prep shell",
+      weeks: [
+        {
+          id: "week-1",
+          label: "Week 1",
+          assignments: [
+            { id: "duplicate", workoutId: "workout-1", dayIndex: 0, position: 0 },
+            { id: "duplicate", workoutId: "workout-2", dayIndex: 1, position: 0 },
+          ],
+        },
+      ],
+    });
+
+    expect(normalized).toEqual({
+      ok: false,
+      error: "Week 1 includes a duplicated assignment id.",
+    });
+  });
+});

--- a/types/database.ts
+++ b/types/database.ts
@@ -992,6 +992,39 @@ export type Database = {
         };
         Relationships: [];
       };
+      programs: {
+        Row: {
+          created_at: string;
+          id: string;
+          source_kind: string;
+          status: string;
+          title: string;
+          updated_at: string;
+          user_id: string;
+          weeks: Json;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          source_kind: string;
+          status: string;
+          title: string;
+          updated_at?: string;
+          user_id: string;
+          weeks: Json;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          source_kind?: string;
+          status?: string;
+          title?: string;
+          updated_at?: string;
+          user_id?: string;
+          weeks?: Json;
+        };
+        Relationships: [];
+      };
       workouts: {
         Row: {
           accepted_at: string;


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-03-25T16:45:24.845Z for branch `feat/program-foundation-2026-03-25` (base ref `origin/main`).
- Latest commit: `19bbf77` - feat(programs): add canonical program shell foundation.
- User-visible changes: User/admin runtime behavior may change on touched routes/components.
- Technical changes: Updated 18 file(s): `app/api/my-library/programs/[programId]/route.ts`, `app/api/my-library/programs/route.ts`, `app/my-library/page.tsx`, `app/my-library/programs/[programId]/page.tsx`, `components/my-library/programs/CreateManualProgramButton.tsx`, `... and 13 more file(s)`.
- Policy impact: yes (inferred from changed scope: `supabase/migrations/20260325170500_programs_foundation_and_library_shell.sql`).
- Policy version note: N/A (if policy text/version changes, replace with YYYY-MM-DD.rev and rationale).
- Brief link(s): `docs/task-briefs/in-progress/2026-03-25-canonical-program-foundation-and-library-shell-10-10.md`
- Scorecard target outcomes: 11 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (3); tests (4); API handlers (2); runtime UI/routes/components (7); other files (2).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (18):
  - `app/api/my-library/programs/[programId]/route.ts`
  - `app/api/my-library/programs/route.ts`
  - `app/my-library/page.tsx`
  - `app/my-library/programs/[programId]/page.tsx`
  - `components/my-library/programs/CreateManualProgramButton.tsx`
  - `components/my-library/programs/ProgramBuilderHub.tsx`
  - `docs/task-briefs/blocked/2026-03-25-program-export-adapters-garmin-ready-pdf-followup-10-10.md`
  - `docs/task-briefs/in-progress/2026-03-25-canonical-program-foundation-and-library-shell-10-10.md`
  - `... and 10 more file(s)`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `19bbf77` (`git revert 19bbf77`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **NOT RUN** (run locally before pushing PR updates).
- `npm run verify:pre-merge`: **PENDING** for `19bbf77` (required before merge to `main`).
- Policy-impact checklist: PENDING (run docs/checklists/policy-impact-release-review.md and update to PASS/FAIL).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  - No local verify log found in `artifacts/test-runs/latest`.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
