### PR TITLE
fix(workouts): make builder entry draft-first

### DIFF
--- a/app/my-library/page.tsx
+++ b/app/my-library/page.tsx
@@ -264,22 +264,23 @@ export default async function MyLibraryPage() {
                           ]
                             .filter(Boolean)
                             .join(" · ")
-                        : "Saved swim sessions will appear here after you start your first manual session or accept a generated draft."}
+                        : "Saved swim sessions will appear here after you create your first manual session or accept a generated draft."}
                   </p>
                 </div>
                 <div className="flex flex-wrap gap-2">
                   {workoutLibrarySnapshot.recentWorkouts[0] ? (
                     <Link
-                      href={`/my-library/workouts/${workoutLibrarySnapshot.recentWorkouts[0].id}`}
+                      href={`/my-library/workouts/${workoutLibrarySnapshot.recentWorkouts[0].id}?savedSessions=open`}
                       className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
                     >
-                      Resume latest saved session
+                      View sessions
                     </Link>
                   ) : null}
                   {workoutLibrarySnapshot.schemaReady ? (
                     <CreateManualWorkoutButton
-                      label="Start manual swim session"
+                      label="Create session"
                       testId="my-library-create-manual-workout"
+                      latestSavedWorkout={workoutLibrarySnapshot.recentWorkouts[0] ?? null}
                       className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
                     />
                   ) : null}

--- a/app/my-library/workouts/[workoutId]/page.tsx
+++ b/app/my-library/workouts/[workoutId]/page.tsx
@@ -12,14 +12,19 @@ type Params = Promise<{
   workoutId: string;
 }>;
 
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
 type Props = {
   params: Params;
+  searchParams: SearchParams;
 };
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-export default async function WorkoutBuilderPage({ params }: Props) {
+export default async function WorkoutBuilderPage({ params, searchParams }: Props) {
   const { workoutId } = await params;
+  const resolvedSearchParams = await searchParams;
+  const savedSessionsOpenByDefault = resolvedSearchParams.savedSessions === "open";
 
   if (!UUID_PATTERN.test(workoutId)) {
     notFound();
@@ -54,9 +59,8 @@ export default async function WorkoutBuilderPage({ params }: Props) {
               </p>
               <h1 className="mt-2 text-3xl font-bold text-slate-900">Swim session builder</h1>
               <p className="mt-2 max-w-[68ch] text-sm text-slate-600">
-                Open one saved swim session in its own route, edit the canonical step structure, and
-                keep the current session front and center while secondary cleanup stays out of the
-                way.
+                Edit one saved swim session at a time, keep the form front and center, and open
+                saved sessions only when you want to switch, print, or clean up older work.
               </p>
             </div>
             <div className="flex flex-wrap gap-2">
@@ -78,6 +82,7 @@ export default async function WorkoutBuilderPage({ params }: Props) {
           <div className="mt-8">
             <WorkoutBuilderHub
               workoutLibrary={workoutLibrary}
+              savedSessionsOpenByDefault={savedSessionsOpenByDefault}
               trainingFocusTitles={trainingFocusTitles}
             />
           </div>

--- a/components/my-library/workouts/CreateManualWorkoutButton.tsx
+++ b/components/my-library/workouts/CreateManualWorkoutButton.tsx
@@ -2,29 +2,38 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { buildManualWorkoutStarterDraft } from "@/lib/workouts/manual";
-import type { WorkoutSaveApiResponse } from "@/lib/workouts/shared";
+import { buildManualWorkoutEmptyDraft } from "@/lib/workouts/manual";
+import type { WorkoutSaveApiResponse, WorkoutSummary } from "@/lib/workouts/shared";
 
 type Props = {
   label?: string;
   pendingLabel?: string;
   className?: string;
   testId?: string;
+  latestSavedWorkout?: Pick<WorkoutSummary, "id" | "title"> | null;
+  currentWorkoutId?: string | null;
+  continueHrefBuilder?: (workoutId: string) => string;
 };
 
 export default function CreateManualWorkoutButton({
-  label = "Start manual swim session",
-  pendingLabel = "Starting manual swim session...",
+  label = "Create session",
+  pendingLabel = "Creating session...",
   className = "",
   testId = "create-manual-workout",
+  latestSavedWorkout = null,
+  currentWorkoutId = null,
+  continueHrefBuilder = (workoutId) => `/my-library/workouts/${workoutId}`,
 }: Props) {
   const router = useRouter();
   const [isCreating, setIsCreating] = useState(false);
+  const [showChooser, setShowChooser] = useState(false);
   const [error, setError] = useState("");
+  const continuingCurrentSession = latestSavedWorkout?.id === currentWorkoutId;
 
-  async function handleCreate() {
+  async function handleCreateEmptySession() {
     setIsCreating(true);
     setError("");
+    setShowChooser(false);
 
     try {
       const response = await fetch("/api/my-library/workouts", {
@@ -34,7 +43,7 @@ export default function CreateManualWorkoutButton({
         },
         body: JSON.stringify({
           sourceKind: "manual",
-          draft: buildManualWorkoutStarterDraft(),
+          draft: buildManualWorkoutEmptyDraft(),
         }),
       });
       const responseBody = (await response
@@ -43,7 +52,7 @@ export default function CreateManualWorkoutButton({
 
       if (!response.ok || !responseBody?.ok) {
         setError(
-          responseBody && !responseBody.ok ? responseBody.error : "Could not create workout."
+          responseBody && !responseBody.ok ? responseBody.error : "Could not create session."
         );
         return;
       }
@@ -51,10 +60,36 @@ export default function CreateManualWorkoutButton({
       router.push(`/my-library/workouts/${responseBody.workout.id}`);
       router.refresh();
     } catch {
-      setError("Could not create workout.");
+      setError("Could not create session.");
     } finally {
       setIsCreating(false);
     }
+  }
+
+  function handleContinueLatestSession() {
+    setError("");
+
+    if (!latestSavedWorkout) {
+      return;
+    }
+
+    if (continuingCurrentSession) {
+      setShowChooser(false);
+      return;
+    }
+
+    router.push(continueHrefBuilder(latestSavedWorkout.id));
+    router.refresh();
+  }
+
+  function handlePrimaryAction() {
+    if (latestSavedWorkout) {
+      setShowChooser((current) => !current);
+      setError("");
+      return;
+    }
+
+    void handleCreateEmptySession();
   }
 
   return (
@@ -62,12 +97,59 @@ export default function CreateManualWorkoutButton({
       <button
         type="button"
         data-testid={testId}
-        onClick={handleCreate}
+        onClick={handlePrimaryAction}
         disabled={isCreating}
         className={className}
       >
         {isCreating ? pendingLabel : label}
       </button>
+      {showChooser && latestSavedWorkout ? (
+        <div
+          data-testid={`${testId}-chooser`}
+          className="rounded-2xl border border-blue-200 bg-blue-50/80 p-4"
+        >
+          <p className="text-sm font-semibold text-blue-950">
+            {continuingCurrentSession
+              ? "Keep editing this current session, or start a clean new one from scratch."
+              : "You already have a saved session. Continue it, or start a clean new one from scratch."}
+          </p>
+          <p className="mt-1 text-sm text-blue-900/90">
+            {continuingCurrentSession
+              ? `Current session: ${latestSavedWorkout.title}`
+              : `Latest saved session: ${latestSavedWorkout.title}`}
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              data-testid={`${testId}-continue`}
+              onClick={handleContinueLatestSession}
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-4 text-sm font-medium text-blue-900 transition hover:bg-blue-100 active:bg-blue-200"
+            >
+              {continuingCurrentSession
+                ? "Keep editing current session"
+                : "Continue latest saved session"}
+            </button>
+            <button
+              type="button"
+              data-testid={`${testId}-start-scratch`}
+              onClick={() => void handleCreateEmptySession()}
+              disabled={isCreating}
+              className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+            >
+              {isCreating ? pendingLabel : "Start from scratch"}
+            </button>
+            <button
+              type="button"
+              data-testid={`${testId}-cancel`}
+              onClick={() => setShowChooser(false)}
+              disabled={isCreating}
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : null}
       {error ? (
         <p data-testid={`${testId}-error`} className="text-sm text-rose-700">
           {error}

--- a/components/my-library/workouts/SavedWorkoutsPanel.tsx
+++ b/components/my-library/workouts/SavedWorkoutsPanel.tsx
@@ -25,6 +25,8 @@ type Props = {
   deletingWorkoutId?: string | null;
   printButtonTestIdBuilder?: (workoutId: string) => string;
   poolsidePdfButtonTestIdBuilder?: (workoutId: string) => string;
+  currentWorkoutId?: string | null;
+  showToggle?: boolean;
 };
 
 export default function SavedWorkoutsPanel({
@@ -47,6 +49,8 @@ export default function SavedWorkoutsPanel({
   deletingWorkoutId = null,
   printButtonTestIdBuilder = (workoutId) => `saved-workouts-print-${workoutId}`,
   poolsidePdfButtonTestIdBuilder = (workoutId) => `saved-workouts-poolside-${workoutId}`,
+  currentWorkoutId = null,
+  showToggle = true,
 }: Props) {
   const [expanded, setExpanded] = useState(() => !collapsedByDefault);
 
@@ -70,24 +74,27 @@ export default function SavedWorkoutsPanel({
             {workouts.length} saved session{workouts.length === 1 ? "" : "s"} ready to reopen
           </p>
         </div>
-        <button
-          type="button"
-          onClick={() => setExpanded((current) => !current)}
-          aria-expanded={expanded}
-          data-testid={`${testId}-toggle`}
-          className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
-        >
-          {expanded ? "Hide saved sessions" : "Show saved sessions"}
-        </button>
+        {showToggle ? (
+          <button
+            type="button"
+            onClick={() => setExpanded((current) => !current)}
+            aria-expanded={expanded}
+            data-testid={`${testId}-toggle`}
+            className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+          >
+            {expanded ? "Hide saved sessions" : "Show saved sessions"}
+          </button>
+        ) : null}
       </div>
 
-      {expanded ? (
+      {!showToggle || expanded ? (
         <div className="mt-4 grid gap-3">
           {workouts.map((workout) => {
             const deleting = deletingWorkoutId === workout.id;
             const pendingDelete = pendingDeleteWorkoutId === workout.id;
             const workoutPdfHref = workoutPdfHrefBuilder?.(workout.id) ?? null;
             const workoutPoolsidePdfHref = workoutPoolsidePdfHrefBuilder?.(workout.id) ?? null;
+            const isCurrentWorkout = currentWorkoutId === workout.id;
 
             return (
               <div
@@ -97,7 +104,17 @@ export default function SavedWorkoutsPanel({
               >
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div>
-                    <p className="text-sm font-semibold text-slate-900">{workout.title}</p>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="text-sm font-semibold text-slate-900">{workout.title}</p>
+                      {isCurrentWorkout ? (
+                        <span
+                          data-testid={`saved-workout-current-${workout.id}`}
+                          className="rounded-full bg-blue-50 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-blue-700"
+                        >
+                          Current
+                        </span>
+                      ) : null}
+                    </div>
                     <p className="mt-1 text-sm text-slate-600">
                       {workout.totalDistanceM ? `${workout.totalDistanceM}m` : null}
                       {workout.totalDistanceM && workout.estimatedDurationMin ? " · " : null}
@@ -107,13 +124,15 @@ export default function SavedWorkoutsPanel({
                     </p>
                   </div>
                   <div className="flex flex-wrap items-center gap-2">
-                    <Link
-                      href={workoutHrefBuilder(workout.id)}
-                      data-testid={editButtonTestIdBuilder(workout.id)}
-                      className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
-                    >
-                      {editLabel}
-                    </Link>
+                    {!isCurrentWorkout ? (
+                      <Link
+                        href={workoutHrefBuilder(workout.id)}
+                        data-testid={editButtonTestIdBuilder(workout.id)}
+                        className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+                      >
+                        {editLabel}
+                      </Link>
+                    ) : null}
                     {workoutPdfHref ? (
                       <Link
                         href={workoutPdfHref}
@@ -136,7 +155,7 @@ export default function SavedWorkoutsPanel({
                         Poolside PDF
                       </Link>
                     ) : null}
-                    {typeof onRequestDeleteWorkout === "function" ? (
+                    {!isCurrentWorkout && typeof onRequestDeleteWorkout === "function" ? (
                       <button
                         type="button"
                         onClick={() => onRequestDeleteWorkout(workout)}

--- a/components/my-library/workouts/WorkoutBuilderHub.tsx
+++ b/components/my-library/workouts/WorkoutBuilderHub.tsx
@@ -19,6 +19,7 @@ import { haveWorkoutDraftChanges } from "@/lib/workouts/shared";
 type Props = {
   workoutLibrary: WorkoutLibrarySnapshot;
   trainingFocusTitles?: string[];
+  savedSessionsOpenByDefault?: boolean;
 };
 
 function upsertRecentWorkoutSummary(current: WorkoutSummary[], next: WorkoutSummary) {
@@ -26,7 +27,11 @@ function upsertRecentWorkoutSummary(current: WorkoutSummary[], next: WorkoutSumm
   return [next, ...existing].slice(0, 6);
 }
 
-export default function WorkoutBuilderHub({ workoutLibrary, trainingFocusTitles = [] }: Props) {
+export default function WorkoutBuilderHub({
+  workoutLibrary,
+  trainingFocusTitles = [],
+  savedSessionsOpenByDefault = false,
+}: Props) {
   const router = useRouter();
   const [savedWorkout, setSavedWorkout] = useState<WorkoutEditorRecord | null>(
     workoutLibrary.selectedWorkout
@@ -39,17 +44,17 @@ export default function WorkoutBuilderHub({ workoutLibrary, trainingFocusTitles 
   const [pendingDeleteWorkoutId, setPendingDeleteWorkoutId] = useState<string | null>(null);
   const [deletingWorkoutId, setDeletingWorkoutId] = useState<string | null>(null);
   const [pendingCurrentDelete, setPendingCurrentDelete] = useState(false);
+  const [savedSessionsOpen, setSavedSessionsOpen] = useState(savedSessionsOpenByDefault);
   const [clientReady, setClientReady] = useState(false);
   const hasUnsavedChanges = haveWorkoutDraftChanges(draft, savedWorkout?.draft ?? null);
-  const currentWorkoutCardCopy = savedWorkout
-    ? (recentWorkouts.find((summary) => summary.id === savedWorkout.id) ?? {
-        id: savedWorkout.id,
-        title: savedWorkout.draft.title,
-      })
-    : null;
-  const alternateRecentWorkouts = savedWorkout
-    ? recentWorkouts.filter((summary) => summary.id !== savedWorkout.id)
-    : recentWorkouts;
+  const latestSavedWorkout =
+    recentWorkouts[0] ??
+    (savedWorkout
+      ? {
+          id: savedWorkout.id,
+          title: savedWorkout.draft.title,
+        }
+      : null);
 
   useAutoDismissNotice(success, setSuccess);
 
@@ -66,10 +71,12 @@ export default function WorkoutBuilderHub({ workoutLibrary, trainingFocusTitles 
     setPendingDeleteWorkoutId(null);
     setDeletingWorkoutId(null);
     setPendingCurrentDelete(false);
+    setSavedSessionsOpen(savedSessionsOpenByDefault);
   }, [
     workoutLibrary.recentWorkouts,
     workoutLibrary.selectedWorkout,
     workoutLibrary.selectedWorkoutMissing,
+    savedSessionsOpenByDefault,
   ]);
 
   async function saveWorkout() {
@@ -172,22 +179,54 @@ export default function WorkoutBuilderHub({ workoutLibrary, trainingFocusTitles 
         <div>
           <h2 className="text-lg font-semibold text-slate-900">Swim session builder</h2>
           <p className="mt-2 max-w-[66ch] text-sm text-slate-600">
-            Create or edit one canonical swim session in a dedicated route. Keep the editor as the
-            primary workspace, then open saved sessions only when you want to switch, print, or
-            clean up older work.
+            {savedWorkout
+              ? "Keep the session form front and center while you edit one saved swim session. Open saved sessions only when you want to switch, print, or clean up older work."
+              : "View saved sessions when you want to reopen existing work, or create a new empty swim session from scratch."}
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          {recentWorkouts.length > 0 ? (
+            <button
+              type="button"
+              data-testid="workout-builder-view-sessions"
+              onClick={() => setSavedSessionsOpen((current) => !current)}
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+            >
+              {savedSessionsOpen ? "Hide sessions" : "View sessions"}
+            </button>
+          ) : null}
           {workoutLibrary.schemaReady ? (
             <CreateManualWorkoutButton
-              label="Start manual swim session"
+              label="Create session"
               testId="workout-builder-create-manual"
+              latestSavedWorkout={
+                savedWorkout
+                  ? {
+                      id: savedWorkout.id,
+                      title: savedWorkout.draft.title,
+                    }
+                  : latestSavedWorkout
+              }
+              currentWorkoutId={savedWorkout?.id ?? null}
               className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
             />
           ) : null}
-          <p className="rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">
-            Saved session workspace
-          </p>
+          {savedWorkout ? (
+            <button
+              type="button"
+              onClick={() => {
+                setPendingCurrentDelete(true);
+                setPendingDeleteWorkoutId(null);
+                setError("");
+                setSuccess("");
+              }}
+              disabled={deletingWorkoutId === savedWorkout.id}
+              data-testid="workout-builder-delete-current-workout"
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-700 transition hover:bg-rose-50 active:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {deletingWorkoutId === savedWorkout.id ? "Deleting..." : "Delete current session"}
+            </button>
+          ) : null}
         </div>
       </div>
 
@@ -219,68 +258,40 @@ export default function WorkoutBuilderHub({ workoutLibrary, trainingFocusTitles 
       ) : null}
 
       <div className="mt-6 space-y-5">
-        {savedWorkout && currentWorkoutCardCopy ? (
+        {savedWorkout && pendingCurrentDelete ? (
           <div
             data-testid="workout-builder-current-workout-actions"
-            className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4"
+            className="rounded-2xl border border-rose-200 bg-rose-50/80 p-4"
           >
-            <div className="flex flex-wrap items-start justify-between gap-3">
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                  Current saved session
-                </p>
-                <p className="mt-2 text-sm font-semibold text-slate-900">
-                  {savedWorkout.draft.title}
-                </p>
-                <p className="mt-1 max-w-[72ch] text-sm text-slate-600">
-                  Keep editing this saved session below. Delete it here only when you want to remove
-                  the session from My Library entirely.
-                </p>
-              </div>
+            <p className="text-sm font-medium text-rose-900">Delete this saved session?</p>
+            <p className="mt-1 text-sm text-rose-900/90">
+              This removes <span className="font-semibold">{savedWorkout.draft.title}</span> from My
+              Library and discards any unsaved local builder edits tied to it.
+            </p>
+            <div className="mt-3 flex flex-wrap items-center gap-2">
               <button
                 type="button"
-                onClick={() => {
-                  setPendingCurrentDelete(true);
-                  setPendingDeleteWorkoutId(null);
-                  setError("");
-                  setSuccess("");
-                }}
+                onClick={() =>
+                  void confirmDeleteWorkout({
+                    id: savedWorkout.id,
+                    title: savedWorkout.draft.title,
+                  })
+                }
                 disabled={deletingWorkoutId === savedWorkout.id}
-                data-testid="workout-builder-delete-current-workout"
+                data-testid="workout-builder-confirm-delete-current-workout"
+                className="inline-flex h-10 items-center justify-center rounded-xl bg-rose-600 px-4 text-sm font-semibold text-white transition hover:bg-rose-500 active:bg-rose-700 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {deletingWorkoutId === savedWorkout.id ? "Deleting..." : "Delete current session"}
+              </button>
+              <button
+                type="button"
+                onClick={() => setPendingCurrentDelete(false)}
+                disabled={deletingWorkoutId === savedWorkout.id}
                 className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-700 transition hover:bg-rose-50 active:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-60"
               >
-                {deletingWorkoutId === savedWorkout.id ? "Deleting..." : "Delete saved session"}
+                Cancel
               </button>
             </div>
-
-            {pendingCurrentDelete ? (
-              <div className="mt-3 rounded-2xl border border-rose-200 bg-rose-50/80 p-3">
-                <p className="text-sm font-medium text-rose-900">Delete this saved session?</p>
-                <p className="mt-1 text-sm text-rose-900/90">
-                  This removes the saved canonical session from My Library and discards any unsaved
-                  local builder edits tied to it.
-                </p>
-                <div className="mt-3 flex flex-wrap items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => void confirmDeleteWorkout(currentWorkoutCardCopy)}
-                    disabled={deletingWorkoutId === savedWorkout.id}
-                    data-testid="workout-builder-confirm-delete-current-workout"
-                    className="inline-flex h-10 items-center justify-center rounded-xl bg-rose-600 px-4 text-sm font-semibold text-white transition hover:bg-rose-500 active:bg-rose-700 disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    {deletingWorkoutId === savedWorkout.id ? "Deleting..." : "Delete saved session"}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setPendingCurrentDelete(false)}
-                    disabled={deletingWorkoutId === savedWorkout.id}
-                    className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-700 transition hover:bg-rose-50 active:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </div>
-            ) : null}
           </div>
         ) : null}
 
@@ -293,14 +304,25 @@ export default function WorkoutBuilderHub({ workoutLibrary, trainingFocusTitles 
                   : "No saved swim session is loaded in this route yet."}
               </p>
               <p className="mt-2 text-sm text-amber-900/90">
-                Start a manual swim session here, return to the generator for a brand-new AI draft,
-                or reopen another saved session below when you want to switch context.
+                Open saved sessions only when you want to switch back to older work, or create a new
+                session from scratch when you want a clean shell.
               </p>
               <div className="mt-4 flex flex-wrap gap-2">
+                {recentWorkouts.length > 0 ? (
+                  <button
+                    type="button"
+                    data-testid="workout-builder-empty-view-sessions"
+                    onClick={() => setSavedSessionsOpen((current) => !current)}
+                    className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+                  >
+                    {savedSessionsOpen ? "Hide sessions" : "View sessions"}
+                  </button>
+                ) : null}
                 {workoutLibrary.schemaReady ? (
                   <CreateManualWorkoutButton
-                    label="Start manual swim session"
+                    label="Create session"
                     testId="workout-builder-empty-create-manual"
+                    latestSavedWorkout={latestSavedWorkout}
                     className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
                   />
                 ) : null}
@@ -341,48 +363,54 @@ export default function WorkoutBuilderHub({ workoutLibrary, trainingFocusTitles 
               startNewDraftLabel="Generate new draft"
               showLoadedBanner={false}
               showPdfPanel={false}
-              recentWorkoutsDescription="Open another saved session here, start a fresh manual session from the header, or jump back to the generator when you want a brand-new AI draft."
+              recentWorkoutsDescription="Use the header actions when you want to view saved sessions, create a clean new session, or jump back to the generator."
               workoutHrefBuilder={(workoutId) => `/my-library/workouts/${workoutId}`}
               saveButtonTestId="workout-builder-save"
             />
           </div>
         ) : null}
 
-        <SavedWorkoutsPanel
-          workouts={alternateRecentWorkouts}
-          heading={savedWorkout ? "Open another saved session" : "Saved swim sessions"}
-          description={
-            savedWorkout
-              ? "Open, print, or delete another saved session here only when you want to switch context or clean up older work."
-              : "Open, print, or delete a saved swim session here, or create a fresh manual session above."
-          }
-          workoutHrefBuilder={(workoutId) => `/my-library/workouts/${workoutId}`}
-          workoutPdfHrefBuilder={(workoutId) => `/api/my-library/workouts/${workoutId}/export/pdf`}
-          workoutPoolsidePdfHrefBuilder={(workoutId) =>
-            `/api/my-library/workouts/${workoutId}/export/pdf?variant=poolside`
-          }
-          editLabel="Edit"
-          testId="session-generator-recent-workouts"
-          editButtonTestIdBuilder={(workoutId) =>
-            savedWorkout
-              ? `session-generator-open-workout-${workoutId}`
-              : `workout-builder-open-workout-${workoutId}`
-          }
-          deleteButtonTestIdBuilder={(workoutId) => `workout-builder-delete-workout-${workoutId}`}
-          confirmDeleteButtonTestIdBuilder={(workoutId) =>
-            `workout-builder-confirm-delete-workout-${workoutId}`
-          }
-          onRequestDeleteWorkout={(workout) => {
-            setPendingDeleteWorkoutId(workout.id);
-            setPendingCurrentDelete(false);
-            setError("");
-            setSuccess("");
-          }}
-          onCancelDeleteWorkout={() => setPendingDeleteWorkoutId(null)}
-          onConfirmDeleteWorkout={confirmDeleteWorkout}
-          pendingDeleteWorkoutId={pendingDeleteWorkoutId}
-          deletingWorkoutId={deletingWorkoutId}
-        />
+        {savedSessionsOpen ? (
+          <SavedWorkoutsPanel
+            workouts={recentWorkouts}
+            heading="Saved sessions"
+            description={
+              savedWorkout
+                ? "Open another saved session, print the current one, or clean up older work without leaving the builder."
+                : "Open, print, or delete a saved swim session here, or create a fresh clean session above."
+            }
+            workoutHrefBuilder={(workoutId) => `/my-library/workouts/${workoutId}`}
+            workoutPdfHrefBuilder={(workoutId) =>
+              `/api/my-library/workouts/${workoutId}/export/pdf`
+            }
+            workoutPoolsidePdfHrefBuilder={(workoutId) =>
+              `/api/my-library/workouts/${workoutId}/export/pdf?variant=poolside`
+            }
+            editLabel="Open"
+            testId="session-generator-recent-workouts"
+            currentWorkoutId={savedWorkout?.id ?? null}
+            showToggle={false}
+            editButtonTestIdBuilder={(workoutId) =>
+              savedWorkout
+                ? `session-generator-open-workout-${workoutId}`
+                : `workout-builder-open-workout-${workoutId}`
+            }
+            deleteButtonTestIdBuilder={(workoutId) => `workout-builder-delete-workout-${workoutId}`}
+            confirmDeleteButtonTestIdBuilder={(workoutId) =>
+              `workout-builder-confirm-delete-workout-${workoutId}`
+            }
+            onRequestDeleteWorkout={(workout) => {
+              setPendingDeleteWorkoutId(workout.id);
+              setPendingCurrentDelete(false);
+              setError("");
+              setSuccess("");
+            }}
+            onCancelDeleteWorkout={() => setPendingDeleteWorkoutId(null)}
+            onConfirmDeleteWorkout={confirmDeleteWorkout}
+            pendingDeleteWorkoutId={pendingDeleteWorkoutId}
+            deletingWorkoutId={deletingWorkoutId}
+          />
+        ) : null}
       </div>
     </section>
   );

--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -2320,6 +2320,20 @@ export default function WorkoutEditor({
         </div>
 
         <div className="mt-4 space-y-4">
+          {stepGroups.length === 0 ? (
+            <div
+              data-testid="session-draft-empty-steps"
+              className="rounded-2xl border border-dashed border-slate-300 bg-slate-50/80 p-4"
+            >
+              <p className="text-sm font-medium text-slate-900">
+                Start from a clean empty session.
+              </p>
+              <p className="mt-1 text-sm text-slate-600">
+                Add your first step or repeat block below when you are ready to build from scratch.
+              </p>
+            </div>
+          ) : null}
+
           {pendingRemoval ? (
             <div
               data-testid="workout-editor-removal-confirm"

--- a/docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md
@@ -107,6 +107,13 @@ Triage update on `2026-03-29`:
   - `a73a376b-1912-457f-9df6-474ffaf48b4c` `What is this?`
   - `7e075645-84e8-4fcb-a23e-518862ad03d5` `Ehy i smh library button here`
 
+Triage update on `2026-03-29` for the current builder-entry follow-up:
+
+- `d487ac23-a1e0-4be9-938a-7407a3c35fe0` `Swim Session Builder`
+  - disposition: owned by this brief.
+  - reason: the production note is a direct continuation of the active builder-entry IA work and asks for a focused `View sessions` / `Create session` model, a truthful continue-vs-start-new choice, and a more form-first builder route.
+  - implementation constraint: there is still no separate cross-page unsaved local draft entity, so `continue draft` must be expressed truthfully as continuing the latest saved/current canonical session rather than implying a hidden draft store.
+
 ## Platform 10/10 Scorecard Mapping
 
 Reference: `docs/quality/platform-10-10-scorecard.md`
@@ -192,6 +199,10 @@ Critical target categories for `10/10` claim in this brief:
   - delete workout,
   - consistent open/edit affordances,
   - truthful print/PDF affordances.
+- Make builder entry and resume choices easier to understand:
+  - `View sessions` for existing saved sessions,
+  - `Create session` for a new manual session,
+  - if a saved/current session already exists, offer a small continue-vs-start-new decision instead of silently creating another scaffold.
 - Rationalize builder/export entrypoints so redundant or misleading print controls are removed or merged into one clearer flow.
 - Make noisy builder support panels calmer by default:
   - Garmin JSON,
@@ -208,6 +219,9 @@ Critical target categories for `10/10` claim in this brief:
   - extra mode buttons such as `Explore mode` / redundant `My Library` controls,
   - whether those surfaces should be hidden, renamed, or explained.
 - Tune poolside/PDF output toward the observed real-world print use case without promising a broader document system than we actually support.
+- Keep the builder route form-first:
+  - when a session is being edited, the session form should remain the dominant surface,
+  - saved-session browsing should stay secondary behind an explicit action instead of always sharing equal visual weight.
 
 ## Out Of Scope
 
@@ -229,7 +243,9 @@ Critical target categories for `10/10` claim in this brief:
 7. My Library no longer shows unexplained `Program shell` or confusing mode buttons without an explicit IA decision.
 8. Poolside/PDF affordances are truthful to the actual supported output, and the preferred print flow is clearer than the current state.
 9. Relevant production admin notes listed above remain explicitly owned by this brief until shipped or intentionally split again.
-10. `npm run lint:briefs`, targeted validation, and `npm run verify:pre-pr` pass before PR update.
+10. Builder entry uses explicit `View sessions` and `Create session` actions, and creating a new manual session from an environment with existing saved work offers a truthful continue-vs-start-new choice.
+11. Starting a new manual session opens a clean scratch session shell rather than a multi-block starter set, while still preserving canonical save guarantees and clear session identity.
+12. `npm run lint:briefs`, targeted validation, and `npm run verify:pre-pr` pass before PR update.
 
 ## Validation
 
@@ -255,6 +271,7 @@ Critical target categories for `10/10` claim in this brief:
 ## Checkpoint Log
 
 - `2026-03-29` — slice 5 implemented on branch `fix/workout-builder-ux-ia-cleanup-2026-03-29`; simplified My Library IA by removing the extra owned/explore jump controls, reframed the early program surface as an optional `Program builder preview`, made manual session entry language more direct, tightened current-session delete copy, and moved builder-route PDF access into the save/action bar instead of a separate support panel. Targeted `typecheck`, builder unit tests, `my-library-workout-builder` desktop Chromium, and `my-library-program-export` desktop Chromium (schema-gated skip after updated readiness detection) are green. Next step: run `npm run lint:briefs` and `npm run verify:pre-pr`, then open/update a PR if green.
+- `2026-03-29` — added production note `d487ac23-a1e0-4be9-938a-7407a3c35fe0` `Swim Session Builder` to this brief. The next slice will make entry actions explicit (`View sessions` / `Create session`), use a truthful continue-vs-start-new chooser when saved work already exists, switch manual create to a clean scratch session shell, and keep saved-session browsing secondary behind an explicit action so the builder route stays form-first.
 - `2026-03-28` — slice 4 implemented on branch `fix/workout-builder-focused-entry-2026-03-28`; renamed the workout-builder surface to `Swim session builder`, made the current saved session/editor the primary route focus, kept other saved sessions secondary instead of duplicating the active one, and simplified row-level PDF language from `Poolside PDF` to `PDF`. Targeted `vitest`, `typecheck`, and desktop-chromium generator/workout-builder e2e are green. Next step: run `npm run lint:briefs` and `npm run verify:pre-pr`, then open a PR if green.
 - `2026-03-27` — moved to `in-progress` on branch `fix/workout-builder-live-review-actions-2026-03-27`; first implementation slice adds owner-scoped workout delete API/UI, calmer collapsed support panels, builder label cleanup, and My Library wording cleanup. Next step: finish targeted validation and run `npm run verify:pre-pr`.
 - `2026-03-28` — slice 3 implemented on branch `fix/workout-builder-current-actions-2026-03-28`; added current-workout action strip, clearer PDF state copy, bluer poolside PDF styling, and targeted generator-intake auth-redirect hardening after a confirmed `verify:pre-merge` auth/Supabase flake. Next step: rerun targeted generator-intake coverage, rerun `npm run verify:pre-merge`, then merge if green.
@@ -358,6 +375,7 @@ Critical target categories for `10/10` claim in this brief:
 
 ## Checkpoint Log
 
+- `2026-03-29 | implementation | slice 7 on branch fix/workout-builder-draft-first-entry-2026-03-29 makes builder entry explicit with `View sessions`and`Create session`, adds a truthful continue-vs-start-scratch chooser whenever saved work already exists, opens the builder route with saved sessions hidden unless explicitly requested, and switches manual create to a cleaner scratch session shell that still respects current workout persistence constraints; targeted unit + desktop-chromium builder e2e + desktop-chromium program-export e2e and full npm run verify:pre-pr are green | next: commit, push, open/update PR, then wait for CI before npm run verify:pre-merge`
 - `2026-03-29 | implementation | slice 6 on branch fix/workout-builder-pdf-poolside-v2-2026-03-29 splits the builder export into a richer full-session PDF and a real compact Poolside PDF, threads open training focuses into the poolside variant, makes one-line-per-interval poolside layout explicit, and surfaces both PDF actions consistently in the editor and saved-session list; targeted typecheck, workout PDF/shared vitest, workout route vitest, builder hub vitest, and desktop-chromium my-library workout-builder e2e are green | next: run npm run verify:pre-pr, then open/update a PR if the full gate stays green`
 - `2026-03-27 | planning | created a dedicated workout-builder live-review UX/actions brief to own the current production-note batch around delete/edit/print actions, calmer panel defaults, form copy cleanup, poolside PDF truthfulness, and My Library IA confusion before program-builder work resumes | next: review manual workout-builder usage against this brief, then pick the first narrow implementation slice`
 - `2026-03-28 | implementation | slice 2 on branch fix/workout-builder-pdf-notices-2026-03-28 adds row-level canonical Poolside PDF links for saved workouts, auto-dismisses transient builder success notices, and clarifies kick/drill authoring guidance without changing the canonical workout model; targeted typecheck, vitest, and desktop-chromium workout-builder e2e are green | next: update runbook coverage, then run npm run lint:briefs and npm run verify:pre-pr`

--- a/lib/workouts/manual.ts
+++ b/lib/workouts/manual.ts
@@ -91,6 +91,26 @@ function buildStarterSteps(seed: string): SessionDraftStep[] {
   ];
 }
 
+function buildCleanStarterSteps(seed: string): SessionDraftStep[] {
+  return [
+    {
+      id: buildStepId(seed, 0),
+      category: "main",
+      name: "First step",
+      stroke: "freestyle",
+      drillType: "none",
+      equipment: "none",
+      intensity: "moderate",
+      durationMode: "distance",
+      distanceM: 100,
+      timeMin: null,
+      targetMode: "none",
+      targetSummary: "",
+      notes: "",
+    },
+  ];
+}
+
 export function buildManualWorkoutStarterDraft(now = new Date()): SessionDraft {
   const createdAt = now.toISOString();
   const seed = createdAt.replace(/[^0-9]/g, "").slice(0, 14);
@@ -123,6 +143,47 @@ export function buildManualWorkoutStarterDraft(now = new Date()): SessionDraft {
     constraintText: null,
     warnings: [],
     steps,
+  };
+  const totals = computeSessionDraftDerivedTotals(baseDraft);
+
+  return {
+    ...baseDraft,
+    totalDistanceM: totals.totalDistanceM,
+    estimatedDurationMin: totals.estimatedDurationMin,
+  };
+}
+
+export function buildManualWorkoutEmptyDraft(now = new Date()): SessionDraft {
+  const createdAt = now.toISOString();
+  const seed = createdAt.replace(/[^0-9]/g, "").slice(0, 14);
+  const title = "Untitled swim session";
+  const baseDraft: SessionDraft = {
+    version: 1,
+    status: "draft",
+    generatorKind: "rule_engine_v1",
+    createdAt,
+    sourceFingerprint: `manual-empty-${seed}`,
+    title,
+    titleSuggestions: [title],
+    description: "",
+    environment: "pool",
+    poolLengthM: 25,
+    sessionType: "endurance",
+    effort: "moderate",
+    sizeMode: "distance",
+    targetDistanceM: null,
+    targetTimeMin: null,
+    totalDistanceM: null,
+    estimatedDurationMin: null,
+    basePaceSecondsPer100m: 120,
+    usedCssPaceLabel: null,
+    allowedStrokes: ["freestyle"],
+    equipmentAllowlist: [],
+    focusText: null,
+    goalTitle: null,
+    constraintText: null,
+    warnings: [],
+    steps: buildCleanStarterSteps(seed),
   };
   const totals = computeSessionDraftDerivedTotals(baseDraft);
 

--- a/lib/workouts/shared.ts
+++ b/lib/workouts/shared.ts
@@ -1825,7 +1825,6 @@ export function normalizeSessionDraftForWorkoutPersistence(
     normalizedDraft.sizeMode === "estimated_time"
       ? (normalizedDraft.targetTimeMin ?? totals.estimatedDurationMin)
       : null;
-
   if (normalizedDraft.sizeMode === "distance" && targetDistanceM === null) {
     return { ok: false, error: "Distance-based workouts need a target distance before saving." };
   }

--- a/tests/e2e/my-library-program-export.spec.ts
+++ b/tests/e2e/my-library-program-export.spec.ts
@@ -59,6 +59,16 @@ async function ensureProgramSchemaReady(page: Page) {
   }
 }
 
+async function triggerCreateSession(page: Page, testId: string) {
+  await page.getByTestId(testId).click();
+  const startScratchButton = page.getByTestId(`${testId}-start-scratch`);
+  const chooserVisible = await startScratchButton.isVisible({ timeout: 1_500 }).catch(() => false);
+
+  if (chooserVisible) {
+    await startScratchButton.click();
+  }
+}
+
 test.describe("my library program export", () => {
   test("exports a saved canonical program as garmin-ready json and printable pdf", async ({
     page,
@@ -80,7 +90,7 @@ test.describe("my library program export", () => {
         response.status() === 200
     );
 
-    await page.getByTestId("my-library-create-manual-workout").click();
+    await triggerCreateSession(page, "my-library-create-manual-workout");
     await createWorkoutResponsePromise;
     await page.waitForURL(/\/my-library\/workouts\/[0-9a-f-]+$/, {
       timeout: 20_000,

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -42,8 +42,18 @@ async function waitForWorkoutBuilderSaveReady(page: Page) {
   await expect(saveButton).toBeVisible({ timeout: 15_000 });
 }
 
+async function triggerCreateSession(page: Page, testId: string) {
+  await page.getByTestId(testId).click();
+  const startScratchButton = page.getByTestId(`${testId}-start-scratch`);
+  const chooserVisible = await startScratchButton.isVisible({ timeout: 1_500 }).catch(() => false);
+
+  if (chooserVisible) {
+    await startScratchButton.click();
+  }
+}
+
 test.describe("my library workout builder", () => {
-  test("creates a manual starter workout and saves canonical edits", async ({ page }, testInfo) => {
+  test("creates a clean new swim session and saves canonical edits", async ({ page }, testInfo) => {
     runOnceOnDesktopChromium(testInfo.project.name);
     test.slow();
 
@@ -61,7 +71,7 @@ test.describe("my library workout builder", () => {
         response.status() === 200
     );
 
-    await page.getByTestId("my-library-create-manual-workout").click();
+    await triggerCreateSession(page, "my-library-create-manual-workout");
     await createResponsePromise;
     await page.waitForURL(/\/my-library\/workouts\/[0-9a-f-]+$/, {
       timeout: 10_000,
@@ -70,18 +80,10 @@ test.describe("my library workout builder", () => {
     await waitForWorkoutBuilderClientReady(page);
     await waitForWorkoutBuilderSaveReady(page);
 
-    await expect(page.getByTestId("session-draft-title")).toHaveValue("Manual pool workout");
+    await expect(page.getByTestId("session-draft-title")).toHaveValue("Untitled swim session");
     await expect(page.getByTestId("session-draft-step-toggle-0")).toBeVisible();
-    await expect(page.getByTestId("session-draft-step-name-0")).toHaveCount(0);
     await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
       "All builder changes are saved to the canonical workout."
-    );
-    await expect(page.getByTestId("workout-editor-garmin-readiness")).toHaveAttribute(
-      "data-readiness-status",
-      "ready"
-    );
-    await expect(page.getByTestId("workout-editor-garmin-readiness-summary")).toHaveText(
-      "Ready for the planned Garmin/export handoff."
     );
     await page.getByTestId("workout-editor-garmin-export-toggle").click();
     await page.getByTestId("workout-editor-handoff-toggle").click();
@@ -93,7 +95,7 @@ test.describe("my library workout builder", () => {
       "Source: Canonical workout"
     );
     await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(
-      "Title: Manual pool workout"
+      "Title: Untitled swim session"
     );
     await expect(page.getByTestId("workout-editor-garmin-export-source")).toHaveAttribute(
       "data-export-state",
@@ -117,9 +119,12 @@ test.describe("my library workout builder", () => {
       "Source: Canonical workout"
     );
     await expect(savedWorkoutPdfPopup.locator('[data-testid="workout-pdf-title"]')).toContainText(
-      "Manual pool workout"
+      "Untitled swim session"
     );
     await savedWorkoutPdfPopup.close();
+
+    await page.getByTestId("session-draft-step-toggle-0").click();
+    await page.getByTestId("session-draft-step-name-0").fill("Warmup swim");
 
     await page.getByTestId("session-draft-step-remove-0").click();
     await expect(page.getByTestId("workout-editor-removal-confirm")).toContainText(
@@ -139,43 +144,24 @@ test.describe("my library workout builder", () => {
     await page.getByTestId("workout-editor-removal-undo-button").click();
     await expect(page.getByTestId("workout-editor-removal-undo")).toHaveCount(0);
     await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
-      "All builder changes are saved to the canonical workout."
+      "Unsaved changes stay local until you save this workout."
     );
-    await expect(page.getByTestId("workout-builder-save")).toBeDisabled();
+    await expect(page.getByTestId("workout-builder-save")).toBeEnabled();
 
-    await page.getByTestId("session-draft-step-toggle-0").click();
     await expect(page.getByTestId("session-draft-step-name-0")).toHaveValue("Warmup swim");
-    await page.getByTestId("session-draft-step-toggle-0").click();
-    await expect(page.getByTestId("session-draft-step-name-0")).toHaveCount(0);
-
     await page.getByTestId("session-draft-pool-length-input").fill("33.33");
-    await page.getByTestId("session-draft-step-toggle-0").click();
     await page.getByTestId("session-draft-step-distance-0").selectOption("custom");
     await page.getByTestId("session-draft-step-distance-custom-0").fill("333");
     await page.getByTestId("session-draft-add-repeat").click();
-    await page.getByTestId("session-draft-repeat-count-5").fill("6");
-    await page.getByTestId("session-draft-step-name-5").fill("Repeat swim focus");
-    await page.getByTestId("session-draft-step-distance-5").selectOption("200");
-    await page.getByTestId("session-draft-step-stroke-5").selectOption("backstroke");
-    await page.getByTestId("session-draft-step-drill-type-5").selectOption("pull");
-    await page.getByTestId("session-draft-step-equipment-5").selectOption("fins");
-    await page.getByTestId("session-draft-step-target-mode-5").selectOption("target_pace");
-    await page.getByTestId("session-draft-step-target-pace-minutes-5").fill("1");
-    await page.getByTestId("session-draft-step-target-pace-seconds-5").fill("35");
-    await page.getByTestId("session-draft-step-toggle-6").click();
-    await page.getByTestId("session-draft-step-duration-mode-6").selectOption("send_off");
-    await page.getByTestId("session-draft-step-sendoff-minutes-6").fill("2");
-    await page.getByTestId("session-draft-step-sendoff-seconds-6").fill("00");
-    await page.getByTestId("session-draft-repeat-duplicate-5").click();
-    await expect(page.getByTestId("session-draft-repeat-count-6")).toHaveValue("6");
-    await page.getByTestId("session-draft-repeat-count-6").fill("3");
-    await page.getByTestId("session-draft-step-name-7").fill("Repeat swim copy focus");
-    await page.getByTestId("session-draft-repeat-add-step-after-6").click();
-    await page.getByTestId("session-draft-step-name-9").fill("QA CSS send-off reset");
-    await page.getByTestId("session-draft-step-duration-mode-9").selectOption("css_send_off");
-    await page.getByTestId("session-draft-step-stroke-9").selectOption("reverse_im_order");
-    await page.getByTestId("session-draft-step-css-sendoff-offset-9").selectOption("2");
-    await page.getByTestId("session-draft-step-target-mode-9").selectOption("none");
+    await page.getByTestId("session-draft-repeat-count-1").fill("6");
+    await page.getByTestId("session-draft-step-name-1").fill("Repeat swim focus");
+    await page.getByTestId("session-draft-step-distance-1").selectOption("200");
+    await page.getByTestId("session-draft-step-stroke-1").selectOption("backstroke");
+    await page.getByTestId("session-draft-step-drill-type-1").selectOption("pull");
+    await page.getByTestId("session-draft-step-equipment-1").selectOption("fins");
+    await page.getByTestId("session-draft-step-target-mode-1").selectOption("target_pace");
+    await page.getByTestId("session-draft-step-target-pace-minutes-1").fill("1");
+    await page.getByTestId("session-draft-step-target-pace-seconds-1").fill("35");
     await page.getByTestId("session-draft-title").fill(uniqueTitle);
     await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
       "Unsaved changes stay local until you save this workout."
@@ -185,14 +171,11 @@ test.describe("my library workout builder", () => {
       "review"
     );
     await expect(page.getByTestId("workout-editor-garmin-readiness-summary")).toHaveText(
-      "Review 5 Garmin/export mapping details before you treat this workout as handoff-ready."
+      "Review 2 Garmin/export mapping details before you treat this workout as handoff-ready."
     );
     await page.getByTestId("workout-editor-garmin-readiness-toggle").click();
     await expect(page.getByTestId("workout-editor-garmin-readiness-issue-0")).toContainText("Pull");
     await expect(page.getByTestId("workout-editor-garmin-readiness-issue-1")).toContainText("Fins");
-    await expect(page.getByTestId("workout-editor-garmin-readiness-issue-4")).toContainText(
-      "Reverse IM order (RIMO)"
-    );
     await expect(page.getByTestId("workout-editor-handoff-source")).toHaveAttribute(
       "data-handoff-state",
       "local_draft"
@@ -241,7 +224,7 @@ test.describe("my library workout builder", () => {
     await expect(pdfPopup.locator('[data-testid="workout-pdf-title"]')).toContainText(uniqueTitle);
     await expect(pdfPopup.locator("body")).toContainText("Workout PDF");
     await expect(pdfPopup.locator("body")).toContainText("Print / Save PDF");
-    await expect(pdfPopup.locator("body")).toContainText("Reverse IM order (RIMO)");
+    await expect(pdfPopup.locator("body")).toContainText("Repeat swim focus");
     await pdfPopup.close();
 
     const poolsidePopupPromise = page.waitForEvent("popup");
@@ -300,36 +283,16 @@ test.describe("my library workout builder", () => {
     await page.getByTestId("session-draft-step-toggle-0").click();
     await expect(page.getByTestId("session-draft-step-distance-0")).toHaveValue("custom");
     await expect(page.getByTestId("session-draft-step-distance-custom-0")).toHaveValue("333");
-    await expect(page.getByTestId("session-draft-repeat-count-5")).toHaveValue("6");
-    await expect(page.getByTestId("session-draft-repeat-count-6")).toHaveValue("3");
-    await page.getByTestId("session-draft-step-toggle-5").click();
-    await expect(page.getByTestId("session-draft-step-name-5")).toHaveValue("Repeat swim focus");
-    await expect(page.getByTestId("session-draft-step-distance-5")).toHaveValue("200");
-    await expect(page.getByTestId("session-draft-step-stroke-5")).toHaveValue("backstroke");
-    await expect(page.getByTestId("session-draft-step-drill-type-5")).toHaveValue("pull");
-    await expect(page.getByTestId("session-draft-step-equipment-5")).toHaveValue("fins");
-    await expect(page.getByTestId("session-draft-step-target-mode-5")).toHaveValue("target_pace");
-    await expect(page.getByTestId("session-draft-step-target-pace-minutes-5")).toHaveValue("1");
-    await expect(page.getByTestId("session-draft-step-target-pace-seconds-5")).toHaveValue("35");
-    await page.getByTestId("session-draft-step-toggle-7").click();
-    await expect(page.getByTestId("session-draft-step-name-7")).toHaveValue(
-      "Repeat swim copy focus"
-    );
-    await expect(page.getByTestId("session-draft-step-distance-7")).toHaveValue("200");
-    await page.getByTestId("session-draft-step-toggle-6").click();
-    await expect(page.getByTestId("session-draft-step-duration-mode-6")).toHaveValue("send_off");
-    await expect(page.getByTestId("session-draft-step-sendoff-minutes-6")).toHaveValue("2");
-    await expect(page.getByTestId("session-draft-step-sendoff-seconds-6")).toHaveValue("00");
-    await page.getByTestId("session-draft-step-toggle-9").click();
-    await expect(page.getByTestId("session-draft-step-name-9")).toHaveValue(
-      "QA CSS send-off reset"
-    );
-    await expect(page.getByTestId("session-draft-step-stroke-9")).toHaveValue("reverse_im_order");
-    await expect(page.getByTestId("session-draft-step-duration-mode-9")).toHaveValue(
-      "css_send_off"
-    );
-    await expect(page.getByTestId("session-draft-step-css-sendoff-offset-9")).toHaveValue("2");
-    await expect(page.getByTestId("session-draft-step-target-mode-9")).toHaveValue("none");
+    await expect(page.getByTestId("session-draft-repeat-count-1")).toHaveValue("6");
+    await page.getByTestId("session-draft-step-toggle-1").click();
+    await expect(page.getByTestId("session-draft-step-name-1")).toHaveValue("Repeat swim focus");
+    await expect(page.getByTestId("session-draft-step-distance-1")).toHaveValue("200");
+    await expect(page.getByTestId("session-draft-step-stroke-1")).toHaveValue("backstroke");
+    await expect(page.getByTestId("session-draft-step-drill-type-1")).toHaveValue("pull");
+    await expect(page.getByTestId("session-draft-step-equipment-1")).toHaveValue("fins");
+    await expect(page.getByTestId("session-draft-step-target-mode-1")).toHaveValue("target_pace");
+    await expect(page.getByTestId("session-draft-step-target-pace-minutes-1")).toHaveValue("1");
+    await expect(page.getByTestId("session-draft-step-target-pace-seconds-1")).toHaveValue("35");
     await expect(
       page.locator("fieldset").filter({ hasText: "Session strokes" }).getByRole("checkbox", {
         name: "Backstroke",

--- a/tests/unit/create-manual-workout-button.test.tsx
+++ b/tests/unit/create-manual-workout-button.test.tsx
@@ -35,13 +35,14 @@ describe("CreateManualWorkoutButton", () => {
 
     render(<CreateManualWorkoutButton />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Start manual swim session" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create session" }));
 
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(
         "/api/my-library/workouts",
-        expect.objectContaining({
+        expect.objectContaining<Record<string, unknown>>({
           method: "POST",
+          body: expect.stringContaining('"title":"Untitled swim session"'),
         })
       );
     });
@@ -65,11 +66,74 @@ describe("CreateManualWorkoutButton", () => {
 
     render(<CreateManualWorkoutButton />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Start manual swim session" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create session" }));
 
     await waitFor(() => {
       expect(screen.getByText("Could not create workout right now.")).toBeVisible();
     });
     expect(navigationState.push).not.toHaveBeenCalled();
+  });
+
+  it("offers continue-or-start-new when a saved session already exists", async () => {
+    render(
+      <CreateManualWorkoutButton
+        latestSavedWorkout={{
+          id: "22222222-2222-4222-8222-222222222222",
+          title: "Saved threshold session",
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Create session" }));
+
+    expect(screen.getByTestId("create-manual-workout-chooser")).toBeVisible();
+    expect(screen.getByText("Latest saved session: Saved threshold session")).toBeVisible();
+
+    fireEvent.click(screen.getByTestId("create-manual-workout-continue"));
+
+    expect(navigationState.push).toHaveBeenCalledWith(
+      "/my-library/workouts/22222222-2222-4222-8222-222222222222"
+    );
+    expect(navigationState.refresh).toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("can start a clean new session from the chooser", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        workout: {
+          id: "33333333-3333-4333-8333-333333333333",
+        },
+      }),
+    } as Response);
+
+    render(
+      <CreateManualWorkoutButton
+        latestSavedWorkout={{
+          id: "22222222-2222-4222-8222-222222222222",
+          title: "Saved threshold session",
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Create session" }));
+    fireEvent.click(screen.getByTestId("create-manual-workout-start-scratch"));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/my-library/workouts",
+        expect.objectContaining<Record<string, unknown>>({
+          method: "POST",
+          body: expect.stringContaining('"title":"Untitled swim session"'),
+        })
+      );
+    });
+    await waitFor(() => {
+      expect(navigationState.push).toHaveBeenCalledWith(
+        "/my-library/workouts/33333333-3333-4333-8333-333333333333"
+      );
+    });
   });
 });

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -887,11 +887,12 @@ describe("WorkoutBuilderHub", () => {
 
     expect(screen.getByText("That saved swim session could not be found.")).toBeVisible();
     expect(screen.getByTestId("workout-builder-empty-create-manual")).toBeVisible();
+    expect(screen.queryByTestId("saved-workout-card-workout-1")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open generator" })).toHaveAttribute(
       "href",
       "/my-library/generator"
     );
-    fireEvent.click(screen.getByTestId("session-generator-recent-workouts-toggle"));
+    fireEvent.click(screen.getByTestId("workout-builder-empty-view-sessions"));
     expect(screen.getByTestId("workout-builder-open-workout-workout-1")).toHaveAttribute(
       "href",
       "/my-library/workouts/workout-1"
@@ -972,9 +973,10 @@ describe("WorkoutBuilderHub", () => {
 
     expect(screen.queryByTestId("saved-workout-card-workout-2")).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByTestId("session-generator-recent-workouts-toggle"));
+    fireEvent.click(screen.getByTestId("workout-builder-view-sessions"));
 
-    expect(screen.queryByTestId("saved-workout-card-workout-1")).not.toBeInTheDocument();
+    expect(screen.getByTestId("saved-workout-card-workout-1")).toBeVisible();
+    expect(screen.getByTestId("saved-workout-current-workout-1")).toBeVisible();
     expect(screen.getByTestId("saved-workout-card-workout-2")).toBeVisible();
 
     fireEvent.click(screen.getByTestId("workout-builder-delete-workout-workout-2"));
@@ -1015,7 +1017,7 @@ describe("WorkoutBuilderHub", () => {
       );
     });
 
-    expect(screen.getByTestId("workout-builder-current-workout-actions")).toBeVisible();
+    expect(screen.queryByTestId("workout-builder-current-workout-actions")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("workout-builder-delete-current-workout"));
 
@@ -1034,5 +1036,37 @@ describe("WorkoutBuilderHub", () => {
     });
 
     expect(navigationState.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("can open saved sessions immediately when requested by the route", async () => {
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          recentWorkouts: [
+            buildWorkoutSummary(),
+            buildWorkoutSummary({
+              id: "workout-2",
+              title: "Follow-up session",
+              totalDistanceM: 1800,
+              estimatedDurationMin: 40,
+            }),
+          ],
+        })}
+        savedSessionsOpenByDefault
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    expect(screen.getByTestId("saved-workout-card-workout-1")).toBeVisible();
+    expect(screen.getByTestId("saved-workout-card-workout-2")).toBeVisible();
+    expect(
+      screen.queryByTestId("session-generator-recent-workouts-toggle")
+    ).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/workouts-server.test.ts
+++ b/tests/unit/workouts-server.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Database } from "@/types/database";
-import { buildManualWorkoutStarterDraft } from "@/lib/workouts/manual";
+import {
+  buildManualWorkoutEmptyDraft,
+  buildManualWorkoutStarterDraft,
+} from "@/lib/workouts/manual";
 import {
   buildWorkoutEditorRecord,
   buildWorkoutInsert,
@@ -137,6 +140,18 @@ describe("workouts server", () => {
     expect(Array.isArray(insert.steps)).toBe(true);
     expect(starter.steps.some((step) => step.category === "rest")).toBe(true);
     expect(starter.steps.some((step) => step.durationMode === "fixed_rest")).toBe(true);
+  });
+
+  it("supports manual source kind for clean scratch session scaffolds", () => {
+    const emptyDraft = buildManualWorkoutEmptyDraft(new Date("2026-03-22T12:00:00.000Z"));
+    const insert = buildWorkoutInsert("user-1", emptyDraft, "manual");
+
+    expect(insert.source_kind).toBe("manual");
+    expect(insert.title).toBe("Untitled swim session");
+    expect(Array.isArray(insert.steps)).toBe(true);
+    expect(insert.steps).toHaveLength(1);
+    expect(insert.total_distance_m).toBe(100);
+    expect(insert.estimated_duration_min).toBe(2);
   });
 
   it("persists and reloads custom pool lengths for manual builder workouts", () => {


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-03-29T04:56:25.888Z for branch `fix/workout-builder-draft-first-entry-2026-03-29` (base ref `origin/main`).
- Latest commit: `63743aa` - fix(workouts): make builder entry draft-first.
- User-visible changes: User/admin runtime behavior may change on touched routes/components.
- Technical changes: Updated 14 file(s): `app/my-library/page.tsx`, `app/my-library/workouts/[workoutId]/page.tsx`, `components/my-library/workouts/CreateManualWorkoutButton.tsx`, `components/my-library/workouts/SavedWorkoutsPanel.tsx`, `components/my-library/workouts/WorkoutBuilderHub.tsx`, `... and 9 more file(s)`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md`
- Scorecard target outcomes: 11 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (1); tests (5); runtime UI/routes/components (8).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (14):
  - `app/my-library/page.tsx`
  - `app/my-library/workouts/[workoutId]/page.tsx`
  - `components/my-library/workouts/CreateManualWorkoutButton.tsx`
  - `components/my-library/workouts/SavedWorkoutsPanel.tsx`
  - `components/my-library/workouts/WorkoutBuilderHub.tsx`
  - `components/my-library/workouts/WorkoutEditor.tsx`
  - `docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md`
  - `lib/workouts/manual.ts`
  - `... and 6 more file(s)`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `63743aa` (`git revert 63743aa`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **NOT RUN** (run locally before pushing PR updates).
- `npm run verify:pre-merge`: **PENDING** for `63743aa` (required before merge to `main`).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  - No local verify log found in `artifacts/test-runs/latest`.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
