### PR TITLE
fix(workouts): polish builder live-review actions

### DIFF
--- a/app/api/my-library/workouts/[workoutId]/route.ts
+++ b/app/api/my-library/workouts/[workoutId]/route.ts
@@ -7,7 +7,11 @@ import {
   buildWorkoutUpdate,
   WORKOUT_SELECT,
 } from "@/lib/workouts/server";
-import type { WorkoutSaveApiResponse, WorkoutSaveRequestBody } from "@/lib/workouts/shared";
+import type {
+  WorkoutDeleteApiResponse,
+  WorkoutSaveApiResponse,
+  WorkoutSaveRequestBody,
+} from "@/lib/workouts/shared";
 
 type RouteContext = {
   params: Promise<{
@@ -18,7 +22,7 @@ type RouteContext = {
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function noStoreJson(
-  body: WorkoutSaveApiResponse | Record<string, unknown>,
+  body: WorkoutSaveApiResponse | WorkoutDeleteApiResponse | Record<string, unknown>,
   init?: {
     status?: number;
   }
@@ -111,6 +115,64 @@ export async function PATCH(request: Request, context: RouteContext) {
       ok: true,
       workout,
       summary: buildWorkoutSummary(result.data),
+    })
+  );
+}
+
+export async function DELETE(_request: Request, context: RouteContext) {
+  const { workoutId } = await context.params;
+  if (!UUID_PATTERN.test(workoutId)) {
+    return noStoreJson({ ok: false, error: "Invalid workout id." }, { status: 400 });
+  }
+
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Unauthorized." }, { status: 401 })
+    );
+  }
+
+  const result = await supabase
+    .from("workouts")
+    .delete()
+    .eq("user_id", user.id)
+    .eq("id", workoutId)
+    .select("id")
+    .maybeSingle();
+
+  if (isWorkoutSchemaMissing(result.error)) {
+    return applySupabaseCookies(
+      noStoreJson(
+        {
+          ok: false,
+          error: "Canonical workout save is still syncing in this environment.",
+        },
+        { status: 503 }
+      )
+    );
+  }
+
+  if (result.error) {
+    console.error("[WorkoutsApi] Could not delete canonical workout", result.error);
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Could not delete workout right now." }, { status: 500 })
+    );
+  }
+
+  if (!result.data) {
+    return applySupabaseCookies(
+      noStoreJson({ ok: false, error: "Workout not found." }, { status: 404 })
+    );
+  }
+
+  return applySupabaseCookies(
+    noStoreJson({
+      ok: true,
+      deletedWorkoutId: workoutId,
     })
   );
 }

--- a/app/my-library/page.tsx
+++ b/app/my-library/page.tsx
@@ -190,7 +190,7 @@ export default async function MyLibraryPage() {
             <section className="rounded-2xl border border-slate-200 bg-white p-5">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
-                  <h2 className="text-lg font-semibold text-slate-900">Program shell</h2>
+                  <h2 className="text-lg font-semibold text-slate-900">Program planning (early)</h2>
                   <p className="mt-2 text-sm text-slate-600">
                     {!programLibrarySnapshot.schemaReady
                       ? "This canonical program layer is still syncing in this environment."
@@ -202,7 +202,7 @@ export default async function MyLibraryPage() {
                           ]
                             .filter(Boolean)
                             .join(" · ")
-                        : "Create your first saved program shell, place accepted workouts into week/day slots, and export the saved schedule once it is ready."}
+                        : "Create your first saved plan, place accepted workouts into week/day slots, and keep one early program surface ready for later planner work."}
                   </p>
                 </div>
                 <div className="flex flex-wrap gap-2">
@@ -211,7 +211,7 @@ export default async function MyLibraryPage() {
                       href={`/my-library/programs/${programLibrarySnapshot.recentPrograms[0].id}`}
                       className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
                     >
-                      Open program shell
+                      Open saved plan
                     </Link>
                   ) : null}
                   {programLibrarySnapshot.schemaReady ? (

--- a/app/my-library/programs/[programId]/page.tsx
+++ b/app/my-library/programs/[programId]/page.tsx
@@ -44,7 +44,7 @@ export default async function ProgramBuilderPage({ params }: Props) {
               <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
                 My Library
               </p>
-              <h1 className="mt-2 text-3xl font-bold text-slate-900">Program shell</h1>
+              <h1 className="mt-2 text-3xl font-bold text-slate-900">Program planning</h1>
               <p className="mt-2 max-w-[68ch] text-sm text-slate-600">
                 Open one saved program in its own route, place accepted workouts into week/day
                 slots, and export the saved canonical program without forking planner identity.

--- a/components/my-library/LibrarySectionTabs.tsx
+++ b/components/my-library/LibrarySectionTabs.tsx
@@ -25,7 +25,7 @@ export default function LibrarySectionTabs({ showExploreTab }: Props) {
         className={TAB_CLASS}
         aria-label="Jump to owned items"
       >
-        My Library
+        Owned
       </a>
       {showExploreTab ? (
         <a
@@ -34,7 +34,7 @@ export default function LibrarySectionTabs({ showExploreTab }: Props) {
           className={TAB_CLASS}
           aria-label="Jump to explore section"
         >
-          Explore More
+          Explore
         </a>
       ) : null}
     </div>

--- a/components/my-library/programs/ProgramBuilderHub.tsx
+++ b/components/my-library/programs/ProgramBuilderHub.tsx
@@ -391,10 +391,10 @@ export default function ProgramBuilderHub({ programLibrary }: Props) {
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h2 className="text-lg font-semibold text-slate-900">Program shell</h2>
+          <h2 className="text-lg font-semibold text-slate-900">Program planning</h2>
           <p className="mt-2 max-w-[66ch] text-sm text-slate-600">
-            Save a canonical program shell, place accepted workouts into week/day slots, and keep
-            one shared program surface ready for later planner and export work.
+            Save a canonical program, place accepted workouts into week/day slots, and keep one
+            shared planning surface ready for later planner and export work.
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">

--- a/components/my-library/workouts/SavedWorkoutsPanel.tsx
+++ b/components/my-library/workouts/SavedWorkoutsPanel.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { getSessionTypeLabel } from "@/lib/session-generator-v1/shared";
+import type { WorkoutSummary } from "@/lib/workouts/shared";
+
+type Props = {
+  workouts: WorkoutSummary[];
+  description: string;
+  workoutHrefBuilder: (workoutId: string) => string;
+  collapsedByDefault?: boolean;
+  testId?: string;
+  heading?: string;
+  editLabel?: string;
+  editButtonTestIdBuilder?: (workoutId: string) => string;
+  deleteButtonTestIdBuilder?: (workoutId: string) => string;
+  confirmDeleteButtonTestIdBuilder?: (workoutId: string) => string;
+  onRequestDeleteWorkout?: ((workout: WorkoutSummary) => void) | null;
+  onCancelDeleteWorkout?: (() => void) | null;
+  onConfirmDeleteWorkout?: ((workout: WorkoutSummary) => void) | null;
+  pendingDeleteWorkoutId?: string | null;
+  deletingWorkoutId?: string | null;
+  currentWorkoutId?: string | null;
+  onOpenCurrentWorkoutPdf?: (() => void) | null;
+  printButtonTestIdBuilder?: (workoutId: string) => string;
+};
+
+export default function SavedWorkoutsPanel({
+  workouts,
+  description,
+  workoutHrefBuilder,
+  collapsedByDefault = true,
+  testId = "session-generator-recent-workouts",
+  heading = "Saved workouts",
+  editLabel = "Edit",
+  editButtonTestIdBuilder = (workoutId) => `saved-workouts-edit-${workoutId}`,
+  deleteButtonTestIdBuilder = (workoutId) => `saved-workouts-delete-${workoutId}`,
+  confirmDeleteButtonTestIdBuilder = (workoutId) => `saved-workouts-confirm-delete-${workoutId}`,
+  onRequestDeleteWorkout = null,
+  onCancelDeleteWorkout = null,
+  onConfirmDeleteWorkout = null,
+  pendingDeleteWorkoutId = null,
+  deletingWorkoutId = null,
+  currentWorkoutId = null,
+  onOpenCurrentWorkoutPdf = null,
+  printButtonTestIdBuilder = (workoutId) => `saved-workouts-print-${workoutId}`,
+}: Props) {
+  const [expanded, setExpanded] = useState(() => !collapsedByDefault);
+
+  useEffect(() => {
+    if (pendingDeleteWorkoutId) {
+      setExpanded(true);
+    }
+  }, [pendingDeleteWorkoutId]);
+
+  if (workouts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div data-testid={testId} className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-slate-900">{heading}</h3>
+          <p className="mt-1 text-sm text-slate-600">{description}</p>
+          <p className="mt-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            {workouts.length} saved workout{workouts.length === 1 ? "" : "s"} ready for review
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setExpanded((current) => !current)}
+          aria-expanded={expanded}
+          data-testid={`${testId}-toggle`}
+          className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+        >
+          {expanded ? "Collapse workouts" : "Show workouts"}
+        </button>
+      </div>
+
+      {expanded ? (
+        <div className="mt-4 grid gap-3">
+          {workouts.map((workout) => {
+            const deleting = deletingWorkoutId === workout.id;
+            const pendingDelete = pendingDeleteWorkoutId === workout.id;
+            const canPrintCurrentWorkout =
+              currentWorkoutId === workout.id && typeof onOpenCurrentWorkoutPdf === "function";
+
+            return (
+              <div
+                key={workout.id}
+                data-testid={`saved-workout-card-${workout.id}`}
+                className="rounded-2xl border border-white/80 bg-white p-3"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-slate-900">{workout.title}</p>
+                    <p className="mt-1 text-sm text-slate-600">
+                      {workout.totalDistanceM ? `${workout.totalDistanceM}m` : null}
+                      {workout.totalDistanceM && workout.estimatedDurationMin ? " · " : null}
+                      {workout.estimatedDurationMin ? `~${workout.estimatedDurationMin} min` : null}
+                      {workout.totalDistanceM || workout.estimatedDurationMin ? " · " : null}
+                      {getSessionTypeLabel(workout.sessionType)}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Link
+                      href={workoutHrefBuilder(workout.id)}
+                      data-testid={editButtonTestIdBuilder(workout.id)}
+                      className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+                    >
+                      {editLabel}
+                    </Link>
+                    {canPrintCurrentWorkout ? (
+                      <button
+                        type="button"
+                        onClick={() => onOpenCurrentWorkoutPdf?.()}
+                        data-testid={printButtonTestIdBuilder(workout.id)}
+                        className="inline-flex h-10 items-center justify-center rounded-xl border border-amber-200 bg-white px-4 text-sm font-medium text-amber-800 transition hover:bg-amber-50 active:bg-amber-100"
+                      >
+                        Poolside PDF
+                      </button>
+                    ) : null}
+                    {typeof onRequestDeleteWorkout === "function" ? (
+                      <button
+                        type="button"
+                        onClick={() => onRequestDeleteWorkout(workout)}
+                        disabled={deleting}
+                        data-testid={deleteButtonTestIdBuilder(workout.id)}
+                        className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-700 transition hover:bg-rose-50 active:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        {deleting ? "Deleting..." : "Delete"}
+                      </button>
+                    ) : null}
+                  </div>
+                </div>
+
+                {pendingDelete ? (
+                  <div className="mt-3 rounded-2xl border border-rose-200 bg-rose-50/80 p-3">
+                    <p className="text-sm font-medium text-rose-900">
+                      Delete this saved workout from My Library?
+                    </p>
+                    <p className="mt-1 text-sm text-rose-900/90">
+                      This removes the canonical workout and any unsaved local edits in this open
+                      builder view.
+                    </p>
+                    <div className="mt-3 flex flex-wrap items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => onConfirmDeleteWorkout?.(workout)}
+                        disabled={deleting}
+                        data-testid={confirmDeleteButtonTestIdBuilder(workout.id)}
+                        className="inline-flex h-10 items-center justify-center rounded-xl bg-rose-600 px-4 text-sm font-semibold text-white transition hover:bg-rose-500 active:bg-rose-700 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        {deleting ? "Deleting..." : "Delete workout"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => onCancelDeleteWorkout?.()}
+                        disabled={deleting}
+                        className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-700 transition hover:bg-rose-50 active:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/my-library/workouts/WorkoutBuilderHub.tsx
+++ b/components/my-library/workouts/WorkoutBuilderHub.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import CreateManualWorkoutButton from "@/components/my-library/workouts/CreateManualWorkoutButton";
+import SavedWorkoutsPanel from "@/components/my-library/workouts/SavedWorkoutsPanel";
 import WorkoutEditor from "@/components/my-library/workouts/WorkoutEditor";
 import type {
+  WorkoutDeleteApiResponse,
   WorkoutEditorRecord,
   WorkoutLibrarySnapshot,
   WorkoutSaveApiResponse,
@@ -22,6 +25,7 @@ function upsertRecentWorkoutSummary(current: WorkoutSummary[], next: WorkoutSumm
 }
 
 export default function WorkoutBuilderHub({ workoutLibrary }: Props) {
+  const router = useRouter();
   const [savedWorkout, setSavedWorkout] = useState<WorkoutEditorRecord | null>(
     workoutLibrary.selectedWorkout
   );
@@ -30,6 +34,8 @@ export default function WorkoutBuilderHub({ workoutLibrary }: Props) {
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
   const [isSaving, setIsSaving] = useState(false);
+  const [pendingDeleteWorkoutId, setPendingDeleteWorkoutId] = useState<string | null>(null);
+  const [deletingWorkoutId, setDeletingWorkoutId] = useState<string | null>(null);
   const [clientReady, setClientReady] = useState(false);
   const hasUnsavedChanges = haveWorkoutDraftChanges(draft, savedWorkout?.draft ?? null);
 
@@ -43,6 +49,8 @@ export default function WorkoutBuilderHub({ workoutLibrary }: Props) {
     setRecentWorkouts(workoutLibrary.recentWorkouts);
     setError("");
     setSuccess("");
+    setPendingDeleteWorkoutId(null);
+    setDeletingWorkoutId(null);
   }, [
     workoutLibrary.recentWorkouts,
     workoutLibrary.selectedWorkout,
@@ -94,6 +102,48 @@ export default function WorkoutBuilderHub({ workoutLibrary }: Props) {
     setDraft(savedWorkout.draft);
     setError("");
     setSuccess("Unsaved builder edits were reset to the last saved workout.");
+  }
+
+  async function confirmDeleteWorkout(workout: WorkoutSummary) {
+    setDeletingWorkoutId(workout.id);
+    setError("");
+    setSuccess("");
+
+    try {
+      const response = await fetch(`/api/my-library/workouts/${workout.id}`, {
+        method: "DELETE",
+      });
+      const responseBody = (await response
+        .json()
+        .catch(() => null)) as WorkoutDeleteApiResponse | null;
+      const responseError =
+        responseBody && !responseBody.ok
+          ? responseBody.error
+          : "Could not delete workout right now.";
+
+      if (!response.ok || !responseBody?.ok) {
+        setError(responseError);
+        return;
+      }
+
+      setRecentWorkouts((current) => current.filter((summary) => summary.id !== workout.id));
+      setPendingDeleteWorkoutId(null);
+
+      if (savedWorkout?.id === workout.id) {
+        setSavedWorkout(null);
+        setDraft(null);
+        router.push("/my-library");
+        router.refresh();
+        return;
+      }
+
+      setSuccess(`Deleted ${workout.title}.`);
+      router.refresh();
+    } catch {
+      setError("Could not delete workout right now.");
+    } finally {
+      setDeletingWorkoutId(null);
+    }
   }
 
   return (
@@ -150,101 +200,97 @@ export default function WorkoutBuilderHub({ workoutLibrary }: Props) {
         </div>
       ) : null}
 
-      {!savedWorkout ? (
-        <div className="mt-6 space-y-5">
-          <div className="rounded-2xl border border-amber-200 bg-amber-50/80 p-4">
-            <p className="text-sm font-medium text-amber-900">
-              {workoutLibrary.selectedWorkoutMissing
-                ? "That saved workout could not be found."
-                : "No canonical workout is loaded in this route."}
-            </p>
-            <p className="mt-2 text-sm text-amber-900/90">
-              Create a starter manual workout here, return to the generator for a brand-new AI
-              draft, or reopen another saved workout below.
-            </p>
-            <div className="mt-4 flex flex-wrap gap-2">
-              {workoutLibrary.schemaReady ? (
-                <CreateManualWorkoutButton
-                  testId="workout-builder-empty-create-manual"
-                  className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
-                />
-              ) : null}
-              <Link
-                href="/my-library/generator"
-                className="inline-flex h-10 items-center justify-center rounded-xl border border-amber-200 bg-white px-4 text-sm font-medium text-amber-900 transition hover:bg-amber-50 active:bg-amber-100"
-              >
-                Open generator
-              </Link>
-              <Link
-                href="/my-library"
-                className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
-              >
-                Back to My Library
-              </Link>
-            </div>
-          </div>
+      <div className="mt-6 space-y-5">
+        <SavedWorkoutsPanel
+          workouts={recentWorkouts}
+          heading="Saved workouts"
+          description="Edit another saved workout here and delete old test sessions when they are no longer useful."
+          workoutHrefBuilder={(workoutId) => `/my-library/workouts/${workoutId}`}
+          editLabel="Edit"
+          testId="session-generator-recent-workouts"
+          editButtonTestIdBuilder={(workoutId) =>
+            savedWorkout
+              ? `session-generator-open-workout-${workoutId}`
+              : `workout-builder-open-workout-${workoutId}`
+          }
+          deleteButtonTestIdBuilder={(workoutId) => `workout-builder-delete-workout-${workoutId}`}
+          confirmDeleteButtonTestIdBuilder={(workoutId) =>
+            `workout-builder-confirm-delete-workout-${workoutId}`
+          }
+          currentWorkoutId={savedWorkout?.id ?? null}
+          onOpenCurrentWorkoutPdf={null}
+          onRequestDeleteWorkout={(workout) => {
+            setPendingDeleteWorkoutId(workout.id);
+            setError("");
+            setSuccess("");
+          }}
+          onCancelDeleteWorkout={() => setPendingDeleteWorkoutId(null)}
+          onConfirmDeleteWorkout={confirmDeleteWorkout}
+          pendingDeleteWorkoutId={pendingDeleteWorkoutId}
+          deletingWorkoutId={deletingWorkoutId}
+        />
 
-          {recentWorkouts.length > 0 ? (
-            <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
-              <h3 className="text-sm font-semibold text-slate-900">Recent accepted workouts</h3>
-              <p className="mt-1 text-sm text-slate-600">
-                Reopen another saved canonical workout directly in this builder route.
+        {!savedWorkout ? (
+          <div className="space-y-5">
+            <div className="rounded-2xl border border-amber-200 bg-amber-50/80 p-4">
+              <p className="text-sm font-medium text-amber-900">
+                {workoutLibrary.selectedWorkoutMissing
+                  ? "That saved workout could not be found."
+                  : "No canonical workout is loaded in this route."}
               </p>
-              <div className="mt-4 grid gap-3">
-                {recentWorkouts.map((workout) => (
-                  <div
-                    key={workout.id}
-                    className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-white/80 bg-white p-3"
-                  >
-                    <div>
-                      <p className="text-sm font-semibold text-slate-900">{workout.title}</p>
-                      <p className="mt-1 text-sm text-slate-600">
-                        {workout.totalDistanceM ? `${workout.totalDistanceM}m` : null}
-                        {workout.totalDistanceM && workout.estimatedDurationMin ? " · " : null}
-                        {workout.estimatedDurationMin
-                          ? `~${workout.estimatedDurationMin} min`
-                          : null}
-                      </p>
-                    </div>
-                    <Link
-                      href={`/my-library/workouts/${workout.id}`}
-                      data-testid={`workout-builder-open-workout-${workout.id}`}
-                      className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
-                    >
-                      Open
-                    </Link>
-                  </div>
-                ))}
+              <p className="mt-2 text-sm text-amber-900/90">
+                Create a starter manual workout here, return to the generator for a brand-new AI
+                draft, or reopen another saved workout below.
+              </p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                {workoutLibrary.schemaReady ? (
+                  <CreateManualWorkoutButton
+                    testId="workout-builder-empty-create-manual"
+                    className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+                  />
+                ) : null}
+                <Link
+                  href="/my-library/generator"
+                  className="inline-flex h-10 items-center justify-center rounded-xl border border-amber-200 bg-white px-4 text-sm font-medium text-amber-900 transition hover:bg-amber-50 active:bg-amber-100"
+                >
+                  Open generator
+                </Link>
+                <Link
+                  href="/my-library"
+                  className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+                >
+                  Back to My Library
+                </Link>
               </div>
             </div>
-          ) : null}
-        </div>
-      ) : null}
+          </div>
+        ) : null}
 
-      {draft && savedWorkout ? (
-        <div className="mt-6">
-          <WorkoutEditor
-            draft={draft}
-            savedWorkout={savedWorkout}
-            recentWorkouts={recentWorkouts}
-            canonicalSaveReady={workoutLibrary.schemaReady}
-            isSaving={isSaving}
-            onSave={saveWorkout}
-            hasUnsavedChanges={hasUnsavedChanges}
-            onDraftChange={(nextDraft) => {
-              setDraft(nextDraft);
-              setSuccess("");
-            }}
-            onResetToSaved={resetDraftToSavedWorkout}
-            startNewDraftHref="/my-library/generator"
-            startNewDraftLabel="Generate new draft"
-            showLoadedBanner={false}
-            recentWorkoutsDescription="Open another saved workout here, create a new manual workout from the header, or jump back to the generator when you want a brand-new AI draft."
-            workoutHrefBuilder={(workoutId) => `/my-library/workouts/${workoutId}`}
-            saveButtonTestId="workout-builder-save"
-          />
-        </div>
-      ) : null}
+        {draft && savedWorkout ? (
+          <div>
+            <WorkoutEditor
+              draft={draft}
+              savedWorkout={savedWorkout}
+              recentWorkouts={[]}
+              canonicalSaveReady={workoutLibrary.schemaReady}
+              isSaving={isSaving}
+              onSave={saveWorkout}
+              hasUnsavedChanges={hasUnsavedChanges}
+              onDraftChange={(nextDraft) => {
+                setDraft(nextDraft);
+                setSuccess("");
+              }}
+              onResetToSaved={resetDraftToSavedWorkout}
+              startNewDraftHref="/my-library/generator"
+              startNewDraftLabel="Generate new draft"
+              showLoadedBanner={false}
+              recentWorkoutsDescription="Open another saved workout here, create a new manual workout from the header, or jump back to the generator when you want a brand-new AI draft."
+              workoutHrefBuilder={(workoutId) => `/my-library/workouts/${workoutId}`}
+              saveButtonTestId="workout-builder-save"
+            />
+          </div>
+        ) : null}
+      </div>
     </section>
   );
 }

--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -119,6 +119,8 @@ type LastRemovedBlock = {
   restoreOpenStepId: string | null;
 };
 
+type SupportSectionKey = "readiness" | "garminExport" | "handoff";
+
 const CUSTOM_DISTANCE_VALUE = "custom";
 
 function buildStepId(index: number) {
@@ -463,6 +465,11 @@ export default function WorkoutEditor({
   const [garminExportError, setGarminExportError] = useState("");
   const [handoffNotice, setHandoffNotice] = useState("");
   const [handoffError, setHandoffError] = useState("");
+  const [supportSectionOpen, setSupportSectionOpen] = useState<Record<SupportSectionKey, boolean>>({
+    readiness: false,
+    garminExport: false,
+    handoff: false,
+  });
   const poolLengthUsesPreset =
     typeof draft.poolLengthM === "number" && isSessionDraftPoolLengthPreset(draft.poolLengthM);
   const handoffDraftState: WorkoutHandoffDraftState =
@@ -559,6 +566,14 @@ export default function WorkoutEditor({
     setHandoffNotice("");
     setHandoffError("");
   }, [handoffText, handoffDraftState, savedWorkout?.id, savedWorkout?.updatedAt]);
+
+  useEffect(() => {
+    setSupportSectionOpen({
+      readiness: false,
+      garminExport: false,
+      handoff: false,
+    });
+  }, [savedWorkout?.id]);
 
   function syncDraftSelections(nextDraft: SessionDraft) {
     const requiredStrokes = Array.from(
@@ -1766,22 +1781,38 @@ export default function WorkoutEditor({
                 : "Builder save still works, but these are handoff warnings that should be reviewed before export or later Garmin delivery."}
             </p>
           </div>
-          <p
-            className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${
-              garminReadiness.status === "ready"
-                ? "bg-white text-emerald-700"
-                : "bg-white text-amber-700"
-            }`}
-          >
-            {garminReadiness.status === "ready"
-              ? "Ready"
-              : `${garminReadiness.issues.length} review ${
-                  garminReadiness.issues.length === 1 ? "item" : "items"
-                }`}
-          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <p
+              className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${
+                garminReadiness.status === "ready"
+                  ? "bg-white text-emerald-700"
+                  : "bg-white text-amber-700"
+              }`}
+            >
+              {garminReadiness.status === "ready"
+                ? "Ready"
+                : `${garminReadiness.issues.length} review ${
+                    garminReadiness.issues.length === 1 ? "item" : "items"
+                  }`}
+            </p>
+            <button
+              type="button"
+              aria-expanded={supportSectionOpen.readiness}
+              data-testid="workout-editor-garmin-readiness-toggle"
+              onClick={() =>
+                setSupportSectionOpen((current) => ({
+                  ...current,
+                  readiness: !current.readiness,
+                }))
+              }
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-white bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-white/80 active:bg-white/70"
+            >
+              {supportSectionOpen.readiness ? "Hide details" : "Show details"}
+            </button>
+          </div>
         </div>
 
-        {garminReadiness.issues.length > 0 ? (
+        {supportSectionOpen.readiness && garminReadiness.issues.length > 0 ? (
           <ul className="mt-3 space-y-2 text-sm text-amber-900">
             {garminReadiness.issues.map((issue, index) => (
               <li key={issue.id} data-testid={`workout-editor-garmin-readiness-issue-${index}`}>
@@ -1796,11 +1827,12 @@ export default function WorkoutEditor({
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">
-              Workout PDF
+              Poolside PDF
             </p>
             <p className="mt-2 text-sm font-medium text-slate-900">
               Open a print-ready workout sheet in a dedicated tab, then use your browser&apos;s
-              Print / Save PDF flow for a poolside copy.
+              Print / Save PDF flow for a poolside copy that matches the current supported workout
+              contract.
             </p>
             <p
               data-testid="workout-editor-pdf-source"
@@ -1818,7 +1850,7 @@ export default function WorkoutEditor({
               data-testid="workout-editor-pdf-open"
               className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
             >
-              Open print view
+              Open poolside PDF
             </button>
           </div>
         </div>
@@ -1868,6 +1900,20 @@ export default function WorkoutEditor({
             >
               Download .json
             </button>
+            <button
+              type="button"
+              aria-expanded={supportSectionOpen.garminExport}
+              data-testid="workout-editor-garmin-export-toggle"
+              onClick={() =>
+                setSupportSectionOpen((current) => ({
+                  ...current,
+                  garminExport: !current.garminExport,
+                }))
+              }
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+            >
+              {supportSectionOpen.garminExport ? "Hide preview" : "Show preview"}
+            </button>
           </div>
         </div>
 
@@ -1889,14 +1935,16 @@ export default function WorkoutEditor({
           </p>
         ) : null}
 
-        <div className="mt-4 overflow-hidden rounded-2xl border border-slate-200 bg-slate-950">
-          <pre
-            data-testid="workout-editor-garmin-export-preview"
-            className="max-h-[320px] overflow-auto whitespace-pre-wrap px-4 py-4 text-xs leading-relaxed text-slate-100"
-          >
-            {garminReadyExportPreview}
-          </pre>
-        </div>
+        {supportSectionOpen.garminExport ? (
+          <div className="mt-4 overflow-hidden rounded-2xl border border-slate-200 bg-slate-950">
+            <pre
+              data-testid="workout-editor-garmin-export-preview"
+              className="max-h-[320px] overflow-auto whitespace-pre-wrap px-4 py-4 text-xs leading-relaxed text-slate-100"
+            >
+              {garminReadyExportPreview}
+            </pre>
+          </div>
+        ) : null}
       </div>
 
       <div className="rounded-2xl border border-slate-200 bg-white p-4">
@@ -1935,6 +1983,20 @@ export default function WorkoutEditor({
             >
               Download .txt
             </button>
+            <button
+              type="button"
+              aria-expanded={supportSectionOpen.handoff}
+              data-testid="workout-editor-handoff-toggle"
+              onClick={() =>
+                setSupportSectionOpen((current) => ({
+                  ...current,
+                  handoff: !current.handoff,
+                }))
+              }
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+            >
+              {supportSectionOpen.handoff ? "Hide preview" : "Show preview"}
+            </button>
           </div>
         </div>
 
@@ -1953,14 +2015,16 @@ export default function WorkoutEditor({
           </p>
         ) : null}
 
-        <div className="mt-4 overflow-hidden rounded-2xl border border-slate-200 bg-slate-950">
-          <pre
-            data-testid="workout-editor-handoff-preview"
-            className="max-h-[320px] overflow-auto whitespace-pre-wrap px-4 py-4 text-xs leading-relaxed text-slate-100"
-          >
-            {handoffText}
-          </pre>
-        </div>
+        {supportSectionOpen.handoff ? (
+          <div className="mt-4 overflow-hidden rounded-2xl border border-slate-200 bg-slate-950">
+            <pre
+              data-testid="workout-editor-handoff-preview"
+              className="max-h-[320px] overflow-auto whitespace-pre-wrap px-4 py-4 text-xs leading-relaxed text-slate-100"
+            >
+              {handoffText}
+            </pre>
+          </div>
+        ) : null}
       </div>
 
       <div className="grid gap-4 md:grid-cols-3">
@@ -1994,25 +2058,9 @@ export default function WorkoutEditor({
         </div>
       </div>
 
-      <div className="rounded-2xl border border-slate-200 bg-white p-4">
-        <h3 className="text-base font-semibold text-slate-900">Title suggestions</h3>
-        <div className="mt-3 flex flex-wrap gap-2">
-          {draft.titleSuggestions.map((suggestion) => (
-            <button
-              key={suggestion}
-              type="button"
-              onClick={() => updateDraft("title", suggestion)}
-              className="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-sm text-slate-700 transition hover:bg-slate-100"
-            >
-              {suggestion}
-            </button>
-          ))}
-        </div>
-      </div>
-
       <div className="grid gap-4 md:grid-cols-2">
         <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
-          Draft title
+          Title
           <input
             type="text"
             value={draft.title}
@@ -2040,7 +2088,7 @@ export default function WorkoutEditor({
         </label>
 
         <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700 md:col-span-2">
-          Draft description
+          Description
           <textarea
             value={draft.description}
             onChange={(event) => updateDraft("description", event.target.value)}

--- a/docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md
@@ -1,0 +1,319 @@
+# Task Brief: Workout Builder Live-Review UX And Actions (10/10)
+
+## Metadata
+
+- `id`: `2026-03-27-workout-builder-live-review-ux-and-actions-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-03-27`
+- `updated`: `2026-03-27`
+
+## Goal
+
+Turn the current live-review wave of workout-builder and My Library friction into one focused UX/actions slice so manual workout authoring, cleanup, printing, and builder navigation feel trustworthy before program-builder work starts.
+
+## Why This Brief Exists
+
+- Real use in `freeswimming.org` surfaced builder friction that is now more valuable than speculative program-builder work.
+- The builder currently lets the owner create multiple canonical workouts, but basic cleanup and action ergonomics are still incomplete.
+- Several notes are tightly related enough that splitting them now would create artificial seams:
+  - workout delete/edit/print actions,
+  - collapsible default states,
+  - clearer edit-form language,
+  - calmer builder-only notices,
+  - poolside/PDF truthfulness,
+  - My Library IA confusion around `Program shell` and extra mode buttons.
+- This brief is intended to own the current UX/action batch without reopening the broader workout-builder parent brief for every small live-review note.
+
+## Dependencies And Boundaries
+
+- Parent builder/runtime foundation:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md`
+- Epic-level orchestration:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/planned/2026-02-28-workout-builder-garmin-familiar-epic-10-10.md`
+- Export lineage that must stay truthful:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md`
+- Program foundation/My Library lineage:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-25-canonical-program-foundation-and-library-shell-10-10.md`
+- Locked boundary decisions unless owner explicitly reprioritizes:
+  - no weekly program calendar/planner implementation in this slice,
+  - no AI session/program generation changes,
+  - no Garmin Training API push,
+  - no training-history reconciliation changes,
+  - do not introduce a parallel workout model; canonical workout remains authoritative.
+
+## Admin Notes Triage Disposition
+
+Production admin notes reviewed against this brief on `2026-03-27`:
+
+- `fed5e8b6-71a5-4b35-8549-2155a2cccdfe` `How do I delete workouts?`
+  - disposition: owned by this brief.
+  - reason: missing destructive cleanup is a core workout-builder ergonomics gap.
+- `f09ade9f-8301-49c3-980f-366675bdb46d` `Delete, edit, print  buttons for the workouts`
+  - disposition: owned by this brief.
+  - reason: same saved-workout action surface as the delete gap above.
+- `fd9d4210-be56-4a02-855f-a347fcbfadeb` `Remove print, ref screenshot`
+  - disposition: owned by this brief.
+  - reason: print/poolside affordances need one coherent builder/export IA decision.
+- `af6ab360-04d1-454c-8824-090260f088e8` `Make collapsable and keep collapsable by default`
+  - disposition: owned by this brief.
+  - reason: builder read surfaces and diagnostics need calmer default density during repeated authoring.
+- `3396b47c-4b78-4a72-bc55-b6806e0fc620` `Edit form`
+  - disposition: owned by this brief.
+  - reason: edit-form terminology and stroke taxonomy are part of the same live-review authoring polish wave.
+- `5b15cd93-813f-415b-a555-6f0bf6729bf7` `Information messages`
+  - disposition: owned by this brief.
+  - reason: builder notices should match the same calmer UX language and placement strategy.
+- `db185e47-0794-4e84-b881-5507d526f911` `Poolside PDF`
+  - disposition: owned by this brief.
+  - reason: poolside print/PDF shape is part of the same truthful execution/export surface review.
+- `a73a376b-1912-457f-9df6-474ffaf48b4c` `What is this?`
+  - disposition: owned by this brief.
+  - reason: `Program shell` confusion is a My Library IA issue adjacent to builder progress and should be decided before planner work restarts.
+- `7e075645-84e8-4fcb-a23e-518862ad03d5` `Ehy i smh library button here`
+  - disposition: owned by this brief.
+  - reason: My Library mode/button clarity belongs in the same IA clean-up wave as `Program shell`.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Visual design quality`
+- `Business logic correctness and data integrity`
+- `Admin workflow and editability`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                | Evidence                                |
+| --------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| Product goals and IA                          | `target`     | Builder and My Library surfaces make it obvious how to create, reopen, edit, delete, print, and understand workout/program placeholders.      | IA review + manual QA + e2e             |
+| UX flow clarity                               | `target`     | A user can identify the right action on saved workouts without guessing, hidden steps, or conflicting duplicate controls.                     | timed manual QA + e2e                   |
+| Visual design quality                         | `target`     | Builder actions, notices, collapsible panels, and print affordances feel calmer and more intentional than the current crowded state.          | screenshot review + manual QA           |
+| Business logic correctness and data integrity | `target`     | Delete/edit/print actions operate on canonical workout IDs only, with explicit confirmation and no ambiguous partial-delete state.            | unit tests + API tests + runtime guards |
+| Admin editor ergonomics                       | `target`     | Manual builder work remains fast enough for repeated real-world testing, including cleanup of extra workouts and calmer read surfaces.        | timed manual QA + e2e                   |
+| Accessibility (a11y)                          | `supporting` | Supporting only: added actions, collapsible sections, and PDF/print affordances must remain keyboard/touch accessible.                        | code review + targeted e2e              |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: action-density and collapse defaults must not materially regress builder route responsiveness or payload size.               | verify evidence + scope rationale       |
+| Data placement and sync boundaries            | `target`     | Brief defines which builder/workout values are server-canonical vs local-only UI state, and destructive actions invalidate deterministically. | brief contract + tests                  |
+| Caching and invalidation strategy             | `supporting` | Supporting only: saved-workout lists and detail views refresh deterministically after delete/edit/print-state mutations.                      | code review + targeted tests            |
+| Reliability and failure handling              | `target`     | Delete, print, and collapse flows show explicit failure/retry guidance instead of silent no-ops or stuck UI.                                  | negative-path tests + manual QA         |
+| Security and authz                            | `supporting` | Supporting only: workout actions stay owner-scoped/authenticated and do not widen access beyond existing My Library boundaries.               | existing auth tests + code review       |
+| Privacy and compliance                        | `N/A`        | N/A because this slice changes builder ergonomics and owner-scoped workout actions, not personal-data policy or public data disclosure.       | scope rationale                         |
+| Content governance                            | `supporting` | Supporting only: copy and label cleanup must stay aligned with the canonical workout model and existing export semantics.                     | copy review + parent-brief alignment    |
+| Admin workflow and editability                | `target`     | Saved workouts can be cleaned up, reopened, printed, and reviewed without forcing detours into unrelated surfaces.                            | e2e + timed manual QA                   |
+| SEO and crawlability                          | `N/A`        | N/A because My Library and workout-builder actions are authenticated/private and do not add public crawl-index surfaces.                      | scope rationale                         |
+| AI discoverability                            | `N/A`        | N/A because this slice changes no public AI-discoverable route or metadata contract.                                                          | scope rationale                         |
+| Analytics and KPI observability               | `supporting` | Supporting only: action usage such as delete/print/open should remain measurable enough to evaluate builder friction later.                   | event review + code review              |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, billing, entitlement, or commercial reporting logic changes in this builder UX slice.                                 | scope rationale                         |
+| Incident response and support operations      | `supporting` | Supporting only: Help/Guide and runbook updates should explain any new destructive-action recovery or print/PDF guidance if shipped.          | help/runbook review                     |
+| Finance and reporting operations              | `N/A`        | N/A because no finance reconciliation, payout, or reporting surface is changed by saved-workout UX cleanup.                                   | scope rationale                         |
+| i18n operational readiness                    | `N/A`        | N/A for this slice because the work is label/IA cleanup inside owner-only builder flows and should not block later localization models.       | scope rationale                         |
+| Stack-fit and dependency discipline           | `target`     | Reuse existing builder, list, and export primitives; do not introduce new state or PDF libraries without clear necessity.                     | dependency diff + architecture review   |
+| Testing and QA automation                     | `target`     | Coverage protects delete, edit/open actions, collapse defaults, truthful print affordances, and My Library IA decisions.                      | unit/e2e coverage + `verify:pre-pr`     |
+| Scalability and cost efficiency               | `supporting` | Supporting only: action cleanup should reduce operator churn without adding wasteful repeated fetch/render or export cost patterns.           | code review + manual QA                 |
+| DevOps and rollback readiness                 | `target`     | Action-surface changes remain reversible without schema drift, and any destructive API addition includes a clear rollback path.               | migration review + PR rollback notes    |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - saved workout rows, workout steps, workout owner scope, export/handoff eligibility state, any persisted print/PDF metadata.
+- Local-only:
+  - collapse/expand state,
+  - transient notices,
+  - unsaved form edits,
+  - local confirmation dialogs,
+  - transient print-preview selections.
+- Sync policy:
+  - canonical workout save/delete/edit actions become authoritative only after server confirmation,
+  - destructive actions must target canonical workout IDs, not visible card order,
+  - list surfaces must refresh deterministically after delete or rename.
+- Retention and sensitivity:
+  - delete is explicit owner cleanup of owner-scoped training content and should remove the canonical workout row according to existing retention policy,
+  - no extra hidden shadow copies should remain after successful delete beyond standard audit-safe storage that already exists in the platform.
+- Cache/invalidation:
+  - saved workout list, workout editor route, recent accepted workouts, and any linked print/handoff surfaces must invalidate on delete/update.
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - `workout.id` remains the only canonical workout identity across builder, My Library, export, and later program planning.
+- Human-readable identifiers:
+  - workout title, description, list subtitle, and PDF labels are editable display metadata and must not be used as canonical identifiers.
+- Mutability rules:
+  - title/description/session metadata are editable in place,
+  - delete removes the workout entity instead of repurposing it,
+  - print/export affordances must reflect the current canonical workout state only.
+- Rename vs repurpose policy:
+  - editing a workout title or description is an in-place rename,
+  - materially different sessions should be created as a new workout, not silently overwrite an unrelated saved workout.
+- Compatibility contract:
+  - existing saved workouts remain valid even if new builder actions or collapsed defaults are added,
+  - `Program shell` and My Library mode changes must not break existing links/routes.
+- Observability and repair:
+  - unresolved workout IDs, failed delete attempts, and stale list rows should surface explicit refresh/retry guidance rather than silent disappearance or stale cards.
+
+## Scope
+
+- Add missing saved-workout actions where they are operationally needed:
+  - delete workout,
+  - consistent open/edit affordances,
+  - truthful print/PDF affordances.
+- Rationalize builder/export entrypoints so redundant or misleading print controls are removed or merged into one clearer flow.
+- Make noisy builder support panels calmer by default:
+  - Garmin JSON,
+  - workout handoff,
+  - recent accepted workouts,
+  - similar read-heavy panels discovered in implementation.
+- Clean up workout edit-form language and authoring inputs:
+  - remove misleading `Draft` prefixes where they do not represent workflow state,
+  - remove low-value title suggestions if they add clutter,
+  - support clearer stroke taxonomy for `drills` and `kicks` where the current form is too narrow.
+- Move builder-only informational messages into calmer, truthful placement and keep them owner/admin-only where appropriate.
+- Clarify My Library IA around:
+  - `Program shell`,
+  - extra mode buttons such as `Explore mode` / redundant `My Library` controls,
+  - whether those surfaces should be hidden, renamed, or explained.
+- Tune poolside/PDF output toward the observed real-world print use case without promising a broader document system than we actually support.
+
+## Out Of Scope
+
+- Weekly program-builder calendar/planner implementation.
+- AI workout or program generation changes.
+- Garmin Training API push or provider integrations.
+- Training-history completion/reconciliation work.
+- Replacing the canonical workout model or adding a second persisted workout representation.
+- Broad notes-system changes beyond builder-facing notices or guidance touched by this UX work.
+
+## Acceptance Criteria
+
+1. Saved-workout lists expose a clear delete path with confirmation and deterministic post-delete refresh.
+2. Saved-workout surfaces expose coherent open/edit/print behavior without duplicate or contradictory calls to action.
+3. Read-heavy builder support panels can be collapsed and default to a calmer state where that materially improves repeated authoring.
+4. Workout edit-form labels no longer imply incorrect workflow state, and low-value suggestion clutter is removed when it adds more noise than help.
+5. Stroke/taxonomy affordances for drills and kicks are handled explicitly enough that authors do not need to misuse unrelated stroke fields.
+6. Builder notices appear in calmer placement and remain truthful about audience and persistence.
+7. My Library no longer shows unexplained `Program shell` or confusing mode buttons without an explicit IA decision.
+8. Poolside/PDF affordances are truthful to the actual supported output, and the preferred print flow is clearer than the current state.
+9. Relevant production admin notes listed above remain explicitly owned by this brief until shipped or intentionally split again.
+10. `npm run lint:briefs`, targeted validation, and `npm run verify:pre-pr` pass before PR update.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run typecheck`
+- targeted unit tests for:
+  - workout delete action/state transitions,
+  - builder list/action availability,
+  - print/PDF affordance gating,
+  - collapse default state logic
+- targeted e2e for:
+  - My Library workout list actions,
+  - manual workout builder cleanup flow,
+  - print/PDF entry flow,
+  - My Library IA visibility/regression checks
+- `npm run verify:pre-pr`
+- before merge recommendation: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm must be installed on the machine used for local validation.
+
+## Checkpoint Log
+
+- `2026-03-27` — moved to `in-progress` on branch `fix/workout-builder-live-review-actions-2026-03-27`; first implementation slice adds owner-scoped workout delete API/UI, calmer collapsed support panels, builder label cleanup, and My Library wording cleanup. Next step: finish targeted validation and run `npm run verify:pre-pr`.
+- Local validation runs from repo root.
+
+## Manual QA Environments
+
+- Production review:
+  - `https://freeswimming.org/my-library/workouts`
+- Local iteration:
+  - `http://127.0.0.1:3000/my-library/workouts`
+- Preview:
+  - PR Vercel preview URL for the implementation branch
+
+## Constraints
+
+- Keep visual language aligned with existing builder/My Library patterns unless the note explicitly calls for removal or simplification.
+- Do not hide unfinished surfaces in a misleading way; if `Program shell` remains visible, it must be explained truthfully.
+- Do not add destructive shortcuts without confirmation/recovery guidance.
+- Keep poolside/PDF claims narrower than the currently supported export contract.
+
+## 10/10 Quality Bar
+
+- The builder should feel safe to use repeatedly for real workouts, not like a prototype that accumulates test clutter.
+- Destructive actions must feel deliberate, reversible where possible, and never ambiguous.
+- Required UI states for changed surfaces:
+  - `loading`
+  - `empty`
+  - `error`
+  - `retry`
+  - `success`
+  - delete pending/confirm
+  - print unavailable/truthful fallback
+- Information density should go down, not up.
+- Any change to workout actions or My Library IA must leave the canonical workout contract clearer than before.
+
+## Help/Guide And Operator Training Contract
+
+- Required if this slice changes workout-builder labels, delete recovery language, print guidance, or My Library explanation copy:
+  - update the relevant Help/Guide surface and any builder runbook/help copy in the same PR,
+  - update at least one automated assertion if help contract text changes.
+
+## Security, Privacy, and Compliance
+
+- All delete/edit/print actions must remain owner-scoped and authenticated.
+- No secrets or raw export tokens may appear in builder UI.
+- Destructive actions must fail closed on unauthorized access and return `401`/`403` instead of `500`.
+
+## Observability and KPI Contract
+
+- Required events/logs if analytics hooks already exist:
+  - workout delete initiated/completed/failed,
+  - print/PDF opened,
+  - saved-workout action usage (`open`, `edit`, `delete`),
+  - collapse usage for heavy builder panels when helpful.
+- Success KPI for this slice:
+  - owner can create, reopen, delete, and print a workout without guessing or leaving cleanup debt behind.
+
+## Session Continuity and Recovery
+
+- Canonical source of truth: git branch + this brief path.
+- Checkpoint cadence:
+  - commit at each validated implementation milestone,
+  - update the checkpoint log before any pause or PR handoff.
+- Recovery protocol:
+  1. `git status -sb`
+  2. `git log --oneline -n 10`
+  3. reopen this brief and continue from the latest checkpoint note
+
+## Git Rhythm Defaults
+
+- Commit + push after each validated builder UX slice.
+- Open/update PR after one coherent vertical slice or after `2-4` validated checkpoint commits, whichever comes first.
+
+## Automation Mode
+
+- `automation-first`
+  - assistant handles implementation, tests, git checkpoints, push, PR open/update, and CI monitoring unless blocked by credentials, UI-only approval, or an explicit owner decision.
+
+## Branch Hygiene Defaults
+
+- Post-merge cleanup:
+  - `git checkout main`
+  - `git pull --ff-only origin main`
+  - `git branch -d <merged-branch>`
+  - `git push origin --delete <merged-branch>` when appropriate
+
+## PR Browser Rule
+
+- Default PR create/review/merge links open in Safari.
+
+## Manual QA URL Rule
+
+- Default UI QA links should be opened in Safari before requesting owner confirmation.
+
+## Checkpoint Log
+
+- `2026-03-27 | planning | created a dedicated workout-builder live-review UX/actions brief to own the current production-note batch around delete/edit/print actions, calmer panel defaults, form copy cleanup, poolside PDF truthfulness, and My Library IA confusion before program-builder work resumes | next: review manual workout-builder usage against this brief, then pick the first narrow implementation slice`

--- a/docs/task-briefs/planned/2026-03-27-admin-notes-ergonomics-multi-image-and-route-surface-followup-10-10.md
+++ b/docs/task-briefs/planned/2026-03-27-admin-notes-ergonomics-multi-image-and-route-surface-followup-10-10.md
@@ -1,0 +1,286 @@
+# Task Brief: Admin Notes Ergonomics Multi-Image And Route-Surface Follow-Up (10/10)
+
+## Metadata
+
+- `id`: `2026-03-27-admin-notes-ergonomics-multi-image-and-route-surface-followup-10-10`
+- `status`: `planned`
+- `owner`: `stianvikra`
+- `created`: `2026-03-27`
+- `updated`: `2026-03-27`
+
+## Goal
+
+Close the remaining operator-facing admin-notes ergonomics gaps after the quick-capture utility-panel rollout so notes are faster to capture, richer in evidence, and easier to keep using across real review sessions.
+
+## Why This Brief Exists
+
+- Core notes workflows, quick capture, clipboard/image intake, and linking are already shipped, but real usage still exposes a smaller follow-up wave.
+- The current gaps are tightly related:
+  - only one pre-save image in quick note/contextual add note,
+  - uncertainty around what quick note should do after save,
+  - incomplete route-surface rollout for quick capture,
+  - attachment metadata/agent-readiness expectations not yet made explicit enough in operator flows.
+- These issues are real notes ergonomics work, but they should stay separated from the larger workout-builder UX/action batch.
+- This brief intentionally owns the operator-facing remainder so the broader admin-notes system is not reopened piecemeal without explicit scope.
+
+## Dependencies And Boundaries
+
+- Existing storage/linking/note foundations that remain authoritative:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-03-21-admin-notes-workflow-v2-attachments-and-linking-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-25-admin-notes-image-intake-simplification-and-clipboard-paste-button-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-27-admin-notes-global-quick-capture-panel-and-manuscript-categories-10-10.md`
+- Recommended boundary decisions unless owner explicitly changes them:
+  - quick note still creates a normal canonical admin note,
+  - canonical note identity remains note ID + canonical route/content context,
+  - quick-note draft can travel across supported surfaces, but original note context stays explicit and locked unless the user intentionally changes it,
+  - this slice improves ergonomics and metadata clarity; it does not replace notes with a larger ticketing system.
+
+## Admin Notes Triage Disposition
+
+Production admin notes reviewed against this brief on `2026-03-27`:
+
+- `0d1fa716-460e-406a-a68d-28c1aaae5b22` `Mulitple Screenshots`
+  - disposition: owned by this brief.
+  - reason: pre-save multi-image evidence is the clearest remaining operator gap in quick note/contextual capture.
+- `40b252d8-ee9f-41ed-89ca-0eb5af8bcc89` `Quick note`
+  - disposition: owned by this brief.
+  - reason: post-save reuse, top-of-page access expectations, and continued capture flow belong in the same ergonomics wave.
+- `881e222b-4c14-4a23-b677-60b0713e220f` `Admin notes quick capture route-surface expansion follow-up`
+  - disposition: owned by this brief.
+  - reason: the route-surface rollout should now be handled as an explicit matrix instead of a vague future placeholder.
+- `204913d0-5c97-41e8-b6f7-ab42de3bc84e` `Admin notes attachment metadata and agent-readiness follow-up`
+  - disposition: owned by this brief.
+  - reason: remaining operator-visible attachment metadata and structured evidence expectations belong together with multi-image capture and route rollout so the note is not only partially covered.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Business logic correctness and data integrity`
+- `Admin workflow and editability`
+- `Incident response and support operations`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                          | Evidence                                |
+| --------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| Product goals and IA                          | `target`     | Admin can understand how to stage evidence, save another quick note, and where quick capture is available without hidden route-specific rules.          | IA review + manual QA                   |
+| UX flow clarity                               | `target`     | Quick note and contextual add note support the expected capture loop with no guessing about image limits, post-save state, or current context.          | timed manual QA + e2e                   |
+| Visual design quality                         | `target`     | Multi-image evidence, metadata, and route-surface affordances stay clean and readable instead of turning notes into cluttered upload forms.             | screenshot review + manual QA           |
+| Business logic correctness and data integrity | `target`     | Multi-image staging, save/reset behavior, and attachment metadata remain canonical, deterministic, and tied to the correct note/context.                | unit tests + API tests + runtime guards |
+| Admin editor ergonomics                       | `target`     | Admin can keep capturing notes during real review sessions without having to reopen or rebuild the same note flow manually after every save.            | e2e + timed manual QA                   |
+| Accessibility (a11y)                          | `supporting` | Supporting only: image intake, staged evidence lists, and route-surface entrypoints must remain keyboard/touch accessible.                              | targeted e2e + code review              |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: richer pre-save evidence and broader route surfaces must not materially regress admin route responsiveness.                            | verify evidence + scope rationale       |
+| Data placement and sync boundaries            | `target`     | Brief defines local staged-image state vs server-canonical attachments and clear save/reset behavior across supported surfaces.                         | brief contract + tests                  |
+| Caching and invalidation strategy             | `supporting` | Supporting only: note panels and quick-capture surfaces refresh deterministically after save, attachment add/remove, or route changes.                  | code review + targeted tests            |
+| Reliability and failure handling              | `target`     | Failed image staging/upload, route changes, or post-save reset behavior show explicit retry/recovery guidance instead of leaving the operator stranded. | negative-path tests + manual QA         |
+| Security and authz                            | `supporting` | Supporting only: richer image intake and route-surface rollout remain admin-only and fail closed on unauthorized access.                                | existing authz tests + code review      |
+| Privacy and compliance                        | `target`     | Images and attachment metadata remain internal/admin-only, and richer evidence flows do not leak into public pages or logs.                             | storage review + tests                  |
+| Content governance                            | `supporting` | Supporting only: new category/metadata copy must remain coherent with canonical admin-note taxonomy and contextual note ownership.                      | copy review + parent-brief alignment    |
+| Admin workflow and editability                | `target`     | Quick note/contextual add note should support repeated, low-friction evidence capture during real work without losing context or requiring detours.     | e2e + timed manual QA                   |
+| SEO and crawlability                          | `N/A`        | N/A because admin-notes capture and attachment surfaces are private admin workflows with no public crawl/index contract.                                | scope rationale                         |
+| AI discoverability                            | `N/A`        | N/A because this slice does not add public AI-facing discovery surfaces; it only improves internal notes capture and metadata structure.                | scope rationale                         |
+| Analytics and KPI observability               | `supporting` | Supporting only: capture entrypoint usage, save-again behavior, and staged-image counts should remain measurable if analytics hooks exist.              | event review + code review              |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, billing, refund, or entitlement logic is touched by this internal-notes ergonomics follow-up.                                   | scope rationale                         |
+| Incident response and support operations      | `target`     | Help/Guide and runbooks must explain multi-image evidence, post-save quick-note behavior, route-surface availability, and attachment metadata handling. | help/runbook review + assertions        |
+| Finance and reporting operations              | `N/A`        | N/A because no finance reconciliation, payout, or reporting workflow changes in this notes follow-up slice.                                             | scope rationale                         |
+| i18n operational readiness                    | `N/A`        | N/A for this slice because it is internal notes ergonomics work and should not block future localization architecture beyond keeping logic out of copy. | scope rationale                         |
+| Stack-fit and dependency discipline           | `target`     | Reuse existing notes, attachment, and quick-capture primitives; do not add third-party upload/state libraries without strong justification.             | dependency diff + architecture review   |
+| Testing and QA automation                     | `target`     | Coverage protects multi-image pre-save flows, post-save quick-note reuse, route-surface rollout, and attachment metadata contracts.                     | unit/e2e coverage + `verify:pre-pr`     |
+| Scalability and cost efficiency               | `supporting` | Supporting only: multi-image pre-save support must stay bounded and avoid runaway client memory, upload, or storage churn.                              | code review + manual QA                 |
+| DevOps and rollback readiness                 | `target`     | Notes ergonomics changes remain reversible without schema ambiguity, and any attachment-metadata migration path is explicit and safe.                   | migration review + rollback notes       |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - admin note rows,
+  - attachment metadata rows,
+  - stored attachment object keys,
+  - canonical route/content context,
+  - any persisted structured attachment metadata required for operator/agent readiness.
+- Local-only:
+  - staged pre-save images,
+  - draft title/text/priority/category inputs,
+  - collapsed/open quick-note state,
+  - local route-surface launcher state.
+- Sync policy:
+  - staged images remain local until explicit save,
+  - save writes the note first and then canonicalizes attachment records according to the existing attachment contract,
+  - post-save reuse/clear behavior must be explicit and deterministic,
+  - route changes may preserve the draft shell, but the note context shown to the user must stay explicit.
+- Retention and sensitivity:
+  - images may contain sensitive internal review material and must remain admin-only,
+  - abandoned staged local images must clear predictably when the user discards the draft or completes the flow.
+- Cache/invalidation:
+  - notes manager, contextual note panels, and quick-capture entrypoints must refresh deterministically after save or attachment changes.
+
+## Identity And Rename Contract
+
+- Canonical stable IDs:
+  - `admin_note.id` remains canonical note identity,
+  - attachment IDs remain canonical per stored image,
+  - route/content context refs remain canonical context identity for where the note belongs.
+- Human-readable identifiers:
+  - note title, category label, and attachment filename/display metadata are operator-facing labels, not canonical identity.
+- Mutability rules:
+  - note wording and category remain editable in place,
+  - route-surface availability may expand, but it must not silently retarget an existing saved note to a different canonical context,
+  - attachment metadata may become richer, but it must not break existing attachments.
+- Rename vs repurpose policy:
+  - editing copy or metadata is an in-place update,
+  - a materially different operational concern should still become a new note row rather than silently rewriting an unrelated note.
+- Compatibility contract:
+  - existing notes with a single attachment or no attachment metadata remain valid,
+  - route-surface expansion must preserve the current utility-panel mental model where quick note still results in a normal admin note.
+- Observability and repair:
+  - broken staged-image saves, missing metadata, and stale route-surface state should surface explicit refresh/retry or recovery guidance.
+
+## Scope
+
+- Add pre-save multi-image support to:
+  - quick note,
+  - contextual `Add note` panels,
+  - any directly related notes-entry surface chosen in this slice.
+- Decide and implement the intended post-save quick-note behavior:
+  - stay open and clear for another capture,
+  - or offer an equally fast repeat-capture loop that does not require rebuilding the same entry flow manually.
+- Expand quick-capture route availability through an explicit route-surface matrix instead of ad hoc surface additions.
+- Improve operator-visible attachment metadata and evidence structure so the saved note is clearer for later human review and future agent-assisted reading.
+- Keep Help/Guide and recovery/runbook language aligned with the final behavior.
+
+## Out Of Scope
+
+- Replacing admin notes with a full issue tracker or threaded comments system.
+- Public user uploads or public note attachments.
+- Non-image attachment types as a first-class system in this slice.
+- Reopening unrelated builder or course-workspace work unless a shared bug is discovered.
+
+## Acceptance Criteria
+
+1. Quick note and contextual `Add note` can stage more than one image before save with clear limit/error handling.
+2. After a quick note is saved, the next-step behavior is explicit and optimized for repeated capture rather than forcing the owner to rebuild the same flow manually.
+3. Quick capture route-surface availability is documented and implemented intentionally for the chosen surfaces.
+4. Attachment metadata shown to operators is rich enough that saved evidence remains understandable later without opening raw storage details.
+5. Quick note still saves a normal canonical admin note tied to an explicit context.
+6. Help/Guide and runbook content are updated in the same PR if labels, save/reuse behavior, or route availability change.
+7. Relevant production admin notes listed above remain explicitly owned by this brief until shipped or intentionally split again.
+8. `npm run lint:briefs`, targeted validation, and `npm run verify:pre-pr` pass before PR update.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run typecheck`
+- targeted unit tests for:
+  - staged multi-image state,
+  - post-save reset/reuse behavior,
+  - attachment metadata rendering,
+  - route-surface availability logic
+- targeted e2e for:
+  - quick note multi-image capture,
+  - contextual add-note multi-image capture,
+  - route-surface persistence/reopen behavior,
+  - admin help-center/update assertions
+- `npm run verify:pre-pr`
+- before merge recommendation: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm must be installed on the machine used for local validation.
+- Local validation runs from repo root.
+
+## Manual QA Environments
+
+- Production review:
+  - `https://freeswimming.org/admin`
+  - relevant admin note entry surfaces encountered during real review work
+- Local iteration:
+  - `http://127.0.0.1:3000/admin`
+- Preview:
+  - PR Vercel preview URL for the implementation branch
+
+## Constraints
+
+- Quick note must remain understandable as a note-capture utility, not a second separate notes system.
+- Multi-image support must be bounded and clear, not an unbounded drag-and-drop bucket.
+- Route-surface expansion should be explicit and support real review workflows, not chase every possible route in one wave.
+- Attachment metadata should help later reading without exposing raw storage implementation details.
+
+## 10/10 Quality Bar
+
+- Notes capture should feel lighter and more reusable after this slice, not heavier.
+- Required UI states for changed surfaces:
+  - `loading`
+  - `empty`
+  - `error`
+  - `retry`
+  - `success`
+  - staged image pending
+  - per-image remove/failure state
+- Multi-image behavior must be obvious before save and predictable after save.
+- Route-surface expansion should improve coverage without making note context ambiguous.
+
+## Help/Guide And Operator Training Contract
+
+- Required:
+  - update Help/Guide and runbook copy for multi-image capture, post-save quick-note behavior, and route-surface availability in the same PR,
+  - update at least one automated assertion that validates the changed help contract.
+
+## Security, Privacy, and Compliance
+
+- All richer image intake and metadata surfaces remain admin-only.
+- Attachment/storage paths must not leak to public users or public routes.
+- Unauthorized note/attachment mutations must fail closed with `401`/`403`.
+
+## Observability and KPI Contract
+
+- Required events/logs if analytics hooks already exist:
+  - quick note opened/collapsed/reopened,
+  - multi-image staged count,
+  - quick note save + save-again flow,
+  - route-surface quick-capture usage,
+  - attachment metadata render/save failures.
+- Success KPI for this slice:
+  - operator can capture and reuse notes across real review sessions with richer evidence and less repeated setup.
+
+## Session Continuity and Recovery
+
+- Canonical source of truth: git branch + this brief path.
+- Checkpoint cadence:
+  - commit at each validated implementation milestone,
+  - update the checkpoint log before any pause or PR handoff.
+- Recovery protocol:
+  1. `git status -sb`
+  2. `git log --oneline -n 10`
+  3. reopen this brief and continue from the latest checkpoint note
+
+## Git Rhythm Defaults
+
+- Commit + push after each validated notes ergonomics slice.
+- Open/update PR after one coherent vertical slice or after `2-4` validated checkpoint commits, whichever comes first.
+
+## Automation Mode
+
+- `automation-first`
+  - assistant handles implementation, tests, git checkpoints, push, PR open/update, and CI monitoring unless blocked by credentials, UI-only approval, or an explicit owner decision.
+
+## Branch Hygiene Defaults
+
+- Post-merge cleanup:
+  - `git checkout main`
+  - `git pull --ff-only origin main`
+  - `git branch -d <merged-branch>`
+  - `git push origin --delete <merged-branch>` when appropriate
+
+## PR Browser Rule
+
+- Default PR create/review/merge links open in Safari.
+
+## Manual QA URL Rule
+
+- Default UI QA links should be opened in Safari before requesting owner confirmation.
+
+## Checkpoint Log
+
+- `2026-03-27 | planning | created a dedicated admin-notes ergonomics follow-up brief to own the remaining production-note batch around multi-image pre-save evidence, quick-note post-save reuse, route-surface rollout, and attachment metadata/agent-readiness expectations | next: confirm the desired repeated-capture workflow and route-surface matrix before implementation starts`

--- a/lib/workouts/shared.ts
+++ b/lib/workouts/shared.ts
@@ -82,6 +82,18 @@ export type WorkoutSaveApiError = {
 
 export type WorkoutSaveApiResponse = WorkoutSaveApiSuccess | WorkoutSaveApiError;
 
+export type WorkoutDeleteApiSuccess = {
+  ok: true;
+  deletedWorkoutId: string;
+};
+
+export type WorkoutDeleteApiError = {
+  ok: false;
+  error: string;
+};
+
+export type WorkoutDeleteApiResponse = WorkoutDeleteApiSuccess | WorkoutDeleteApiError;
+
 export type WorkoutLibrarySnapshot = {
   schemaReady: boolean;
   loadError: string | null;

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -80,6 +80,8 @@ test.describe("my library workout builder", () => {
     await expect(page.getByTestId("workout-editor-garmin-readiness-summary")).toHaveText(
       "Ready for the planned Garmin/export handoff."
     );
+    await page.getByTestId("workout-editor-garmin-export-toggle").click();
+    await page.getByTestId("workout-editor-handoff-toggle").click();
     await expect(page.getByTestId("workout-editor-handoff-source")).toHaveAttribute(
       "data-handoff-state",
       "canonical"
@@ -168,6 +170,7 @@ test.describe("my library workout builder", () => {
     await expect(page.getByTestId("workout-editor-garmin-readiness-summary")).toHaveText(
       "Review 5 Garmin/export mapping details before you treat this workout as handoff-ready."
     );
+    await page.getByTestId("workout-editor-garmin-readiness-toggle").click();
     await expect(page.getByTestId("workout-editor-garmin-readiness-issue-0")).toContainText("Pull");
     await expect(page.getByTestId("workout-editor-garmin-readiness-issue-1")).toContainText("Fins");
     await expect(page.getByTestId("workout-editor-garmin-readiness-issue-4")).toContainText(
@@ -302,5 +305,32 @@ test.describe("my library workout builder", () => {
         name: "Fins",
       })
     ).toBeChecked();
+
+    const workoutMatch = page.url().match(/\/my-library\/workouts\/([0-9a-f-]+)$/);
+    expect(workoutMatch?.[1]).toBeTruthy();
+    const workoutId = workoutMatch![1];
+
+    const deleteResponsePromise = page.waitForResponse(
+      (response) =>
+        response.url().endsWith(`/api/my-library/workouts/${workoutId}`) &&
+        response.request().method() === "DELETE"
+    );
+
+    await page.getByTestId("session-generator-recent-workouts-toggle").click();
+    await page.getByTestId(`workout-builder-delete-workout-${workoutId}`).click();
+    await page.getByTestId(`workout-builder-confirm-delete-workout-${workoutId}`).click();
+
+    const deleteResponse = await deleteResponsePromise;
+    const deletePayload = (await deleteResponse.json().catch(() => null)) as {
+      ok?: boolean;
+    } | null;
+
+    expect(deleteResponse.status()).toBe(200);
+    expect(deletePayload?.ok).toBe(true);
+    await page.waitForURL(/\/my-library$/, {
+      timeout: 10_000,
+      waitUntil: "domcontentloaded",
+    });
+    await expect(page.getByRole("heading", { name: "My Library" })).toBeVisible();
   });
 });

--- a/tests/unit/library-section-tabs.test.tsx
+++ b/tests/unit/library-section-tabs.test.tsx
@@ -16,6 +16,9 @@ describe("LibrarySectionTabs", () => {
   it("tracks section-nav switches to library and explore", () => {
     render(<LibrarySectionTabs showExploreTab />);
 
+    expect(screen.getByText("Owned")).toBeVisible();
+    expect(screen.getByText("Explore")).toBeVisible();
+
     fireEvent.click(screen.getByRole("link", { name: "Jump to owned items" }));
     fireEvent.click(screen.getByRole("link", { name: "Jump to explore section" }));
 
@@ -33,6 +36,8 @@ describe("LibrarySectionTabs", () => {
     render(<LibrarySectionTabs showExploreTab={false} />);
 
     expect(screen.getByRole("link", { name: "Jump to owned items" })).toBeInTheDocument();
+    expect(screen.getByText("Owned")).toBeVisible();
+    expect(screen.queryByText("Explore")).toBeNull();
     expect(screen.queryByRole("link", { name: "Jump to explore section" })).toBeNull();
   });
 });

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -166,6 +166,8 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.getByTestId("workout-editor-garmin-readiness-summary")).toHaveTextContent(
       "Ready for the planned Garmin/export handoff."
     );
+    fireEvent.click(screen.getByTestId("workout-editor-garmin-export-toggle"));
+    fireEvent.click(screen.getByTestId("workout-editor-handoff-toggle"));
     expect(screen.getByTestId("workout-builder-save")).toBeDisabled();
     expect(screen.getByTestId("workout-editor-reset")).toBeDisabled();
 
@@ -244,11 +246,14 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.getByTestId("workout-editor-garmin-readiness-summary")).toHaveTextContent(
       "Review 3 Garmin/export mapping details before you treat this workout as handoff-ready."
     );
+    fireEvent.click(screen.getByTestId("workout-editor-garmin-readiness-toggle"));
     expect(screen.getByTestId("workout-editor-garmin-readiness-issue-0")).toHaveTextContent("Pull");
     expect(screen.getByTestId("workout-editor-garmin-readiness-issue-1")).toHaveTextContent("Fins");
     expect(screen.getByTestId("workout-editor-garmin-readiness-issue-2")).toHaveTextContent(
       "IM by round"
     );
+    fireEvent.click(screen.getByTestId("workout-editor-garmin-export-toggle"));
+    fireEvent.click(screen.getByTestId("workout-editor-handoff-toggle"));
     expect(screen.getByText(/Review the Garmin\/export notes above/i)).toBeVisible();
     expect(screen.getByTestId("workout-builder-save")).toBeEnabled();
     expect(screen.getByTestId("workout-editor-reset")).toBeEnabled();
@@ -622,6 +627,9 @@ describe("WorkoutBuilderHub", () => {
       );
     });
 
+    fireEvent.click(screen.getByTestId("workout-editor-garmin-export-toggle"));
+    fireEvent.click(screen.getByTestId("workout-editor-handoff-toggle"));
+
     expect(screen.getByTestId("workout-editor-handoff-source")).toHaveAttribute(
       "data-handoff-state",
       "canonical"
@@ -808,9 +816,68 @@ describe("WorkoutBuilderHub", () => {
       "href",
       "/my-library/generator"
     );
+    fireEvent.click(screen.getByTestId("session-generator-recent-workouts-toggle"));
     expect(screen.getByTestId("workout-builder-open-workout-workout-1")).toHaveAttribute(
       "href",
       "/my-library/workouts/workout-1"
     );
+  });
+
+  it("collapses saved workouts by default and deletes a non-current workout deterministically", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        deletedWorkoutId: "workout-2",
+      }),
+    } as Response);
+
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          recentWorkouts: [
+            buildWorkoutSummary(),
+            buildWorkoutSummary({
+              id: "workout-2",
+              title: "Old QA cleanup workout",
+              totalDistanceM: 1600,
+              estimatedDurationMin: 37,
+            }),
+          ],
+        })}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    expect(screen.queryByTestId("saved-workout-card-workout-2")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("session-generator-recent-workouts-toggle"));
+
+    expect(screen.getByTestId("saved-workout-card-workout-2")).toBeVisible();
+
+    fireEvent.click(screen.getByTestId("workout-builder-delete-workout-workout-2"));
+
+    expect(screen.getByText("Delete this saved workout from My Library?")).toBeVisible();
+
+    fireEvent.click(screen.getByTestId("workout-builder-confirm-delete-workout-workout-2"));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith("/api/my-library/workouts/workout-2", {
+        method: "DELETE",
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("saved-workout-card-workout-2")).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Deleted Old QA cleanup workout.")).toBeVisible();
+    expect(navigationState.refresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/workouts-routes.test.ts
+++ b/tests/unit/workouts-routes.test.ts
@@ -8,7 +8,10 @@ vi.mock("@/lib/supabase/route-handler", () => ({
   createRouteHandlerSupabaseClient: createRouteHandlerSupabaseClientMock,
 }));
 
-import { PATCH as patchWorkout } from "@/app/api/my-library/workouts/[workoutId]/route";
+import {
+  DELETE as deleteWorkout,
+  PATCH as patchWorkout,
+} from "@/app/api/my-library/workouts/[workoutId]/route";
 import { POST as postWorkout } from "@/app/api/my-library/workouts/route";
 import type { SessionDraft } from "@/lib/session-generator-v1/shared";
 import type { Database } from "@/types/database";
@@ -583,5 +586,82 @@ describe("workouts routes", () => {
 
     expect(response.status).toBe(404);
     expect(from).toHaveBeenCalledWith("workouts");
+  });
+
+  it("fails closed for unauthenticated workout delete", async () => {
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+        },
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await deleteWorkout(
+      new Request(
+        "http://127.0.0.1:3000/api/my-library/workouts/11111111-1111-4111-8111-111111111111",
+        {
+          method: "DELETE",
+        }
+      ),
+      {
+        params: Promise.resolve({
+          workoutId: "11111111-1111-4111-8111-111111111111",
+        }),
+      }
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("deletes canonical workouts for the authenticated owner", async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: { id: "11111111-1111-4111-8111-111111111111" },
+      error: null,
+    });
+    const select = vi.fn(() => ({ maybeSingle }));
+    const eqWorkoutId = vi.fn(() => ({ select }));
+    const eqUserId = vi.fn(() => ({ eq: eqWorkoutId }));
+    const deleteRows = vi.fn(() => ({ eq: eqUserId }));
+    const from = vi.fn().mockReturnValue({ delete: deleteRows });
+
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } } }),
+        },
+        from,
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await deleteWorkout(
+      new Request(
+        "http://127.0.0.1:3000/api/my-library/workouts/11111111-1111-4111-8111-111111111111",
+        {
+          method: "DELETE",
+        }
+      ),
+      {
+        params: Promise.resolve({
+          workoutId: "11111111-1111-4111-8111-111111111111",
+        }),
+      }
+    );
+    const payload = (await response.json()) as {
+      ok: boolean;
+      deletedWorkoutId: string;
+    };
+
+    expect(response.status).toBe(200);
+    expect(from).toHaveBeenCalledWith("workouts");
+    expect(eqUserId).toHaveBeenCalledWith("user_id", "user-1");
+    expect(eqWorkoutId).toHaveBeenCalledWith("id", "11111111-1111-4111-8111-111111111111");
+    expect(select).toHaveBeenCalledWith("id");
+    expect(payload).toEqual({
+      ok: true,
+      deletedWorkoutId: "11111111-1111-4111-8111-111111111111",
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Added a calmer saved-workouts surface with collapsed-by-default recent workouts plus direct `Edit` and `Delete` actions.
- Added owner-scoped workout deletion through `DELETE /api/my-library/workouts/[workoutId]`, including builder refresh and safe redirect when deleting the currently open workout.
- Reduced builder clutter by collapsing Garmin readiness / Garmin JSON / handoff sections and renaming labels to clearer user-facing wording (`Title`, `Description`, `Poolside PDF`, `Program planning (early)`, `Owned`, `Explore`).
- Brief link(s): `docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md`

## Scope

- In scope: workout builder live-review UX/actions, saved-workout deletion flow, My Library wording cleanup, targeted test updates, and brief triage ownership for builder/notes follow-ups.
- Out of scope: program-builder calendar implementation, multi-image notes ergonomics implementation, and broader generator/program export work.
- Changed files (15):
  - `app/api/my-library/workouts/[workoutId]/route.ts`
  - `app/my-library/page.tsx`
  - `app/my-library/programs/[programId]/page.tsx`
  - `components/my-library/LibrarySectionTabs.tsx`
  - `components/my-library/programs/ProgramBuilderHub.tsx`
  - `components/my-library/workouts/SavedWorkoutsPanel.tsx`
  - `components/my-library/workouts/WorkoutBuilderHub.tsx`
  - `components/my-library/workouts/WorkoutEditor.tsx`
  - `docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md`
  - `docs/task-briefs/planned/2026-03-27-admin-notes-ergonomics-multi-image-and-route-surface-followup-10-10.md`
  - `lib/workouts/shared.ts`
  - `tests/e2e/my-library-workout-builder.spec.ts`
  - `tests/unit/library-section-tabs.test.tsx`
  - `tests/unit/workout-builder-hub.test.tsx`
  - `tests/unit/workouts-routes.test.ts`

## Risk

- Main risk: deleting saved workouts or reloading builder state incorrectly could strand the editor on stale state or remove the wrong owner-scoped record.
- Rollback plan: revert `7a205a2` (`git revert 7a205a2`) to restore the previous builder/workout list behavior.

## Test Evidence

- `npm run verify:pre-pr`: **PASS** for `7a205a2`
- `npm run verify:pre-merge`: **PASS** for `7a205a2` on `2026-03-28` (public-mode full verification; private-gate step skipped because `SITE_LOCK_ENABLED!=1`).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key local validation:
  - `npm run lint:briefs:all`
  - `npm run typecheck`
  - `npx vitest run tests/unit/workouts-routes.test.ts tests/unit/workout-builder-hub.test.tsx tests/unit/library-section-tabs.test.tsx`
  - `npx playwright test tests/e2e/my-library-workout-builder.spec.ts tests/e2e/my-library-generator-intake.spec.ts --project=desktop-chromium`
  - `npm run verify:pre-pr`
  - `npm run verify:pre-merge`
  - Latest pre-merge summary: `89 passed`, `271 skipped`, `0 failed`
- CI links: PR checks are green (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [x] `npm run lint:briefs`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [x] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [x] PR is intentionally larger because it includes two new task briefs plus new delete flow/test coverage (`15 files`, `1284 insertions`, `153 deletions`)
- [x] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/308`
- [x] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
