### PR TITLE
fix(admin): simplify notes image intake

### DIFF
--- a/components/admin/AdminHelpCenter.tsx
+++ b/components/admin/AdminHelpCenter.tsx
@@ -18,7 +18,7 @@ type ActionGroup = {
   actions: Array<{ label: string; meaning: string }>;
 };
 
-const LAST_UPDATED = "2026-03-24";
+const LAST_UPDATED = "2026-03-25";
 
 const QUICK_ACTIONS = [
   { id: "overview", label: "Start here" },
@@ -391,7 +391,7 @@ const BUTTON_GUIDE: ActionGroup[] = [
       {
         label: "Quick note",
         meaning:
-          "Opens the lightweight quick-capture sheet so you can save a route-aware note, optionally paste one clipboard image or stage one screenshot, and stay on the current admin surface.",
+          "Opens the lightweight quick-capture sheet so you can save a route-aware note, optionally paste one clipboard image or upload one image, and stay on the current admin surface.",
       },
       {
         label: "Use P0 template / Use P1 template / Use P2 template",
@@ -416,12 +416,12 @@ const BUTTON_GUIDE: ActionGroup[] = [
       {
         label: "Add images / Delete image",
         meaning:
-          "Attach admin-only screenshots for memory/debugging, or fall back here when clipboard paste/capture is not the best fit. Delete must remove both note metadata and the underlying stored image.",
+          "Attach admin-only screenshots or other note images, or fall back here when clipboard paste is not the best fit. Delete must remove both note metadata and the underlying stored image.",
       },
       {
-        label: "Capture screenshot / Retake screenshot / Retry upload",
+        label: "Paste image from clipboard / Upload image",
         meaning:
-          "Starts browser capture from the image tools area, lets you drag a tighter crop in preview, and keeps the screenshot local until note save plus attachment upload succeed.",
+          "Makes image entry explicit: either copy a screenshot/image first and paste it from clipboard, or upload a file directly without relying on hidden keyboard memory.",
       },
       {
         label: "Link note / Remove link",
@@ -430,7 +430,7 @@ const BUTTON_GUIDE: ActionGroup[] = [
       {
         label: "Save note / Save changes / Delete",
         meaning:
-          "Creates, updates, or removes task notes with route/content context. Create and Quick note can stage one pasted/captured image before first save; Edit can add/remove more screenshots and related-note links later.",
+          "Creates, updates, or removes task notes with route/content context. Create and Quick note can stage one pasted/uploaded image before first save; Edit can add/remove more images and related-note links later.",
       },
       {
         label: "Save category / Delete",
@@ -562,11 +562,10 @@ const DAILY_PLAYBOOKS: Playbook[] = [
       "Open the exact page/content row you are reviewing.",
       "Use `Quick note` when you want to capture the issue fast from the current surface without losing context.",
       "Create note with category, priority, and context link, then copy the visible note ID if you need to reference it later.",
-      "Paste an image anywhere in the note form when the screenshot is already on your clipboard; otherwise open image tools and use `Capture screenshot`.",
-      "Use `Capture screenshot` when the issue is visual, drag to the relevant crop in preview, and save only after the preview looks right.",
-      "Remember that pasted or captured images stay local until note save and attachment upload both succeed; if permission is denied or the preview never appears, fall back to `Add images`.",
+      "If the issue is visual, copy the screenshot or image to your clipboard first, then use `Paste image from clipboard`, or choose `Upload image` if you already have the file.",
+      "Remember that pasted or uploaded pre-save images stay local until note save and attachment upload both succeed; if clipboard access is blocked or no image is found, fall back to `Upload image`.",
       `If a note title starts with \`${ADMIN_NOTE_TEST_ARTIFACT_PREFIX}\`, it is automated test residue and should clear automatically; if it stays open, use the admin-notes recovery runbook before deleting anything manually.`,
-      "On mobile, keep image tools collapsed unless you actively need paste/capture so title, body, and context stay close together.",
+      "On mobile, the two image actions stay visible so you do not need to remember hidden paste shortcuts.",
       "Link any follow-up note instead of pasting duplicate text.",
       "Use Search + Priority + Context filters in Notes to reopen the same note quickly.",
       "Mark completion status once resolved, then use Done archive to confirm it is recoverable.",
@@ -887,11 +886,12 @@ export default function AdminHelpCenter() {
           </article>
           <article className="rounded-xl border border-amber-200 bg-amber-50 p-3">
             <p className="text-sm font-semibold text-amber-900">
-              Screenshot capture is denied or upload fails
+              Clipboard paste is blocked or image upload fails
             </p>
             <p className="mt-1 text-sm text-amber-800">
-              Retry capture first. If browser permission is blocked or upload still fails, keep the
-              note ID, refresh Notes, and use Add images or the admin-notes recovery runbook.
+              Confirm the screenshot was copied first. If clipboard access is blocked or upload
+              still fails, keep the note ID, refresh Notes, and use Upload image or the admin-notes
+              recovery runbook.
             </p>
           </article>
           <article className="rounded-xl border border-slate-200 bg-slate-50 p-3">

--- a/components/admin/AdminNoteClipboardPasteButton.tsx
+++ b/components/admin/AdminNoteClipboardPasteButton.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+import { readAdminNoteClipboardImageFromNavigator } from "@/lib/admin/note-compose";
+
+type Props = {
+  onPasteReady: (file: File) => Promise<void> | void;
+  onError?: (message: string) => void;
+  onSuccess?: () => void;
+  buttonLabel?: string;
+  loadingLabel?: string;
+  disabled?: boolean;
+  className?: string;
+  buttonTestId?: string;
+};
+
+export default function AdminNoteClipboardPasteButton({
+  onPasteReady,
+  onError,
+  onSuccess,
+  buttonLabel = "Paste image from clipboard",
+  loadingLabel = "Pasting…",
+  disabled = false,
+  className = "",
+  buttonTestId,
+}: Props) {
+  const [loading, setLoading] = useState(false);
+
+  async function handleClick() {
+    if (disabled || loading) return;
+
+    setLoading(true);
+    try {
+      const result = await readAdminNoteClipboardImageFromNavigator({
+        clipboard: navigator.clipboard,
+        secureContext: window.isSecureContext,
+      });
+
+      if (!result.ok) {
+        onError?.(result.error);
+        return;
+      }
+
+      await onPasteReady(result.file);
+      onSuccess?.();
+    } catch (error) {
+      onError?.(
+        error instanceof Error
+          ? error.message
+          : "Could not read an image from the clipboard right now. Use Upload image instead."
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      data-testid={buttonTestId}
+      disabled={disabled || loading}
+      onClick={() => {
+        void handleClick();
+      }}
+      className={[
+        "inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {loading ? loadingLabel : buttonLabel}
+    </button>
+  );
+}

--- a/components/admin/AdminNoteQuickCaptureLauncher.tsx
+++ b/components/admin/AdminNoteQuickCaptureLauncher.tsx
@@ -2,12 +2,15 @@
 
 import { useEffect, useId, useMemo, useState } from "react";
 import Modal from "@/components/Modal";
-import AdminNoteScreenshotCaptureButton from "@/components/admin/AdminNoteScreenshotCaptureButton";
+import AdminNoteClipboardPasteButton from "@/components/admin/AdminNoteClipboardPasteButton";
 import type { AdminRole } from "@/lib/admin/access";
 import { hasRequiredAdminRole } from "@/lib/admin/access";
 import { applyAdminTabToSearchParams } from "@/lib/admin/admin-workspace";
 import type { AdminCategoryRow } from "@/lib/admin/categories";
-import { extractAdminNoteClipboardImage } from "@/lib/admin/note-compose";
+import {
+  extractAdminNoteClipboardImage,
+  prepareAdminNoteImageFile,
+} from "@/lib/admin/note-compose";
 import type { AdminNoteContextType } from "@/lib/admin/note-context";
 import { uploadAdminNoteFiles } from "@/lib/admin/notes-client";
 import {
@@ -66,7 +69,7 @@ type SavedNotice = {
   title: string;
 };
 
-type PendingScreenshot = {
+type PendingImage = {
   file: File;
   previewUrl: string;
 };
@@ -129,8 +132,7 @@ export default function AdminNoteQuickCaptureLauncher({
   const [error, setError] = useState<string | null>(null);
   const [savedNotice, setSavedNotice] = useState<SavedNotice | null>(null);
   const [createdCaptureRecovery, setCreatedCaptureRecovery] = useState<SavedNotice | null>(null);
-  const [pendingScreenshot, setPendingScreenshot] = useState<PendingScreenshot | null>(null);
-  const [imageToolsExpanded, setImageToolsExpanded] = useState(false);
+  const [pendingImage, setPendingImage] = useState<PendingImage | null>(null);
   const datalistId = useId();
 
   const notesHref = useMemo(() => {
@@ -145,17 +147,11 @@ export default function AdminNoteQuickCaptureLauncher({
 
   useEffect(() => {
     return () => {
-      if (pendingScreenshot?.previewUrl) {
-        URL.revokeObjectURL(pendingScreenshot.previewUrl);
+      if (pendingImage?.previewUrl) {
+        URL.revokeObjectURL(pendingImage.previewUrl);
       }
     };
-  }, [pendingScreenshot]);
-
-  useEffect(() => {
-    if (pendingScreenshot || createdCaptureRecovery) {
-      setImageToolsExpanded(true);
-    }
-  }, [createdCaptureRecovery, pendingScreenshot]);
+  }, [pendingImage]);
 
   useEffect(() => {
     if (!open || categoryOptions.length > 0 || loadingCategories) return;
@@ -201,8 +197,8 @@ export default function AdminNoteQuickCaptureLauncher({
     return null;
   }
 
-  function setPendingScreenshotFromFile(file: File) {
-    setPendingScreenshot((current) => {
+  function setPendingImageFromFile(file: File) {
+    setPendingImage((current) => {
       if (current?.previewUrl) {
         URL.revokeObjectURL(current.previewUrl);
       }
@@ -213,8 +209,8 @@ export default function AdminNoteQuickCaptureLauncher({
     });
   }
 
-  function clearPendingScreenshot() {
-    setPendingScreenshot((current) => {
+  function clearPendingImage() {
+    setPendingImage((current) => {
       if (current?.previewUrl) {
         URL.revokeObjectURL(current.previewUrl);
       }
@@ -226,7 +222,6 @@ export default function AdminNoteQuickCaptureLauncher({
     setError(null);
     setSavedNotice(null);
     setCreatedCaptureRecovery(null);
-    setImageToolsExpanded(false);
     setOpen(true);
   }
 
@@ -239,8 +234,7 @@ export default function AdminNoteQuickCaptureLauncher({
     setError(null);
     setFormState(createInitialFormState());
     setCreatedCaptureRecovery(null);
-    setImageToolsExpanded(false);
-    clearPendingScreenshot();
+    clearPendingImage();
   }
 
   function handleFormPaste(event: React.ClipboardEvent<HTMLFormElement>) {
@@ -261,43 +255,53 @@ export default function AdminNoteQuickCaptureLauncher({
 
     setError(null);
     setCreatedCaptureRecovery(null);
-    setPendingScreenshotFromFile(result.file);
-    setImageToolsExpanded(true);
+    setPendingImageFromFile(result.file);
   }
 
-  async function uploadPendingScreenshot(noteId: string) {
-    if (!pendingScreenshot) {
-      throw new Error("No screenshot is ready to upload.");
+  function handlePendingImageSelection(files: FileList | null) {
+    const selectedFile = files?.[0];
+    if (!selectedFile) return;
+
+    const prepared = prepareAdminNoteImageFile({ file: selectedFile });
+    if (!prepared.ok) {
+      setError(prepared.error);
+      return;
+    }
+
+    setError(null);
+    setCreatedCaptureRecovery(null);
+    setPendingImageFromFile(prepared.file);
+  }
+
+  async function uploadPendingImage(noteId: string) {
+    if (!pendingImage) {
+      throw new Error("No image is ready to upload.");
     }
 
     return uploadAdminNoteFiles({
       noteId,
-      files: [pendingScreenshot.file],
+      files: [pendingImage.file],
     });
   }
 
-  async function retryPendingScreenshotUpload() {
-    if (!createdCaptureRecovery || !pendingScreenshot || submitting) return;
+  async function retryPendingImageUpload() {
+    if (!createdCaptureRecovery || !pendingImage || submitting) return;
 
     setSubmitting(true);
     setError(null);
 
     try {
-      const updatedItem = await uploadPendingScreenshot(createdCaptureRecovery.id);
+      const updatedItem = await uploadPendingImage(createdCaptureRecovery.id);
       setSavedNotice({
         id: updatedItem.id,
         title: updatedItem.title,
       });
       setCreatedCaptureRecovery(null);
-      clearPendingScreenshot();
+      clearPendingImage();
       onSaved?.(updatedItem);
       setOpen(false);
     } catch (uploadError) {
-      setError(
-        uploadError instanceof Error
-          ? uploadError.message
-          : "Could not upload screenshot attachment."
-      );
+      setError(uploadError instanceof Error ? uploadError.message : "Could not upload image.");
     } finally {
       setSubmitting(false);
     }
@@ -330,14 +334,14 @@ export default function AdminNoteQuickCaptureLauncher({
         return;
       }
 
-      if (pendingScreenshot) {
+      if (pendingImage) {
         try {
-          const updatedItem = await uploadPendingScreenshot(payload.item.id);
+          const updatedItem = await uploadPendingImage(payload.item.id);
           setSavedNotice({
             id: updatedItem.id,
             title: updatedItem.title,
           });
-          clearPendingScreenshot();
+          clearPendingImage();
           setCreatedCaptureRecovery(null);
           onSaved?.(updatedItem);
           setOpen(false);
@@ -352,8 +356,8 @@ export default function AdminNoteQuickCaptureLauncher({
           onSaved?.(payload.item);
           setError(
             uploadError instanceof Error
-              ? `Note saved, but ${uploadError.message.toLowerCase()} Retry screenshot upload or open the note in Notes.`
-              : "Note saved, but screenshot upload failed. Retry screenshot upload or open the note in Notes."
+              ? `Note saved, but ${uploadError.message.toLowerCase()} Retry image upload or open the note in Notes.`
+              : "Note saved, but image upload failed. Retry image upload or open the note in Notes."
           );
           return;
         }
@@ -403,11 +407,7 @@ export default function AdminNoteQuickCaptureLauncher({
       ) : null}
 
       <Modal open={open} onClose={closeLauncher} ariaLabel="Quick note capture">
-        <div
-          className="flex h-full min-h-0 flex-col"
-          data-testid="admin-note-quick-capture-dialog"
-          data-admin-screenshot-hide-during-capture="true"
-        >
+        <div className="flex h-full min-h-0 flex-col" data-testid="admin-note-quick-capture-dialog">
           <div className="flex items-start justify-between gap-3 border-b border-slate-200 px-5 py-4">
             <div>
               <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
@@ -440,59 +440,63 @@ export default function AdminNoteQuickCaptureLauncher({
                     Image evidence
                   </p>
                   <p className="mt-1 text-sm font-medium text-slate-900">
-                    Keep image tools tucked away until you need them
+                    Add one image if it helps explain the issue
                   </p>
                   <p className="mt-1 text-xs text-slate-600">
-                    Paste from clipboard anywhere in this form with Cmd+V or Ctrl+V, or open image
-                    tools when you need a screenshot.
+                    Copy a screenshot or image to clipboard, then paste it here, or upload a file.
                   </p>
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => setImageToolsExpanded((current) => !current)}
-                    className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50"
-                  >
-                    {imageToolsExpanded ? "Hide image tools" : "Add image"}
-                  </button>
-                  {imageToolsExpanded ? (
-                    <AdminNoteScreenshotCaptureButton
-                      buttonLabel={pendingScreenshot ? "Retake screenshot" : "Capture screenshot"}
-                      onCaptureReady={async (file) => {
-                        setError(null);
-                        setCreatedCaptureRecovery(null);
-                        setPendingScreenshotFromFile(file);
+                  <AdminNoteClipboardPasteButton
+                    onPasteReady={async (file) => {
+                      setError(null);
+                      setCreatedCaptureRecovery(null);
+                      setPendingImageFromFile(file);
+                    }}
+                    onError={(message) => {
+                      setError(message);
+                    }}
+                  />
+                  <label className="inline-flex cursor-pointer items-center justify-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 transition hover:bg-slate-50">
+                    <span>Upload image</span>
+                    <input
+                      type="file"
+                      accept="image/png,image/jpeg,image/webp,image/gif"
+                      className="sr-only"
+                      onChange={(event) => {
+                        handlePendingImageSelection(event.target.files);
+                        event.currentTarget.value = "";
                       }}
                     />
-                  ) : null}
+                  </label>
                 </div>
               </div>
 
-              {imageToolsExpanded && !pendingScreenshot ? (
+              {!pendingImage ? (
                 <p className="mt-3 text-xs text-slate-600">
-                  No image attached yet. Paste an image from clipboard or use screenshot capture to
-                  stage one before save.
+                  No image attached yet. Use the clipboard button after copying a screenshot, or
+                  upload an image file before save.
                 </p>
               ) : null}
 
-              {pendingScreenshot ? (
+              {pendingImage ? (
                 <div className="mt-3 rounded-xl border border-slate-200 bg-white px-3 py-3">
                   <div className="flex flex-wrap items-center justify-between gap-3">
                     <div className="flex items-center gap-3">
                       {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img
-                        src={pendingScreenshot.previewUrl}
-                        alt="Pending screenshot preview"
+                        src={pendingImage.previewUrl}
+                        alt="Pending image preview"
                         className="h-14 w-14 rounded-lg object-cover"
                       />
                       <div>
                         <p className="text-xs font-semibold text-slate-900">
-                          Screenshot ready to attach
+                          Image ready to attach
                         </p>
                         <p className="mt-1 text-[11px] text-slate-600">
                           {createdCaptureRecovery
-                            ? "The note is already saved. Retry the screenshot upload or finish without it."
-                            : "The next note save will upload this screenshot as an admin-only attachment."}
+                            ? "The note is already saved. Retry the image upload or finish without it."
+                            : "The next note save will upload this image as an admin-only attachment."}
                         </p>
                       </div>
                     </div>
@@ -501,7 +505,7 @@ export default function AdminNoteQuickCaptureLauncher({
                         <button
                           type="button"
                           onClick={() => {
-                            void retryPendingScreenshotUpload();
+                            void retryPendingImageUpload();
                           }}
                           disabled={submitting}
                           className="inline-flex h-9 items-center justify-center rounded-lg bg-blue-600 px-3 text-xs font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
@@ -518,12 +522,12 @@ export default function AdminNoteQuickCaptureLauncher({
                             setOpen(false);
                             setFormState(createInitialFormState());
                           }
-                          clearPendingScreenshot();
+                          clearPendingImage();
                         }}
                         disabled={submitting}
                         className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
                       >
-                        Remove screenshot
+                        Remove image
                       </button>
                     </div>
                   </div>
@@ -539,7 +543,7 @@ export default function AdminNoteQuickCaptureLauncher({
                   >
                     Open in Notes
                   </a>{" "}
-                  if you want to finish without retrying the screenshot.
+                  if you want to finish without retrying the image upload.
                 </p>
               ) : null}
             </div>
@@ -648,7 +652,7 @@ export default function AdminNoteQuickCaptureLauncher({
               <div className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 pt-4">
                 <p className="text-xs text-slate-500">
                   {createdCaptureRecovery
-                    ? "The note is already saved. Retry the screenshot upload or close and reopen it from Notes."
+                    ? "The note is already saved. Retry the image upload or close and reopen it from Notes."
                     : loadingCategories
                       ? "Loading category suggestions…"
                       : "The note stays local until you click Save note. Clipboard images stay local until the save/upload path succeeds."}

--- a/components/admin/AdminNotesManager.tsx
+++ b/components/admin/AdminNotesManager.tsx
@@ -2,12 +2,15 @@
 
 import { useCallback, useDeferredValue, useEffect, useMemo, useState } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
-import AdminNoteScreenshotCaptureButton from "@/components/admin/AdminNoteScreenshotCaptureButton";
+import AdminNoteClipboardPasteButton from "@/components/admin/AdminNoteClipboardPasteButton";
 import {
   ADMIN_NOTE_CONTEXT_TYPE_VALUES,
   type AdminNoteContextType,
 } from "@/lib/admin/note-context";
-import { extractAdminNoteClipboardImage } from "@/lib/admin/note-compose";
+import {
+  extractAdminNoteClipboardImage,
+  prepareAdminNoteImageFile,
+} from "@/lib/admin/note-compose";
 import {
   buildAdminNoteContextCatalog,
   resolveAdminNoteContextLabel,
@@ -579,14 +582,31 @@ export default function AdminNotesManager() {
     }
 
     setActionError(null);
-    setActionNotice("Pasted image ready to attach on the next note save.");
+    setActionNotice("Image ready to attach on the next note save.");
     setCreateCaptureRecovery(null);
     setCreatePendingScreenshotFromFile(result.file);
   }
 
+  function handleCreateImageSelection(files: FileList | null) {
+    const selectedFile = files?.[0];
+    if (!selectedFile) return;
+
+    const prepared = prepareAdminNoteImageFile({ file: selectedFile });
+    if (!prepared.ok) {
+      setActionError(prepared.error);
+      setActionNotice(null);
+      return;
+    }
+
+    setActionError(null);
+    setActionNotice("Image ready to attach on the next note save.");
+    setCreateCaptureRecovery(null);
+    setCreatePendingScreenshotFromFile(prepared.file);
+  }
+
   async function uploadCreatePendingScreenshot(noteId: string) {
     if (!createPendingScreenshot) {
-      throw new Error("No screenshot is ready to upload.");
+      throw new Error("No image is ready to upload.");
     }
 
     return uploadAdminNoteFiles({
@@ -609,11 +629,9 @@ export default function AdminNotesManager() {
       );
       clearCreatePendingScreenshot();
       setCreateCaptureRecovery(null);
-      setActionNotice("Screenshot attached to the saved note.");
+      setActionNotice("Image attached to the saved note.");
     } catch (error) {
-      setActionError(
-        error instanceof Error ? error.message : "Could not upload screenshot attachment."
-      );
+      setActionError(error instanceof Error ? error.message : "Could not upload image.");
     } finally {
       setSubmitting(false);
     }
@@ -668,7 +686,7 @@ export default function AdminNotesManager() {
           clearCreatePendingScreenshot();
           setCreateCaptureRecovery(null);
           setFormState(INITIAL_FORM);
-          setActionNotice("Note saved with screenshot attached.");
+          setActionNotice("Note saved with image attached.");
           return;
         } catch (uploadError) {
           setItems((prev) =>
@@ -681,8 +699,8 @@ export default function AdminNotesManager() {
           setFormState(INITIAL_FORM);
           setActionError(
             uploadError instanceof Error
-              ? `Note saved, but ${uploadError.message.toLowerCase()} Retry upload below or use Edit to add the screenshot later.`
-              : "Note saved, but screenshot upload failed. Retry upload below or use Edit to add the screenshot later."
+              ? `Note saved, but ${uploadError.message.toLowerCase()} Retry upload below or use Edit to add the image later.`
+              : "Note saved, but image upload failed. Retry upload below or use Edit to add the image later."
           );
           return;
         }
@@ -958,11 +976,11 @@ export default function AdminNotesManager() {
       });
       applyMutatedItem(itemId, updatedItem);
       setActionNotice(
-        updatedItem.attachments.length === 1 ? "Attachment uploaded." : "Attachments uploaded."
+        updatedItem.attachments.length === 1 ? "Image uploaded." : "Images uploaded."
       );
       return updatedItem;
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Could not upload attachments.";
+      const message = error instanceof Error ? error.message : "Could not upload images.";
       setActionError(message);
       return null;
     } finally {
@@ -1011,17 +1029,15 @@ export default function AdminNotesManager() {
       const payload = (await response.json()) as AdminNoteUpdateResponse;
       if (!response.ok || !payload.ok) {
         setActionError(
-          payload.ok
-            ? "Could not delete attachment."
-            : (payload.error ?? "Could not delete attachment.")
+          payload.ok ? "Could not delete image." : (payload.error ?? "Could not delete image.")
         );
         return;
       }
 
       applyMutatedItem(noteId, payload.item);
-      setActionNotice("Attachment deleted.");
+      setActionNotice("Image deleted.");
     } catch {
-      setActionError("Could not delete attachment.");
+      setActionError("Could not delete image.");
     } finally {
       setDeletingAttachmentId(null);
     }
@@ -1460,7 +1476,7 @@ export default function AdminNotesManager() {
 
                   {!isEditing && item.attachments.length > 0 ? (
                     <div className="mt-3 space-y-2 rounded-lg border border-slate-200 bg-white/80 p-3">
-                      <p className="text-xs font-semibold text-slate-700">Images / screenshots</p>
+                      <p className="text-xs font-semibold text-slate-700">Images</p>
                       <div className="flex flex-wrap gap-3">
                         {item.attachments.map((attachment) => (
                           <a
@@ -1753,30 +1769,29 @@ export default function AdminNotesManager() {
                       <div className="space-y-2 rounded-lg border border-slate-200 bg-slate-50/70 p-3 sm:col-span-2">
                         <div className="flex flex-wrap items-center justify-between gap-2">
                           <div>
-                            <p className="text-xs font-semibold text-slate-900">
-                              Images / screenshots
-                            </p>
+                            <p className="text-xs font-semibold text-slate-900">Images</p>
                             <p className="mt-1 text-[11px] text-slate-600">
-                              PNG, JPEG, WEBP, or GIF up to 5 MB each. Paste an image from clipboard
-                              anywhere in this form or use the capture/upload controls.
+                              PNG, JPEG, WEBP, or GIF up to 5 MB each. Upload images or paste one
+                              image from clipboard directly.
                             </p>
                           </div>
                           <div className="flex flex-wrap items-center gap-2">
-                            <AdminNoteScreenshotCaptureButton
-                              buttonLabel={isUploading ? "Uploading…" : "Capture screenshot"}
-                              onCaptureReady={async (file) => {
-                                const updatedItem = await uploadFilesForNote(item.id, [file]);
-                                if (!updatedItem) {
-                                  throw new Error("Could not upload screenshot attachment.");
-                                }
-                                setActionNotice("Screenshot attached.");
+                            <AdminNoteClipboardPasteButton
+                              onPasteReady={async (file) => {
+                                setActionError(null);
+                                setActionNotice(null);
+                                await uploadFilesForNote(item.id, [file]);
+                              }}
+                              onError={(message) => {
+                                setActionError(message);
+                                setActionNotice(null);
                               }}
                               disabled={Boolean(
                                 isUploading || deletingAttachmentId || updatingId || deletingId
                               )}
                             />
                             <label className="inline-flex cursor-pointer items-center justify-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 transition hover:bg-slate-100">
-                              <span>{isUploading ? "Uploading…" : "Add images"}</span>
+                              <span>{isUploading ? "Uploading…" : "Upload images"}</span>
                               <input
                                 type="file"
                                 accept="image/png,image/jpeg,image/webp,image/gif"
@@ -1859,7 +1874,7 @@ export default function AdminNotesManager() {
                             })}
                           </ul>
                         ) : (
-                          <p className="text-[11px] text-slate-600">No screenshots attached yet.</p>
+                          <p className="text-[11px] text-slate-600">No images attached yet.</p>
                         )}
                       </div>
 
@@ -2022,8 +2037,8 @@ export default function AdminNotesManager() {
           Store planning notes with category, priority, date, and completion tracking.
         </p>
         <p className="mt-2 text-xs text-slate-500">
-          Stage one screenshot before save if needed, then use Edit to attach more images or link
-          related notes afterward.
+          Stage one image before save if needed, then use Edit to attach more images or link related
+          notes afterward.
         </p>
         <div className="mt-3 rounded-xl border border-amber-200 bg-amber-50 p-3">
           <p className="text-xs font-semibold text-amber-900">Incident quick templates</p>
@@ -2137,21 +2152,40 @@ export default function AdminNotesManager() {
           <div className="space-y-3 rounded-xl border border-slate-200 bg-slate-50/70 p-4 sm:col-span-2">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
-                <p className="text-sm font-semibold text-slate-900">Screenshot (optional)</p>
+                <p className="text-sm font-semibold text-slate-900">Image (optional)</p>
                 <p className="mt-1 text-xs text-slate-600">
-                  Paste an image from clipboard anywhere in this form with Cmd+V or Ctrl+V, or
-                  capture a browser screenshot now and attach it after the note save succeeds.
+                  Copy a screenshot or image to clipboard, then paste it here, or upload one file
+                  before save.
                 </p>
               </div>
-              <AdminNoteScreenshotCaptureButton
-                buttonLabel={createPendingScreenshot ? "Retake screenshot" : "Capture screenshot"}
-                onCaptureReady={async (file) => {
-                  setActionError(null);
-                  setCreateCaptureRecovery(null);
-                  setCreatePendingScreenshotFromFile(file);
-                }}
-                disabled={Boolean(submitting)}
-              />
+              <div className="flex flex-wrap items-center gap-2">
+                <AdminNoteClipboardPasteButton
+                  onPasteReady={async (file) => {
+                    setActionError(null);
+                    setActionNotice("Image ready to attach on the next note save.");
+                    setCreateCaptureRecovery(null);
+                    setCreatePendingScreenshotFromFile(file);
+                  }}
+                  onError={(message) => {
+                    setActionError(message);
+                    setActionNotice(null);
+                  }}
+                  disabled={Boolean(submitting)}
+                />
+                <label className="inline-flex cursor-pointer items-center justify-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 transition hover:bg-slate-50">
+                  <span>Upload image</span>
+                  <input
+                    type="file"
+                    accept="image/png,image/jpeg,image/webp,image/gif"
+                    className="sr-only"
+                    disabled={Boolean(submitting)}
+                    onChange={(event) => {
+                      handleCreateImageSelection(event.target.files);
+                      event.currentTarget.value = "";
+                    }}
+                  />
+                </label>
+              </div>
             </div>
 
             {createPendingScreenshot ? (
@@ -2161,17 +2195,15 @@ export default function AdminNotesManager() {
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src={createPendingScreenshot.previewUrl}
-                      alt="Pending screenshot preview"
+                      alt="Pending image preview"
                       className="h-14 w-14 rounded-lg object-cover"
                     />
                     <div>
-                      <p className="text-xs font-semibold text-slate-900">
-                        Screenshot ready to attach
-                      </p>
+                      <p className="text-xs font-semibold text-slate-900">Image ready to attach</p>
                       <p className="mt-1 text-[11px] text-slate-600">
                         {createCaptureRecovery
-                          ? "The note is already saved. Retry upload or finish without the screenshot."
-                          : "The screenshot stays local until this note save finishes successfully."}
+                          ? "The note is already saved. Retry upload or finish without the image."
+                          : "The image stays local until this note save finishes successfully."}
                       </p>
                     </div>
                   </div>
@@ -2196,14 +2228,14 @@ export default function AdminNotesManager() {
                           setCreateCaptureRecovery(null);
                           setActionError(null);
                           setActionNotice(
-                            "Note saved without screenshot. Use Edit to attach one later if needed."
+                            "Note saved without image. Use Edit to attach one later if needed."
                           );
                         }
                       }}
                       disabled={submitting}
                       className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
                     >
-                      Remove screenshot
+                      Remove image
                     </button>
                   </div>
                 </div>

--- a/docs/runbooks/admin-notes-recovery.md
+++ b/docs/runbooks/admin-notes-recovery.md
@@ -12,11 +12,11 @@ Use this runbook for AW-012 workflow `A4` stale-note reconciliation edge cases.
 
 - Save returns `Could not update note.` or `Could not save note.` even though another operator already changed the row.
 - Quick capture save fails or closes unexpectedly and you need to confirm whether a note was actually created.
-- Screenshot capture permission is denied, cancelled, or never reaches preview and you need to finish the note safely.
+- Clipboard image paste is blocked, empty, or never stages a preview and you need to finish the note safely.
 - A pasted clipboard image never reaches preview, disappears before save, or you are unsure whether it uploaded after note save.
 - A contextual note panel shows outdated title/body/status after recent edits in admin.
 - You suspect duplicate/overlapping edits on the same note.
-- Screenshot upload/delete returns an error and you are unsure whether the stored image was fully removed.
+- Image upload/delete returns an error and you are unsure whether the stored image was fully removed.
 - Related-note link/unlink returns an error and you need to confirm whether the link actually exists.
 - A note title starts with `[E2E Admin Note Artifact]` and did not clear automatically after automated testing.
 
@@ -38,14 +38,15 @@ Use this runbook for AW-012 workflow `A4` stale-note reconciliation edge cases.
    - context label (`Course Lesson`, `Product`, `Page`, etc.),
    - raw context ref/path when relevant.
 7. If screenshots are involved:
-   - if capture permission was denied or cancelled, confirm whether the screenshot ever reached preview; if not, nothing was saved and you can retry or use `Add images`,
-   - if you pasted an image from clipboard and no preview ever appeared, nothing was saved; reopen image tools if needed and paste again or use `Add images`,
-   - if preview existed but note save failed, search by `Note ID` or title before retrying capture so you do not create duplicate notes,
+   - if `Paste image from clipboard` says no image was found, confirm you copied the screenshot first and retry, or use `Upload image`,
+   - if clipboard access was blocked, retry from the explicit paste button after granting browser permission, or use `Upload image`,
+   - if you pasted an image from clipboard and no preview ever appeared, nothing was saved; retry paste or use `Upload image`,
+   - if preview existed but note save failed, search by `Note ID` or title before retrying image staging so you do not create duplicate notes,
    - if a pasted image preview existed but note save failed, search by `Note ID` or title before retrying paste so you do not create duplicate notes,
    - confirm the attachment list and image count in the note row,
    - if delete failed, refresh once and verify whether the image is still present before retrying,
    - if upload failed after note save, retry only after confirming you are not looking at a stale duplicate preview,
-   - if the staged screenshot or pasted image was removed locally, use clipboard paste or `Capture screenshot` again, or fall back to `Add images`.
+   - if the staged image was removed locally, use clipboard paste again or fall back to `Upload image`.
 8. If related notes are involved:
    - open the visible linked note IDs from Search if needed,
    - confirm the intended link exists only once,
@@ -59,7 +60,7 @@ Use this runbook for AW-012 workflow `A4` stale-note reconciliation edge cases.
 - Recovery completes without deleting valid note history.
 - Final note state is consistent in admin list and contextual panel.
 - Attachment/image state and related-note links are consistent after one refresh.
-- Permission-denied or cancelled screenshot flows leave no fake saved attachment behind.
+- Blocked or empty clipboard-paste flows leave no fake saved attachment behind.
 - AW-012 checkpoint includes branch/SHA + one-line result summary.
 
 ## Evidence Note Template (Checkpoint Entry)

--- a/docs/task-briefs/in-progress/2026-03-25-admin-notes-image-intake-simplification-and-clipboard-paste-button-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-25-admin-notes-image-intake-simplification-and-clipboard-paste-button-10-10.md
@@ -1,0 +1,196 @@
+# Task Brief: Admin Notes Image Intake Simplification And Clipboard Paste Button (10/10)
+
+## Metadata
+
+- `id`: `2026-03-25-admin-notes-image-intake-simplification-and-clipboard-paste-button-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-03-25`
+- `updated`: `2026-03-25`
+
+## Goal
+
+Admin notes image intake becomes obvious and low-friction by exposing two clear attachment paths: `Upload image` and `Paste image from clipboard`.
+
+## Why This Brief Exists
+
+- Live operator feedback on `2026-03-25` says the shipped clipboard-paste support is too hidden because it depends on remembering `Cmd+V` / `Ctrl+V`.
+- Live operator feedback on `2026-03-25` also says in-app screenshot capture is still confusing in practice because quick note can appear to cover the captured screen and the flow feels harder than normal OS screenshot-to-clipboard tools.
+- The current image intake UI therefore optimizes for technical capability more than operator clarity.
+- This slice keeps the already-shipped attachment model, but simplifies the visible UX so the normal admin mental model is:
+  - copy screenshot to clipboard,
+  - click `Paste image from clipboard`,
+  - or use `Upload image`.
+
+## Admin-Notes Triage Disposition
+
+- Canonical reviewed production-note lineage:
+  - `9c35eed6-10d3-4495-a720-53dc7947f4b0` `Admin note addition - paste image from clipboard to notes`
+    - Disposition: partially covered by [2026-03-24-admin-notes-compose-parity-and-input-stability-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-24-admin-notes-compose-parity-and-input-stability-10-10.md), residual discoverability and explicit button UX now owned by this brief.
+  - `b730efef-bdc9-43f1-b8a5-5423afd3edda` `Quick note`
+    - Disposition: typing-focus regression was fixed in [2026-03-25-admin-notes-quick-capture-and-page-notes-regressions-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-25-admin-notes-quick-capture-and-page-notes-regressions-10-10.md), but quick-capture image-entry ergonomics remain owned by this brief.
+- Direct production/operator verification on `2026-03-25`:
+  - hidden clipboard image paste is too hard to discover and should become a visible button flow.
+  - in-app screenshot capture should no longer be a primary visible image-intake path on admin notes surfaces.
+  - Disposition: owned by this brief even though the residual operator feedback is not yet represented by a new separate surviving production note row.
+
+## Dependencies And Boundaries
+
+- Depends on:
+  - [2026-03-24-admin-notes-compose-parity-and-input-stability-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-24-admin-notes-compose-parity-and-input-stability-10-10.md)
+  - [2026-03-22-admin-notes-screenshot-region-capture-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-22-admin-notes-screenshot-region-capture-10-10.md)
+  - [2026-03-25-admin-notes-quick-capture-and-page-notes-regressions-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-25-admin-notes-quick-capture-and-page-notes-regressions-10-10.md)
+- This slice owns:
+  - visible `Paste image from clipboard` actions on in-scope admin note forms,
+  - visible `Upload image` actions on in-scope admin note forms,
+  - simplifying image-entry copy so screenshot capture is no longer the primary recommended path,
+  - consistent pending-image staging semantics before first note save.
+- This slice does not own:
+  - a new attachment storage model,
+  - OCR, annotation, or screenshot editing,
+  - public-user uploads,
+  - broader admin-notes workflow redesign outside image intake.
+
+## Scope
+
+- Add a visible `Paste image from clipboard` button to:
+  - quick note,
+  - admin-notes create flow,
+  - admin-notes edit flow.
+- Add or keep a visible upload action alongside the clipboard button on the same surfaces.
+- Remove visible screenshot-capture buttons from admin-notes surfaces so only two primary image-entry methods remain in the UI:
+  - `Upload image`
+  - `Paste image from clipboard`
+- Keep existing keyboard paste support as a non-primary fallback where it already works.
+- Keep the same canonical attachment lifecycle:
+  - local-only staging before first save,
+  - attachment upload only after canonical note save when needed,
+  - normal attachment upload/delete for existing notes.
+
+## Out Of Scope
+
+- Rebuilding screenshot capture instead of de-emphasizing it.
+- Desktop-native screenshot tooling.
+- Multiple pre-save staged images on quick note/create when only one local pending image currently exists.
+- Changes to related-note links, categories, or note identity rules.
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - saved note rows,
+  - saved attachment metadata rows,
+  - saved attachment storage objects.
+- Local-only:
+  - in-progress quick note/create draft values,
+  - one pending pre-save image file and preview before successful note save,
+  - clipboard-read transient state and local button-loading state.
+- Sync policy:
+  - clipboard button and upload button must not create server attachments before the note exists,
+  - existing-note edit flows may upload immediately because canonical note identity already exists,
+  - clipboard intake and file-upload intake must converge on the same attachment validation rules.
+- Retention and sensitivity:
+  - copied screenshots stay local until explicit save/upload,
+  - no hidden local persistence beyond the current editing session.
+- Cache/invalidation:
+  - successful image upload/delete still refreshes note surfaces through existing admin-note APIs.
+
+## Identity And Rename Contract
+
+- Canonical stable IDs:
+  - `admin_note.id` remains canonical note identity.
+  - `admin_note_attachment.id` remains canonical attachment identity after save.
+- Human-readable identifiers:
+  - attachment filenames and helper labels are display metadata only.
+- Mutability rules:
+  - this slice changes intake UX only, not note or attachment identity semantics.
+- Rename vs repurpose policy:
+  - a newly pasted or uploaded image remains a new attachment instead of repurposing an existing attachment row.
+- Compatibility contract:
+  - already-saved note attachments remain valid,
+  - existing hidden keyboard-paste support may remain as a fallback but must not be the only discoverable path.
+- Observability and repair:
+  - unsupported clipboard reads, permission denial, empty clipboard, and upload failures must surface actionable recovery.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Business logic correctness and data integrity`
+- `Admin editor ergonomics`
+- `Reliability and failure handling`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                                  | Evidence                          |
+| --------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| Product goals and IA                          | `target`     | Operators can understand the two supported image-entry paths immediately without relying on hidden keyboard memory.                                             | UI review + manual QA             |
+| UX flow clarity                               | `target`     | In-scope forms present exactly two obvious image actions, and clipboard-button failure states give clear next steps.                                            | unit/e2e + manual QA              |
+| Visual design quality                         | `supporting` | Supporting only: simplified image controls should feel calmer and less cluttered than the current capture-first presentation.                                   | screenshot review                 |
+| Business logic correctness and data integrity | `target`     | Clipboard-button and upload-button paths preserve the same canonical attachment validation and save semantics as existing note attachments.                     | unit tests + code review          |
+| Admin editor ergonomics                       | `target`     | Admin can add an image from clipboard or file without guessing hidden shortcuts or opening an unnecessary capture flow.                                         | timed manual QA + workflow review |
+| Accessibility (a11y)                          | `target`     | New image-intake buttons stay keyboard accessible with clear labels and deterministic loading/error states.                                                     | testing-library + e2e             |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: UX simplification should not add noticeable client-weight or rerender churn.                                                                   | build + code review               |
+| Data placement and sync boundaries            | `target`     | Pre-save image staging remains local-only until canonical note save or existing-note attachment upload.                                                         | contract review + tests           |
+| Caching and invalidation strategy             | `supporting` | Supporting only: attachment upload/delete continues using the existing deterministic admin refresh model.                                                       | code review                       |
+| Reliability and failure handling              | `target`     | Empty clipboard, blocked clipboard access, invalid files, and upload failures all recover clearly without fake saved-image state.                               | unit tests + manual QA            |
+| Security and authz                            | `supporting` | Supporting only: admin-only attachment restrictions remain fail-closed and unchanged by the new button UI.                                                      | existing negative-path coverage   |
+| Privacy and compliance                        | `supporting` | Supporting only: clipboard images remain local until explicit save/upload and do not widen visibility beyond existing admin-only attachment rules.              | code review + tests               |
+| Content governance                            | `N/A`        | N/A because this slice changes no editorial governance, publishing policy, or content ownership semantics.                                                      | scope rationale                   |
+| Admin workflow and editability                | `target`     | Quick note, create, and edit image-entry workflows remain consistent enough that operators do not need surface-specific memory.                                 | manual QA + regression coverage   |
+| SEO and crawlability                          | `N/A`        | N/A because admin-note image intake is private admin-only workflow with no public crawl contract.                                                               | scope rationale                   |
+| AI discoverability                            | `N/A`        | N/A because this slice changes no public AI-facing discoverability surface.                                                                                     | scope rationale                   |
+| Analytics and KPI observability               | `supporting` | Supporting only: simplified image-entry paths should remain measurable through existing workflow events or future instrumentation without adding hidden states. | code review                       |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, billing, payout, or commerce operations change in this admin-notes image-intake slice.                                                  | scope rationale                   |
+| Incident response and support operations      | `target`     | Help/Guide and runbook copy must explain the two supported image-entry paths and recovery when clipboard access fails.                                          | docs + help-center assertions     |
+| Finance and reporting operations              | `N/A`        | N/A because this slice does not touch finance, reconciliation, or reporting flows.                                                                              | scope rationale                   |
+| i18n operational readiness                    | `supporting` | Supporting only: labels such as `Paste image from clipboard` and recovery copy stay locale-safe and avoid encoding logic in hidden UI.                          | copy review                       |
+| Stack-fit and dependency discipline           | `target`     | Reuse browser-native clipboard APIs and existing attachment infrastructure with no new dependencies.                                                            | dependency diff + code review     |
+| Testing and QA automation                     | `target`     | Coverage protects explicit clipboard-button success/failure paths plus consistent upload affordances on quick note, create, and edit surfaces.                  | tests + `verify:pre-pr`           |
+| Scalability and cost efficiency               | `supporting` | Supporting only: simplified intake should not create duplicate uploads or hidden retry loops.                                                                   | code review                       |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: UI simplification remains isolated and easy to revert without schema or data rollback.                                                         | diff review                       |
+
+## Acceptance Criteria
+
+1. Quick note, admin-notes create, and admin-notes edit surfaces expose a visible `Paste image from clipboard` action.
+2. Quick note and admin-notes create surfaces expose a visible upload action alongside the clipboard button.
+3. Screenshot-capture buttons are no longer visible on in-scope admin-note surfaces.
+4. Clicking `Paste image from clipboard` stages or uploads an image when clipboard image data exists, using the same attachment validation rules as normal image uploads.
+5. Clicking `Paste image from clipboard` with no readable image in clipboard shows actionable recovery guidance instead of silently doing nothing.
+6. Existing hidden keyboard paste support may remain, but the visible UI no longer depends on it for discoverability.
+7. `npm run lint:briefs`, targeted tests, and `npm run verify:pre-pr` pass before PR update.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run typecheck`
+- targeted `vitest` for:
+  - clipboard-button file extraction and error mapping,
+  - quick note image staging,
+  - create/edit image-intake actions
+- targeted `playwright` for admin notes workflow where stable
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Constraints
+
+- Keep the image-intake change small and operator-focused.
+- Do not reopen unrelated admin-note workflow scope.
+- Preserve the canonical attachment lifecycle and validation rules.
+
+## 10/10 Quality Bar
+
+- Operators should no longer need to remember hidden shortcuts just to attach a clipboard screenshot.
+- The visible image-entry model should be simple enough to explain in one sentence:
+  - upload a file,
+  - or paste from clipboard.
+- Failures must tell the operator what to do next:
+  - copy the screenshot first,
+  - allow clipboard access,
+  - or use upload instead.
+
+## Checkpoint Log
+
+- `2026-03-25 | in-progress | created a dedicated residual UX brief after live operator feedback showed that hidden keyboard paste is still too undiscoverable and in-app screenshot capture remains more confusing than normal OS screenshot-to-clipboard tools; decided to simplify admin notes image intake to visible upload + clipboard-paste actions before further admin-notes or planner work | next: implement explicit clipboard-paste buttons, add visible upload on quick note/create, remove visible screenshot-capture controls, and validate with targeted tests plus full verify`
+- `2026-03-25 | in-progress | implemented the simplified image-intake model across quick note, create, and edit; added explicit clipboard-paste button support plus visible upload affordances; updated Help/Guide + runbook copy; verified with targeted vitest, targeted Playwright (`admin-help-center`pass,`admin-notes-workflow` 2 pass / 1 environment skip), and full \`npm run verify:pre-pr\` pass | next: commit, push, open PR, and run \`npm run verify:pre-merge\` before merge`

--- a/lib/admin/note-compose.ts
+++ b/lib/admin/note-compose.ts
@@ -15,6 +15,21 @@ type AdminNoteClipboardImageResult =
       file: File;
     };
 
+type AdminNotePreparedImageFileResult =
+  | {
+      ok: false;
+      error: string;
+    }
+  | {
+      ok: true;
+      file: File;
+    };
+
+type ClipboardReadableItem = {
+  types: readonly string[];
+  getType: (type: string) => Promise<Blob>;
+};
+
 function extensionForMimeType(mimeType: string): string {
   switch (mimeType) {
     case "image/jpeg":
@@ -31,6 +46,46 @@ function extensionForMimeType(mimeType: string): string {
 
 function buildClipboardFallbackName(mimeType: string): string {
   return `pasted-image.${extensionForMimeType(mimeType)}`;
+}
+
+export function prepareAdminNoteImageFile(params: {
+  file: Blob | File;
+  fileName?: string;
+}): AdminNotePreparedImageFileResult {
+  const mimeType = params.file.type.trim().toLowerCase();
+  if (!mimeType.startsWith("image/")) {
+    return { ok: false, error: "Only PNG, JPEG, WEBP, and GIF images are allowed." };
+  }
+
+  const fileName =
+    params.fileName?.trim() ||
+    ("name" in params.file && typeof params.file.name === "string"
+      ? params.file.name.trim()
+      : "") ||
+    buildClipboardFallbackName(mimeType);
+  const validated = validateAdminNoteAttachment({
+    fileName,
+    mimeType,
+    sizeBytes: params.file.size,
+  });
+
+  if (!validated.ok) {
+    return {
+      ok: false,
+      error: validated.error,
+    };
+  }
+
+  return {
+    ok: true,
+    file: new File([params.file], validated.value.fileName, {
+      type: validated.value.mimeType,
+      lastModified:
+        "lastModified" in params.file && typeof params.file.lastModified === "number"
+          ? params.file.lastModified
+          : Date.now(),
+    }),
+  };
 }
 
 export function extractAdminNoteClipboardImage(params: {
@@ -57,31 +112,85 @@ export function extractAdminNoteClipboardImage(params: {
     return {
       matched: true,
       ok: false,
-      error: "Could not read the pasted image. Try again or use screenshot capture instead.",
+      error: "Could not read the pasted image. Try again or use Upload image instead.",
     };
   }
 
-  const fileName = rawFile.name.trim() || buildClipboardFallbackName(rawFile.type);
-  const validated = validateAdminNoteAttachment({
-    fileName,
-    mimeType: rawFile.type,
-    sizeBytes: rawFile.size,
+  const prepared = prepareAdminNoteImageFile({
+    file: rawFile,
+    fileName: rawFile.name.trim() || buildClipboardFallbackName(rawFile.type),
   });
 
-  if (!validated.ok) {
+  return prepared.ok
+    ? { matched: true, ok: true, file: prepared.file }
+    : { matched: true, ok: false, error: prepared.error };
+}
+
+export async function readAdminNoteClipboardImageFromNavigator(params: {
+  clipboard:
+    | {
+        read: () => Promise<readonly ClipboardReadableItem[]>;
+      }
+    | null
+    | undefined;
+  secureContext?: boolean;
+}): Promise<AdminNotePreparedImageFileResult> {
+  if (params.secureContext === false) {
     return {
-      matched: true,
       ok: false,
-      error: validated.error,
+      error:
+        "Clipboard image paste requires a secure browser context here. Use Upload image instead.",
     };
   }
 
-  return {
-    matched: true,
-    ok: true,
-    file: new File([rawFile], validated.value.fileName, {
-      type: validated.value.mimeType,
-      lastModified: rawFile.lastModified || Date.now(),
-    }),
-  };
+  if (!params.clipboard?.read) {
+    return {
+      ok: false,
+      error:
+        "This browser cannot read clipboard images from a button here yet. Use Upload image instead.",
+    };
+  }
+
+  try {
+    const items = await params.clipboard.read();
+    for (const item of items) {
+      const imageMimeType = item.types.find((type) =>
+        type.trim().toLowerCase().startsWith("image/")
+      );
+      if (!imageMimeType) {
+        continue;
+      }
+
+      const blob = await item.getType(imageMimeType);
+      return prepareAdminNoteImageFile({
+        file: blob,
+        fileName: buildClipboardFallbackName(blob.type || imageMimeType),
+      });
+    }
+
+    return {
+      ok: false,
+      error: "Clipboard does not contain an image yet. Copy a screenshot first, then try again.",
+    };
+  } catch (error) {
+    const errorName =
+      error instanceof DOMException
+        ? error.name
+        : error && typeof error === "object" && "name" in error
+          ? String(error.name)
+          : "";
+
+    if (errorName === "NotAllowedError") {
+      return {
+        ok: false,
+        error:
+          "Clipboard access was blocked. Allow paste access, then try again, or use Upload image instead.",
+      };
+    }
+
+    return {
+      ok: false,
+      error: "Could not read an image from the clipboard right now. Use Upload image instead.",
+    };
+  }
 }

--- a/tests/e2e/admin-help-center.spec.ts
+++ b/tests/e2e/admin-help-center.spec.ts
@@ -111,9 +111,7 @@ test.describe("admin help center", () => {
     await expect(page.getByText("Visible note ID:")).toBeVisible();
     await expect(page.getByText("Priority:")).toBeVisible();
     await expect(page.getByText("Add images / Delete image:")).toBeVisible();
-    await expect(
-      page.getByText("Capture screenshot / Retake screenshot / Retry upload:")
-    ).toBeVisible();
+    await expect(page.getByText("Paste image from clipboard / Upload image:")).toBeVisible();
     await expect(page.getByText("Link note / Remove link:")).toBeVisible();
     await expect(page.getByText("Open lock operations workflow:")).toBeVisible();
     await expect(page.getByText("Open password page:")).toBeVisible();
@@ -144,17 +142,12 @@ test.describe("admin help center", () => {
     ).toBeVisible();
     await expect(
       page.getByText(
-        "Paste an image anywhere in the note form when the screenshot is already on your clipboard; otherwise open image tools and use `Capture screenshot`."
+        "If the issue is visual, copy the screenshot or image to your clipboard first, then use `Paste image from clipboard`, or choose `Upload image` if you already have the file."
       )
     ).toBeVisible();
     await expect(
       page.getByText(
-        "Use `Capture screenshot` when the issue is visual, drag to the relevant crop in preview, and save only after the preview looks right."
-      )
-    ).toBeVisible();
-    await expect(
-      page.getByText(
-        "Remember that pasted or captured images stay local until note save and attachment upload both succeed; if permission is denied or the preview never appears, fall back to `Add images`."
+        "Remember that pasted or uploaded pre-save images stay local until note save and attachment upload both succeed; if clipboard access is blocked or no image is found, fall back to `Upload image`."
       )
     ).toBeVisible();
     await expect(
@@ -164,9 +157,9 @@ test.describe("admin help center", () => {
     ).toBeVisible();
     await expect(
       page.getByText(
-        "On mobile, keep image tools collapsed unless you actively need paste/capture so title, body, and context stay close together."
+        "On mobile, the two image actions stay visible so you do not need to remember hidden paste shortcuts."
       )
     ).toBeVisible();
-    await expect(page.getByText("Screenshot capture is denied or upload fails")).toBeVisible();
+    await expect(page.getByText("Clipboard paste is blocked or image upload fails")).toBeVisible();
   });
 });

--- a/tests/e2e/admin-notes-workflow.spec.ts
+++ b/tests/e2e/admin-notes-workflow.spec.ts
@@ -218,39 +218,31 @@ async function deleteNoteAndWait(page: Page, noteId: string, trigger: () => Prom
   }
 }
 
-async function installAdminScreenshotCaptureMock(
-  page: Page,
-  mode: "success" | "permission_denied"
-) {
+async function installAdminClipboardReadMock(page: Page, mode: "success" | "permission_denied") {
   await page.addInitScript(
-    ({ base64, captureMode }) => {
+    ({ base64, clipboardMode }) => {
       const decodePng = () => Uint8Array.from(atob(base64), (character) => character.charCodeAt(0));
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: {
+          read: async () => {
+            if (clipboardMode === "permission_denied") {
+              throw new DOMException("Permission denied", "NotAllowedError");
+            }
 
-      window.__FS_ADMIN_SCREENSHOT_CAPTURE_OVERRIDE__ = {
-        isSupported: () => true,
-        capture: async () => {
-          if (captureMode === "permission_denied") {
-            const error = new Error("Permission denied");
-            error.name = "NotAllowedError";
-            throw error;
-          }
-
-          return {
-            blob: new Blob([decodePng()], { type: "image/png" }),
-            width: 1,
-            height: 1,
-            fileName: "captured-proof.png",
-          };
+            return [
+              {
+                types: ["image/png"],
+                getType: async () => new Blob([decodePng()], { type: "image/png" }),
+              },
+            ];
+          },
         },
-        cropToFile: async () =>
-          new File([decodePng()], "captured-proof.png", {
-            type: "image/png",
-          }),
-      };
+      });
     },
     {
       base64: TINY_PNG_BASE64,
-      captureMode: mode,
+      clipboardMode: mode,
     }
   );
 }
@@ -278,7 +270,7 @@ test.describe("admin notes workflow", () => {
     test.slow();
     test.setTimeout(90_000);
 
-    await installAdminScreenshotCaptureMock(page, "success");
+    await installAdminClipboardReadMock(page, "success");
     await loginAsAdminViaDevBypass(page);
     await openNotesSection(page);
 
@@ -303,6 +295,13 @@ test.describe("admin notes workflow", () => {
 
     await page.getByRole("button", { name: "Use P1 template" }).click();
     const createForm = page.getByTestId("admin-notes-create-form");
+    await expect(
+      createForm.getByRole("button", { name: "Paste image from clipboard" })
+    ).toBeVisible();
+    await expect(createForm.getByLabel("Upload image")).toBeVisible();
+    await expect(createForm.getByRole("button", { name: "Capture screenshot" })).toHaveCount(0);
+    await createForm.getByRole("button", { name: "Paste image from clipboard" }).click();
+    await expect(createForm.getByText("Image ready to attach")).toBeVisible({ timeout: 10_000 });
     await expect(createForm.getByLabel("Category")).toHaveValue("Incident P1");
     await createForm.getByLabel("Title").fill(title);
     await createForm.getByLabel("Category").fill("Operations");
@@ -329,19 +328,29 @@ test.describe("admin notes workflow", () => {
     }
     await lessonPicker.selectOption({ index: 1 });
     let createResponse: Awaited<ReturnType<Page["waitForResponse"]>> | undefined;
+    let createAttachmentResponse: Awaited<ReturnType<Page["waitForResponse"]>> | undefined;
     try {
-      [createResponse] = await Promise.all([
+      [createResponse, createAttachmentResponse] = await Promise.all([
         page.waitForResponse(
           (response) =>
-            response.url().includes("/api/admin/notes") && response.request().method() === "POST",
+            response.url().includes("/api/admin/notes") &&
+            !response.url().includes("/attachments") &&
+            response.request().method() === "POST",
+          { timeout: 15_000 }
+        ),
+        page.waitForResponse(
+          (response) =>
+            response.url().includes("/api/admin/notes/") &&
+            response.url().includes("/attachments") &&
+            response.request().method() === "POST",
           { timeout: 15_000 }
         ),
         createForm.getByRole("button", { name: "Save note" }).click(),
       ]);
     } catch {
-      test.skip(true, "Admin notes create request timed out in this environment.");
+      test.skip(true, "Admin notes create or staged-image upload timed out in this environment.");
     }
-    if (!createResponse) {
+    if (!createResponse || !createAttachmentResponse) {
       return;
     }
 
@@ -357,8 +366,22 @@ test.describe("admin notes workflow", () => {
           : `status ${createResponse.status()}`;
       test.skip(true, `Admin notes create is not write-ready in this environment (${reason}).`);
     }
+    const createAttachmentPayload = (await createAttachmentResponse.json().catch(() => null)) as {
+      ok?: boolean;
+      error?: string;
+    } | null;
+    if (!createAttachmentResponse.ok() || createAttachmentPayload?.ok === false) {
+      const reason =
+        typeof createAttachmentPayload?.error === "string"
+          ? createAttachmentPayload.error
+          : `status ${createAttachmentResponse.status()}`;
+      test.skip(
+        true,
+        `Admin notes staged-image upload is not ready in this environment (${reason}).`
+      );
+    }
 
-    await expect(page.getByText("Note saved to open work queue.")).toBeVisible({
+    await expect(page.getByText("Note saved with image attached.")).toBeVisible({
       timeout: 5_000,
     });
 
@@ -368,6 +391,7 @@ test.describe("admin notes workflow", () => {
     await expect(createdItem).toContainText(body);
     await expect(createdItem).toContainText("High");
     await expect(createdItem).toContainText("Course Lesson:");
+    await expect(createdItem).toContainText("1 image");
     const noteIdText = await createdItem.getByTestId("admin-note-id").textContent();
     const noteId = noteIdText?.replace("Note ID", "").trim() ?? "";
     expect(noteId.length).toBeGreaterThan(5);
@@ -382,7 +406,9 @@ test.describe("admin notes workflow", () => {
       [secondaryCreateResponse] = await Promise.all([
         page.waitForResponse(
           (response) =>
-            response.url().includes("/api/admin/notes") && response.request().method() === "POST",
+            response.url().includes("/api/admin/notes") &&
+            !response.url().includes("/attachments") &&
+            response.request().method() === "POST",
           { timeout: 15_000 }
         ),
         createForm.getByRole("button", { name: "Save note" }).click(),
@@ -468,17 +494,18 @@ test.describe("admin notes workflow", () => {
           { timeout: 15_000 }
         ),
         (async () => {
-          await attachmentsEditForm.getByRole("button", { name: "Capture screenshot" }).click();
-          const captureDialog = page.getByTestId("admin-note-screenshot-capture-dialog");
-          await expect(captureDialog).toBeVisible();
           await expect(
-            captureDialog.getByTestId("admin-note-screenshot-preview-image")
-          ).toBeVisible();
-          await captureDialog.getByRole("button", { name: "Save screenshot" }).click();
+            attachmentsEditForm.getByRole("button", { name: "Capture screenshot" })
+          ).toHaveCount(0);
+          await attachmentsEditForm.getByTestId("admin-note-attachment-input").setInputFiles({
+            name: "uploaded-proof.png",
+            mimeType: "image/png",
+            buffer: Buffer.from(TINY_PNG_BASE64, "base64"),
+          });
         })(),
       ]);
     } catch {
-      test.skip(true, "Admin notes screenshot capture upload timed out in this environment.");
+      test.skip(true, "Admin notes image upload timed out in this environment.");
     }
     if (!uploadResponse) {
       return;
@@ -492,13 +519,10 @@ test.describe("admin notes workflow", () => {
         typeof uploadPayload?.error === "string"
           ? uploadPayload.error
           : `status ${uploadResponse.status()}`;
-      test.skip(
-        true,
-        `Admin notes screenshot capture upload is not ready in this environment (${reason}).`
-      );
+      test.skip(true, `Admin notes image upload is not ready in this environment (${reason}).`);
     }
 
-    await expect(updatedItem).toContainText("1 image");
+    await expect(updatedItem).toContainText("2 images");
 
     await attachmentsEditForm
       .getByTestId("admin-note-related-select")
@@ -548,7 +572,7 @@ test.describe("admin notes workflow", () => {
         attachmentsEditForm.getByTestId("admin-note-attachment-delete").click(),
       ]);
     } catch {
-      test.skip(true, "Admin notes screenshot delete request timed out in this environment.");
+      test.skip(true, "Admin notes image delete request timed out in this environment.");
     }
     if (!deleteAttachmentResponse) {
       return;
@@ -563,13 +587,10 @@ test.describe("admin notes workflow", () => {
         typeof deleteAttachmentPayload?.error === "string"
           ? deleteAttachmentPayload.error
           : `status ${deleteAttachmentResponse.status()}`;
-      test.skip(
-        true,
-        `Admin notes screenshot delete is not ready in this environment (${reason}).`
-      );
+      test.skip(true, `Admin notes image delete is not ready in this environment (${reason}).`);
     }
 
-    await expect(updatedItem).not.toContainText("1 image");
+    await expect(updatedItem).toContainText("1 image");
     await attachmentsEditForm.getByRole("button", { name: "Cancel" }).click();
 
     await page.getByTestId("admin-notes-category-filter").selectOption("Product");
@@ -643,25 +664,26 @@ test.describe("admin notes workflow", () => {
     ).toHaveCount(0);
   });
 
-  test("shows recovery when screenshot capture permission is denied", async ({
-    page,
-  }, testInfo) => {
+  test("shows recovery when clipboard image paste is blocked", async ({ page }, testInfo) => {
     runOnceOnDesktopChromium(testInfo.project.name);
 
-    await installAdminScreenshotCaptureMock(page, "permission_denied");
+    await installAdminClipboardReadMock(page, "permission_denied");
     await loginAsAdminViaDevBypass(page);
     await openNotesSection(page);
 
     const createForm = page.getByTestId("admin-notes-create-form");
-    await expect(createForm.getByRole("button", { name: "Capture screenshot" })).toBeVisible({
+    await expect(
+      createForm.getByRole("button", { name: "Paste image from clipboard" })
+    ).toBeVisible({
       timeout: 10_000,
     });
-    await createForm.getByRole("button", { name: "Capture screenshot" }).click();
-
-    const captureDialog = page.getByTestId("admin-note-screenshot-capture-dialog");
-    await expect(captureDialog).toBeVisible({ timeout: 10_000 });
-    await expect(captureDialog).toContainText(/Screenshot permission was denied/i);
-    await expect(captureDialog.getByRole("button", { name: "Retry capture" })).toBeVisible();
+    await expect(createForm.getByRole("button", { name: "Capture screenshot" })).toHaveCount(0);
+    await createForm.getByRole("button", { name: "Paste image from clipboard" }).click();
+    await expect(
+      page.getByText(
+        "Clipboard access was blocked. Allow paste access, then try again, or use Upload image instead."
+      )
+    ).toBeVisible({ timeout: 10_000 });
   });
 
   test("allowlisted admin can quick-capture a dashboard note and jump into Notes", async ({

--- a/tests/unit/admin-note-clipboard-paste-button.test.tsx
+++ b/tests/unit/admin-note-clipboard-paste-button.test.tsx
@@ -1,0 +1,72 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import AdminNoteClipboardPasteButton from "@/components/admin/AdminNoteClipboardPasteButton";
+
+describe("AdminNoteClipboardPasteButton", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("reads an image from the clipboard and forwards it to the caller", async () => {
+    const user = userEvent.setup();
+    const onPasteReady = vi.fn().mockResolvedValue(undefined);
+    const onSuccess = vi.fn();
+    const read = vi.fn().mockResolvedValue([
+      {
+        types: ["image/png"],
+        getType: async () => new Blob(["png"], { type: "image/png" }),
+      },
+    ]);
+
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { read },
+    });
+
+    render(<AdminNoteClipboardPasteButton onPasteReady={onPasteReady} onSuccess={onSuccess} />);
+
+    await user.click(screen.getByRole("button", { name: "Paste image from clipboard" }));
+
+    await waitFor(() => {
+      expect(onPasteReady).toHaveBeenCalledTimes(1);
+    });
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+
+    const firstArg = onPasteReady.mock.calls[0]?.[0];
+    expect(firstArg).toBeInstanceOf(File);
+    expect(firstArg?.name).toBe("pasted-image.png");
+    expect(firstArg?.type).toBe("image/png");
+  });
+
+  it("surfaces actionable recovery when the clipboard button cannot read an image", async () => {
+    const user = userEvent.setup();
+    const onPasteReady = vi.fn();
+    const onError = vi.fn();
+
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { read: undefined },
+    });
+
+    render(<AdminNoteClipboardPasteButton onPasteReady={onPasteReady} onError={onError} />);
+
+    await user.click(screen.getByRole("button", { name: "Paste image from clipboard" }));
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(
+        "This browser cannot read clipboard images from a button here yet. Use Upload image instead."
+      );
+    });
+    expect(onPasteReady).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/admin-note-compose.test.ts
+++ b/tests/unit/admin-note-compose.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { extractAdminNoteClipboardImage } from "@/lib/admin/note-compose";
+import {
+  extractAdminNoteClipboardImage,
+  prepareAdminNoteImageFile,
+  readAdminNoteClipboardImageFromNavigator,
+} from "@/lib/admin/note-compose";
 
 function buildClipboardData(params: {
   kind?: string;
@@ -87,5 +91,102 @@ describe("extractAdminNoteClipboardImage", () => {
       throw new Error("Expected oversized clipboard image to fail validation.");
     }
     expect(result.error).toMatch(/5 MB or smaller/i);
+  });
+});
+
+describe("prepareAdminNoteImageFile", () => {
+  it("normalizes uploaded image files with the same attachment rules", () => {
+    const file = new File(["png"], "evidence.png", { type: "image/png" });
+    const result = prepareAdminNoteImageFile({ file });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("Expected uploaded image preparation to succeed.");
+    }
+
+    expect(result.file.name).toBe("evidence.png");
+    expect(result.file.type).toBe("image/png");
+  });
+
+  it("rejects non-image uploads before staging them locally", () => {
+    const file = new File(["pdf"], "notes.pdf", { type: "application/pdf" });
+    const result = prepareAdminNoteImageFile({ file });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Only PNG, JPEG, WEBP, and GIF images are allowed.",
+    });
+  });
+});
+
+describe("readAdminNoteClipboardImageFromNavigator", () => {
+  it("reads an image from the async clipboard button flow", async () => {
+    const result = await readAdminNoteClipboardImageFromNavigator({
+      clipboard: {
+        read: async () => [
+          {
+            types: ["image/png"],
+            getType: async () => new Blob(["png"], { type: "image/png" }),
+          },
+        ],
+      },
+      secureContext: true,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("Expected clipboard button image read to succeed.");
+    }
+    expect(result.file.name).toBe("pasted-image.png");
+    expect(result.file.type).toBe("image/png");
+  });
+
+  it("explains when the clipboard button is unsupported in the current browser", async () => {
+    await expect(
+      readAdminNoteClipboardImageFromNavigator({
+        clipboard: null,
+        secureContext: true,
+      })
+    ).resolves.toEqual({
+      ok: false,
+      error:
+        "This browser cannot read clipboard images from a button here yet. Use Upload image instead.",
+    });
+  });
+
+  it("explains when no clipboard image is available for the button flow", async () => {
+    await expect(
+      readAdminNoteClipboardImageFromNavigator({
+        clipboard: {
+          read: async () => [
+            {
+              types: ["text/plain"],
+              getType: async () => new Blob(["text"], { type: "text/plain" }),
+            },
+          ],
+        },
+        secureContext: true,
+      })
+    ).resolves.toEqual({
+      ok: false,
+      error: "Clipboard does not contain an image yet. Copy a screenshot first, then try again.",
+    });
+  });
+
+  it("maps blocked clipboard access to actionable recovery guidance", async () => {
+    await expect(
+      readAdminNoteClipboardImageFromNavigator({
+        clipboard: {
+          read: async () => {
+            throw new DOMException("blocked", "NotAllowedError");
+          },
+        },
+        secureContext: true,
+      })
+    ).resolves.toEqual({
+      ok: false,
+      error:
+        "Clipboard access was blocked. Allow paste access, then try again, or use Upload image instead.",
+    });
   });
 });

--- a/tests/unit/admin-note-quick-capture-launcher.test.tsx
+++ b/tests/unit/admin-note-quick-capture-launcher.test.tsx
@@ -140,19 +140,8 @@ describe("AdminNoteQuickCaptureLauncher", () => {
     expect(openLink).toHaveAttribute("href", expect.stringContaining("notesContextRef=%2Fplans"));
   });
 
-  it("saves a quick note and uploads a captured screenshot attachment", async () => {
+  it("saves a quick note and uploads a selected image attachment", async () => {
     const onSaved = vi.fn();
-    window.__FS_ADMIN_SCREENSHOT_CAPTURE_OVERRIDE__ = {
-      isSupported: () => true,
-      capture: async () => ({
-        blob: new Blob(["capture"], { type: "image/png" }),
-        width: 200,
-        height: 100,
-        fileName: "captured-proof.png",
-      }),
-      cropToFile: async () => new File(["cropped"], "captured-proof.png", { type: "image/png" }),
-    };
-
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({
@@ -234,11 +223,12 @@ describe("AdminNoteQuickCaptureLauncher", () => {
     fireEvent.click(screen.getByTestId("admin-note-quick-capture-trigger"));
     await screen.findByTestId("admin-note-quick-capture-dialog");
 
-    fireEvent.click(screen.getByRole("button", { name: "Add image" }));
-    fireEvent.click(screen.getByRole("button", { name: "Capture screenshot" }));
-    await screen.findByTestId("admin-note-screenshot-preview-image");
-    fireEvent.click(screen.getByRole("button", { name: "Save screenshot" }));
-    await screen.findByText("Screenshot ready to attach");
+    fireEvent.change(screen.getByLabelText("Upload image"), {
+      target: {
+        files: [new File(["png"], "captured-proof.png", { type: "image/png" })],
+      },
+    });
+    await screen.findByText("Image ready to attach");
 
     fireEvent.change(screen.getByLabelText("Title"), {
       target: { value: "Plans screenshot follow-up" },
@@ -260,18 +250,7 @@ describe("AdminNoteQuickCaptureLauncher", () => {
     await screen.findByText("Quick note saved.");
   });
 
-  it("keeps screenshot recovery visible when note save succeeds but attachment upload fails", async () => {
-    window.__FS_ADMIN_SCREENSHOT_CAPTURE_OVERRIDE__ = {
-      isSupported: () => true,
-      capture: async () => ({
-        blob: new Blob(["capture"], { type: "image/png" }),
-        width: 200,
-        height: 100,
-        fileName: "captured-proof.png",
-      }),
-      cropToFile: async () => new File(["cropped"], "captured-proof.png", { type: "image/png" }),
-    };
-
+  it("keeps image recovery visible when note save succeeds but attachment upload fails", async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({
@@ -325,11 +304,12 @@ describe("AdminNoteQuickCaptureLauncher", () => {
     fireEvent.click(screen.getByTestId("admin-note-quick-capture-trigger"));
     await screen.findByTestId("admin-note-quick-capture-dialog");
 
-    fireEvent.click(screen.getByRole("button", { name: "Add image" }));
-    fireEvent.click(screen.getByRole("button", { name: "Capture screenshot" }));
-    await screen.findByTestId("admin-note-screenshot-preview-image");
-    fireEvent.click(screen.getByRole("button", { name: "Save screenshot" }));
-    await screen.findByText("Screenshot ready to attach");
+    fireEvent.change(screen.getByLabelText("Upload image"), {
+      target: {
+        files: [new File(["png"], "captured-proof.png", { type: "image/png" })],
+      },
+    });
+    await screen.findByText("Image ready to attach");
 
     fireEvent.change(screen.getByLabelText("Title"), {
       target: { value: "Plans screenshot follow-up" },
@@ -341,7 +321,7 @@ describe("AdminNoteQuickCaptureLauncher", () => {
     expect(screen.getByRole("link", { name: "Open in Notes" })).toBeInTheDocument();
   });
 
-  it("stages a pasted clipboard image and uploads it after the note save succeeds", async () => {
+  it("stages a clipboard image from the explicit paste button and uploads it after the note save succeeds", async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({
@@ -409,6 +389,21 @@ describe("AdminNoteQuickCaptureLauncher", () => {
         }),
       });
     vi.stubGlobal("fetch", fetchMock);
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        read: vi.fn().mockResolvedValue([
+          {
+            types: ["image/png"],
+            getType: async () => new Blob(["png"], { type: "image/png" }),
+          },
+        ]),
+      },
+    });
 
     render(
       <AdminNoteQuickCaptureLauncher
@@ -421,17 +416,9 @@ describe("AdminNoteQuickCaptureLauncher", () => {
 
     fireEvent.click(screen.getByTestId("admin-note-quick-capture-trigger"));
     await screen.findByTestId("admin-note-quick-capture-form");
-    const titleInput = screen.getByLabelText("Title");
+    fireEvent.click(screen.getByRole("button", { name: "Paste image from clipboard" }));
 
-    const pastedFile = new File(["png"], "", { type: "image/png" });
-    fireEvent.paste(titleInput, {
-      clipboardData: {
-        items: [],
-        files: [pastedFile],
-      },
-    });
-
-    await screen.findByText("Screenshot ready to attach");
+    await screen.findByText("Image ready to attach");
 
     fireEvent.change(screen.getByLabelText("Title"), {
       target: { value: "Clipboard note" },


### PR DESCRIPTION
## Summary

- Simplifies admin-notes image intake to two explicit paths: `Paste image from clipboard` and `Upload image`.
- Removes screenshot-capture controls from quick note and full admin notes so the flow no longer depends on the overlay capture UI.
- Keeps keyboard paste as a fallback, but makes clipboard paste discoverable with an explicit button in both note surfaces.
- Updates help/runbook copy to match the shipped operator workflow.

## Scope

- In scope: admin note compose UX, clipboard image intake, upload affordances, operator docs, and regression coverage.
- Out of scope: broader admin-notes linking/workflow follow-ups and any non-image note editing behavior.

## Risk

- Main risk: clipboard API availability varies by browser and permissions.
- Mitigation: upload remains available, keyboard paste fallback remains supported, and the UI shows recovery copy when clipboard image access is blocked.
- Rollback: `git revert fd8dff5`

## Validation Evidence

- `npm run verify:pre-pr` PASS on `fd8dff5`
- `npm run verify:pre-merge` PASS on `fd8dff5`
- Targeted unit coverage includes:
  - `tests/unit/admin-note-clipboard-paste-button.test.tsx`
  - `tests/unit/admin-note-quick-capture-launcher.test.tsx`
  - `tests/unit/admin-note-compose.test.ts`
- Targeted E2E/help coverage is included in the full verify runs, including admin notes workflow + help center flows.
- GitHub required checks are rerunning on `fd8dff5` after rebase onto `main`; merge only when green.

## Notes

- No manual preview QA is recorded in this PR body.
- Brief: `docs/task-briefs/in-progress/2026-03-25-admin-notes-image-intake-simplification-and-clipboard-paste-button-10-10.md`
