### PR TITLE
fix(workouts): add row pdf and calmer notices

### DIFF
--- a/app/api/my-library/workouts/[workoutId]/export/pdf/route.ts
+++ b/app/api/my-library/workouts/[workoutId]/export/pdf/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
+import { buildWorkoutPdfHtmlDocument } from "@/lib/workouts/shared";
+import { buildWorkoutEditorRecord, WORKOUT_SELECT } from "@/lib/workouts/server";
+import { isWorkoutSchemaMissing } from "@/lib/workouts/schema";
+
+type RouteContext = {
+  params: Promise<{
+    workoutId: string;
+  }>;
+};
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function noStoreHtml(body: string, status = 200) {
+  return new NextResponse(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+      "Content-Type": "text/html; charset=utf-8",
+      "X-Robots-Tag": "noindex, nofollow",
+    },
+  });
+}
+
+function noStoreText(body: string, status = 200) {
+  return new NextResponse(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+      "Content-Type": "text/plain; charset=utf-8",
+      "X-Robots-Tag": "noindex, nofollow",
+    },
+  });
+}
+
+export async function GET(_request: Request, context: RouteContext) {
+  const { workoutId } = await context.params;
+  if (!UUID_PATTERN.test(workoutId)) {
+    return noStoreText("Invalid workout id.", 400);
+  }
+
+  const { supabase, applySupabaseCookies } = await createRouteHandlerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return applySupabaseCookies(noStoreText("Unauthorized.", 401));
+  }
+
+  const result = await supabase
+    .from("workouts")
+    .select(WORKOUT_SELECT)
+    .eq("user_id", user.id)
+    .eq("id", workoutId)
+    .maybeSingle();
+
+  if (isWorkoutSchemaMissing(result.error)) {
+    return applySupabaseCookies(
+      noStoreText("Canonical workout save is still syncing in this environment.", 503)
+    );
+  }
+
+  if (result.error) {
+    console.error("[WorkoutExportPdfApi] Could not load canonical workout", result.error);
+    return applySupabaseCookies(noStoreText("Could not load workout right now.", 500));
+  }
+
+  if (!result.data) {
+    return applySupabaseCookies(noStoreText("Workout not found.", 404));
+  }
+
+  const workout = buildWorkoutEditorRecord(result.data);
+  return applySupabaseCookies(
+    noStoreHtml(buildWorkoutPdfHtmlDocument(workout.draft, { draftState: "canonical" }))
+  );
+}

--- a/components/my-library/workouts/SavedWorkoutsPanel.tsx
+++ b/components/my-library/workouts/SavedWorkoutsPanel.tsx
@@ -9,6 +9,7 @@ type Props = {
   workouts: WorkoutSummary[];
   description: string;
   workoutHrefBuilder: (workoutId: string) => string;
+  workoutPdfHrefBuilder?: ((workoutId: string) => string) | null;
   collapsedByDefault?: boolean;
   testId?: string;
   heading?: string;
@@ -21,8 +22,6 @@ type Props = {
   onConfirmDeleteWorkout?: ((workout: WorkoutSummary) => void) | null;
   pendingDeleteWorkoutId?: string | null;
   deletingWorkoutId?: string | null;
-  currentWorkoutId?: string | null;
-  onOpenCurrentWorkoutPdf?: (() => void) | null;
   printButtonTestIdBuilder?: (workoutId: string) => string;
 };
 
@@ -30,6 +29,7 @@ export default function SavedWorkoutsPanel({
   workouts,
   description,
   workoutHrefBuilder,
+  workoutPdfHrefBuilder = null,
   collapsedByDefault = true,
   testId = "session-generator-recent-workouts",
   heading = "Saved workouts",
@@ -42,8 +42,6 @@ export default function SavedWorkoutsPanel({
   onConfirmDeleteWorkout = null,
   pendingDeleteWorkoutId = null,
   deletingWorkoutId = null,
-  currentWorkoutId = null,
-  onOpenCurrentWorkoutPdf = null,
   printButtonTestIdBuilder = (workoutId) => `saved-workouts-print-${workoutId}`,
 }: Props) {
   const [expanded, setExpanded] = useState(() => !collapsedByDefault);
@@ -84,8 +82,7 @@ export default function SavedWorkoutsPanel({
           {workouts.map((workout) => {
             const deleting = deletingWorkoutId === workout.id;
             const pendingDelete = pendingDeleteWorkoutId === workout.id;
-            const canPrintCurrentWorkout =
-              currentWorkoutId === workout.id && typeof onOpenCurrentWorkoutPdf === "function";
+            const workoutPdfHref = workoutPdfHrefBuilder?.(workout.id) ?? null;
 
             return (
               <div
@@ -112,15 +109,16 @@ export default function SavedWorkoutsPanel({
                     >
                       {editLabel}
                     </Link>
-                    {canPrintCurrentWorkout ? (
-                      <button
-                        type="button"
-                        onClick={() => onOpenCurrentWorkoutPdf?.()}
+                    {workoutPdfHref ? (
+                      <Link
+                        href={workoutPdfHref}
+                        target="_blank"
+                        rel="noopener noreferrer"
                         data-testid={printButtonTestIdBuilder(workout.id)}
                         className="inline-flex h-10 items-center justify-center rounded-xl border border-amber-200 bg-white px-4 text-sm font-medium text-amber-800 transition hover:bg-amber-50 active:bg-amber-100"
                       >
                         Poolside PDF
-                      </button>
+                      </Link>
                     ) : null}
                     {typeof onRequestDeleteWorkout === "function" ? (
                       <button

--- a/components/my-library/workouts/WorkoutBuilderHub.tsx
+++ b/components/my-library/workouts/WorkoutBuilderHub.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import CreateManualWorkoutButton from "@/components/my-library/workouts/CreateManualWorkoutButton";
 import SavedWorkoutsPanel from "@/components/my-library/workouts/SavedWorkoutsPanel";
 import WorkoutEditor from "@/components/my-library/workouts/WorkoutEditor";
+import { useAutoDismissNotice } from "@/components/my-library/workouts/useAutoDismissNotice";
 import type {
   WorkoutDeleteApiResponse,
   WorkoutEditorRecord,
@@ -38,6 +39,8 @@ export default function WorkoutBuilderHub({ workoutLibrary }: Props) {
   const [deletingWorkoutId, setDeletingWorkoutId] = useState<string | null>(null);
   const [clientReady, setClientReady] = useState(false);
   const hasUnsavedChanges = haveWorkoutDraftChanges(draft, savedWorkout?.draft ?? null);
+
+  useAutoDismissNotice(success, setSuccess);
 
   useEffect(() => {
     setClientReady(true);
@@ -204,8 +207,9 @@ export default function WorkoutBuilderHub({ workoutLibrary }: Props) {
         <SavedWorkoutsPanel
           workouts={recentWorkouts}
           heading="Saved workouts"
-          description="Edit another saved workout here and delete old test sessions when they are no longer useful."
+          description="Edit, print, or delete another saved workout here when you need to clean up old test sessions."
           workoutHrefBuilder={(workoutId) => `/my-library/workouts/${workoutId}`}
+          workoutPdfHrefBuilder={(workoutId) => `/api/my-library/workouts/${workoutId}/export/pdf`}
           editLabel="Edit"
           testId="session-generator-recent-workouts"
           editButtonTestIdBuilder={(workoutId) =>
@@ -217,8 +221,6 @@ export default function WorkoutBuilderHub({ workoutLibrary }: Props) {
           confirmDeleteButtonTestIdBuilder={(workoutId) =>
             `workout-builder-confirm-delete-workout-${workoutId}`
           }
-          currentWorkoutId={savedWorkout?.id ?? null}
-          onOpenCurrentWorkoutPdf={null}
           onRequestDeleteWorkout={(workout) => {
             setPendingDeleteWorkoutId(workout.id);
             setError("");

--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { useAutoDismissNotice } from "@/components/my-library/workouts/useAutoDismissNotice";
 import {
   SESSION_DRAFT_STEP_CATEGORIES,
   SESSION_DRAFT_STEP_CSS_TARGET_OFFSETS,
@@ -197,6 +198,18 @@ function formatEditablePoolLength(value: number | null | undefined) {
 function formatEditableDistance(value: number | null | undefined) {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return "";
   return String(Math.round(value));
+}
+
+function buildStepStrokeGuidance(step: SessionDraftStep) {
+  if (step.category === "kick") {
+    return "Kick category already marks this as kick work. Use Primary stroke for the stroke pattern this kick set supports, and use the focus field only when you want extra kick, pull, or drill notation.";
+  }
+
+  if (step.category === "drill" || step.stroke === "drill") {
+    return "Use Drill shell when the step is built around a drill. Then use the focus field to clarify whether it is a general drill, kick drill, or pull drill.";
+  }
+
+  return "Use Primary stroke for the swim pattern. Add focus only when the step needs extra drill, kick, or pull notation.";
 }
 
 function buildRepeatStarterSteps(index: number): SessionDraftStep[] {
@@ -517,6 +530,10 @@ export default function WorkoutEditor({
       ? "Handoff preview reflects unsaved local edits. Save first if you want the canonical workout and handoff to match."
       : "Handoff preview matches the saved canonical workout."
     : "Handoff preview reflects the current local draft before canonical save.";
+
+  useAutoDismissNotice(workoutPdfNotice, setWorkoutPdfNotice);
+  useAutoDismissNotice(garminExportNotice, setGarminExportNotice);
+  useAutoDismissNotice(handoffNotice, setHandoffNotice);
 
   useEffect(() => {
     setPoolLengthInput(formatEditablePoolLength(draft.poolLengthM));
@@ -1270,7 +1287,7 @@ export default function WorkoutEditor({
             </label>
 
             <label className="text-sm text-slate-700">
-              Stroke
+              Primary stroke
               <select
                 value={step.stroke ?? "choice"}
                 onChange={(event) => {
@@ -1299,7 +1316,7 @@ export default function WorkoutEditor({
             </label>
 
             <label className="text-sm text-slate-700">
-              Drill focus
+              Drill / kick / pull focus
               <select
                 value={step.drillType ?? "none"}
                 onChange={(event) =>
@@ -1318,6 +1335,8 @@ export default function WorkoutEditor({
                 ))}
               </select>
             </label>
+
+            <p className="text-sm text-slate-500 md:col-span-2">{buildStepStrokeGuidance(step)}</p>
 
             <label className="text-sm text-slate-700">
               Equipment

--- a/components/my-library/workouts/useAutoDismissNotice.ts
+++ b/components/my-library/workouts/useAutoDismissNotice.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, type Dispatch, type SetStateAction } from "react";
+
+export const WORKOUT_NOTICE_AUTO_DISMISS_MS = 5000;
+
+export function useAutoDismissNotice(
+  value: string,
+  setValue: Dispatch<SetStateAction<string>>,
+  delayMs = WORKOUT_NOTICE_AUTO_DISMISS_MS
+) {
+  useEffect(() => {
+    if (!value) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setValue("");
+    }, delayMs);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [delayMs, setValue, value]);
+}

--- a/docs/runbooks/core-flow-incident-response.md
+++ b/docs/runbooks/core-flow-incident-response.md
@@ -53,8 +53,11 @@ Additional `My Library` sub-route checks:
   - confirm `/api/my-library/generator-intake` returns owner-scoped `200` or fail-closed `401`,
   - confirm `/api/my-library/generator/session-draft` returns owner-scoped `200` for session target, `401` for unauthenticated reads, and explicit `422` when program target is chosen in this slice,
   - confirm `/api/my-library/workouts` and `/api/my-library/workouts/[workoutId]` return owner-scoped `200`, fail-closed `401`, and `404` for missing canonical workout ids,
+  - confirm `/api/my-library/workouts/[workoutId]/export/pdf` returns owner-scoped printable `200`, fail-closed `401`, `404` for missing canonical workout ids, and `503` when the canonical workouts schema is not ready,
+  - confirm saved-workout row actions stay card-scoped (`Edit`, `Poolside PDF`, `Delete`) and do not open, print, or delete a different canonical workout than the one selected on that row,
   - confirm stale/missing block copy names the affected source area (`profile`, `goals`, `focus`),
   - confirm refresh does not mutate saved My Library records,
+  - confirm transient success notices clear on their own while error states stay visible until the owner resolves them,
   - confirm notes remain excluded from default intake prefill in v1,
   - confirm generated drafts stay local until explicit accept/save,
   - confirm accepted workouts reopen in the same generator editor without mutating another user's data.

--- a/docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md
@@ -6,7 +6,7 @@
 - `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-03-27`
-- `updated`: `2026-03-27`
+- `updated`: `2026-03-28`
 
 ## Goal
 
@@ -260,6 +260,10 @@ Critical target categories for `10/10` claim in this brief:
 - Required if this slice changes workout-builder labels, delete recovery language, print guidance, or My Library explanation copy:
   - update the relevant Help/Guide surface and any builder runbook/help copy in the same PR,
   - update at least one automated assertion if help contract text changes.
+- This slice still has no dedicated in-product My Library/workout-builder Help surface, so the contract is satisfied by:
+  - updating `docs/runbooks/core-flow-incident-response.md` for the new saved-workout and canonical PDF verification path,
+  - keeping automated regression coverage in `tests/e2e/my-library-workout-builder.spec.ts`,
+  - treating `AdminHelpCenter` as `N/A` for this owner-only builder slice because no admin workflow/help copy changed.
 
 ## Security, Privacy, and Compliance
 
@@ -317,3 +321,4 @@ Critical target categories for `10/10` claim in this brief:
 ## Checkpoint Log
 
 - `2026-03-27 | planning | created a dedicated workout-builder live-review UX/actions brief to own the current production-note batch around delete/edit/print actions, calmer panel defaults, form copy cleanup, poolside PDF truthfulness, and My Library IA confusion before program-builder work resumes | next: review manual workout-builder usage against this brief, then pick the first narrow implementation slice`
+- `2026-03-28 | implementation | slice 2 on branch fix/workout-builder-pdf-notices-2026-03-28 adds row-level canonical Poolside PDF links for saved workouts, auto-dismisses transient builder success notices, and clarifies kick/drill authoring guidance without changing the canonical workout model; targeted typecheck, vitest, and desktop-chromium workout-builder e2e are green | next: update runbook coverage, then run npm run lint:briefs and npm run verify:pre-pr`

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -104,6 +104,26 @@ test.describe("my library workout builder", () => {
     );
     await expect(page.getByTestId("workout-builder-save")).toBeDisabled();
 
+    await page.getByTestId("session-generator-recent-workouts-toggle").click();
+    const savedWorkoutCard = page
+      .locator('[data-testid^="saved-workout-card-"]')
+      .filter({ hasText: "Manual pool workout" })
+      .first();
+    const savedWorkoutPdfPopupPromise = page.waitForEvent("popup");
+    await savedWorkoutCard.getByRole("link", { name: "Poolside PDF" }).click();
+    const savedWorkoutPdfPopup = await savedWorkoutPdfPopupPromise;
+    await expect(
+      savedWorkoutPdfPopup.locator('[data-testid="workout-pdf-print-view"]')
+    ).toBeVisible();
+    await expect(savedWorkoutPdfPopup.locator('[data-testid="workout-pdf-source"]')).toContainText(
+      "Source: Canonical workout"
+    );
+    await expect(savedWorkoutPdfPopup.locator('[data-testid="workout-pdf-title"]')).toContainText(
+      "Manual pool workout"
+    );
+    await savedWorkoutPdfPopup.close();
+    await page.getByTestId("session-generator-recent-workouts-toggle").click();
+
     await page.getByTestId("session-draft-step-remove-0").click();
     await expect(page.getByTestId("workout-editor-removal-confirm")).toContainText(
       "Remove Warmup swim?"

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -1,6 +1,7 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import WorkoutBuilderHub from "@/components/my-library/workouts/WorkoutBuilderHub";
+import { WORKOUT_NOTICE_AUTO_DISMISS_MS } from "@/components/my-library/workouts/useAutoDismissNotice";
 import type { SessionDraft } from "@/lib/session-generator-v1/shared";
 import type {
   WorkoutEditorRecord,
@@ -121,6 +122,7 @@ describe("WorkoutBuilderHub", () => {
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
@@ -800,6 +802,50 @@ describe("WorkoutBuilderHub", () => {
     );
   });
 
+  it("shows clearer kick and drill taxonomy guidance inside the step form", async () => {
+    render(<WorkoutBuilderHub workoutLibrary={buildWorkoutLibrary()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("session-draft-step-toggle-0"));
+
+    expect(screen.getByText("Primary stroke")).toBeVisible();
+    expect(screen.getByText("Drill / kick / pull focus")).toBeVisible();
+    expect(
+      screen.getByText(
+        "Use Primary stroke for the swim pattern. Add focus only when the step needs extra drill, kick, or pull notation."
+      )
+    ).toBeVisible();
+
+    fireEvent.change(screen.getByLabelText("Category"), {
+      target: { value: "kick" },
+    });
+
+    expect(
+      screen.getByText(
+        "Kick category already marks this as kick work. Use Primary stroke for the stroke pattern this kick set supports, and use the focus field only when you want extra kick, pull, or drill notation."
+      )
+    ).toBeVisible();
+
+    fireEvent.change(screen.getByLabelText("Category"), {
+      target: { value: "drill" },
+    });
+    fireEvent.change(screen.getByTestId("session-draft-step-stroke-0"), {
+      target: { value: "drill" },
+    });
+
+    expect(
+      screen.getByText(
+        "Use Drill shell when the step is built around a drill. Then use the focus field to clarify whether it is a general drill, kick drill, or pull drill."
+      )
+    ).toBeVisible();
+  });
+
   it("shows recovery guidance when the requested workout is missing", () => {
     render(
       <WorkoutBuilderHub
@@ -821,6 +867,42 @@ describe("WorkoutBuilderHub", () => {
       "href",
       "/my-library/workouts/workout-1"
     );
+    expect(screen.getByTestId("saved-workouts-print-workout-1")).toHaveAttribute(
+      "href",
+      "/api/my-library/workouts/workout-1/export/pdf"
+    );
+  });
+
+  it("auto-dismisses workout pdf notices after a short delay", async () => {
+    const printWindow = {
+      document: {
+        open: vi.fn(),
+        write: vi.fn(),
+        close: vi.fn(),
+      },
+      focus: vi.fn(),
+    };
+
+    vi.spyOn(window, "open").mockReturnValue(printWindow as unknown as Window);
+
+    render(<WorkoutBuilderHub workoutLibrary={buildWorkoutLibrary()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByTestId("workout-editor-pdf-open"));
+    expect(screen.getByTestId("workout-editor-pdf-notice")).toBeVisible();
+
+    act(() => {
+      vi.advanceTimersByTime(WORKOUT_NOTICE_AUTO_DISMISS_MS);
+    });
+
+    expect(screen.queryByTestId("workout-editor-pdf-notice")).not.toBeInTheDocument();
   });
 
   it("collapses saved workouts by default and deletes a non-current workout deterministically", async () => {

--- a/tests/unit/workouts-routes.test.ts
+++ b/tests/unit/workouts-routes.test.ts
@@ -12,6 +12,7 @@ import {
   DELETE as deleteWorkout,
   PATCH as patchWorkout,
 } from "@/app/api/my-library/workouts/[workoutId]/route";
+import { GET as getWorkoutPdf } from "@/app/api/my-library/workouts/[workoutId]/export/pdf/route";
 import { POST as postWorkout } from "@/app/api/my-library/workouts/route";
 import type { SessionDraft } from "@/lib/session-generator-v1/shared";
 import type { Database } from "@/types/database";
@@ -155,6 +156,30 @@ describe("workouts routes", () => {
     expect(response.status).toBe(401);
   });
 
+  it("fails closed for unauthenticated workout pdf export", async () => {
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+        },
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await getWorkoutPdf(
+      new Request(
+        "http://127.0.0.1:3000/api/my-library/workouts/11111111-1111-4111-8111-111111111111/export/pdf"
+      ),
+      {
+        params: Promise.resolve({
+          workoutId: "11111111-1111-4111-8111-111111111111",
+        }),
+      }
+    );
+
+    expect(response.status).toBe(401);
+  });
+
   it("creates canonical workouts for the authenticated owner", async () => {
     const single = vi.fn().mockResolvedValue({
       data: buildWorkoutRow(),
@@ -202,6 +227,47 @@ describe("workouts routes", () => {
     expect(payload.ok).toBe(true);
     expect(payload.workout.id).toBe("11111111-1111-4111-8111-111111111111");
     expect(payload.summary.title).toBe("Threshold / CSS 25m Pool draft");
+  });
+
+  it("returns printable canonical workout pdf html for the authenticated owner", async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: buildWorkoutRow({
+        title: "Poolside QA workout",
+      }),
+      error: null,
+    });
+    const eqId = vi.fn(() => ({ maybeSingle }));
+    const eqUser = vi.fn(() => ({ eq: eqId }));
+    const select = vi.fn(() => ({ eq: eqUser }));
+    const from = vi.fn().mockReturnValue({ select });
+
+    createRouteHandlerSupabaseClientMock.mockResolvedValue({
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } } }),
+        },
+        from,
+      },
+      applySupabaseCookies: applyResponseCookiesIdentity,
+    });
+
+    const response = await getWorkoutPdf(
+      new Request(
+        "http://127.0.0.1:3000/api/my-library/workouts/11111111-1111-4111-8111-111111111111/export/pdf"
+      ),
+      {
+        params: Promise.resolve({
+          workoutId: "11111111-1111-4111-8111-111111111111",
+        }),
+      }
+    );
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/html");
+    expect(body).toContain("Workout PDF print view");
+    expect(body).toContain("Poolside QA workout");
+    expect(body).toContain("Source: Canonical workout");
   });
 
   it("creates manual canonical workouts when the request source kind is manual", async () => {


### PR DESCRIPTION
## Summary

- adds a new owner-scoped canonical `Poolside PDF` route for saved workouts at `/api/my-library/workouts/[workoutId]/export/pdf`
- adds row-level `Poolside PDF` actions to saved workouts so print/export is tied to the selected workout card instead of only the currently loaded editor state
- auto-dismisses transient success notices in workout-builder surfaces while leaving error states persistent
- clarifies workout step authoring labels and guidance for `kick` / `drill` usage without changing the canonical workout model
- updates the active builder brief and the My Library incident runbook to reflect the new PDF/action verification path

## Validation

- `npm run typecheck` ✅
- `npx vitest run tests/unit/workouts-routes.test.ts tests/unit/workout-builder-hub.test.tsx` ✅
- `npx playwright test tests/e2e/my-library-workout-builder.spec.ts --project=desktop-chromium` ✅
- `npm run verify:pre-pr` ✅ on `41ffaee`
- `npm run verify:pre-merge` ⏳ pending after required CI is green

## Risk / Notes

- no schema migration in this slice
- workout actions remain owner-scoped and canonical-ID based
- rollback is a simple revert of `41ffaee`
- manual Vercel preview QA is still pending before merge recommendation

## Target Scores

- Product goals and IA: `4/5`
- UX flow clarity: `5/5`
- Visual design quality: `4/5`
- Business logic correctness and data integrity: `5/5`
- Admin editor ergonomics: `4/5`
- Data placement and sync boundaries: `5/5`
- Reliability and failure handling: `4/5`
- Stack-fit and dependency discipline: `5/5`
- Testing and QA automation: `5/5`
- DevOps and rollback readiness: `5/5`

No target category is below `4/5`, so there is no release-blocking defer for this slice. Remaining follow-up stays inside the same active brief rather than blocking merge of this narrower checkpoint.
