### PR TITLE
fix(generator): clarify intake ux and progressive disclosure

### DIFF
--- a/app/my-library/generator/page.tsx
+++ b/app/my-library/generator/page.tsx
@@ -66,9 +66,9 @@ export default async function MyLibraryGeneratorPage({ searchParams }: Props) {
               </p>
               <h1 className="mt-2 text-3xl font-bold text-slate-900">Generator intake</h1>
               <p className="mt-2 max-w-[68ch] text-sm text-slate-600">
-                Review which saved My Library signals should prefill session generation, then apply
-                one-run overrides without editing your stored profile, records, goals, or primary
-                focus cue.
+                Choose what to bring in from My Library, add any one-off settings for this run, and
+                generate a swim session without editing your saved profile, records, goals, or
+                focus.
               </p>
             </div>
             <div className="flex flex-wrap gap-2">
@@ -92,29 +92,29 @@ export default async function MyLibraryGeneratorPage({ searchParams }: Props) {
             <div className="mt-3 grid gap-3 md:grid-cols-3">
               <div className="rounded-2xl border border-white/80 bg-white/80 p-4">
                 <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
-                  Saved My Library data
+                  Loaded from My Library
                 </p>
                 <p className="mt-2 text-sm text-slate-700">
-                  Profile, CSS, preferences, records, goals, and the selected primary focus cue stay
-                  server-owned.
+                  Profile, CSS, preferences, records, goals, and focus stay saved in My Library.
+                  This page reads them without editing them.
                 </p>
               </div>
               <div className="rounded-2xl border border-white/80 bg-white/80 p-4">
                 <p className="text-xs font-semibold uppercase tracking-wide text-emerald-700">
-                  This run only
+                  Just this run
                 </p>
                 <p className="mt-2 text-sm text-slate-700">
-                  Include or exclude blocks and set overrides that do not write back into My
+                  Choose what to include and add one-off settings that do not write back into My
                   Library.
                 </p>
               </div>
               <div className="rounded-2xl border border-white/80 bg-white/80 p-4">
                 <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">
-                  Canonical workout save
+                  After you generate
                 </p>
                 <p className="mt-2 text-sm text-slate-700">
-                  This page can now accept one reviewed session into a canonical workout and hand it
-                  off into the dedicated workout builder route for later editing.
+                  Save one reviewed swim session into My Library, then reopen it in the dedicated
+                  builder route for later editing.
                 </p>
               </div>
             </div>

--- a/components/my-library/generator/GeneratorIntakeHub.tsx
+++ b/components/my-library/generator/GeneratorIntakeHub.tsx
@@ -39,6 +39,8 @@ type StoredDraft = {
   overrides: GeneratorIntakeOverrides;
 };
 
+type GeneratorSectionKey = "source" | "overrides" | "technical";
+
 const STORAGE_KEY_PREFIX = "my-library-generator-intake-draft:";
 const BLOCK_COPY_ORDER = [...GENERATOR_INTAKE_BLOCK_KEYS];
 
@@ -124,6 +126,11 @@ export default function GeneratorIntakeHub({ initialSnapshot, userId, workoutLib
   const [isOnline, setIsOnline] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [lastPreparedSignature, setLastPreparedSignature] = useState<string | null>(null);
+  const [sectionOpen, setSectionOpen] = useState<Record<GeneratorSectionKey, boolean>>({
+    source: false,
+    overrides: false,
+    technical: false,
+  });
 
   const storageKey = getStorageKey(userId);
   const payload = buildGeneratorHandoffPayload(snapshot, selection, overrides, {
@@ -133,6 +140,21 @@ export default function GeneratorIntakeHub({ initialSnapshot, userId, workoutLib
   const payloadSignature = JSON.stringify(payload);
   const isPreparedCurrent = lastPreparedSignature === payloadSignature;
   const selectedBlockCount = payload.includedBlocks.length;
+  const sourceSummary =
+    selectedBlockCount > 0
+      ? `${selectedBlockCount} block${selectedBlockCount === 1 ? "" : "s"} included`
+      : "No saved blocks included";
+  const overrideSummary =
+    overrides.targetType === "program"
+      ? payload.effectiveDefaults.sessionCount
+        ? `${payload.effectiveDefaults.sessionCount} swim session${
+            payload.effectiveDefaults.sessionCount === 1 ? "" : "s"
+          } per week`
+        : "Multi-session program"
+      : "Single session";
+  const technicalSummary = isPreparedCurrent
+    ? "Prepared with current choices"
+    : "Hidden by default";
   const hasActiveOverrides =
     Boolean(payload.overrides.desiredSessionCount) ||
     Boolean(payload.overrides.desiredSessionMinutes) ||
@@ -289,6 +311,13 @@ export default function GeneratorIntakeHub({ initialSnapshot, userId, workoutLib
     setActionSuccess("");
   }
 
+  function toggleSection(section: GeneratorSectionKey) {
+    setSectionOpen((current) => ({
+      ...current,
+      [section]: !current[section],
+    }));
+  }
+
   function resetIntakeDraft() {
     clearDraft(storageKey);
     setSelection(getDefaultGeneratorIntakeSelection(snapshot));
@@ -302,7 +331,7 @@ export default function GeneratorIntakeHub({ initialSnapshot, userId, workoutLib
 
   function prepareHandoff() {
     setActionError("");
-    setActionSuccess("Generator handoff prepared for the next slice.");
+    setActionSuccess("Generator is ready for this run.");
     setLastPreparedSignature(payloadSignature);
     void sendClientAnalyticsEvent("generator_intake_handoff_prepared", {
       targetType: payload.overrides.targetType,
@@ -325,8 +354,8 @@ export default function GeneratorIntakeHub({ initialSnapshot, userId, workoutLib
           <div>
             <h2 className="text-base font-semibold text-slate-900">Before you continue</h2>
             <p className="mt-2 max-w-[66ch] text-sm text-slate-600">
-              Include or remove saved My Library blocks here. Then add one-run generator overrides
-              below. Neither choice writes back into your saved records. Notes stay out of default
+              Review what to bring in from My Library, then choose any one-off settings for this
+              run. Nothing here writes back into your saved records. Notes stay out of default
               generator prefill in v1.
             </p>
           </div>
@@ -396,194 +425,242 @@ export default function GeneratorIntakeHub({ initialSnapshot, userId, workoutLib
       <section className="rounded-2xl border border-slate-200 bg-white p-5">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <h2 className="text-lg font-semibold text-slate-900">Saved My Library context</h2>
+            <h2 className="text-lg font-semibold text-slate-900">Loaded from My Library</h2>
             <p className="mt-2 max-w-[66ch] text-sm text-slate-600">
-              Available blocks default to included. Unavailable blocks stay visible so you can see
-              what is missing, still syncing, or needs a retry before later generation.
+              Read-only information for this run. Open it when you want to review what is coming
+              from your saved My Library data before generating anything.
             </p>
           </div>
-          <p className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-700">
-            {selectedBlockCount} included now
-          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-700">
+              {sourceSummary}
+            </p>
+            <button
+              type="button"
+              onClick={() => toggleSection("source")}
+              aria-expanded={sectionOpen.source}
+              data-testid="generator-intake-source-toggle"
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+            >
+              {sectionOpen.source ? "Hide details" : "Show details"}
+            </button>
+          </div>
         </div>
 
-        <div className="mt-5 grid gap-4 lg:grid-cols-2">
-          {BLOCK_COPY_ORDER.map((blockKey) => {
-            const block = snapshot.blocks[blockKey];
-            const tone = buildBlockTone(block);
-            const checkboxId = `generator-intake-${blockKey}`;
+        {sectionOpen.source ? (
+          <div className="mt-5 grid gap-4 lg:grid-cols-2">
+            {BLOCK_COPY_ORDER.map((blockKey) => {
+              const block = snapshot.blocks[blockKey];
+              const tone = buildBlockTone(block);
+              const checkboxId = `generator-intake-${blockKey}`;
 
-            return (
-              <article key={block.key} className={`rounded-2xl border p-4 ${tone.container}`}>
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                      Saved source
-                    </p>
-                    <h3 className="mt-1 text-base font-semibold text-slate-900">{block.label}</h3>
-                    <p className="mt-2 text-sm text-slate-700">{block.description}</p>
+              return (
+                <article key={block.key} className={`rounded-2xl border p-4 ${tone.container}`}>
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        From My Library
+                      </p>
+                      <h3 className="mt-1 text-base font-semibold text-slate-900">{block.label}</h3>
+                      <p className="mt-2 text-sm text-slate-700">{block.description}</p>
+                    </div>
+                    <span
+                      className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${tone.badge}`}
+                    >
+                      {tone.label}
+                    </span>
                   </div>
-                  <span
-                    className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${tone.badge}`}
-                  >
-                    {tone.label}
-                  </span>
-                </div>
 
-                <p className="mt-4 text-sm text-slate-700">{block.summary}</p>
+                  <p className="mt-4 text-sm text-slate-700">{block.summary}</p>
 
-                {block.missingReason ? (
-                  <p className="mt-2 text-sm text-slate-600">{block.missingReason}</p>
-                ) : null}
+                  {block.missingReason ? (
+                    <p className="mt-2 text-sm text-slate-600">{block.missingReason}</p>
+                  ) : null}
 
-                {block.lastUpdatedAt ? (
-                  <p className="mt-2 text-xs text-slate-500">Last updated: {block.lastUpdatedAt}</p>
-                ) : null}
+                  {block.lastUpdatedAt ? (
+                    <p className="mt-2 text-xs text-slate-500">
+                      Last updated: {block.lastUpdatedAt}
+                    </p>
+                  ) : null}
 
-                <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
-                  <label
-                    htmlFor={checkboxId}
-                    className="inline-flex cursor-pointer items-center gap-3 text-sm font-medium text-slate-900"
-                  >
-                    <input
-                      id={checkboxId}
-                      type="checkbox"
-                      checked={selection[blockKey]}
-                      disabled={!block.available}
-                      onChange={() => toggleBlock(blockKey)}
-                      data-testid={`generator-intake-include-${blockKey}`}
-                      className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
-                    />
-                    Include {toBlockLabel(blockKey)} for this run
-                  </label>
+                  <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+                    <label
+                      htmlFor={checkboxId}
+                      className="inline-flex cursor-pointer items-center gap-3 text-sm font-medium text-slate-900"
+                    >
+                      <input
+                        id={checkboxId}
+                        type="checkbox"
+                        checked={selection[blockKey]}
+                        disabled={!block.available}
+                        onChange={() => toggleBlock(blockKey)}
+                        data-testid={`generator-intake-include-${blockKey}`}
+                        className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+                      />
+                      Include {toBlockLabel(blockKey)} for this run
+                    </label>
 
-                  <Link
-                    href={block.manageHref}
-                    className="text-sm font-medium text-blue-700 underline-offset-4 hover:underline"
-                  >
-                    {block.manageLabel}
-                  </Link>
-                </div>
-              </article>
-            );
-          })}
-        </div>
+                    <Link
+                      href={block.manageHref}
+                      className="text-sm font-medium text-blue-700 underline-offset-4 hover:underline"
+                    >
+                      {block.manageLabel}
+                    </Link>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        ) : null}
       </section>
 
       <section className="rounded-2xl border border-slate-200 bg-white p-5">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <h2 className="text-lg font-semibold text-slate-900">One-run overrides</h2>
+            <h2 className="text-lg font-semibold text-slate-900">Just this run</h2>
             <p className="mt-2 max-w-[66ch] text-sm text-slate-600">
-              These settings change only this generator attempt. They never mutate saved My Library
-              source data.
+              These choices only affect this generator attempt. Use them when you want to steer this
+              run without editing your saved My Library information.
             </p>
           </div>
-          <p className="rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">
-            Local only
-          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">
+              {overrideSummary}
+            </p>
+            <button
+              type="button"
+              onClick={() => toggleSection("overrides")}
+              aria-expanded={sectionOpen.overrides}
+              data-testid="generator-intake-overrides-toggle"
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+            >
+              {sectionOpen.overrides ? "Hide choices" : "Show choices"}
+            </button>
+          </div>
         </div>
 
-        <div className="mt-5 grid gap-4 md:grid-cols-2">
-          <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4">
-            <legend className="px-1 text-sm font-semibold text-slate-900">Generator target</legend>
-            <div className="mt-3 flex flex-wrap gap-3">
-              <label className="inline-flex items-center gap-2 text-sm text-slate-700">
-                <input
-                  type="radio"
-                  name="generator-target-type"
-                  checked={overrides.targetType === "session"}
-                  onChange={() => updateOverride("targetType", "session")}
-                  data-testid="generator-intake-target-session"
-                />
-                Single session
+        {sectionOpen.overrides ? (
+          <>
+            <div className="mt-5 grid gap-4 md:grid-cols-2">
+              <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4">
+                <legend className="px-1 text-sm font-semibold text-slate-900">
+                  What do you want to generate?
+                </legend>
+                <div className="mt-3 flex flex-wrap gap-3">
+                  <label className="inline-flex items-center gap-2 text-sm text-slate-700">
+                    <input
+                      type="radio"
+                      name="generator-target-type"
+                      checked={overrides.targetType === "session"}
+                      onChange={() => updateOverride("targetType", "session")}
+                      data-testid="generator-intake-target-session"
+                    />
+                    Single session
+                  </label>
+                  <label className="inline-flex items-center gap-2 text-sm text-slate-700">
+                    <input
+                      type="radio"
+                      name="generator-target-type"
+                      checked={overrides.targetType === "program"}
+                      onChange={() => updateOverride("targetType", "program")}
+                      data-testid="generator-intake-target-program"
+                    />
+                    Multi-session program
+                  </label>
+                </div>
+              </fieldset>
+
+              {overrides.targetType === "program" ? (
+                <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
+                  Swim sessions per week
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    value={overrides.desiredSessionCount}
+                    onChange={(event) => updateOverride("desiredSessionCount", event.target.value)}
+                    data-testid="generator-intake-session-count"
+                    className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                    placeholder="Leave blank to use saved weekly preference later"
+                  />
+                </label>
+              ) : null}
+
+              <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
+                Desired session length
+                <select
+                  value={overrides.desiredSessionMinutes}
+                  onChange={(event) => updateOverride("desiredSessionMinutes", event.target.value)}
+                  data-testid="generator-intake-session-minutes"
+                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                >
+                  <option value="">Use saved preference or leave open</option>
+                  {TRAINING_SESSION_DURATION_OPTIONS.map((option) => (
+                    <option key={option.value} value={String(option.value)}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
               </label>
-              <label className="inline-flex items-center gap-2 text-sm text-slate-700">
+
+              <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
+                Focus for this run
                 <input
-                  type="radio"
-                  name="generator-target-type"
-                  checked={overrides.targetType === "program"}
-                  onChange={() => updateOverride("targetType", "program")}
-                  data-testid="generator-intake-target-program"
+                  type="text"
+                  value={overrides.focusText}
+                  onChange={(event) => updateOverride("focusText", event.target.value)}
+                  data-testid="generator-intake-focus-text"
+                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                  placeholder="Example: Breathing timing under fatigue"
                 />
-                Multi-session program
               </label>
             </div>
-          </fieldset>
 
-          <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
-            Desired session count
-            <input
-              type="text"
-              inputMode="numeric"
-              value={overrides.desiredSessionCount}
-              onChange={(event) => updateOverride("desiredSessionCount", event.target.value)}
-              data-testid="generator-intake-session-count"
-              className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-              placeholder="Leave blank to keep later defaults"
-            />
-          </label>
-
-          <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
-            Desired session length
-            <select
-              value={overrides.desiredSessionMinutes}
-              onChange={(event) => updateOverride("desiredSessionMinutes", event.target.value)}
-              data-testid="generator-intake-session-minutes"
-              className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-            >
-              <option value="">Use saved preference or leave open</option>
-              {TRAINING_SESSION_DURATION_OPTIONS.map((option) => (
-                <option key={option.value} value={String(option.value)}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
-            Focus for this run
-            <input
-              type="text"
-              value={overrides.focusText}
-              onChange={(event) => updateOverride("focusText", event.target.value)}
-              data-testid="generator-intake-focus-text"
-              className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-              placeholder="Example: Breathing timing under fatigue"
-            />
-          </label>
-        </div>
-
-        <label className="mt-4 block rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
-          Constraints for this run
-          <textarea
-            value={overrides.constraintText}
-            onChange={(event) => updateOverride("constraintText", event.target.value)}
-            data-testid="generator-intake-constraint-text"
-            rows={4}
-            className="mt-2 block w-full rounded-xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-            placeholder="Example: Keep total volume moderate and avoid heavy kick work."
-          />
-        </label>
+            <label className="mt-4 block rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
+              Constraints for this run
+              <textarea
+                value={overrides.constraintText}
+                onChange={(event) => updateOverride("constraintText", event.target.value)}
+                data-testid="generator-intake-constraint-text"
+                rows={4}
+                className="mt-2 block w-full rounded-xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                placeholder="Example: Keep total volume moderate and avoid heavy kick work."
+              />
+            </label>
+          </>
+        ) : null}
       </section>
 
       <section className="rounded-2xl border border-slate-200 bg-white p-5">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <h2 className="text-lg font-semibold text-slate-900">Deterministic handoff</h2>
+            <h2 className="text-lg font-semibold text-slate-900">Prepare the generator</h2>
             <p className="mt-2 max-w-[66ch] text-sm text-slate-600">
-              This preview shows exactly what later generator slices would receive right now. It
-              uses canonical IDs and normalized values instead of only display labels.
+              Lock this run to the saved information and one-off choices you want to use. The raw
+              technical preview stays hidden unless you explicitly open it.
             </p>
           </div>
-          <button
-            type="button"
-            onClick={prepareHandoff}
-            data-testid="generator-intake-prepare"
-            className="inline-flex h-11 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700"
-          >
-            {isPreparedCurrent ? "Handoff prepared" : "Prepare generator handoff"}
-          </button>
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-700">
+              {technicalSummary}
+            </p>
+            <button
+              type="button"
+              onClick={() => toggleSection("technical")}
+              aria-expanded={sectionOpen.technical}
+              data-testid="generator-intake-technical-toggle"
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+            >
+              {sectionOpen.technical ? "Hide technical preview" : "Show technical preview"}
+            </button>
+            <button
+              type="button"
+              onClick={prepareHandoff}
+              data-testid="generator-intake-prepare"
+              className="inline-flex h-11 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700"
+            >
+              {isPreparedCurrent ? "Prepared for this run" : "Prepare generator"}
+            </button>
+          </div>
         </div>
 
         <div className="mt-4 grid gap-3 md:grid-cols-3">
@@ -618,19 +695,21 @@ export default function GeneratorIntakeHub({ initialSnapshot, userId, workoutLib
 
         {lastPreparedSignature && !isPreparedCurrent ? (
           <p className="mt-4 text-sm text-amber-800">
-            Intake choices changed after the last prepare action. Review the preview and prepare the
-            handoff again before moving downstream.
+            Intake choices changed after the last prepare action. Review them and prepare again
+            before moving downstream.
           </p>
         ) : null}
 
-        <div className="mt-4 overflow-hidden rounded-2xl border border-slate-200 bg-slate-950">
-          <pre
-            data-testid="generator-intake-handoff-preview"
-            className="max-h-[420px] overflow-auto px-4 py-4 text-xs leading-relaxed text-slate-100"
-          >
-            {payloadPreview}
-          </pre>
-        </div>
+        {sectionOpen.technical ? (
+          <div className="mt-4 overflow-hidden rounded-2xl border border-slate-200 bg-slate-950">
+            <pre
+              data-testid="generator-intake-handoff-preview"
+              className="max-h-[420px] overflow-auto px-4 py-4 text-xs leading-relaxed text-slate-100"
+            >
+              {payloadPreview}
+            </pre>
+          </div>
+        ) : null}
       </section>
 
       <SessionGeneratorPanel

--- a/components/my-library/generator/SessionGeneratorPanel.tsx
+++ b/components/my-library/generator/SessionGeneratorPanel.tsx
@@ -359,8 +359,8 @@ export default function SessionGeneratorPanel({
           className="mt-5 rounded-2xl border border-blue-200 bg-blue-50/80 p-4"
         >
           <p className="text-sm text-blue-900">
-            Prepare the deterministic handoff above before generating a session draft, so this run
-            uses the exact saved profile, goal, and focus context you just reviewed.
+            Prepare the generator above before generating a session draft, so this run uses the
+            saved profile, goal, and focus context you just reviewed.
           </p>
         </div>
       ) : null}

--- a/docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md
@@ -73,6 +73,28 @@ Production admin notes reviewed against this brief on `2026-03-27`:
 - `7e075645-84e8-4fcb-a23e-518862ad03d5` `Ehy i smh library button here`
   - disposition: owned by this brief.
   - reason: My Library mode/button clarity belongs in the same IA clean-up wave as `Program shell`.
+- `f21f4a8d-7afa-4eeb-a572-53f1d5c85996` `Create manual workout`
+  - disposition: owned by this brief.
+  - reason: manual session entrypoint naming and whether the editor should dominate the page are part of the same builder IA/entry flow review.
+- `c54e1d72-3efb-47a7-ab7e-ef4f32d05d33` `Rename Workout builder`
+  - disposition: owned by this brief.
+  - reason: builder naming should stay coherent if workout/session/strength/stretch variants expand later.
+- `a1d2db16-2f21-4d38-add1-62a462cfa015` `PDF`
+  - disposition: owned by this brief.
+  - reason: PDF naming, compact poolside variant expectations, and focus-line content all belong to the same export-truthfulness wave.
+- `ac6ab21e-063c-4a60-a2e3-1d4878856eb0` `Delete current workout location UI and UX`
+  - disposition: owned by this brief.
+  - reason: current-workout delete placement and builder-entry visibility are still part of the same live-review action/IA cleanup.
+
+Triage update on `2026-03-28`:
+
+- closed as effectively shipped:
+  - `fed5e8b6-71a5-4b35-8549-2155a2cccdfe` `How do I delete workouts?`
+  - `f09ade9f-8301-49c3-980f-366675bdb46d` `Delete, edit, print buttons for the workouts`
+- split residual follow-up notes for partially shipped originals:
+  - `d76825bd-4b5c-4e7e-aa22-49e6c25350ba` `Saved workouts list density follow-up` from `af6ab360-04d1-454c-8824-090260f088e8`
+  - `9245eaba-e5fd-4bc2-83c1-2f53c7df100e` `Workout builder drill and kick taxonomy follow-up` from `3396b47c-4b78-4a72-bc55-b6806e0fc620`
+  - `854d3f39-9275-4d80-a624-a687e47db320` `Workout builder notice placement and audience follow-up` from `5b15cd93-813f-415b-a555-6f0bf6729bf7`
 
 ## Platform 10/10 Scorecard Mapping
 
@@ -224,6 +246,7 @@ Critical target categories for `10/10` claim in this brief:
 - `2026-03-27` — moved to `in-progress` on branch `fix/workout-builder-live-review-actions-2026-03-27`; first implementation slice adds owner-scoped workout delete API/UI, calmer collapsed support panels, builder label cleanup, and My Library wording cleanup. Next step: finish targeted validation and run `npm run verify:pre-pr`.
 - `2026-03-28` — slice 3 implemented on branch `fix/workout-builder-current-actions-2026-03-28`; added current-workout action strip, clearer PDF state copy, bluer poolside PDF styling, and targeted generator-intake auth-redirect hardening after a confirmed `verify:pre-merge` auth/Supabase flake. Next step: rerun targeted generator-intake coverage, rerun `npm run verify:pre-merge`, then merge if green.
 - `2026-03-28` — local `verify:pre-merge` also exposed a macOS-specific `.next/.DS_Store` build flake (`ENOTEMPTY` while Next tried to remove `.next/server`). Added a pre-build sanitizer so local gates stop failing on Finder metadata rather than product code. Next step: rerun `npm run build`, then rerun `npm run verify:pre-merge` on the hardened build path.
+- `2026-03-28` — post-merge prod triage added four newer builder/admin notes to this brief (`Create manual workout`, `Rename Workout builder`, `PDF`, and `Delete current workout location UI and UX`) and prepared residual follow-up splits for the parts of older notes that are no longer the primary ask after shipped slices. Next step: keep this brief open for the next workout-builder UX pass while generator-intake clarity is handled in its own child brief first.
 - Local validation runs from repo root.
 
 ## Manual QA Environments

--- a/docs/task-briefs/in-progress/2026-03-28-generator-intake-ux-clarity-and-progressive-disclosure-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-28-generator-intake-ux-clarity-and-progressive-disclosure-10-10.md
@@ -1,0 +1,258 @@
+# Task Brief: Generator Intake UX Clarity And Progressive Disclosure (10/10)
+
+## Metadata
+
+- `id`: `2026-03-28-generator-intake-ux-clarity-and-progressive-disclosure-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-03-28`
+- `updated`: `2026-03-28`
+
+## Goal
+
+Make `/my-library/generator` understandable on first use by hiding program-only controls from the single-session path, simplifying language, and moving technical payload detail behind calmer progressive disclosure.
+
+## Why This Brief Exists
+
+- Real use in `freeswimming.org` shows the generator intake is functionally correct but still reads too much like an internal staging tool.
+- The current friction is tightly related:
+  - `Desired session count` appears even when the user is generating a single session,
+  - `Saved My Library context` is too technical as a heading,
+  - `One-run overrides` is correct but not self-explanatory enough,
+  - `Deterministic handoff` exposes raw payload/ID detail too aggressively in the normal flow.
+- These are primarily IA, copy, and progressive-disclosure problems, not missing data-contract problems.
+- The correct next step is a focused UX cleanup that keeps the existing canonical handoff model intact while making the page much easier to understand.
+
+## Dependencies And Boundaries
+
+- Existing intake/data-contract foundation that remains authoritative:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-19-my-library-generator-intake-and-prefill-foundation-10-10.md`
+- Existing session-builder/workout-builder downstream surfaces that must stay compatible:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md`
+- Locked boundary decisions unless explicitly changed later:
+  - generator handoff remains canonical and deterministic,
+  - notes still stay out of default generator prefill in this slice,
+  - no new program-planner implementation,
+  - no AI generation logic change,
+  - no new persisted generator entity.
+
+## Admin Notes Triage Disposition
+
+Production admin notes reviewed against this brief on `2026-03-28`:
+
+- `54c8c570-ed7b-4e63-94a5-5b3748389337` `Hva er denne koden på bildet?`
+  - disposition: owned by this brief.
+  - reason: the raw payload/canonical ID preview is too exposed in the normal session flow.
+- `8eb45996-83d4-4e78-ab3b-807272982d6d` `Deterministic handoff`
+  - disposition: owned by this brief.
+  - reason: the technical preview needs calmer IA, clearer explanation, and progressive disclosure.
+- `33e123ad-d05f-4ef3-add0-803bf52b96d2` `One-run overrides`
+  - disposition: owned by this brief.
+  - reason: the section is correct conceptually but needs clearer labels, explanation, and less default density.
+- `a80e8f69-2a5c-4c4c-ba4d-21009cf589e6` `Saved My Library Context`
+  - disposition: owned by this brief.
+  - reason: the heading/copy is too technical and should explain that this is read-only information loaded from My Library.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `Product goals and IA`
+- `UX flow clarity`
+- `Visual design quality`
+- `Business logic correctness and data integrity`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                                  | Evidence                              |
+| --------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| Product goals and IA                          | `target`     | A first-time user can distinguish saved source data, this-run-only choices, and advanced technical preview without internal-tool confusion.                     | IA review + manual QA + e2e           |
+| UX flow clarity                               | `target`     | Single-session users never see irrelevant program-only controls by default, and every changed heading/action explains what it affects in plain language.        | timed manual QA + unit/e2e            |
+| Visual design quality                         | `target`     | The generator page feels calmer and more intentional, with advanced technical detail visually de-emphasized and non-technical sections easier to scan.          | screenshot review + manual QA         |
+| Business logic correctness and data integrity | `target`     | Hiding or collapsing fields must not change the canonical handoff contract; session/program overrides still serialize deterministically when intentionally set. | unit tests + runtime guards           |
+| Admin editor ergonomics                       | `N/A`        | N/A because this slice changes a private end-user generator flow, not an admin/editor workflow.                                                                 | explicit scope rationale              |
+| Accessibility (a11y)                          | `target`     | New disclosure controls and conditional fields remain keyboard accessible, correctly labeled, and announce expanded/collapsed state.                            | targeted unit/e2e + manual QA         |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: calmer disclosure must not materially increase client JS or add extra fetches on the generator route.                                          | verify evidence + scope rationale     |
+| Data placement and sync boundaries            | `target`     | UI-only disclosure state stays local, while canonical snapshot and handoff payload rules remain unchanged and explicit.                                         | brief contract + tests                |
+| Caching and invalidation strategy             | `supporting` | Supporting only: disclosure/copy cleanup must keep existing refresh and stale-source behavior deterministic.                                                    | code review + targeted tests          |
+| Reliability and failure handling              | `target`     | Hidden/collapsed technical detail never blocks generate/prepare actions, and users still get clear retry/recovery states for stale or refreshed data.           | negative-path review + targeted tests |
+| Security and authz                            | `supporting` | Supporting only: the slice must not widen any private route or technical payload visibility beyond the authenticated owner.                                     | existing auth tests + code review     |
+| Privacy and compliance                        | `target`     | Progressive disclosure must reduce accidental exposure of raw private payload detail in the default UI while preserving the same owner-scoped contract.         | code review + manual QA               |
+| Content governance                            | `supporting` | Supporting only: labels and descriptions stay coherent with My Library and the canonical generator-input model.                                                 | copy review + lineage review          |
+| Admin workflow and editability                | `N/A`        | N/A because no admin/operator workflow changes in this slice.                                                                                                   | explicit scope rationale              |
+| SEO and crawlability                          | `N/A`        | N/A because `/my-library/generator` is an authenticated private route with no public crawl/index contract.                                                      | explicit scope rationale              |
+| AI discoverability                            | `N/A`        | N/A because this slice changes no public metadata or discoverable route content.                                                                                | explicit scope rationale              |
+| Analytics and KPI observability               | `supporting` | Supporting only: existing prepare/generate events should remain truthful after label and disclosure changes.                                                    | analytics review + code review        |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, checkout, entitlement, or billing behavior changes here.                                                                                | explicit scope rationale              |
+| Incident response and support operations      | `supporting` | Supporting only: the generator runbook/help copy should explain any renamed sections or advanced-preview placement if operator/support guidance changes.        | runbook/help review                   |
+| Finance and reporting operations              | `N/A`        | N/A because no finance reconciliation, payout, or reporting logic changes in this private generator-intake cleanup.                                             | explicit scope rationale              |
+| i18n operational readiness                    | `supporting` | Supporting only: new simpler labels should remain locale-extensible and avoid hard-coded technical jargon that is harder to localize later.                     | copy review + scope rationale         |
+| Stack-fit and dependency discipline           | `target`     | The slice reuses existing Next.js/TypeScript/test patterns and adds no new dependencies for disclosure/copy cleanup.                                            | dependency diff + code review         |
+| Testing and QA automation                     | `target`     | Conditional field visibility, renamed headings, and advanced-preview disclosure are covered with targeted unit/e2e tests and full pre-PR verification.          | tests + verify outputs                |
+| Scalability and cost efficiency               | `supporting` | Supporting only: calmer UI should reduce unnecessary user churn without adding redundant data loads or expensive derived work.                                  | code review + manual QA               |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: copy/disclosure changes are easy to revert without data migration or contract drift.                                                           | PR diff + rollback notes              |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - generator intake snapshot blocks,
+  - source data loaded from My Library,
+  - canonical handoff payload assembly rules.
+- Local-only:
+  - section expanded/collapsed state,
+  - selected target type before handoff,
+  - visible/invisible program-only override fields,
+  - restored draft UI state already scoped to the current user/device.
+- Sync policy:
+  - hiding program-only fields for `session` must not erase intentional program values unless the target changes and normalization already requires it,
+  - advanced-preview disclosure remains local-only and must not affect what `prepare` serializes,
+  - refresh/reset behavior must continue to use the existing snapshot/draft rules.
+- Retention and sensitivity:
+  - raw handoff preview contains more technical private detail than the main UI and should stay hidden by default,
+  - no additional private data is introduced in this slice.
+- Cache/invalidation:
+  - no new fetch paths,
+  - existing refresh/reset and stale-source warnings remain authoritative.
+
+## Identity And Rename Contract
+
+- Canonical stable IDs:
+  - source entity IDs and handoff payload identity remain unchanged.
+- Human-readable identifiers:
+  - section headings, helper text, and field labels are presentation copy only and may be renamed for clarity.
+- Mutability rules:
+  - renamed UI copy must not imply any new persistence semantics,
+  - program-only fields remain mutable as local overrides only.
+- Rename vs repurpose policy:
+  - this slice renames and re-explains existing UI sections in place,
+  - it does not create a second intake model or alternate handoff type.
+- Compatibility contract:
+  - downstream generator/session builder code keeps reading the same payload fields,
+  - conditional visibility for session/program must not break existing tests or saved local drafts.
+- Observability and repair:
+  - if a restored draft contains program-only values while target type is `session`, the UI should normalize or safely hide them without silent payload corruption.
+
+## Scope
+
+- Rename and simplify the main generator intake copy so the page reads as a user-facing tool instead of an internal staging screen.
+- Hide the `desiredSessionCount` field when target type is `session`.
+- When target type is `program`, relabel that field clearly as `Swim sessions per week`.
+- Simplify the source-data section heading/copy so it reads as information loaded from My Library.
+- Simplify the overrides section heading/copy so it clearly means `this run only`.
+- Move the raw technical payload preview behind calmer progressive disclosure and reduce its prominence in the normal flow.
+- Keep the current canonical handoff model, refresh/reset behavior, and session-generator compatibility intact.
+
+## Out Of Scope
+
+- Program planner/calendar implementation.
+- AI generation logic changes.
+- New persistence or schema changes.
+- Reopening notes-prefill scope.
+- Broad My Library IA changes outside the generator route.
+
+## Acceptance Criteria
+
+1. `Desired session count` is not shown when target type is `Single session`.
+2. When target type is `Multi-session program`, the same control is shown with a clear weekly-program label.
+3. The section previously labeled `Saved My Library context` is renamed and explained in plainer user-facing language.
+4. The section previously labeled `One-run overrides` is renamed and explained in plainer user-facing language.
+5. The raw handoff preview is visually de-emphasized behind an explicit disclosure control that defaults closed.
+6. The changed UX remains truthful to the canonical handoff model and does not alter the payload contract unintentionally.
+7. Relevant production admin notes listed above remain explicitly owned by this brief until shipped or intentionally split again.
+8. `npm run lint:briefs`, targeted validation, and `npm run verify:pre-pr` pass before PR update.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run typecheck`
+- targeted unit tests for:
+  - target-type conditional field visibility,
+  - renamed copy/disclosure states,
+  - unchanged handoff payload serialization
+- targeted e2e for:
+  - generator intake single-session path,
+  - generator intake program path,
+  - technical preview disclosure behavior
+- `npm run verify:pre-pr`
+- before merge recommendation: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm must be installed on the machine used for local validation.
+- Local validation runs from repo root.
+
+## Manual QA Environments
+
+- Production review:
+  - `https://freeswimming.org/my-library/generator`
+- Local iteration:
+  - `http://127.0.0.1:3000/my-library/generator`
+- Preview:
+  - PR Vercel preview URL for the implementation branch
+
+## Constraints
+
+- Keep the route consistent with existing My Library language.
+- Do not expose more technical JSON/ID detail in the default view than today.
+- Do not change the downstream handoff schema in this slice.
+- Prefer clearer progressive disclosure over adding more on-screen explanation text.
+
+## 10/10 Quality Bar
+
+- A first-time user should understand what is saved, what is temporary, and what is advanced without asking for help.
+- The single-session path should feel simpler after this slice, not more configurable.
+- Required UI states for changed surfaces:
+  - `loading`
+  - `empty`
+  - `error`
+  - `retry`
+  - `success`
+  - collapsed/expanded advanced preview
+  - session/program conditional override visibility
+- The page must preserve visual calm and avoid raw internal/debug language in primary view.
+- Business logic must stay deterministic and canonical under every disclosure state.
+
+## Help/Guide And Operator Training Contract
+
+- Required if labels or explanations change in a way that affects support/recovery language:
+  - update the relevant private runbook/help copy in the same PR,
+  - update at least one automated assertion if the visible help contract changes.
+- `AdminHelpCenter` is `N/A` unless this slice changes shared admin/operator help text rather than private My Library copy.
+
+## Security, Privacy, and Compliance
+
+- `/my-library/generator` remains authenticated and owner-scoped.
+- The technical preview remains private and should become less casually visible, not more.
+- No secret/env values or cross-user data may appear in disclosure copy or payload preview.
+
+## Observability and KPI Contract
+
+- Existing analytics remain sufficient if they still truthfully capture:
+  - refresh,
+  - reset,
+  - handoff prepared,
+  - target type selected.
+- Success KPI for this slice:
+  - a user can explain what each main section does without needing internal product vocabulary.
+
+## Session Continuity and Recovery
+
+- Canonical source of truth: git branch + this brief path.
+- Checkpoint cadence:
+  - commit at each validated implementation milestone,
+  - update checkpoint log before pause or PR handoff.
+- Recovery protocol:
+  1. `git status -sb`
+  2. `git log --oneline -n 10`
+  3. reopen this brief and continue from the latest checkpoint note
+
+## Git Rhythm Defaults
+
+- Commit + push after each validated generator-intake UX slice.
+
+## Checkpoint Log
+
+- `2026-03-28` — brief created directly in `in-progress` after live production-note triage confirmed the next highest-value generator work is IA/copy/progressive-disclosure cleanup, not new generator capability. Next step: update the generator route UI to hide program-only fields in the single-session path, simplify headings, and collapse the technical preview by default, then run targeted tests and `npm run verify:pre-pr`.
+- `2026-03-28` — implemented the first generator-intake UX cleanup slice: single-session hides the weekly session-count override, program mode relabels it to `Swim sessions per week`, source/override/technical sections now use calmer plain-language headings, and the technical payload preview is hidden behind explicit disclosure. Targeted generator unit/e2e, `npm run typecheck`, and full `npm run verify:pre-pr` passed. During verification, two unrelated full-suite flakes (`course-progress-sync` and `soft-launch-banner`) were hardened with more stable browser-context polling and retryable route navigation so the release gate reflects the generator slice instead of transient test races. Next step: stage the changed briefs so `npm run lint:briefs` evaluates them directly, then commit, push, and open the PR for review.

--- a/lib/generator-intake/shared.ts
+++ b/lib/generator-intake/shared.ts
@@ -105,38 +105,37 @@ const BLOCK_META: Record<
 > = {
   profile: {
     label: "Athlete profile",
-    description: "Stable swimmer context that should not change from one run override to another.",
+    description: "Name and swimmer profile details loaded from My Library.",
     manageHref: "/my-library/profile",
     manageLabel: "Edit athlete profile",
   },
   css: {
     label: "CSS pace",
-    description: "Trusted current CSS from My Library for pace-aware generation later.",
+    description: "Current CSS pace loaded from My Library.",
     manageHref: "/my-library/profile",
     manageLabel: "Edit CSS",
   },
   preferences: {
     label: "Training preferences",
-    description: "Pool length and practical scheduling defaults from My Library.",
+    description: "Pool length and training preferences loaded from My Library.",
     manageHref: "/my-library/profile",
     manageLabel: "Edit preferences",
   },
   personal_records: {
     label: "Personal records",
-    description: "Saved benchmark swims that can inform later generator difficulty and pacing.",
+    description: "Saved benchmark swims you may want this run to consider.",
     manageHref: "/my-library/profile",
     manageLabel: "Edit personal records",
   },
   goals: {
     label: "Open goals",
-    description: "Longer-horizon targets that can shape what later generator work aims toward.",
+    description: "Open goals that can shape what this run aims toward.",
     manageHref: "/my-library/goals",
     manageLabel: "Edit goals",
   },
   focus: {
     label: "Primary focus cue",
-    description:
-      "A single current swim cue for generator use when My Library has one clear primary focus.",
+    description: "Your current main swim focus from My Library.",
     manageHref: "/my-library/training",
     manageLabel: "Edit focuses",
   },
@@ -165,7 +164,8 @@ export function normalizeGeneratorIntakeOverrides(
 
   return {
     targetType,
-    desiredSessionCount: normalizeIntegerDraft(overrides.desiredSessionCount),
+    desiredSessionCount:
+      targetType === "program" ? normalizeIntegerDraft(overrides.desiredSessionCount) : "",
     desiredSessionMinutes: normalizeIntegerDraft(overrides.desiredSessionMinutes),
     focusText: normalizeFreeText(overrides.focusText, 120),
     constraintText: normalizeFreeText(overrides.constraintText, 280),

--- a/tests/e2e/course-progress-sync.spec.ts
+++ b/tests/e2e/course-progress-sync.spec.ts
@@ -1,29 +1,34 @@
-import { expect, test, type APIResponse, type Page } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
-type CourseProgressPayload = {
-  rows?: Array<{ lessonId?: string; done?: boolean }>;
+type CourseProgressPollResult = {
+  status: number | "transient";
+  done: boolean | null;
 };
 
-function isTransientNetworkError(error: unknown): boolean {
-  const errorMessage = error instanceof Error ? error.message : String(error);
-  return /ECONNRESET|ECONNREFUSED|ETIMEDOUT|Request context disposed|socket hang up|Target page, context or browser has been closed/i.test(
-    errorMessage
-  );
-}
+async function getCourseProgressSnapshot(page: Page, canonicalLessonId: string) {
+  return page.evaluate(async (lessonId) => {
+    try {
+      const response = await fetch("/api/progress/course", {
+        method: "GET",
+        cache: "no-store",
+        credentials: "same-origin",
+      });
+      if (response.status === 404) {
+        return { status: 404, done: null };
+      }
+      if (!response.ok) {
+        return { status: response.status, done: null };
+      }
 
-async function getCourseProgressOrNull(page: Page): Promise<APIResponse | null> {
-  try {
-    const response = await page.request.get("/api/progress/course");
-    if (response.status() === 404) {
-      return null;
+      const payload = (await response.json().catch(() => null)) as {
+        rows?: Array<{ lessonId?: string; done?: boolean }>;
+      } | null;
+      const row = payload?.rows?.find((entry) => entry.lessonId === lessonId);
+      return { status: response.status, done: row?.done ?? false };
+    } catch {
+      return { status: "transient", done: null };
     }
-    return response;
-  } catch (error) {
-    if (isTransientNetworkError(error)) {
-      return null;
-    }
-    throw error;
-  }
+  }, canonicalLessonId) as Promise<CourseProgressPollResult>;
 }
 
 async function satisfyDoneGateIfPresent(page: import("@playwright/test").Page) {
@@ -71,10 +76,10 @@ test("signed-in mark-as-done syncs to account progress API", async ({ page }, te
   await expect
     .poll(
       async () => {
-        const response = await getCourseProgressOrNull(page);
-        return response?.status() ?? "transient";
+        const snapshot = await getCourseProgressSnapshot(page, canonicalLessonId);
+        return snapshot.status;
       },
-      { timeout: 20_000 }
+      { timeout: 30_000 }
     )
     .toBe(200);
   await page.waitForTimeout(1_200);
@@ -92,12 +97,9 @@ test("signed-in mark-as-done syncs to account progress API", async ({ page }, te
   await expect
     .poll(
       async () => {
-        const response = await getCourseProgressOrNull(page);
-        if (!response) return "transient";
-        if (response.status() !== 200) return `status:${response.status()}`;
-        const payload = (await response.json()) as CourseProgressPayload;
-        const row = payload.rows?.find((entry) => entry.lessonId === canonicalLessonId);
-        return row?.done ? "true" : "false";
+        const snapshot = await getCourseProgressSnapshot(page, canonicalLessonId);
+        if (snapshot.status !== 200) return `status:${snapshot.status}`;
+        return snapshot.done ? "true" : "false";
       },
       { timeout: 20_000 }
     )
@@ -109,12 +111,9 @@ test("signed-in mark-as-done syncs to account progress API", async ({ page }, te
   await expect
     .poll(
       async () => {
-        const response = await getCourseProgressOrNull(page);
-        if (!response) return "transient";
-        if (response.status() !== 200) return `status:${response.status()}`;
-        const payload = (await response.json()) as CourseProgressPayload;
-        const row = payload.rows?.find((entry) => entry.lessonId === canonicalLessonId);
-        return row?.done ? "true" : "false";
+        const snapshot = await getCourseProgressSnapshot(page, canonicalLessonId);
+        if (snapshot.status !== 200) return `status:${snapshot.status}`;
+        return snapshot.done ? "true" : "false";
       },
       { timeout: 20_000 }
     )

--- a/tests/e2e/my-library-generator-intake.spec.ts
+++ b/tests/e2e/my-library-generator-intake.spec.ts
@@ -150,6 +150,8 @@ test.describe("my library generator intake", () => {
       page.getByText("Notes stay out of default generator prefill in v1.", { exact: false })
     ).toBeVisible();
 
+    await expect(page.getByTestId("generator-intake-session-count")).toHaveCount(0);
+    await page.getByTestId("generator-intake-overrides-toggle").click();
     await page.getByTestId("generator-intake-target-program").check();
     await page.getByTestId("generator-intake-session-count").fill("4");
     await page.getByTestId("generator-intake-session-minutes").selectOption("45");
@@ -158,8 +160,9 @@ test.describe("my library generator intake", () => {
       .getByTestId("generator-intake-constraint-text")
       .fill("Keep the first week moderate.");
     await page.getByTestId("generator-intake-prepare").click();
+    await page.getByTestId("generator-intake-technical-toggle").click();
 
-    await expect(page.getByText("Generator handoff prepared for the next slice.")).toBeVisible();
+    await expect(page.getByText("Generator is ready for this run.")).toBeVisible();
     await expect(page.getByTestId("generator-intake-handoff-preview")).toContainText(
       '"targetType": "program"'
     );
@@ -181,6 +184,7 @@ test.describe("my library generator intake", () => {
     await expect(page).toHaveURL(/\/my-library\/generator$/);
     await waitForGeneratorIntakeClientReady(page);
 
+    await page.getByTestId("generator-intake-overrides-toggle").click();
     await page.getByTestId("generator-intake-target-session").check();
     await page.getByTestId("generator-intake-prepare").click();
     await prewarmSessionDraftRoute(page);

--- a/tests/e2e/soft-launch-banner.spec.ts
+++ b/tests/e2e/soft-launch-banner.spec.ts
@@ -14,9 +14,29 @@ async function waitForRouteToSettle(page: Page) {
   await expect(compilingIndicator).toHaveCount(0, { timeout: 60_000 });
 }
 
+async function gotoStable(page: Page, href: string) {
+  let lastError: unknown = null;
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      await page.goto(href, { waitUntil: "domcontentloaded", timeout: 60_000 });
+      await waitForRouteToSettle(page);
+      return;
+    } catch (error) {
+      lastError = error;
+      const message = error instanceof Error ? error.message : String(error);
+      if (!/ERR_ABORTED|frame was detached/i.test(message) || attempt === 2) {
+        throw error;
+      }
+      await page.waitForTimeout(750);
+    }
+  }
+
+  throw lastError;
+}
+
 test("public pages do not render legacy under-construction banner", async ({ page }) => {
-  await page.goto("/", { waitUntil: "domcontentloaded", timeout: 60_000 });
-  await waitForRouteToSettle(page);
+  await gotoStable(page, "/");
   if (new URL(page.url()).pathname === "/preview-access") {
     test.skip(true, "Public-banner assertions are skipped while site lock is enabled.");
   }
@@ -27,8 +47,7 @@ test("public pages do not render legacy under-construction banner", async ({ pag
   await expect(page.getByTestId("header-auth-link")).toBeVisible();
   await expect(page.getByTestId("site-utility-footer")).toHaveCount(0);
 
-  await page.goto("/auth/sign-in", { waitUntil: "domcontentloaded", timeout: 60_000 });
-  await waitForRouteToSettle(page);
+  await gotoStable(page, "/auth/sign-in");
 
   await expect(page.getByTestId("soft-launch-banner")).toHaveCount(0);
   await expect(page.getByTestId("site-utility-footer")).toHaveCount(0);

--- a/tests/unit/generator-intake-hub.test.tsx
+++ b/tests/unit/generator-intake-hub.test.tsx
@@ -214,11 +214,14 @@ describe("GeneratorIntakeHub", () => {
       />
     );
 
-    expect(screen.getByRole("heading", { name: "Saved My Library context" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "One-run overrides" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Loaded from My Library" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Just this run" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Prepare the generator" })).toBeInTheDocument();
     expect(
       screen.getByText("Notes stay out of default generator prefill in v1.", { exact: false })
     ).toBeInTheDocument();
+    expect(screen.queryByTestId("generator-intake-session-count")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("generator-intake-handoff-preview")).not.toBeInTheDocument();
   });
 
   it("updates the handoff preview when blocks are excluded and overrides change", () => {
@@ -230,6 +233,7 @@ describe("GeneratorIntakeHub", () => {
       />
     );
 
+    fireEvent.click(screen.getByTestId("generator-intake-overrides-toggle"));
     fireEvent.click(screen.getByTestId("generator-intake-target-program"));
     fireEvent.change(screen.getByTestId("generator-intake-session-count"), {
       target: { value: "4" },
@@ -237,7 +241,9 @@ describe("GeneratorIntakeHub", () => {
     fireEvent.change(screen.getByTestId("generator-intake-focus-text"), {
       target: { value: "Race-pace breathing control" },
     });
+    fireEvent.click(screen.getByTestId("generator-intake-source-toggle"));
     fireEvent.click(screen.getByTestId("generator-intake-include-goals"));
+    fireEvent.click(screen.getByTestId("generator-intake-technical-toggle"));
 
     const preview = screen.getByTestId("generator-intake-handoff-preview").textContent ?? "";
     const parsed = JSON.parse(preview) as {
@@ -255,5 +261,28 @@ describe("GeneratorIntakeHub", () => {
     expect(parsed.overrides.targetType).toBe("program");
     expect(parsed.overrides.desiredSessionCount).toBe(4);
     expect(parsed.overrides.focusText).toBe("Race-pace breathing control");
+  });
+
+  it("shows swim sessions per week only for the multi-session program path", () => {
+    render(
+      <GeneratorIntakeHub
+        initialSnapshot={buildSnapshot()}
+        userId="user-1"
+        workoutLibrary={buildWorkoutLibrary()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("generator-intake-overrides-toggle"));
+
+    expect(screen.queryByTestId("generator-intake-session-count")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("generator-intake-target-program"));
+
+    expect(screen.getByText("Swim sessions per week")).toBeInTheDocument();
+    expect(screen.getByTestId("generator-intake-session-count")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("generator-intake-target-session"));
+
+    expect(screen.queryByTestId("generator-intake-session-count")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- User-visible changes: `/my-library/generator` now hides the weekly session-count control on the single-session path, relabels it to `Swim sessions per week` for the multi-session program path, and makes saved data, temporary overrides, and advanced technical preview easier to distinguish.
- Technical changes: updated `GeneratorIntakeHub`, generator shared normalization, generator page/panel copy, targeted generator tests, and hardened the unrelated `course-progress-sync` + `soft-launch-banner` Playwright tests that flaked during full verification.
- Policy impact: no - this slice changes no auth/session/account contract, analytics contract, user-data-rights path, or third-party processor behavior.
- Policy version note: N/A (no policy-impacting scope detected).

## Scope

- In scope:
  - generator intake IA/copy/progressive disclosure on `/my-library/generator`
  - conditional hiding/relabeling of the weekly session-count override
  - targeted generator unit/e2e updates
  - full-suite flake hardening discovered during verification
  - admin-note triage checkpoint updates in the active workout-builder brief
- Out of scope:
  - program planner/calendar implementation
  - AI generation logic changes
  - persistence/schema changes
  - reopening notes-prefill scope

## Brief Links

- [2026-03-28-generator-intake-ux-clarity-and-progressive-disclosure-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-03-28-generator-intake-ux-clarity-and-progressive-disclosure-10-10.md)
- [2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md)

## Risk

- Main risk: copy/disclosure cleanup could accidentally drift the canonical handoff contract or hide a needed control on the wrong path.
- Rollback plan: revert `d62c756`.

## Test Evidence

- Policy-impact checklist: N/A (no policy-impacting scope detected in changed runtime/API files).
- `npm run lint:briefs`: PASS
- `npm run lint`: PASS
- `npm run typecheck`: PASS
- `npm run test:unit`: PASS
- `npm run build`: PASS
- `npm run test:e2e`: PASS (via `npm run verify:pre-pr`; `course-progress-sync` and `soft-launch-banner` were rerun green after test hardening)
- `npm run verify:pre-pr`: PASS
- `npm run verify:pre-merge`: PENDING for `d62c756`
- Targeted validation: `npx vitest run tests/unit/generator-intake-hub.test.tsx tests/unit/generator-intake-server.test.ts tests/unit/session-generator-panel.test.tsx`
- Targeted validation: `npx playwright test tests/e2e/course-progress-sync.spec.ts tests/e2e/soft-launch-banner.spec.ts tests/e2e/my-library-generator-intake.spec.ts --project=desktop-chromium`

- [x] `npm run lint:briefs`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] `npm run test:e2e` (via `npm run verify:pre-pr`)
- [x] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL
- [ ] Vercel preview manual QA done
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached
- [ ] Mobile behavior checked

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [x] No secrets or sensitive data added
- [ ] Required checks are green
- [ ] `Squash and merge` clicked by repo owner

## Notes

- `Desired session count` is now intentionally hidden for `Single session`.
- When the generator target is `Multi-session program`, the field now reads `Swim sessions per week`.
- The technical preview is still available, but it is no longer a loud default surface.
