### PR TITLE
fix(admin): dock quick note utility panel and add planning categories

### DIFF
--- a/components/admin/AdminHelpCenter.tsx
+++ b/components/admin/AdminHelpCenter.tsx
@@ -391,12 +391,12 @@ const BUTTON_GUIDE: ActionGroup[] = [
       {
         label: "Quick note",
         meaning:
-          "Opens the lightweight quick-capture sheet so you can save a route-aware note, optionally paste one clipboard image or upload one image, and stay on the current admin surface. If you need to scroll the page before saving, collapse it and resume the same draft from the floating quick-note card.",
+          "Opens the lightweight quick-capture utility panel so you can save a route-aware note, optionally paste one clipboard image or upload one image, and keep the page underneath interactive while you work.",
       },
       {
         label: "Collapse / Resume quick note",
         meaning:
-          "Temporarily tucks the quick-capture draft to the page edge without discarding text or the staged image, so you can keep reviewing the current surface before reopening the same note.",
+          "Temporarily slides the quick-note draft out to the right edge without discarding text or the staged image. Reopen it from the slim edge handle when you are ready to continue.",
       },
       {
         label: "Use P0 template / Use P1 template / Use P2 template",
@@ -567,7 +567,8 @@ const DAILY_PLAYBOOKS: Playbook[] = [
     steps: [
       "Open the exact page/content row you are reviewing.",
       "Use `Quick note` when you want to capture the issue fast from the current surface without losing context.",
-      "If you still need to scroll or collect a screenshot before saving, collapse `Quick note` and reopen the same draft from the docked edge handle on the right.",
+      "If you still need to scroll, click, or collect a screenshot before saving, collapse `Quick note`; the page stays interactive underneath and you can reopen the same draft from the docked edge handle on the right.",
+      "If you navigate to another supported admin/context surface before saving, the same draft can follow you, but it stays attached to the original locked context shown in the panel.",
       "Use the top `Add note` section when you want full fields in place; if notes already exist it stays collapsed until you expand it again.",
       "Create note with category, priority, and context link, then copy the visible note ID if you need to reference it later.",
       "If the issue is visual, copy the screenshot or image to your clipboard first, then use `Paste image from clipboard`, or choose `Upload image` if you already have the file.",

--- a/components/admin/AdminNoteQuickCaptureLauncher.tsx
+++ b/components/admin/AdminNoteQuickCaptureLauncher.tsx
@@ -1,10 +1,24 @@
 "use client";
 
-import { useEffect, useId, useMemo, useState } from "react";
-import Modal from "@/components/Modal";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import AdminNoteClipboardPasteButton from "@/components/admin/AdminNoteClipboardPasteButton";
 import type { AdminRole } from "@/lib/admin/access";
 import { hasRequiredAdminRole } from "@/lib/admin/access";
+import {
+  claimQuickCaptureDraftOwner,
+  clearQuickCaptureDraftStore,
+  createQuickCaptureInitialFormState,
+  getQuickCaptureDraftOwnerId,
+  isQuickCaptureDraftDirty,
+  readQuickCaptureDraftStore,
+  releaseQuickCaptureDraftOwner,
+  type QuickCaptureFormState,
+  type QuickCaptureLockedContext,
+  type QuickCapturePendingImage,
+  type QuickCaptureSavedNotice,
+  writeQuickCaptureDraftStore,
+} from "@/lib/admin/admin-note-quick-capture-draft";
 import { applyAdminTabToSearchParams } from "@/lib/admin/admin-workspace";
 import type { AdminCategoryRow } from "@/lib/admin/categories";
 import {
@@ -55,51 +69,8 @@ type Props = {
   onSaved?: (item: AdminNoteItem) => void;
 };
 
-type FormState = {
-  title: string;
-  category: string;
-  noteDate: string;
-  priority: AdminNotePriority;
-  body: string;
-  isDone: boolean;
-};
-
-type SavedNotice = {
-  id: string;
-  title: string;
-};
-
-type PendingImage = {
-  file: File;
-  previewUrl: string;
-};
-
-const INITIAL_CATEGORY = "General";
-
 function todayDateInputValue(): string {
   return new Date().toISOString().slice(0, 10);
-}
-
-function createInitialFormState(): FormState {
-  return {
-    title: "",
-    category: INITIAL_CATEGORY,
-    noteDate: todayDateInputValue(),
-    priority: "normal",
-    body: "",
-    isDone: false,
-  };
-}
-
-function isQuickCaptureDraftDirty(formState: FormState): boolean {
-  return (
-    formState.title.trim().length > 0 ||
-    formState.category.trim() !== INITIAL_CATEGORY ||
-    formState.noteDate !== todayDateInputValue() ||
-    formState.priority !== "normal" ||
-    formState.body.trim().length > 0 ||
-    formState.isDone
-  );
 }
 
 function formatPriorityLabel(priority: AdminNotePriority): string {
@@ -123,55 +94,151 @@ function buildAdminNotesHref(params: {
   return search ? `/admin?${search}` : "/admin";
 }
 
-export default function AdminNoteQuickCaptureLauncher({
-  adminRole,
-  contextType,
-  contextRef,
-  contextLabel,
+function buildCurrentContext(params: Props): QuickCaptureLockedContext {
+  return {
+    contextType: params.contextType,
+    contextRef: params.contextRef,
+    contextLabel: params.contextLabel,
+  };
+}
+
+function ChevronIcon({
+  direction,
   className = "",
-  triggerLabel = "Quick note",
-  triggerTestId = "admin-note-quick-capture-trigger",
-  description = "Capture a context-aware admin note without leaving this surface.",
-  onSaved,
-}: Props) {
+}: {
+  direction: "left" | "right";
+  className?: string;
+}) {
+  const path = direction === "left" ? "M11.5 5.5L7 10l4.5 4.5" : "M8.5 5.5L13 10l-4.5 4.5";
+  return (
+    <svg viewBox="0 0 20 20" fill="none" aria-hidden="true" className={className}>
+      <path
+        d={path}
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export default function AdminNoteQuickCaptureLauncher(props: Props) {
+  const {
+    adminRole,
+    contextType,
+    contextRef,
+    contextLabel,
+    className = "",
+    triggerLabel = "Quick note",
+    triggerTestId = "admin-note-quick-capture-trigger",
+    description = "Capture a context-aware admin note without leaving this surface.",
+    onSaved,
+  } = props;
+
   const canCreateNotes = Boolean(adminRole && hasRequiredAdminRole(adminRole, "editor"));
-  const [open, setOpen] = useState(false);
-  const [formState, setFormState] = useState<FormState>(() => createInitialFormState());
+  const instanceId = useId();
+  const datalistId = useId();
+  const titleInputRef = useRef<HTMLInputElement | null>(null);
+
+  const [portalRoot, setPortalRoot] = useState<HTMLElement | null>(null);
+  const [panelState, setPanelState] = useState<"closed" | "open" | "collapsed">("closed");
+  const [draftContext, setDraftContext] = useState<QuickCaptureLockedContext>(() =>
+    buildCurrentContext(props)
+  );
+  const [formState, setFormState] = useState<QuickCaptureFormState>(() =>
+    createQuickCaptureInitialFormState(todayDateInputValue())
+  );
   const [categoryOptions, setCategoryOptions] = useState<string[]>([]);
   const [loadingCategories, setLoadingCategories] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [savedNotice, setSavedNotice] = useState<SavedNotice | null>(null);
-  const [createdCaptureRecovery, setCreatedCaptureRecovery] = useState<SavedNotice | null>(null);
-  const [pendingImage, setPendingImage] = useState<PendingImage | null>(null);
-  const [minimized, setMinimized] = useState(false);
-  const datalistId = useId();
+  const [savedNotice, setSavedNotice] = useState<QuickCaptureSavedNotice | null>(null);
+  const [createdCaptureRecovery, setCreatedCaptureRecovery] =
+    useState<QuickCaptureSavedNotice | null>(null);
+  const [pendingImage, setPendingImage] = useState<QuickCapturePendingImage | null>(null);
+  const [focusTitleOnOpen, setFocusTitleOnOpen] = useState(false);
+
+  const open = panelState === "open";
+  const minimized = panelState === "collapsed";
+  const todayValue = todayDateInputValue();
+  const hasDraftState = useMemo(
+    () =>
+      isQuickCaptureDraftDirty(formState, todayValue) ||
+      Boolean(pendingImage) ||
+      Boolean(createdCaptureRecovery),
+    [createdCaptureRecovery, formState, pendingImage, todayValue]
+  );
+  const currentSurfaceMatchesDraftContext =
+    draftContext.contextType === contextType && draftContext.contextRef === contextRef;
 
   const notesHref = useMemo(() => {
     const notice = savedNotice ?? createdCaptureRecovery;
     if (!notice) return null;
     return buildAdminNotesHref({
       noteId: notice.id,
-      contextType,
-      contextRef,
+      contextType: draftContext.contextType,
+      contextRef: draftContext.contextRef,
     });
-  }, [contextRef, contextType, createdCaptureRecovery, savedNotice]);
+  }, [createdCaptureRecovery, draftContext.contextRef, draftContext.contextType, savedNotice]);
 
-  const hasDraftState = useMemo(
-    () =>
-      isQuickCaptureDraftDirty(formState) ||
-      Boolean(pendingImage) ||
-      Boolean(createdCaptureRecovery),
-    [createdCaptureRecovery, formState, pendingImage]
-  );
+  const headerCloseActionLabel = createdCaptureRecovery
+    ? "Close panel"
+    : hasDraftState
+      ? "Discard"
+      : "Close panel";
+  const closeActionLabel = createdCaptureRecovery
+    ? "Close panel"
+    : hasDraftState
+      ? "Discard draft"
+      : "Close panel";
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      setPortalRoot(document.body);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!canCreateNotes) return;
+
+    const currentOwnerId = getQuickCaptureDraftOwnerId();
+    if (currentOwnerId && currentOwnerId !== instanceId) {
+      return;
+    }
+
+    const storedDraft = readQuickCaptureDraftStore();
+    if (!storedDraft) {
+      return;
+    }
+
+    claimQuickCaptureDraftOwner(instanceId);
+    setDraftContext(storedDraft.snapshot.context);
+    setFormState(storedDraft.snapshot.formState);
+    setCreatedCaptureRecovery(storedDraft.snapshot.createdCaptureRecovery);
+    setPendingImage(storedDraft.pendingImage);
+    setPanelState(storedDraft.snapshot.panelState);
+  }, [canCreateNotes, instanceId]);
 
   useEffect(() => {
     return () => {
-      if (pendingImage?.previewUrl) {
-        URL.revokeObjectURL(pendingImage.previewUrl);
-      }
+      releaseQuickCaptureDraftOwner(instanceId);
     };
-  }, [pendingImage]);
+  }, [instanceId]);
+
+  useEffect(() => {
+    if (readQuickCaptureDraftStore()) {
+      return;
+    }
+
+    if (panelState === "closed" && !hasDraftState) {
+      setDraftContext({
+        contextType,
+        contextRef,
+        contextLabel,
+      });
+    }
+  }, [contextLabel, contextRef, contextType, hasDraftState, panelState]);
 
   useEffect(() => {
     if (!savedNotice) return;
@@ -225,8 +292,62 @@ export default function AdminNoteQuickCaptureLauncher({
     };
   }, [categoryOptions.length, loadingCategories, open]);
 
+  useEffect(() => {
+    const currentOwnerId = getQuickCaptureDraftOwnerId();
+    if (currentOwnerId && currentOwnerId !== instanceId) {
+      return;
+    }
+
+    const shouldPersist = panelState !== "closed" || hasDraftState;
+    if (!shouldPersist) {
+      if (currentOwnerId === instanceId) {
+        clearQuickCaptureDraftStore();
+        releaseQuickCaptureDraftOwner(instanceId);
+      }
+      return;
+    }
+
+    claimQuickCaptureDraftOwner(instanceId);
+    writeQuickCaptureDraftStore({
+      snapshot: {
+        version: 1,
+        panelState: minimized ? "collapsed" : "open",
+        context: draftContext,
+        formState,
+        createdCaptureRecovery,
+        updatedAt: Date.now(),
+      },
+      pendingImage,
+    });
+  }, [
+    createdCaptureRecovery,
+    draftContext,
+    formState,
+    hasDraftState,
+    instanceId,
+    minimized,
+    panelState,
+    pendingImage,
+  ]);
+
+  useEffect(() => {
+    if (!open || !focusTitleOnOpen) return;
+    titleInputRef.current?.focus();
+    setFocusTitleOnOpen(false);
+  }, [focusTitleOnOpen, open]);
+
   if (!canCreateNotes) {
     return null;
+  }
+
+  function resetDraftState() {
+    setPanelState("closed");
+    setFormState(createQuickCaptureInitialFormState(todayDateInputValue()));
+    setCreatedCaptureRecovery(null);
+    setError(null);
+    setFocusTitleOnOpen(false);
+    setDraftContext(buildCurrentContext(props));
+    clearPendingImage();
   }
 
   function setPendingImageFromFile(file: File) {
@@ -250,22 +371,45 @@ export default function AdminNoteQuickCaptureLauncher({
     });
   }
 
+  function notifySaved(item: AdminNoteItem) {
+    if (currentSurfaceMatchesDraftContext) {
+      onSaved?.(item);
+    }
+  }
+
   function openLauncher() {
     setSavedNotice(null);
-    if (minimized) {
-      setOpen(true);
-      setMinimized(false);
+    setError(null);
+    setFocusTitleOnOpen(true);
+
+    if (panelState === "collapsed") {
+      setPanelState("open");
       return;
     }
-    setError(null);
-    setCreatedCaptureRecovery(null);
-    setOpen(true);
+
+    const currentOwnerId = getQuickCaptureDraftOwnerId();
+    const storedDraft = readQuickCaptureDraftStore();
+    if (storedDraft && (!currentOwnerId || currentOwnerId === instanceId)) {
+      claimQuickCaptureDraftOwner(instanceId);
+      setDraftContext(storedDraft.snapshot.context);
+      setFormState(storedDraft.snapshot.formState);
+      setCreatedCaptureRecovery(storedDraft.snapshot.createdCaptureRecovery);
+      setPendingImage(storedDraft.pendingImage);
+      setPanelState("open");
+      return;
+    }
+
+    if (panelState === "closed" && !hasDraftState) {
+      setDraftContext(buildCurrentContext(props));
+    }
+
+    setPanelState("open");
   }
 
   function minimizeLauncher() {
     if (submitting) return;
-    setOpen(false);
-    setMinimized(true);
+    setError(null);
+    setPanelState("collapsed");
   }
 
   function closeLauncher() {
@@ -273,12 +417,7 @@ export default function AdminNoteQuickCaptureLauncher({
     if (createdCaptureRecovery) {
       setSavedNotice(createdCaptureRecovery);
     }
-    setOpen(false);
-    setMinimized(false);
-    setError(null);
-    setFormState(createInitialFormState());
-    setCreatedCaptureRecovery(null);
-    clearPendingImage();
+    resetDraftState();
   }
 
   function handleFormPaste(event: React.ClipboardEvent<HTMLFormElement>) {
@@ -342,9 +481,10 @@ export default function AdminNoteQuickCaptureLauncher({
       });
       setCreatedCaptureRecovery(null);
       clearPendingImage();
-      onSaved?.(updatedItem);
-      setOpen(false);
-      setMinimized(false);
+      notifySaved(updatedItem);
+      setPanelState("closed");
+      setFormState(createQuickCaptureInitialFormState(todayDateInputValue()));
+      setDraftContext(buildCurrentContext(props));
     } catch (uploadError) {
       setError(uploadError instanceof Error ? uploadError.message : "Could not upload image.");
     } finally {
@@ -368,8 +508,8 @@ export default function AdminNoteQuickCaptureLauncher({
         credentials: "same-origin",
         body: JSON.stringify({
           ...formState,
-          contextType,
-          contextRef,
+          contextType: draftContext.contextType,
+          contextRef: draftContext.contextRef,
         }),
       });
 
@@ -388,18 +528,18 @@ export default function AdminNoteQuickCaptureLauncher({
           });
           clearPendingImage();
           setCreatedCaptureRecovery(null);
-          onSaved?.(updatedItem);
-          setOpen(false);
-          setMinimized(false);
-          setFormState(createInitialFormState());
+          notifySaved(updatedItem);
+          setPanelState("closed");
+          setFormState(createQuickCaptureInitialFormState(todayDateInputValue()));
+          setDraftContext(buildCurrentContext(props));
           return;
         } catch (uploadError) {
           setCreatedCaptureRecovery({
             id: payload.item.id,
             title: payload.item.title,
           });
-          setFormState(createInitialFormState());
-          onSaved?.(payload.item);
+          setFormState(createQuickCaptureInitialFormState(todayDateInputValue()));
+          notifySaved(payload.item);
           setError(
             uploadError instanceof Error
               ? `Note saved, but ${uploadError.message.toLowerCase()} Retry image upload or open the note in Notes.`
@@ -414,16 +554,362 @@ export default function AdminNoteQuickCaptureLauncher({
         title: payload.item.title,
       });
       setCreatedCaptureRecovery(null);
-      onSaved?.(payload.item);
-      setOpen(false);
-      setMinimized(false);
-      setFormState(createInitialFormState());
+      notifySaved(payload.item);
+      setPanelState("closed");
+      setFormState(createQuickCaptureInitialFormState(todayDateInputValue()));
+      setDraftContext(buildCurrentContext(props));
     } catch {
       setError("Could not save note.");
     } finally {
       setSubmitting(false);
     }
   }
+
+  const quickCaptureSurface =
+    portalRoot && (open || minimized)
+      ? createPortal(
+          <div className="pointer-events-none fixed inset-y-0 right-0 z-[70] flex items-start justify-end">
+            {minimized ? (
+              <div
+                className="pointer-events-auto mr-0 mt-24"
+                data-testid="admin-note-quick-capture-minimized"
+              >
+                <button
+                  type="button"
+                  onClick={openLauncher}
+                  data-testid="admin-note-quick-capture-resume"
+                  aria-label="Resume quick note"
+                  className="bg-white/96 flex h-36 w-14 translate-x-[calc(100%-1.75rem)] flex-col items-center justify-start rounded-l-[22px] border border-r-0 border-blue-200 px-2 py-3 text-blue-800 shadow-[0_18px_42px_rgba(15,23,42,0.16)] backdrop-blur transition-transform duration-200 ease-out hover:translate-x-[calc(100%-2.1rem)] hover:bg-blue-50"
+                >
+                  <span className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-blue-200 bg-blue-50 text-blue-700">
+                    <ChevronIcon direction="left" className="h-4 w-4" />
+                  </span>
+                  <span className="mt-3 text-center text-[11px] font-semibold leading-tight">
+                    Quick
+                    <br />
+                    note
+                  </span>
+                </button>
+              </div>
+            ) : null}
+
+            {open ? (
+              <aside
+                aria-label="Quick note capture panel"
+                data-testid="admin-note-quick-capture-dialog"
+                className="pointer-events-auto mb-3 mr-3 mt-16 flex h-[calc(100vh-5rem)] w-[min(28rem,calc(100vw-1rem))] min-w-0 flex-col overflow-hidden rounded-[28px] border border-slate-200 bg-white shadow-[0_24px_64px_rgba(15,23,42,0.18)]"
+              >
+                <div className="flex items-start justify-between gap-3 border-b border-slate-200 px-5 py-4">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
+                      Quick capture
+                    </p>
+                    <h2 className="mt-1 text-lg font-semibold text-slate-900">Create note fast</h2>
+                    <p className="mt-1 text-sm text-slate-600">{description}</p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={minimizeLauncher}
+                      aria-label="Collapse quick note"
+                      className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 transition hover:bg-slate-50"
+                    >
+                      <ChevronIcon direction="right" className="h-4 w-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={closeLauncher}
+                      className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+                    >
+                      {headerCloseActionLabel}
+                    </button>
+                  </div>
+                </div>
+
+                <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+                  <div className="rounded-2xl border border-blue-100 bg-blue-50/60 px-4 py-3">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
+                      Locked context
+                    </p>
+                    <p className="mt-1 text-sm font-medium text-slate-900">
+                      {draftContext.contextLabel}
+                    </p>
+                    <p className="mt-1 text-xs text-slate-600">
+                      This note stays attached to the page/item where you started it, even if you
+                      browse somewhere else before saving.
+                    </p>
+                  </div>
+
+                  {!currentSurfaceMatchesDraftContext ? (
+                    <p className="mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+                      You are viewing another page right now. This draft will still save to{" "}
+                      <span className="font-semibold">{draftContext.contextLabel}</span>.
+                    </p>
+                  ) : null}
+
+                  <div className="mt-4 rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-slate-600">
+                          Image evidence
+                        </p>
+                        <p className="mt-1 text-sm font-medium text-slate-900">
+                          Add one image if it helps explain the issue
+                        </p>
+                        <p className="mt-1 text-xs text-slate-600">
+                          Copy a screenshot or image to clipboard, then paste it here, or upload a
+                          file.
+                        </p>
+                      </div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <AdminNoteClipboardPasteButton
+                          onPasteReady={async (file) => {
+                            setError(null);
+                            setCreatedCaptureRecovery(null);
+                            setPendingImageFromFile(file);
+                          }}
+                          onError={(message) => {
+                            setError(message);
+                          }}
+                        />
+                        <label className="inline-flex cursor-pointer items-center justify-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 transition hover:bg-slate-50">
+                          <span>Upload image</span>
+                          <input
+                            aria-label="Upload image"
+                            type="file"
+                            accept="image/png,image/jpeg,image/webp,image/gif"
+                            className="sr-only"
+                            onChange={(event) => {
+                              handlePendingImageSelection(event.target.files);
+                              event.currentTarget.value = "";
+                            }}
+                          />
+                        </label>
+                      </div>
+                    </div>
+
+                    {!pendingImage ? (
+                      <p className="mt-3 text-xs text-slate-600">
+                        No image attached yet. Use the clipboard button after copying a screenshot,
+                        or upload an image file before save.
+                      </p>
+                    ) : null}
+
+                    {pendingImage ? (
+                      <div className="mt-3 rounded-xl border border-slate-200 bg-white px-3 py-3">
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                          <div className="flex items-center gap-3">
+                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                            <img
+                              src={pendingImage.previewUrl}
+                              alt="Pending image preview"
+                              className="h-14 w-14 rounded-lg object-cover"
+                            />
+                            <div>
+                              <p className="text-xs font-semibold text-slate-900">
+                                Image ready to attach
+                              </p>
+                              <p className="mt-1 text-[11px] text-slate-600">
+                                {createdCaptureRecovery
+                                  ? "The note is already saved. Retry the image upload or finish without it."
+                                  : "The next note save will upload this image as an admin-only attachment."}
+                              </p>
+                            </div>
+                          </div>
+                          <div className="flex flex-wrap items-center gap-2">
+                            {createdCaptureRecovery ? (
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  void retryPendingImageUpload();
+                                }}
+                                disabled={submitting}
+                                className="inline-flex h-9 items-center justify-center rounded-lg bg-blue-600 px-3 text-xs font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+                              >
+                                {submitting ? "Retrying…" : "Retry upload"}
+                              </button>
+                            ) : null}
+                            <button
+                              type="button"
+                              onClick={() => {
+                                if (createdCaptureRecovery) {
+                                  setSavedNotice(createdCaptureRecovery);
+                                  setCreatedCaptureRecovery(null);
+                                  setPanelState("closed");
+                                  setFormState(
+                                    createQuickCaptureInitialFormState(todayDateInputValue())
+                                  );
+                                  setDraftContext(buildCurrentContext(props));
+                                }
+                                clearPendingImage();
+                              }}
+                              disabled={submitting}
+                              className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                              Remove image
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    ) : null}
+
+                    {createdCaptureRecovery && notesHref ? (
+                      <p className="mt-3 text-xs text-slate-600">
+                        Note saved already.{" "}
+                        <a
+                          href={notesHref}
+                          className="font-semibold text-blue-700 underline underline-offset-2"
+                        >
+                          Open in Notes
+                        </a>{" "}
+                        if you want to finish without retrying the image upload.
+                      </p>
+                    ) : null}
+                  </div>
+
+                  {error ? (
+                    <p className="mt-4 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+                      {error}
+                    </p>
+                  ) : null}
+
+                  <form
+                    className="mt-4 grid gap-3"
+                    onSubmit={handleSubmit}
+                    onPasteCapture={handleFormPaste}
+                    data-testid="admin-note-quick-capture-form"
+                  >
+                    <label className="space-y-1 text-xs font-medium text-slate-700">
+                      <span>Title</span>
+                      <input
+                        ref={titleInputRef}
+                        type="text"
+                        required
+                        value={formState.title}
+                        onChange={(event) =>
+                          setFormState((prev) => ({ ...prev, title: event.target.value }))
+                        }
+                        placeholder="What should be changed?"
+                        className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                      />
+                    </label>
+
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <label className="space-y-1 text-xs font-medium text-slate-700">
+                        <span>Category</span>
+                        <input
+                          type="text"
+                          list={datalistId}
+                          value={formState.category}
+                          onChange={(event) =>
+                            setFormState((prev) => ({ ...prev, category: event.target.value }))
+                          }
+                          className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                        />
+                      </label>
+
+                      <label className="space-y-1 text-xs font-medium text-slate-700">
+                        <span>Date</span>
+                        <input
+                          type="date"
+                          value={formState.noteDate}
+                          onChange={(event) =>
+                            setFormState((prev) => ({ ...prev, noteDate: event.target.value }))
+                          }
+                          className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                        />
+                      </label>
+                    </div>
+
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <label className="space-y-1 text-xs font-medium text-slate-700">
+                        <span>Priority</span>
+                        <select
+                          value={formState.priority}
+                          onChange={(event) =>
+                            setFormState((prev) => ({
+                              ...prev,
+                              priority: event.target.value as AdminNotePriority,
+                            }))
+                          }
+                          className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
+                        >
+                          {ADMIN_NOTE_PRIORITY_VALUES.map((priority) => (
+                            <option key={priority} value={priority}>
+                              {formatPriorityLabel(priority)}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+
+                      <label className="inline-flex items-center gap-2 self-end rounded-xl border border-slate-200 bg-slate-50 px-3 py-3 text-xs font-medium text-slate-700">
+                        <input
+                          type="checkbox"
+                          checked={formState.isDone}
+                          onChange={(event) =>
+                            setFormState((prev) => ({ ...prev, isDone: event.target.checked }))
+                          }
+                          className="h-4 w-4 rounded border-slate-300 text-blue-600"
+                        />
+                        Mark as done
+                      </label>
+                    </div>
+
+                    <label className="space-y-1 text-xs font-medium text-slate-700">
+                      <span>Text</span>
+                      <textarea
+                        rows={5}
+                        value={formState.body}
+                        onChange={(event) =>
+                          setFormState((prev) => ({ ...prev, body: event.target.value }))
+                        }
+                        placeholder="Write the details you need to remember."
+                        className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
+                      />
+                    </label>
+
+                    <div className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 pt-4">
+                      <p className="text-xs text-slate-500">
+                        {createdCaptureRecovery
+                          ? "The note is already saved. Retry the image upload or close and reopen it from Notes."
+                          : loadingCategories
+                            ? "Loading category suggestions…"
+                            : "The draft stays local until you click Save note. Collapse hides the panel without discarding it."}
+                      </p>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={closeLauncher}
+                          disabled={submitting}
+                          className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          {closeActionLabel}
+                        </button>
+                        {!createdCaptureRecovery ? (
+                          <button
+                            type="submit"
+                            disabled={submitting}
+                            className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+                          >
+                            {submitting ? "Saving…" : "Save note"}
+                          </button>
+                        ) : null}
+                      </div>
+                    </div>
+                  </form>
+
+                  <datalist id={datalistId}>
+                    {categoryOptions.map((option) => (
+                      <option key={option} value={option} />
+                    ))}
+                  </datalist>
+                </div>
+              </aside>
+            ) : null}
+          </div>,
+          portalRoot
+        )
+      : null;
 
   return (
     <div className={className}>
@@ -453,328 +939,7 @@ export default function AdminNoteQuickCaptureLauncher({
         </div>
       ) : null}
 
-      {minimized ? (
-        <div
-          className="fixed right-0 top-24 z-[70]"
-          data-testid="admin-note-quick-capture-minimized"
-        >
-          <div className="bg-white/96 translate-x-[calc(100%-3.75rem)] rounded-l-[22px] border border-r-0 border-blue-200 shadow-[0_18px_42px_rgba(15,23,42,0.16)] backdrop-blur transition-transform duration-200 ease-out">
-            <button
-              type="button"
-              onClick={openLauncher}
-              data-testid="admin-note-quick-capture-resume"
-              aria-label="Resume quick note"
-              className="flex h-36 w-16 flex-col items-center justify-start gap-3 rounded-l-[22px] px-2 py-3 text-blue-800 transition hover:bg-blue-50"
-            >
-              <span className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-blue-200 bg-blue-50 text-blue-700">
-                <svg viewBox="0 0 20 20" fill="none" aria-hidden="true" className="h-4 w-4">
-                  <path
-                    d="M11.5 5.5L7 10l4.5 4.5"
-                    stroke="currentColor"
-                    strokeWidth="1.8"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </span>
-              <span className="text-center text-[11px] font-semibold leading-tight">
-                Quick
-                <br />
-                note
-              </span>
-              <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-600">
-                {createdCaptureRecovery ? "Saved" : pendingImage ? "Image" : "Draft"}
-              </span>
-            </button>
-          </div>
-        </div>
-      ) : null}
-
-      <Modal
-        open={open}
-        onClose={hasDraftState ? minimizeLauncher : closeLauncher}
-        ariaLabel="Quick note capture"
-      >
-        <div className="flex h-full min-h-0 flex-col" data-testid="admin-note-quick-capture-dialog">
-          <div className="flex items-start justify-between gap-3 border-b border-slate-200 px-5 py-4">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
-                Quick capture
-              </p>
-              <h2 className="mt-1 text-lg font-semibold text-slate-900">Create note fast</h2>
-              <p className="mt-1 text-sm text-slate-600">{description}</p>
-            </div>
-            <button
-              type="button"
-              onClick={hasDraftState ? minimizeLauncher : closeLauncher}
-              className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
-            >
-              {hasDraftState ? "Collapse" : "Close"}
-            </button>
-          </div>
-          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
-            <div className="rounded-2xl border border-blue-100 bg-blue-50/60 px-4 py-3">
-              <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Context</p>
-              <p className="mt-1 text-sm font-medium text-slate-900">{contextLabel}</p>
-              <p className="mt-1 text-xs text-slate-600">
-                This note will be attached to the canonical route/content context for this surface.
-              </p>
-            </div>
-
-            <div className="mt-4 rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3">
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <div>
-                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-600">
-                    Image evidence
-                  </p>
-                  <p className="mt-1 text-sm font-medium text-slate-900">
-                    Add one image if it helps explain the issue
-                  </p>
-                  <p className="mt-1 text-xs text-slate-600">
-                    Copy a screenshot or image to clipboard, then paste it here, or upload a file.
-                  </p>
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
-                  <AdminNoteClipboardPasteButton
-                    onPasteReady={async (file) => {
-                      setError(null);
-                      setCreatedCaptureRecovery(null);
-                      setPendingImageFromFile(file);
-                    }}
-                    onError={(message) => {
-                      setError(message);
-                    }}
-                  />
-                  <label className="inline-flex cursor-pointer items-center justify-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 transition hover:bg-slate-50">
-                    <span>Upload image</span>
-                    <input
-                      type="file"
-                      accept="image/png,image/jpeg,image/webp,image/gif"
-                      className="sr-only"
-                      onChange={(event) => {
-                        handlePendingImageSelection(event.target.files);
-                        event.currentTarget.value = "";
-                      }}
-                    />
-                  </label>
-                </div>
-              </div>
-
-              {!pendingImage ? (
-                <p className="mt-3 text-xs text-slate-600">
-                  No image attached yet. Use the clipboard button after copying a screenshot, or
-                  upload an image file before save.
-                </p>
-              ) : null}
-
-              {pendingImage ? (
-                <div className="mt-3 rounded-xl border border-slate-200 bg-white px-3 py-3">
-                  <div className="flex flex-wrap items-center justify-between gap-3">
-                    <div className="flex items-center gap-3">
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img
-                        src={pendingImage.previewUrl}
-                        alt="Pending image preview"
-                        className="h-14 w-14 rounded-lg object-cover"
-                      />
-                      <div>
-                        <p className="text-xs font-semibold text-slate-900">
-                          Image ready to attach
-                        </p>
-                        <p className="mt-1 text-[11px] text-slate-600">
-                          {createdCaptureRecovery
-                            ? "The note is already saved. Retry the image upload or finish without it."
-                            : "The next note save will upload this image as an admin-only attachment."}
-                        </p>
-                      </div>
-                    </div>
-                    <div className="flex flex-wrap items-center gap-2">
-                      {createdCaptureRecovery ? (
-                        <button
-                          type="button"
-                          onClick={() => {
-                            void retryPendingImageUpload();
-                          }}
-                          disabled={submitting}
-                          className="inline-flex h-9 items-center justify-center rounded-lg bg-blue-600 px-3 text-xs font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
-                        >
-                          {submitting ? "Retrying…" : "Retry upload"}
-                        </button>
-                      ) : null}
-                      <button
-                        type="button"
-                        onClick={() => {
-                          if (createdCaptureRecovery) {
-                            setSavedNotice(createdCaptureRecovery);
-                            setCreatedCaptureRecovery(null);
-                            setOpen(false);
-                            setFormState(createInitialFormState());
-                          }
-                          clearPendingImage();
-                        }}
-                        disabled={submitting}
-                        className="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-                      >
-                        Remove image
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              ) : null}
-
-              {createdCaptureRecovery && notesHref ? (
-                <p className="mt-3 text-xs text-slate-600">
-                  Note saved already.{" "}
-                  <a
-                    href={notesHref}
-                    className="font-semibold text-blue-700 underline underline-offset-2"
-                  >
-                    Open in Notes
-                  </a>{" "}
-                  if you want to finish without retrying the image upload.
-                </p>
-              ) : null}
-            </div>
-
-            {error ? (
-              <p className="mt-4 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
-                {error}
-              </p>
-            ) : null}
-
-            <form
-              className="mt-4 grid gap-3"
-              onSubmit={handleSubmit}
-              onPasteCapture={handleFormPaste}
-              data-testid="admin-note-quick-capture-form"
-            >
-              <label className="space-y-1 text-xs font-medium text-slate-700">
-                <span>Title</span>
-                <input
-                  type="text"
-                  required
-                  autoFocus
-                  value={formState.title}
-                  onChange={(event) =>
-                    setFormState((prev) => ({ ...prev, title: event.target.value }))
-                  }
-                  placeholder="What should be changed?"
-                  className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
-                />
-              </label>
-
-              <div className="grid gap-3 sm:grid-cols-2">
-                <label className="space-y-1 text-xs font-medium text-slate-700">
-                  <span>Category</span>
-                  <input
-                    type="text"
-                    list={datalistId}
-                    value={formState.category}
-                    onChange={(event) =>
-                      setFormState((prev) => ({ ...prev, category: event.target.value }))
-                    }
-                    className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
-                  />
-                </label>
-
-                <label className="space-y-1 text-xs font-medium text-slate-700">
-                  <span>Date</span>
-                  <input
-                    type="date"
-                    value={formState.noteDate}
-                    onChange={(event) =>
-                      setFormState((prev) => ({ ...prev, noteDate: event.target.value }))
-                    }
-                    className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
-                  />
-                </label>
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-2">
-                <label className="space-y-1 text-xs font-medium text-slate-700">
-                  <span>Priority</span>
-                  <select
-                    value={formState.priority}
-                    onChange={(event) =>
-                      setFormState((prev) => ({
-                        ...prev,
-                        priority: event.target.value as AdminNotePriority,
-                      }))
-                    }
-                    className="h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900"
-                  >
-                    {ADMIN_NOTE_PRIORITY_VALUES.map((priority) => (
-                      <option key={priority} value={priority}>
-                        {formatPriorityLabel(priority)}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-
-                <label className="inline-flex items-center gap-2 self-end rounded-xl border border-slate-200 bg-slate-50 px-3 py-3 text-xs font-medium text-slate-700">
-                  <input
-                    type="checkbox"
-                    checked={formState.isDone}
-                    onChange={(event) =>
-                      setFormState((prev) => ({ ...prev, isDone: event.target.checked }))
-                    }
-                    className="h-4 w-4 rounded border-slate-300 text-blue-600"
-                  />
-                  Mark as done
-                </label>
-              </div>
-
-              <label className="space-y-1 text-xs font-medium text-slate-700">
-                <span>Text</span>
-                <textarea
-                  rows={5}
-                  value={formState.body}
-                  onChange={(event) =>
-                    setFormState((prev) => ({ ...prev, body: event.target.value }))
-                  }
-                  placeholder="Write the details you need to remember."
-                  className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
-                />
-              </label>
-
-              <div className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 pt-4">
-                <p className="text-xs text-slate-500">
-                  {createdCaptureRecovery
-                    ? "The note is already saved. Retry the image upload or close and reopen it from Notes."
-                    : loadingCategories
-                      ? "Loading category suggestions…"
-                      : "The note stays local until you click Save note. Clipboard images stay local until the save/upload path succeeds."}
-                </p>
-                <div className="flex flex-wrap items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={closeLauncher}
-                    disabled={submitting}
-                    className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    {createdCaptureRecovery ? "Done" : hasDraftState ? "Discard draft" : "Cancel"}
-                  </button>
-                  {!createdCaptureRecovery ? (
-                    <button
-                      type="submit"
-                      disabled={submitting}
-                      className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
-                    >
-                      {submitting ? "Saving…" : "Save note"}
-                    </button>
-                  ) : null}
-                </div>
-              </div>
-            </form>
-
-            <datalist id={datalistId}>
-              {categoryOptions.map((option) => (
-                <option key={option} value={option} />
-              ))}
-            </datalist>
-          </div>
-        </div>
-      </Modal>
+      {quickCaptureSurface}
     </div>
   );
 }

--- a/docs/runbooks/admin-notes-recovery.md
+++ b/docs/runbooks/admin-notes-recovery.md
@@ -24,21 +24,22 @@ Use this runbook for AW-012 workflow `A4` stale-note reconciliation edge cases.
 
 1. Pause edits on the current row and copy your intended final text to a temporary local note.
 2. If the failure happened in `Quick note`, first search by the visible success state or intended title in `/admin?tab=notes` before retrying so you do not create duplicates.
-3. If you still need to inspect the page before saving, collapse the quick-note draft instead of closing it; reopening from the docked right-edge handle should preserve the current text and staged image.
-4. In `/admin?tab=notes`, keep the `Notes` tab active and click `Refresh` to reload server-canonical rows.
-5. If the row title starts with `[E2E Admin Note Artifact]`, treat it as automated test residue:
+3. If you still need to inspect the page before saving, collapse the quick-note draft instead of closing it; the page underneath should remain interactive, and reopening from the docked right-edge handle should preserve the current text and staged image.
+4. If you navigated to another supported admin/context surface before saving, confirm the quick-note `Locked context` card still points to the original page/item you meant to annotate before you save.
+5. In `/admin?tab=notes`, keep the `Notes` tab active and click `Refresh` to reload server-canonical rows.
+6. If the row title starts with `[E2E Admin Note Artifact]`, treat it as automated test residue:
    - do not repurpose it for operator work,
    - refresh once,
    - if it still remains open, follow the active admin-note artifact cleanup brief or delete only after confirming it matches the test-artifact contract.
-6. If the note is no longer visible in the default queue, switch to `Done archive` or search by the visible `Note ID`.
-7. Re-open the target note and confirm:
+7. If the note is no longer visible in the default queue, switch to `Done archive` or search by the visible `Note ID`.
+8. Re-open the target note and confirm:
    - note ID,
    - title/body/category/date,
    - priority,
    - completion status,
    - context label (`Course Lesson`, `Product`, `Page`, etc.),
    - raw context ref/path when relevant.
-8. If screenshots are involved:
+9. If screenshots are involved:
    - if contextual `Add note` is collapsed because notes already exist, expand it first before retrying image intake,
    - if `Paste image from clipboard` says no image was found, confirm you copied the screenshot first and retry, or use `Upload image`,
    - if clipboard access was blocked, retry from the explicit paste button after granting browser permission, or use `Upload image`,
@@ -49,13 +50,15 @@ Use this runbook for AW-012 workflow `A4` stale-note reconciliation edge cases.
    - if delete failed, refresh once and verify whether the image is still present before retrying,
    - if upload failed after note save, retry only after confirming you are not looking at a stale duplicate preview,
    - if the staged image was removed locally, use clipboard paste again or fall back to `Upload image`.
-9. If related notes are involved:
-   - click the linked note title to jump straight to that note in the queue when available, or search by the visible `Note ID` if needed,
-   - confirm the intended link exists only once,
-   - remove and re-add the link only if the relationship is clearly wrong.
-10. Re-apply only the intended delta and click `Save changes`.
-11. Confirm success notice (`Note updated.` or attachment/link success notice) and verify the same row in its contextual surface (`/course` or `/plans`) when relevant.
-12. If update still fails, create one incident note (P1/P2) with owner + next action and link it by note ID in AW-012 checkpoint evidence.
+10. If related notes are involved:
+
+- click the linked note title to jump straight to that note in the queue when available, or search by the visible `Note ID` if needed,
+- confirm the intended link exists only once,
+- remove and re-add the link only if the relationship is clearly wrong.
+
+11. Re-apply only the intended delta and click `Save changes`.
+12. Confirm success notice (`Note updated.` or attachment/link success notice) and verify the same row in its contextual surface (`/course` or `/plans`) when relevant.
+13. If update still fails, create one incident note (P1/P2) with owner + next action and link it by note ID in AW-012 checkpoint evidence.
 
 ## Pass Criteria
 

--- a/docs/task-briefs/in-progress/2026-03-27-admin-notes-global-quick-capture-panel-and-manuscript-categories-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-27-admin-notes-global-quick-capture-panel-and-manuscript-categories-10-10.md
@@ -1,0 +1,247 @@
+# Task Brief: Admin Notes Global Quick Capture Panel And Manuscript Categories (10/10)
+
+## Metadata
+
+- `id`: `2026-03-27-admin-notes-global-quick-capture-panel-and-manuscript-categories-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-03-27`
+- `updated`: `2026-03-27`
+
+## Goal
+
+Quick note should behave like a true non-modal right-docked utility panel that admins can collapse, reopen, and keep using while scrolling or navigating the app, and the notes taxonomy should add the manuscript/planning categories the owner needs for live content production.
+
+## Why This Brief Exists
+
+- The original quick-capture launcher shipped the right note-creation foundation, but the current shell still behaves too much like a modal for the real screenshot-and-review workflow.
+- Live use exposed the intended operator mental model clearly:
+  - start a quick note,
+  - temporarily slide it out of the way,
+  - keep the page underneath interactive,
+  - collect screenshots or inspect other pages,
+  - reopen the same note with the same draft still intact.
+- Production admin note `881e222b-4c14-4a23-b677-60b0713e220f` explicitly keeps the route-surface and rollout question open for quick capture, so this is the correct owner brief for turning quick capture into a better global utility surface rather than a route-local modal.
+- The owner also needs manuscript-focused note categories for planning course/page/video content in notes, plus a `Swimshop` category for tracking prospective buy/sell items.
+
+## Dependencies And Boundaries
+
+- Shipped launcher baseline:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-22-admin-notes-quick-capture-launcher-10-10.md`
+- Shipped compose/image-intake follow-ups:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-24-admin-notes-compose-parity-and-input-stability-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-25-admin-notes-image-intake-simplification-and-clipboard-paste-button-10-10.md`
+- This slice owns:
+  - quick-note panel shell behavior,
+  - collapse/reopen model,
+  - cross-route draft continuity,
+  - new note-category taxonomy rows needed for current editorial use.
+- This slice does not own:
+  - broad all-pages launcher rollout beyond already supported surfaces,
+  - full route-surface eligibility policy for every page in the app,
+  - content-model changes for lessons/pages/videos themselves,
+  - non-note commerce/catalog workflows beyond the note-category taxonomy needed for `Swimshop`.
+
+## Admin Notes Triage Status
+
+Production admin notes reviewed against this scope on `2026-03-27`:
+
+- `881e222b-4c14-4a23-b677-60b0713e220f` `Admin notes quick capture route-surface expansion follow-up`
+  - disposition: owned by this brief.
+  - rationale: the requested redesign turns quick capture into a better app-wide utility surface with clearer behavior during route/page review, which is exactly the unresolved follow-up question in that production note.
+
+Owner-requested scope not currently represented as its own production admin note:
+
+- Add note categories:
+  - `Video Manuscript`
+  - `Lesson Manuscript`
+  - `Page Manuscript`
+  - `Swimshop`
+  - disposition: directly owned here as current editorial-taxonomy setup requested during live content production.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Business logic correctness and data integrity`
+- `Reliability and failure handling`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                                 | Evidence                                          |
+| --------------------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| Product goals and IA                          | `target`     | Quick note reads as a reusable utility panel, not a dead-end modal, and the category additions map cleanly to manuscript/planning jobs without taxonomy noise. | manual QA + code review + brief acceptance        |
+| UX flow clarity                               | `target`     | Admin can open, collapse, reopen, scroll behind, navigate, and save/discard a quick note without guessing which action preserves the draft.                    | unit + e2e + manual QA                            |
+| Visual design quality                         | `target`     | Open and collapsed quick-note states feel edge-docked, intentional, and non-obstructive; no floating box obscures primary content.                             | screenshots + manual QA                           |
+| Business logic correctness and data integrity | `target`     | Draft state persists predictably across collapse/reopen and route changes, while saved notes still write one normal canonical admin note with locked context.  | unit tests + e2e + runtime guard review           |
+| Admin editor ergonomics                       | `target`     | Screenshot/content-review flow no longer requires discarding or recreating drafts just to inspect the page or move to another route.                           | manual QA + e2e                                   |
+| Accessibility (a11y)                          | `target`     | Quick note remains keyboard reachable with clear labels for collapse, reopen, close, and discard; underlying page remains navigable when panel is open.        | unit + e2e + code review                          |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: redesign should not add obvious route-level regressions or heavy dependencies.                                                                | build + dependency diff                           |
+| Data placement and sync boundaries            | `target`     | Brief and implementation explicitly define what draft state is local, what note data is server-canonical, and how route changes interact with draft context.   | brief contract + unit tests                       |
+| Caching and invalidation strategy             | `supporting` | Supporting only: saved notes still refresh canonical notes surfaces predictably after mutation.                                                                | existing mutation flow + e2e                      |
+| Reliability and failure handling              | `target`     | Collapse/navigation/reopen never silently discards the draft; failures preserve recovery path and explain next action.                                         | unit + e2e + recovery-doc update                  |
+| Security and authz                            | `target`     | Quick note remains role-gated and continues to fail closed for unauthorized users and endpoints.                                                               | existing negative-path coverage + targeted tests  |
+| Privacy and compliance                        | `supporting` | Supporting only: draft persistence must avoid leaking sensitive note content outside the signed-in browser session.                                            | code review + local storage contract              |
+| Content governance                            | `supporting` | Supporting only: manuscript categories improve planning taxonomy without changing canonical content ownership or publish flows.                                | migration + admin category behavior review        |
+| Admin workflow and editability                | `target`     | Manuscript and `Swimshop` categories appear in normal note workflows without special casing, and quick note stays compatible with full Notes management.       | manual QA + category fetch behavior               |
+| SEO and crawlability                          | `N/A`        | N/A because this slice affects admin-only tooling and note taxonomy only, with no public metadata or crawl surface changes.                                    | scope rationale                                   |
+| AI discoverability                            | `N/A`        | N/A because the work changes no public semantic/content-discovery surface.                                                                                     | scope rationale                                   |
+| Analytics and KPI observability               | `N/A`        | N/A because this slice adds no new analytics requirement; workflow value can be judged from operator use directly.                                             | scope rationale                                   |
+| Commerce and revenue ops                      | `N/A`        | N/A because `Swimshop` is only a notes category for operator planning and does not change catalog, pricing, checkout, or entitlements.                         | scope rationale                                   |
+| Incident response and support operations      | `target`     | Help/Guide and recovery docs explain the new collapse/reopen behavior, page interaction model, and cross-route draft expectations.                             | Help/Guide + runbook update + tests               |
+| Finance and reporting operations              | `N/A`        | N/A because note-category additions do not affect finance records, reporting, reconciliation, or payouts.                                                      | scope rationale                                   |
+| i18n operational readiness                    | `supporting` | Supporting only: new category titles and panel labels remain localization-safe plain strings with no hidden logic.                                             | copy review                                       |
+| Stack-fit and dependency discipline           | `target`     | Reuse existing Next/React/admin-note patterns without adding new dependencies.                                                                                 | dependency diff + code review                     |
+| Testing and QA automation                     | `target`     | Coverage protects collapse/reopen, non-modal behavior, cross-route draft continuity, note save/discard paths, and category availability.                       | unit + e2e + `verify:pre-pr`                      |
+| Scalability and cost efficiency               | `supporting` | Supporting only: local draft persistence stays lightweight and avoids runaway network chatter or duplicate note creation.                                      | code review + test assertions                     |
+| DevOps and rollback readiness                 | `target`     | Category additions ship via migration, and the quick-note shell can be rolled back without data migration or saved-note corruption.                            | migration diff + rollback reasoning + verify gate |
+
+## Data Placement And Sync Contract
+
+- Server-canonical data:
+  - saved admin-note rows,
+  - admin-note attachments after explicit upload,
+  - admin-note categories in `public.admin_categories`.
+- Local data:
+  - open/collapsed quick-note panel state,
+  - unsaved draft text, staged image preview, and locked draft context while the operator is still composing.
+- Sync policy:
+  - draft remains local until explicit save,
+  - save continues to use canonical admin-notes APIs,
+  - once a quick-note draft starts, the note context stays locked to the original context even if the operator navigates elsewhere before saving,
+  - route changes may restore or rehydrate the same local draft, but must not silently mutate the original note context.
+- Retention and sensitivity:
+  - draft persistence is browser-session scoped only and must not become a cross-user/shared artifact,
+  - image preview/local metadata should stay ephemeral and clear on discard or successful save.
+- Cache/invalidation:
+  - category reads stay `no-store` and server-canonical,
+  - successful note saves continue to refresh/reinsert the saved item through existing notes-surface logic.
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - `admin_note.id` remains the source-of-truth identity for saved notes.
+  - `admin_categories.id` remains the source-of-truth identity for categories.
+- Human-readable identifiers:
+  - category `slug` is the stable machine-readable taxonomy key,
+  - category `title` is the operator-facing label and may be edited later through normal category-management workflows if needed.
+- Mutability rules:
+  - quick-note draft context is temporarily local and not a durable identifier,
+  - draft context is locked for that draft instance after the first open so a route change does not repurpose the same draft unexpectedly.
+- Rename vs repurpose policy:
+  - new manuscript/`Swimshop` categories should be created as new rows, not repurposed from older generic categories.
+- Compatibility contract:
+  - existing note flows continue to accept any server-provided active note category by title without special migration in UI.
+- Observability and repair:
+  - if draft restore fails, the operator still gets a clear empty-state panel instead of a broken shell, and no server note is created until save succeeds.
+
+## Scope
+
+- Redesign `AdminNoteQuickCaptureLauncher` into a non-modal right-docked utility panel.
+- Replace destructive modal-close mental model with:
+  - explicit collapse/reopen arrows,
+  - separate close/discard behavior,
+  - persistent slim edge handle when collapsed.
+- Keep the page underneath interactive while the panel is open:
+  - no backdrop,
+  - no body scroll lock,
+  - no inerting of underlying content.
+- Preserve unsaved quick-note drafts across client-side route navigation while keeping original note context locked and visible.
+- Add note categories:
+  - `Video Manuscript`
+  - `Lesson Manuscript`
+  - `Page Manuscript`
+  - `Swimshop`
+- Update Help/Guide and admin-notes recovery docs for the new panel behavior.
+
+## Out Of Scope
+
+- Broad redesign of full admin notes manager.
+- Automatic retargeting of a draft note to the page you navigate to later.
+- General-purpose multi-draft notes workspace.
+- Public-user note capture or public taxonomy changes.
+- Commerce/catalog feature work beyond adding the `Swimshop` notes category.
+
+## Acceptance Criteria
+
+1. Quick note opens as a non-modal right-docked panel, not a blocking modal sheet.
+2. While quick note is open, the page behind it remains scrollable and clickable.
+3. Quick note always exposes a clear collapse action that slides the panel out to the right and leaves a slim reopen handle with an arrow.
+4. Quick note collapse/reopen preserves current draft fields and one staged image without covering arbitrary page content when collapsed.
+5. Navigating to another supported route while a draft exists preserves the draft and reopens it with the original locked context still shown clearly.
+6. Discard/close remains separate from collapse so admins can intentionally abandon a draft instead of hiding it temporarily.
+7. Saving from quick note still creates one normal admin note in the existing notes workflow with canonical context and attachment behavior.
+8. The notes category list includes `Video Manuscript`, `Lesson Manuscript`, `Page Manuscript`, and `Swimshop`, and those categories are available in quick capture and other note-compose surfaces that load active note categories from the API.
+9. Help/Guide and recovery docs explain the new utility-panel behavior and the difference between collapse and discard.
+10. `npm run lint:briefs`, targeted tests, and `npm run verify:pre-pr` pass before PR update.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run typecheck`
+- `npx vitest run tests/unit/admin-note-quick-capture-launcher.test.tsx`
+- targeted Playwright:
+  - `npx playwright test tests/e2e/admin-notes-workflow.spec.ts --project=desktop-chromium`
+  - `npx playwright test tests/e2e/admin-contextual-notes.spec.ts --project=desktop-chromium`
+  - `npx playwright test tests/e2e/admin-help-center.spec.ts --project=desktop-chromium`
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Manual QA Environments
+
+- Production/admin verification after merge:
+  - `https://freeswimming.org/admin`
+  - `https://freeswimming.org/course`
+  - one additional supported quick-capture surface such as `/plans`
+- Local iteration:
+  - `http://127.0.0.1:3100/admin`
+
+## Constraints
+
+- Preserve existing visual language; this should feel like a refinement of the admin notes utility, not a brand-new design system.
+- Do not regress the already-shipped quick-note save/image flows while changing shell behavior.
+- Avoid new dependencies.
+- Keep draft persistence limited enough that it is helpful during current work but does not become a hidden multi-session sync problem.
+
+## 10/10 Quality Bar
+
+- Quick note must communicate three distinct intents clearly:
+  - `collapse/hide temporarily`,
+  - `reopen/resume`,
+  - `discard/close for real`.
+- Required states for the panel:
+  - loading categories,
+  - empty draft,
+  - draft with staged image,
+  - upload-retry recovery,
+  - save error,
+  - collapsed handle,
+  - restored draft after navigation.
+- Accessibility:
+  - collapse/reopen controls labeled,
+  - keyboard reachable,
+  - no focus trap that blocks page interaction when the utility panel is open.
+- Performance:
+  - no obvious interaction lag from draft persistence or repeated category fetches,
+  - no new dependency cost.
+- Visual consistency:
+  - collapsed state reads like a docked utility handle, not a floating widget or random obstructive card.
+- Business-logic correctness:
+  - original context remains visible and stable for the life of a draft,
+  - no accidental draft loss on collapse/navigation,
+  - no duplicate note creation on save/retry.
+
+## Help/Guide And Operator Training Contract
+
+- Required in same PR:
+  - explain that quick note is now a non-modal docked utility panel,
+  - explain collapse vs discard,
+  - explain that the underlying page remains interactive,
+  - explain that draft context stays tied to the original page/item even if the operator navigates elsewhere before saving.
+
+## Checkpoint Log
+
+- `2026-03-27 | verify:pre-pr green + prod categories inserted | replaced modal quick capture with a non-modal docked utility panel, preserved drafts across supported-route navigation with locked original context, updated Help/Guide + recovery docs, added Lesson Manuscript/Page Manuscript/Video Manuscript/Swimshop via migration, inserted the same four categories directly into the production admin_categories table, and passed targeted unit/e2e plus full \`npm run verify:pre-pr\` | next: review worktree, commit, push, open PR, and wait for CI before merge gate`
+- `2026-03-27 | planning | confirmed production note 881e222b-4c14-4a23-b677-60b0713e220f as the canonical quick-capture follow-up owner, and added owner-requested taxonomy scope for Video Manuscript, Lesson Manuscript, Page Manuscript, and Swimshop | next: implement non-modal docked panel, draft persistence, category migration, docs, and tests`

--- a/lib/admin/admin-note-quick-capture-draft.ts
+++ b/lib/admin/admin-note-quick-capture-draft.ts
@@ -1,0 +1,178 @@
+import type { AdminNoteContextType } from "@/lib/admin/note-context";
+import type { AdminNotePriority } from "@/lib/admin/notes";
+
+const QUICK_CAPTURE_STORAGE_KEY = "fs-admin-note-quick-capture-draft-v1";
+
+export type QuickCaptureFormState = {
+  title: string;
+  category: string;
+  noteDate: string;
+  priority: AdminNotePriority;
+  body: string;
+  isDone: boolean;
+};
+
+export type QuickCaptureSavedNotice = {
+  id: string;
+  title: string;
+};
+
+export type QuickCapturePendingImage = {
+  file: File;
+  previewUrl: string;
+};
+
+export type QuickCaptureLockedContext = {
+  contextType: AdminNoteContextType;
+  contextRef: string;
+  contextLabel: string;
+};
+
+export type QuickCapturePanelState = "open" | "collapsed";
+
+export type QuickCaptureDraftSnapshot = {
+  version: 1;
+  panelState: QuickCapturePanelState;
+  context: QuickCaptureLockedContext;
+  formState: QuickCaptureFormState;
+  createdCaptureRecovery: QuickCaptureSavedNotice | null;
+  updatedAt: number;
+};
+
+export type QuickCaptureDraftStore = {
+  snapshot: QuickCaptureDraftSnapshot;
+  pendingImage: QuickCapturePendingImage | null;
+};
+
+let memoryDraftStore: QuickCaptureDraftStore | null = null;
+let memoryDraftOwnerId: string | null = null;
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined";
+}
+
+function revokePreviewUrl(url: string | null | undefined) {
+  if (!url || !isBrowser()) return;
+  try {
+    URL.revokeObjectURL(url);
+  } catch {
+    // safe cleanup fallback
+  }
+}
+
+function writeSnapshotToSessionStorage(snapshot: QuickCaptureDraftSnapshot | null) {
+  if (!isBrowser()) return;
+
+  try {
+    if (!snapshot) {
+      window.sessionStorage.removeItem(QUICK_CAPTURE_STORAGE_KEY);
+      return;
+    }
+
+    window.sessionStorage.setItem(QUICK_CAPTURE_STORAGE_KEY, JSON.stringify(snapshot));
+  } catch {
+    // storage is a best-effort fallback only
+  }
+}
+
+function parseStoredSnapshot(raw: string | null): QuickCaptureDraftSnapshot | null {
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as QuickCaptureDraftSnapshot;
+    if (
+      parsed &&
+      parsed.version === 1 &&
+      (parsed.panelState === "open" || parsed.panelState === "collapsed") &&
+      typeof parsed.context?.contextRef === "string" &&
+      typeof parsed.context?.contextLabel === "string" &&
+      typeof parsed.context?.contextType === "string" &&
+      typeof parsed.formState?.title === "string" &&
+      typeof parsed.formState?.category === "string" &&
+      typeof parsed.formState?.noteDate === "string" &&
+      typeof parsed.formState?.priority === "string" &&
+      typeof parsed.formState?.body === "string" &&
+      typeof parsed.formState?.isDone === "boolean"
+    ) {
+      return parsed;
+    }
+  } catch {
+    // ignore malformed storage
+  }
+
+  return null;
+}
+
+export function createQuickCaptureInitialFormState(today: string): QuickCaptureFormState {
+  return {
+    title: "",
+    category: "General",
+    noteDate: today,
+    priority: "normal",
+    body: "",
+    isDone: false,
+  };
+}
+
+export function isQuickCaptureDraftDirty(formState: QuickCaptureFormState, today: string): boolean {
+  return (
+    formState.title.trim().length > 0 ||
+    formState.category.trim() !== "General" ||
+    formState.noteDate !== today ||
+    formState.priority !== "normal" ||
+    formState.body.trim().length > 0 ||
+    formState.isDone
+  );
+}
+
+export function readQuickCaptureDraftStore(): QuickCaptureDraftStore | null {
+  if (memoryDraftStore) {
+    return memoryDraftStore;
+  }
+
+  if (!isBrowser()) {
+    return null;
+  }
+
+  const snapshot = parseStoredSnapshot(window.sessionStorage.getItem(QUICK_CAPTURE_STORAGE_KEY));
+  if (!snapshot) {
+    return null;
+  }
+
+  memoryDraftStore = {
+    snapshot,
+    pendingImage: null,
+  };
+  return memoryDraftStore;
+}
+
+export function writeQuickCaptureDraftStore(store: QuickCaptureDraftStore | null) {
+  const previousPreviewUrl = memoryDraftStore?.pendingImage?.previewUrl ?? null;
+  const nextPreviewUrl = store?.pendingImage?.previewUrl ?? null;
+
+  if (previousPreviewUrl && previousPreviewUrl !== nextPreviewUrl) {
+    revokePreviewUrl(previousPreviewUrl);
+  }
+
+  memoryDraftStore = store;
+  writeSnapshotToSessionStorage(store?.snapshot ?? null);
+}
+
+export function clearQuickCaptureDraftStore() {
+  writeQuickCaptureDraftStore(null);
+  memoryDraftOwnerId = null;
+}
+
+export function claimQuickCaptureDraftOwner(ownerId: string) {
+  memoryDraftOwnerId = ownerId;
+}
+
+export function releaseQuickCaptureDraftOwner(ownerId: string) {
+  if (memoryDraftOwnerId === ownerId) {
+    memoryDraftOwnerId = null;
+  }
+}
+
+export function getQuickCaptureDraftOwnerId(): string | null {
+  return memoryDraftOwnerId;
+}

--- a/supabase/migrations/20260327113000_admin_note_manuscript_and_swimshop_categories.sql
+++ b/supabase/migrations/20260327113000_admin_note_manuscript_and_swimshop_categories.sql
@@ -1,0 +1,9 @@
+-- Add manuscript-planning and Swimshop categories for admin notes.
+
+insert into public.admin_categories (scope, slug, title, sort_order, is_active)
+values
+  ('notes', 'lesson-manuscript', 'Lesson Manuscript', 22, true),
+  ('notes', 'page-manuscript', 'Page Manuscript', 24, true),
+  ('notes', 'video-manuscript', 'Video Manuscript', 26, true),
+  ('notes', 'swimshop', 'Swimshop', 40, true)
+on conflict (scope, slug) do nothing;

--- a/tests/e2e/admin-help-center.spec.ts
+++ b/tests/e2e/admin-help-center.spec.ts
@@ -137,7 +137,12 @@ test.describe("admin help center", () => {
     ).toBeVisible();
     await expect(
       page.getByText(
-        "If you still need to scroll or collect a screenshot before saving, collapse `Quick note` and reopen the same draft from the docked edge handle on the right."
+        "If you still need to scroll, click, or collect a screenshot before saving, collapse `Quick note`; the page stays interactive underneath and you can reopen the same draft from the docked edge handle on the right."
+      )
+    ).toBeVisible();
+    await expect(
+      page.getByText(
+        "If you navigate to another supported admin/context surface before saving, the same draft can follow you, but it stays attached to the original locked context shown in the panel."
       )
     ).toBeVisible();
     await expect(

--- a/tests/e2e/admin-notes-workflow.spec.ts
+++ b/tests/e2e/admin-notes-workflow.spec.ts
@@ -728,7 +728,7 @@ test.describe("admin notes workflow", () => {
     await expect(textInput).toHaveValue(detailCopy);
     await expect(textInput).toBeFocused();
 
-    await page.getByRole("button", { name: "Collapse" }).click();
+    await page.getByRole("button", { name: "Collapse quick note" }).click();
     await expect(quickCaptureDialog).toHaveCount(0);
     const minimizedQuickCapture = page.getByTestId("admin-note-quick-capture-minimized");
     await expect(minimizedQuickCapture).toBeVisible({ timeout: 10_000 });

--- a/tests/unit/admin-note-quick-capture-launcher.test.tsx
+++ b/tests/unit/admin-note-quick-capture-launcher.test.tsx
@@ -2,12 +2,15 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import AdminNoteQuickCaptureLauncher from "@/components/admin/AdminNoteQuickCaptureLauncher";
+import { clearQuickCaptureDraftStore } from "@/lib/admin/admin-note-quick-capture-draft";
 
 describe("AdminNoteQuickCaptureLauncher", () => {
   afterEach(() => {
     cleanup();
     vi.useRealTimers();
     vi.unstubAllGlobals();
+    clearQuickCaptureDraftStore();
+    window.sessionStorage.clear();
     delete window.__FS_ADMIN_SCREENSHOT_CAPTURE_OVERRIDE__;
   });
 
@@ -53,6 +56,33 @@ describe("AdminNoteQuickCaptureLauncher", () => {
 
     expect(titleInput).toHaveValue("Typing should stay active");
     expect(titleInput).toHaveFocus();
+  });
+
+  it("opens as a non-modal utility panel instead of a blocking dialog", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        items: [{ id: "category-1", title: "Operations", is_active: true }],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <AdminNoteQuickCaptureLauncher
+        adminRole="editor"
+        contextType="page"
+        contextRef="/plans"
+        contextLabel="Plans page"
+      />
+    );
+
+    await user.click(screen.getByTestId("admin-note-quick-capture-trigger"));
+    await screen.findByTestId("admin-note-quick-capture-dialog");
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Collapse quick note" })).toBeInTheDocument();
   });
 
   it("saves a quick note with canonical context and exposes the notes link", async () => {
@@ -350,7 +380,7 @@ describe("AdminNoteQuickCaptureLauncher", () => {
       target: { value: "Keep this draft while reviewing the page." },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Collapse" }));
+    fireEvent.click(screen.getByRole("button", { name: "Collapse quick note" }));
 
     await waitFor(() => {
       expect(screen.queryByTestId("admin-note-quick-capture-dialog")).not.toBeInTheDocument();
@@ -369,6 +399,67 @@ describe("AdminNoteQuickCaptureLauncher", () => {
     expect(screen.getByLabelText("Title")).toHaveValue("Collapsed quick note");
     expect(screen.getByLabelText("Text")).toHaveValue("Keep this draft while reviewing the page.");
     expect(screen.getByText("Image ready to attach")).toBeInTheDocument();
+  });
+
+  it("restores the same draft on another supported surface while keeping the original locked context", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        items: [{ id: "category-1", title: "Operations", is_active: true }],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const firstRender = render(
+      <AdminNoteQuickCaptureLauncher
+        adminRole="editor"
+        contextType="page"
+        contextRef="/plans"
+        contextLabel="Plans page"
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("admin-note-quick-capture-trigger"));
+    await screen.findByTestId("admin-note-quick-capture-dialog");
+
+    fireEvent.change(screen.getByLabelText("Title"), {
+      target: { value: "Carry this draft across pages" },
+    });
+    fireEvent.change(screen.getByLabelText("Text"), {
+      target: { value: "Stay attached to the original page context." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Collapse quick note" }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("admin-note-quick-capture-dialog")).not.toBeInTheDocument();
+    });
+
+    firstRender.unmount();
+
+    render(
+      <AdminNoteQuickCaptureLauncher
+        adminRole="editor"
+        contextType="course_lesson"
+        contextRef="lesson-123"
+        contextLabel="Lesson: Floating on your back"
+      />
+    );
+
+    expect(screen.getByTestId("admin-note-quick-capture-minimized")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("admin-note-quick-capture-resume"));
+
+    await screen.findByTestId("admin-note-quick-capture-dialog");
+    expect(screen.getByLabelText("Title")).toHaveValue("Carry this draft across pages");
+    expect(screen.getByLabelText("Text")).toHaveValue(
+      "Stay attached to the original page context."
+    );
+    expect(screen.getAllByText("Plans page")).toHaveLength(2);
+    expect(
+      screen.getByText("You are viewing another page right now. This draft will still save to", {
+        exact: false,
+      })
+    ).toBeInTheDocument();
   });
 
   it("keeps image recovery visible when note save succeeds but attachment upload fails", async () => {


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-03-27T15:12:57.636Z for branch `fix/admin-quick-capture-docked-utility-panel-2026-03-27` (base ref `origin/main`).
- Latest commit: `e5736fa` - fix(admin): dock quick note utility panel and add planning categories.
- User-visible changes: Admin-facing behavior/guardrails may change in touched admin routes or APIs.
- Technical changes: Updated 9 file(s): `components/admin/AdminHelpCenter.tsx`, `components/admin/AdminNoteQuickCaptureLauncher.tsx`, `docs/runbooks/admin-notes-recovery.md`, `docs/task-briefs/in-progress/2026-03-27-admin-notes-global-quick-capture-panel-and-manuscript-categories-10-10.md`, `lib/admin/admin-note-quick-capture-draft.ts`, `... and 4 more file(s)`.
- Policy impact: yes (inferred from changed scope: `supabase/migrations/20260327113000_admin_note_manuscript_and_swimshop_categories.sql`).
- Policy version note: N/A (if policy text/version changes, replace with YYYY-MM-DD.rev and rationale).
- Brief link(s): `docs/task-briefs/in-progress/2026-03-27-admin-notes-global-quick-capture-panel-and-manuscript-categories-10-10.md`
- Scorecard target outcomes: 14 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (2); tests (3); runtime UI/routes/components (3); other files (1).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (9):
  - `components/admin/AdminHelpCenter.tsx`
  - `components/admin/AdminNoteQuickCaptureLauncher.tsx`
  - `docs/runbooks/admin-notes-recovery.md`
  - `docs/task-briefs/in-progress/2026-03-27-admin-notes-global-quick-capture-panel-and-manuscript-categories-10-10.md`
  - `lib/admin/admin-note-quick-capture-draft.ts`
  - `supabase/migrations/20260327113000_admin_note_manuscript_and_swimshop_categories.sql`
  - `tests/e2e/admin-help-center.spec.ts`
  - `tests/e2e/admin-notes-workflow.spec.ts`
  - `... and 1 more file(s)`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `e5736fa` (`git revert e5736fa`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **NOT RUN** (run locally before pushing PR updates).
- `npm run verify:pre-merge`: **PENDING** for `e5736fa` (required before merge to `main`).
- Policy-impact checklist: PENDING (run docs/checklists/policy-impact-release-review.md and update to PASS/FAIL).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  - No local verify log found in `artifacts/test-runs/latest`.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
