### PR TITLE
fix(generator): simplify ai session setup flow

### DIFF
--- a/app/my-library/generator/page.tsx
+++ b/app/my-library/generator/page.tsx
@@ -65,10 +65,6 @@ export default async function MyLibraryGeneratorPage({ searchParams }: Props) {
                 My Library
               </p>
               <h1 className="mt-2 text-3xl font-bold text-slate-900">AI session generator</h1>
-              <p className="mt-2 max-w-[68ch] text-sm text-slate-600">
-                Use your athlete profile, saved My Library data, and one-time choices for this run
-                to generate a new swim-session draft.
-              </p>
             </div>
             <div className="flex flex-wrap gap-2">
               <Link

--- a/components/my-library/generator/GeneratorIntakeHub.tsx
+++ b/components/my-library/generator/GeneratorIntakeHub.tsx
@@ -7,18 +7,15 @@ import SessionGeneratorPanel from "@/components/my-library/generator/SessionGene
 import {
   GENERATOR_INTAKE_BLOCK_KEYS,
   buildGeneratorHandoffPayload,
-  getDefaultGeneratorIntakeOverrides,
   getDefaultGeneratorIntakeSelection,
   normalizeGeneratorIntakeOverrides,
   normalizeGeneratorIntakeSelection,
+  type GeneratorIntakeOverrides,
   type GeneratorIntakeBlockKey,
   type GeneratorIntakeBlockSummary,
-  type GeneratorIntakeOverrides,
   type GeneratorIntakeSelection,
   type GeneratorIntakeSnapshot,
 } from "@/lib/generator-intake/shared";
-import { TRAINING_SESSION_DURATION_OPTIONS } from "@/lib/athlete-profile/training-setup";
-import { readNavigatorOnlineState } from "@/lib/utils/navigator-online";
 import type { WorkoutLibrarySnapshot } from "@/lib/workouts/shared";
 
 type Props = {
@@ -27,22 +24,15 @@ type Props = {
   workoutLibrary: WorkoutLibrarySnapshot;
 };
 
-type ApiPayload = {
-  ok?: boolean;
-  error?: string;
-  snapshot?: GeneratorIntakeSnapshot;
-};
-
 type StoredDraft = {
   sourceFingerprint: string;
   selection: GeneratorIntakeSelection;
   overrides: GeneratorIntakeOverrides;
 };
 
-type GeneratorSectionKey = "source" | "overrides";
-
 const STORAGE_KEY_PREFIX = "my-library-generator-intake-draft:";
 const BLOCK_COPY_ORDER = [...GENERATOR_INTAKE_BLOCK_KEYS];
+type SessionOnlyOverrideKey = "focusText" | "constraintText";
 
 function getStorageKey(userId: string) {
   return `${STORAGE_KEY_PREFIX}${userId}`;
@@ -61,12 +51,6 @@ function readDraft(key: string): StoredDraft | null {
 function writeDraft(key: string, value: StoredDraft) {
   try {
     localStorage.setItem(key, JSON.stringify(value));
-  } catch {}
-}
-
-function clearDraft(key: string) {
-  try {
-    localStorage.removeItem(key);
   } catch {}
 }
 
@@ -110,55 +94,48 @@ function toBlockLabel(key: GeneratorIntakeBlockKey) {
   return key.replaceAll("_", " ");
 }
 
+function normalizeSessionOnlyOverrides(overrides: StoredDraft["overrides"] | null | undefined) {
+  const normalized = normalizeGeneratorIntakeOverrides(overrides);
+  return {
+    ...normalized,
+    targetType: "session" as const,
+    desiredSessionCount: "",
+  };
+}
+
 export default function GeneratorIntakeHub({ initialSnapshot, userId, workoutLibrary }: Props) {
-  const [snapshot, setSnapshot] = useState(initialSnapshot);
+  const snapshot = initialSnapshot;
   const [selection, setSelection] = useState<GeneratorIntakeSelection>(() =>
     getDefaultGeneratorIntakeSelection(initialSnapshot)
   );
-  const [overrides, setOverrides] = useState<GeneratorIntakeOverrides>(() =>
-    getDefaultGeneratorIntakeOverrides()
-  );
+  const [overrides, setOverrides] = useState(() => normalizeSessionOnlyOverrides(null));
   const [isClientReady, setIsClientReady] = useState(false);
   const [draftRecovered, setDraftRecovered] = useState(false);
   const [staleSourceWarning, setStaleSourceWarning] = useState("");
-  const [actionError, setActionError] = useState("");
-  const [actionSuccess, setActionSuccess] = useState("");
-  const [isOnline, setIsOnline] = useState(true);
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const [sectionOpen, setSectionOpen] = useState<Record<GeneratorSectionKey, boolean>>({
-    source: false,
-    overrides: false,
-  });
+  const [sourceOpen, setSourceOpen] = useState(false);
 
   const storageKey = getStorageKey(userId);
-  const payload = buildGeneratorHandoffPayload(snapshot, selection, overrides, {
-    createdAt: snapshot.loadedAt,
+  const payload = buildGeneratorHandoffPayload(initialSnapshot, selection, overrides, {
+    createdAt: initialSnapshot.loadedAt,
   });
   const selectedBlockCount = payload.includedBlocks.length;
   const sourceSummary =
     selectedBlockCount > 0
       ? `${selectedBlockCount} block${selectedBlockCount === 1 ? "" : "s"} included`
       : "No saved blocks included";
-  const overrideSummary =
-    overrides.targetType === "program"
-      ? payload.effectiveDefaults.sessionCount
-        ? `${payload.effectiveDefaults.sessionCount} swim session${
-            payload.effectiveDefaults.sessionCount === 1 ? "" : "s"
-          } per week`
-        : "Multi-session program"
-      : "Single session";
 
+  // Restoring unsaved generator choices must happen after hydration because the
+  // server render cannot read localStorage for this private My Library flow.
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
-    setIsOnline(readNavigatorOnlineState());
-
     const fallbackSelection = getDefaultGeneratorIntakeSelection(initialSnapshot);
-    const fallbackOverrides = getDefaultGeneratorIntakeOverrides();
+    const fallbackOverrides = normalizeSessionOnlyOverrides(null);
     const storedDraft = readDraft(storageKey);
     const nextSelection = normalizeGeneratorIntakeSelection(
       initialSnapshot,
       storedDraft?.selection ?? fallbackSelection
     );
-    const nextOverrides = normalizeGeneratorIntakeOverrides(
+    const nextOverrides = normalizeSessionOnlyOverrides(
       storedDraft?.overrides ?? fallbackOverrides
     );
     const restored =
@@ -174,95 +151,18 @@ export default function GeneratorIntakeHub({ initialSnapshot, userId, workoutLib
         : ""
     );
     setIsClientReady(true);
-
-    function onOnline() {
-      setIsOnline(true);
-    }
-
-    function onOffline() {
-      setIsOnline(false);
-    }
-
-    window.addEventListener("online", onOnline);
-    window.addEventListener("offline", onOffline);
-
-    return () => {
-      window.removeEventListener("online", onOnline);
-      window.removeEventListener("offline", onOffline);
-    };
   }, [initialSnapshot, storageKey]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   useEffect(() => {
     if (!isClientReady) return;
 
     writeDraft(storageKey, {
-      sourceFingerprint: snapshot.sourceFingerprint,
+      sourceFingerprint: initialSnapshot.sourceFingerprint,
       selection,
       overrides,
     });
-  }, [isClientReady, overrides, selection, snapshot.sourceFingerprint, storageKey]);
-
-  async function parseError(response: Response, fallback: string) {
-    const responseBody = (await response.json().catch(() => null)) as ApiPayload | null;
-    return responseBody?.error || fallback;
-  }
-
-  async function refreshSnapshot() {
-    if (!isOnline) {
-      setActionError(
-        "You are offline. Existing intake context stays visible, but refresh is paused."
-      );
-      return;
-    }
-
-    setIsRefreshing(true);
-    setActionError("");
-    setActionSuccess("");
-
-    try {
-      const response = await fetch("/api/my-library/generator-intake", {
-        method: "GET",
-        cache: "no-store",
-      });
-
-      if (!response.ok) {
-        setActionError(await parseError(response, "Could not refresh generator intake right now."));
-        return;
-      }
-
-      const responseBody = (await response.json().catch(() => null)) as ApiPayload | null;
-      if (!responseBody?.ok || !responseBody.snapshot) {
-        setActionError("Could not refresh generator intake right now.");
-        return;
-      }
-
-      const nextSnapshot = responseBody.snapshot;
-      const nextSelection = normalizeGeneratorIntakeSelection(nextSnapshot, selection);
-      const droppedBlocks = BLOCK_COPY_ORDER.filter(
-        (key) => selection[key] && !nextSelection[key] && snapshot.blocks[key].available
-      );
-
-      setSnapshot(nextSnapshot);
-      setSelection(nextSelection);
-      setStaleSourceWarning(
-        nextSnapshot.sourceFingerprint !== snapshot.sourceFingerprint
-          ? droppedBlocks.length > 0
-            ? `${droppedBlocks.map((key) => nextSnapshot.blocks[key].label).join(", ")} changed or became unavailable after refresh. Review the handoff before continuing.`
-            : "Saved My Library context changed after refresh. Review included blocks before continuing."
-          : ""
-      );
-      setActionSuccess("Updated from My Library.");
-      void sendClientAnalyticsEvent("generator_intake_refreshed", {
-        availableBlockCount: Object.values(nextSnapshot.blocks).filter((block) => block.available)
-          .length,
-        selectedBlockCount: Object.values(nextSelection).filter(Boolean).length,
-      });
-    } catch {
-      setActionError("Could not refresh generator intake right now.");
-    } finally {
-      setIsRefreshing(false);
-    }
-  }
+  }, [initialSnapshot.sourceFingerprint, isClientReady, overrides, selection, storageKey]);
 
   function toggleBlock(blockKey: GeneratorIntakeBlockKey) {
     const block = snapshot.blocks[blockKey];
@@ -274,8 +174,6 @@ export default function GeneratorIntakeHub({ initialSnapshot, userId, workoutLib
     };
 
     setSelection(nextSelection);
-    setActionError("");
-    setActionSuccess("");
     void sendClientAnalyticsEvent("generator_intake_block_toggled", {
       blockKey,
       included: nextSelection[blockKey],
@@ -283,35 +181,21 @@ export default function GeneratorIntakeHub({ initialSnapshot, userId, workoutLib
     });
   }
 
-  function updateOverride<K extends keyof GeneratorIntakeOverrides>(
-    key: K,
-    value: GeneratorIntakeOverrides[K]
-  ) {
+  function updateOverride(key: SessionOnlyOverrideKey, value: string) {
     setOverrides((current) =>
-      normalizeGeneratorIntakeOverrides({
+      normalizeSessionOnlyOverrides({
         ...current,
         [key]: value,
       })
     );
-    setActionError("");
-    setActionSuccess("");
   }
 
-  function toggleSection(section: GeneratorSectionKey) {
-    setSectionOpen((current) => ({
-      ...current,
-      [section]: !current[section],
-    }));
+  function toggleSourceSection() {
+    setSourceOpen((current) => !current);
   }
 
-  function resetIntakeDraft() {
-    clearDraft(storageKey);
-    setSelection(getDefaultGeneratorIntakeSelection(snapshot));
-    setOverrides(getDefaultGeneratorIntakeOverrides());
-    setDraftRecovered(false);
-    setStaleSourceWarning("");
-    setActionError("");
-    setActionSuccess("Cleared one-time changes.");
+  function resetSessionOverrides() {
+    setOverrides(normalizeSessionOnlyOverrides(null));
   }
 
   return (
@@ -320,46 +204,6 @@ export default function GeneratorIntakeHub({ initialSnapshot, userId, workoutLib
       data-client-ready={isClientReady ? "true" : "false"}
       className="space-y-6"
     >
-      <section className="rounded-2xl border border-slate-200 bg-slate-50/80 p-5">
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <h2 className="text-base font-semibold text-slate-900">Before you generate</h2>
-            <p className="mt-2 max-w-[66ch] text-sm text-slate-600">
-              Choose what to use from My Library and add any one-time changes for this run. Nothing
-              here changes your saved records.
-            </p>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <button
-              type="button"
-              onClick={refreshSnapshot}
-              disabled={isRefreshing}
-              data-testid="generator-intake-refresh"
-              className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {isRefreshing ? "Updating..." : "Update from My Library"}
-            </button>
-            <button
-              type="button"
-              onClick={resetIntakeDraft}
-              data-testid="generator-intake-reset"
-              className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
-            >
-              Clear one-time changes
-            </button>
-          </div>
-        </div>
-      </section>
-
-      {!isOnline ? (
-        <section className="rounded-2xl border border-amber-200 bg-amber-50/80 p-4">
-          <p className="text-sm text-amber-900">
-            You are offline. Saved intake context stays visible, but refresh is paused until you
-            reconnect.
-          </p>
-        </section>
-      ) : null}
-
       {draftRecovered ? (
         <section className="rounded-2xl border border-emerald-200 bg-emerald-50/80 p-4">
           <p className="text-sm text-emerald-900">
@@ -374,18 +218,6 @@ export default function GeneratorIntakeHub({ initialSnapshot, userId, workoutLib
         </section>
       ) : null}
 
-      {actionError ? (
-        <section className="rounded-2xl border border-rose-200 bg-rose-50/80 p-4">
-          <p className="text-sm text-rose-900">{actionError}</p>
-        </section>
-      ) : null}
-
-      {actionSuccess ? (
-        <section className="rounded-2xl border border-emerald-200 bg-emerald-50/80 p-4">
-          <p className="text-sm text-emerald-900">{actionSuccess}</p>
-        </section>
-      ) : null}
-
       {snapshot.loadError ? (
         <section className="rounded-2xl border border-amber-200 bg-amber-50/80 p-4">
           <p className="text-sm text-amber-900">{snapshot.loadError}</p>
@@ -395,11 +227,7 @@ export default function GeneratorIntakeHub({ initialSnapshot, userId, workoutLib
       <section className="rounded-2xl border border-slate-200 bg-white p-5">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <h2 className="text-lg font-semibold text-slate-900">From My Library</h2>
-            <p className="mt-2 max-w-[66ch] text-sm text-slate-600">
-              Read-only information you can include in this AI-generated session. Open it when you
-              want to review what is coming from your saved My Library data.
-            </p>
+            <h2 className="text-lg font-semibold text-slate-900">Information from My Library</h2>
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <p className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-700">
@@ -407,17 +235,17 @@ export default function GeneratorIntakeHub({ initialSnapshot, userId, workoutLib
             </p>
             <button
               type="button"
-              onClick={() => toggleSection("source")}
-              aria-expanded={sectionOpen.source}
+              onClick={toggleSourceSection}
+              aria-expanded={sourceOpen}
               data-testid="generator-intake-source-toggle"
               className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
             >
-              {sectionOpen.source ? "Hide details" : "Show details"}
+              {sourceOpen ? "Hide details" : "Show details"}
             </button>
           </div>
         </div>
 
-        {sectionOpen.source ? (
+        {sourceOpen ? (
           <div className="mt-5 grid gap-4 lg:grid-cols-2">
             {BLOCK_COPY_ORDER.map((blockKey) => {
               const block = snapshot.blocks[blockKey];
@@ -428,9 +256,6 @@ export default function GeneratorIntakeHub({ initialSnapshot, userId, workoutLib
                 <article key={block.key} className={`rounded-2xl border p-4 ${tone.container}`}>
                   <div className="flex items-start justify-between gap-3">
                     <div>
-                      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                        From My Library
-                      </p>
                       <h3 className="mt-1 text-base font-semibold text-slate-900">{block.label}</h3>
                       <p className="mt-2 text-sm text-slate-700">{block.description}</p>
                     </div>
@@ -467,7 +292,7 @@ export default function GeneratorIntakeHub({ initialSnapshot, userId, workoutLib
                         data-testid={`generator-intake-include-${blockKey}`}
                         className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
                       />
-                      Include {toBlockLabel(blockKey)} for this run
+                      Use {toBlockLabel(blockKey)} in this session
                     </label>
 
                     <Link
@@ -484,126 +309,12 @@ export default function GeneratorIntakeHub({ initialSnapshot, userId, workoutLib
         ) : null}
       </section>
 
-      <section className="rounded-2xl border border-slate-200 bg-white p-5">
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <h2 className="text-lg font-semibold text-slate-900">This run only</h2>
-            <p className="mt-2 max-w-[66ch] text-sm text-slate-600">
-              Optional changes that only affect this AI draft. Use them when you want to steer this
-              run without editing your saved My Library information.
-            </p>
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <p className="rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">
-              {overrideSummary}
-            </p>
-            <button
-              type="button"
-              onClick={() => toggleSection("overrides")}
-              aria-expanded={sectionOpen.overrides}
-              data-testid="generator-intake-overrides-toggle"
-              className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
-            >
-              {sectionOpen.overrides ? "Hide choices" : "Show choices"}
-            </button>
-          </div>
-        </div>
-
-        {sectionOpen.overrides ? (
-          <>
-            <div className="mt-5 grid gap-4 md:grid-cols-2">
-              <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4">
-                <legend className="px-1 text-sm font-semibold text-slate-900">
-                  What do you want to generate?
-                </legend>
-                <div className="mt-3 flex flex-wrap gap-3">
-                  <label className="inline-flex items-center gap-2 text-sm text-slate-700">
-                    <input
-                      type="radio"
-                      name="generator-target-type"
-                      checked={overrides.targetType === "session"}
-                      onChange={() => updateOverride("targetType", "session")}
-                      data-testid="generator-intake-target-session"
-                    />
-                    Single session
-                  </label>
-                  <label className="inline-flex items-center gap-2 text-sm text-slate-700">
-                    <input
-                      type="radio"
-                      name="generator-target-type"
-                      checked={overrides.targetType === "program"}
-                      onChange={() => updateOverride("targetType", "program")}
-                      data-testid="generator-intake-target-program"
-                    />
-                    Multi-session program
-                  </label>
-                </div>
-              </fieldset>
-
-              {overrides.targetType === "program" ? (
-                <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
-                  Swim sessions per week
-                  <input
-                    type="text"
-                    inputMode="numeric"
-                    value={overrides.desiredSessionCount}
-                    onChange={(event) => updateOverride("desiredSessionCount", event.target.value)}
-                    data-testid="generator-intake-session-count"
-                    className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                    placeholder="Leave blank to use saved weekly preference later"
-                  />
-                </label>
-              ) : null}
-
-              <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
-                Desired session length
-                <select
-                  value={overrides.desiredSessionMinutes}
-                  onChange={(event) => updateOverride("desiredSessionMinutes", event.target.value)}
-                  data-testid="generator-intake-session-minutes"
-                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                >
-                  <option value="">Use saved preference or leave open</option>
-                  {TRAINING_SESSION_DURATION_OPTIONS.map((option) => (
-                    <option key={option.value} value={String(option.value)}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
-
-              <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
-                Focus for this run
-                <input
-                  type="text"
-                  value={overrides.focusText}
-                  onChange={(event) => updateOverride("focusText", event.target.value)}
-                  data-testid="generator-intake-focus-text"
-                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                  placeholder="Example: Breathing timing under fatigue"
-                />
-              </label>
-            </div>
-
-            <label className="mt-4 block rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
-              Constraints for this run
-              <textarea
-                value={overrides.constraintText}
-                onChange={(event) => updateOverride("constraintText", event.target.value)}
-                data-testid="generator-intake-constraint-text"
-                rows={4}
-                className="mt-2 block w-full rounded-xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                placeholder="Example: Keep total volume moderate and avoid heavy kick work."
-              />
-            </label>
-          </>
-        ) : null}
-      </section>
-
       <SessionGeneratorPanel
         payload={payload}
         selection={selection}
         overrides={overrides}
+        onOverrideChange={updateOverride}
+        onResetOverrides={resetSessionOverrides}
         workoutLibrary={workoutLibrary}
       />
     </div>

--- a/components/my-library/generator/SessionGeneratorPanel.tsx
+++ b/components/my-library/generator/SessionGeneratorPanel.tsx
@@ -40,6 +40,8 @@ type Props = {
   payload: GeneratorIntakeHandoffPayload;
   selection: GeneratorIntakeSelection;
   overrides: GeneratorIntakeOverrides;
+  onOverrideChange: (key: "focusText" | "constraintText", value: string) => void;
+  onResetOverrides: () => void;
   workoutLibrary: WorkoutLibrarySnapshot;
 };
 
@@ -47,6 +49,8 @@ export default function SessionGeneratorPanel({
   payload,
   selection,
   overrides,
+  onOverrideChange,
+  onResetOverrides,
   workoutLibrary,
 }: Props) {
   const [formState, setFormState] = useState<SessionGeneratorFormState>(() =>
@@ -87,6 +91,18 @@ export default function SessionGeneratorPanel({
   const hasUnsavedChanges = savedWorkout
     ? haveWorkoutDraftChanges(draft, savedWorkout.draft)
     : true;
+
+  function applyOverrideChange(key: "focusText" | "constraintText", value: string) {
+    setError("");
+    setSuccess("");
+    onOverrideChange(key, value);
+  }
+
+  function handleResetOverrides() {
+    setError("");
+    setSuccess("");
+    onResetOverrides();
+  }
 
   function updateFormState<K extends keyof SessionGeneratorFormState>(
     key: K,
@@ -229,11 +245,7 @@ export default function SessionGeneratorPanel({
     >
       <div>
         <div>
-          <h2 className="text-lg font-semibold text-slate-900">Generate swim session</h2>
-          <p className="mt-2 max-w-[66ch] text-sm text-slate-600">
-            Use your athlete profile, saved My Library data, and this run&apos;s choices to draft
-            one swim session, then review it before saving it into My sessions.
-          </p>
+          <h2 className="text-lg font-semibold text-slate-900">Generate session</h2>
         </div>
       </div>
 
@@ -273,21 +285,50 @@ export default function SessionGeneratorPanel({
         </div>
       ) : null}
 
-      {payload.overrides.targetType === "program" ? (
-        <div
-          data-testid="session-generator-program-deferred"
-          className="mt-5 rounded-2xl border border-amber-200 bg-amber-50/80 p-4"
-        >
-          <p className="text-sm text-amber-900">
-            Program generation stays deferred for now. Switch the generator target back to
-            <span className="font-semibold"> Single session </span>
-            to draft one workout in this slice.
-          </p>
-        </div>
-      ) : null}
-
       {!hasLoadedCanonicalWorkout && sessionReady ? (
         <>
+          <div className="mt-5 rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h3 className="text-base font-semibold text-slate-900">Session information</h3>
+              </div>
+              <button
+                type="button"
+                onClick={handleResetOverrides}
+                data-testid="session-generator-reset-overrides"
+                className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+              >
+                Clear session notes
+              </button>
+            </div>
+
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              <label className="rounded-2xl border border-slate-200 bg-white p-4 text-sm text-slate-700 md:col-span-2">
+                Session focus
+                <input
+                  type="text"
+                  value={overrides.focusText}
+                  onChange={(event) => applyOverrideChange("focusText", event.target.value)}
+                  data-testid="session-generator-focus-text"
+                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                  placeholder="Example: Breathing timing under fatigue"
+                />
+              </label>
+
+              <label className="rounded-2xl border border-slate-200 bg-white p-4 text-sm text-slate-700 md:col-span-2">
+                Special instructions
+                <textarea
+                  value={overrides.constraintText}
+                  onChange={(event) => applyOverrideChange("constraintText", event.target.value)}
+                  data-testid="session-generator-constraint-text"
+                  rows={4}
+                  className="mt-2 block w-full rounded-xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                  placeholder="Example: Keep total volume moderate and avoid heavy kick work."
+                />
+              </label>
+            </div>
+          </div>
+
           <div className="mt-5 grid gap-4 md:grid-cols-3">
             <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
               <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
@@ -438,7 +479,7 @@ export default function SessionGeneratorPanel({
                 </label>
               ) : (
                 <label className="mt-4 block text-sm text-slate-700">
-                  Estimated duration (min)
+                  Estimated duration (15-180 min)
                   <input
                     type="text"
                     inputMode="numeric"
@@ -531,11 +572,7 @@ export default function SessionGeneratorPanel({
               data-testid="session-generator-generate"
               className="inline-flex h-11 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
             >
-              {isGenerating
-                ? "Generating..."
-                : draft
-                  ? "Regenerate draft"
-                  : "Generate session draft"}
+              {isGenerating ? "Generating..." : draft ? "Regenerate session" : "Generate session"}
             </button>
           </div>
         </>

--- a/docs/task-briefs/in-progress/2026-03-28-generator-intake-ux-clarity-and-progressive-disclosure-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-28-generator-intake-ux-clarity-and-progressive-disclosure-10-10.md
@@ -6,11 +6,11 @@
 - `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-03-28`
-- `updated`: `2026-03-29`
+- `updated`: `2026-03-30`
 
 ## Goal
 
-Make `/my-library/generator` understandable on first use by hiding program-only controls from the single-session path, simplifying language, and moving technical payload detail behind calmer progressive disclosure.
+Make `/my-library/generator` understandable on first use by treating it as a true single-session AI generator, simplifying language, and removing redundant setup layers that still read like an internal staging tool.
 
 ## Why This Brief Exists
 
@@ -21,6 +21,10 @@ Make `/my-library/generator` understandable on first use by hiding program-only 
   - `One-run overrides` is correct but not self-explanatory enough,
   - `Deterministic handoff` exposes raw payload/ID detail too aggressively in the normal flow.
 - These are primarily IA, copy, and progressive-disclosure problems, not missing data-contract problems.
+- Live review after slice 1 also showed a second-order UX issue:
+  - `Before you generate` and `This run only` still create too much explanatory overhead,
+  - single-session users still see concepts that belong to a later AI program generator,
+  - session-specific notes/settings feel split across two different areas.
 - The correct next step is a focused UX cleanup that keeps the existing canonical handoff model intact while making the page much easier to understand.
 
 ## Dependencies And Boundaries
@@ -137,10 +141,10 @@ Critical target categories for `10/10` claim in this brief:
 ## Scope
 
 - Rename and simplify the main generator intake copy so the page reads as a user-facing tool instead of an internal staging screen.
-- Hide the `desiredSessionCount` field when target type is `session`.
-- When target type is `program`, relabel that field clearly as `Swim sessions per week`.
-- Simplify the source-data section heading/copy so it reads as information loaded from My Library.
-- Simplify the overrides section heading/copy so it clearly means `this run only`.
+- Treat `/my-library/generator` as a single-session generator for now and hide program-generation controls from the normal flow.
+- Simplify the source-data section heading/copy so it reads as saved information from My Library.
+- Remove the separate `Before you generate` section and its refresh action from the normal user flow.
+- Move remaining one-time session notes into the actual generator panel so users do not have to understand two overlapping setup layers.
 - Rename the route and entrypoint so the experience reads as `AI session generator`, not a technical `generator intake`.
 - Remove the explicit `prepare` step from the normal user flow so current saved data plus this-run-only choices can generate immediately.
 - Remove the raw technical payload preview from the normal end-user flow.
@@ -157,17 +161,18 @@ Critical target categories for `10/10` claim in this brief:
 
 ## Acceptance Criteria
 
-1. `Desired session count` is not shown when target type is `Single session`.
-2. When target type is `Multi-session program`, the same control is shown with a clear weekly-program label.
-3. The section previously labeled `Saved My Library context` is renamed and explained in plainer user-facing language.
-4. The section previously labeled `One-run overrides` is renamed and explained in plainer user-facing language.
-5. The route and My Library entrypoint read as `AI session generator`, not an internal `generator intake` tool.
-6. The explicit `prepare` step is removed from the normal user flow, and generating uses current saved data plus this-run-only choices directly.
-7. The raw technical handoff preview is no longer exposed in the normal end-user flow.
-8. The generator route does not repeat a full saved-session list that already lives in `My sessions`; it uses lighter navigation to that dedicated browse surface instead.
-9. The changed UX remains truthful to the canonical handoff model and does not alter the payload contract unintentionally.
-10. Relevant production admin notes listed above remain explicitly owned by this brief until shipped or intentionally split again.
-11. `npm run lint:briefs`, targeted validation, and `npm run verify:pre-pr` pass before PR update.
+1. `/my-library/generator` behaves as a single-session AI generator in the normal flow; program-generation controls are not shown.
+2. The first intro paragraph and the full `Before you generate` section are removed from the main route.
+3. The source-data section uses plainer, consistent language around saved My Library information.
+4. One-time session notes no longer live in a separate intake section; they are grouped with the generator panel where the session is actually configured.
+5. Session-length guidance in the single-session flow is clear and supports up to `180` minutes where time-based generation is used.
+6. The route and My Library entrypoint read as `AI session generator`, not an internal `generator intake` tool.
+7. The explicit `prepare` step is removed from the normal user flow, and generating uses current saved data plus this-run-only choices directly.
+8. The raw technical handoff preview is no longer exposed in the normal end-user flow.
+9. The generator route does not repeat a full saved-session list that already lives in `My sessions`; it uses lighter navigation to that dedicated browse surface instead.
+10. The changed UX remains truthful to the canonical handoff model and does not alter the payload contract unintentionally.
+11. Relevant production admin notes listed above remain explicitly owned by this brief until shipped or intentionally split again.
+12. `npm run lint:briefs`, targeted validation, and `npm run verify:pre-pr` pass before PR update.
 
 ## Validation
 
@@ -257,6 +262,12 @@ Critical target categories for `10/10` claim in this brief:
 - Commit + push after each validated generator-intake UX slice.
 
 ## Checkpoint Log
+
+- `2026-03-30` — Slice 3 live-review follow-up started on branch `fix/ai-session-generator-ux-clarity-2026-03-30`.
+  - remove the redundant `Before you generate` layer from the normal flow
+  - keep the route session-only for now and hide program-generation controls
+  - rename source context to calmer My Library language
+  - move one-time session notes into the generator panel to reduce overlap with `Generate session`
 
 - `2026-03-29` — slice 2 completed on branch `fix/swim-sessions-and-generator-ia-cleanup-2026-03-29`; the route now reads as `AI session generator`, uses athlete-profile/My Library language instead of internal intake/debug language, removes the explicit prepare gate and technical-preview UI from the normal flow, and keeps canonical saved sessions in the dedicated `My sessions` route instead of duplicating the list inside generator work. Targeted generator/workout vitest and desktop-chromium generator-intake + workout-builder + dryland e2e are green. Next step: run `npm run lint:briefs` and `npm run verify:pre-pr`, then commit/push/open PR if the full gate stays green.`
 - `2026-03-29` — slice 2 started on branch `fix/swim-sessions-and-generator-ia-cleanup-2026-03-29`; live review showed the route still read like an internal tool, so this slice renames the surface to `AI session generator`, removes the explicit prepare gate and visible technical preview from the normal flow, and keeps saved sessions in the dedicated `My sessions` surface instead of duplicating the list inside generator work. Next step: finish the code cleanup, run targeted generator/workout validation, and then `npm run verify:pre-pr`.

--- a/lib/generator-intake/shared.ts
+++ b/lib/generator-intake/shared.ts
@@ -123,13 +123,13 @@ const BLOCK_META: Record<
   },
   personal_records: {
     label: "Personal records",
-    description: "Saved benchmark swims you may want this run to consider.",
+    description: "Saved benchmark swims the generator can use as background.",
     manageHref: "/my-library/profile",
     manageLabel: "Edit personal records",
   },
   goals: {
     label: "Open goals",
-    description: "Open goals that can shape what this run aims toward.",
+    description: "Open goals that can shape what this session aims toward.",
     manageHref: "/my-library/goals",
     manageLabel: "Edit goals",
   },

--- a/tests/e2e/my-library-dryland-builder.spec.ts
+++ b/tests/e2e/my-library-dryland-builder.spec.ts
@@ -56,11 +56,33 @@ test.describe("my library dryland builder", () => {
     );
 
     await createButton.click();
-    await createResponsePromise;
-    await page.waitForURL(/\/my-library\/dryland\/[0-9a-f-]+$/, {
-      timeout: 10_000,
-      waitUntil: "domcontentloaded",
-    });
+    const createResponse = await createResponsePromise;
+    const createResponseBody = (await createResponse.json()) as {
+      ok?: boolean;
+      session?: { id?: string };
+    };
+    const createdSessionId = createResponseBody.session?.id;
+
+    expect(createResponseBody.ok).toBe(true);
+    expect(createdSessionId).toMatch(/^[0-9a-f-]+$/i);
+
+    const targetUrl = new RegExp(`/my-library/dryland/${createdSessionId}$`);
+    const navigatedAfterCreate = await page
+      .waitForURL(targetUrl, {
+        timeout: 10_000,
+        waitUntil: "domcontentloaded",
+      })
+      .then(() => true)
+      .catch(() => false);
+
+    if (!navigatedAfterCreate) {
+      await page.goto(`/my-library/dryland/${createdSessionId}`, {
+        timeout: 60_000,
+        waitUntil: "domcontentloaded",
+      });
+    }
+
+    await expect(page).toHaveURL(targetUrl);
     await waitForDrylandBuilderClientReady(page);
 
     await page.getByTestId("dryland-draft-title").fill(`QA dryland ${Date.now()}`);

--- a/tests/e2e/my-library-generator-intake.spec.ts
+++ b/tests/e2e/my-library-generator-intake.spec.ts
@@ -116,7 +116,7 @@ async function waitForWorkoutBuilderClientReady(page: Page) {
 }
 
 test.describe("my library generator intake", () => {
-  test("opens the AI generator and shows program-only choices only when needed", async ({
+  test("opens the AI generator with saved-library context and session-only settings", async ({
     page,
   }, testInfo) => {
     runOnceOnDesktopChromium(testInfo.project.name);
@@ -146,18 +146,18 @@ test.describe("my library generator intake", () => {
     ).toBeVisible();
     await waitForGeneratorIntakeClientReady(page);
 
+    await expect(page.getByText("Information from My Library")).toBeVisible();
+    await expect(page.getByText("Session information")).toBeVisible();
     await expect(page.getByTestId("generator-intake-session-count")).toHaveCount(0);
-    await page.getByTestId("generator-intake-overrides-toggle").click();
-    await page.getByTestId("generator-intake-target-program").check();
-    await page.getByTestId("generator-intake-session-count").fill("4");
-    await page.getByTestId("generator-intake-session-minutes").selectOption("45");
-    await page.getByTestId("generator-intake-focus-text").fill("Race-pace breathing control");
+    await expect(page.getByTestId("generator-intake-target-program")).toHaveCount(0);
+    await page.getByTestId("session-generator-focus-text").fill("Race-pace breathing control");
     await page
-      .getByTestId("generator-intake-constraint-text")
+      .getByTestId("session-generator-constraint-text")
       .fill("Keep the first week moderate.");
+    await page.getByTestId("generator-intake-source-toggle").click();
 
-    await expect(page.getByTestId("generator-intake-session-count")).toBeVisible();
-    await expect(page.getByTestId("session-generator-program-deferred")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Athlete profile", level: 3 })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Edit athlete profile" })).toBeVisible();
   });
 
   test("accepts one generated session draft and reopens it in the workout builder route", async ({
@@ -173,8 +173,7 @@ test.describe("my library generator intake", () => {
     await expect(page).toHaveURL(/\/my-library\/generator$/);
     await waitForGeneratorIntakeClientReady(page);
 
-    await page.getByTestId("generator-intake-overrides-toggle").click();
-    await page.getByTestId("generator-intake-target-session").check();
+    await page.getByTestId("session-generator-focus-text").fill("Breathing timing under fatigue");
     await prewarmSessionDraftRoute(page);
 
     const generateResponsePromise = page.waitForResponse(

--- a/tests/unit/generator-intake-hub.test.tsx
+++ b/tests/unit/generator-intake-hub.test.tsx
@@ -205,7 +205,7 @@ describe("GeneratorIntakeHub", () => {
     vi.clearAllMocks();
   });
 
-  it("explains the boundary between saved data and one-run overrides", () => {
+  it("keeps the page focused on saved My Library info and session settings", () => {
     render(
       <GeneratorIntakeHub
         initialSnapshot={buildSnapshot()}
@@ -214,13 +214,17 @@ describe("GeneratorIntakeHub", () => {
       />
     );
 
-    expect(screen.getByRole("heading", { name: "Before you generate" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "From My Library" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "This run only" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Information from My Library" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Session information" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Before you generate" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "This run only" })).not.toBeInTheDocument();
     expect(screen.queryByTestId("generator-intake-session-count")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("generator-intake-target-program")).not.toBeInTheDocument();
   });
 
-  it("updates source and override summaries when blocks and one-time choices change", () => {
+  it("updates the saved-information summary when included blocks change", () => {
     render(
       <GeneratorIntakeHub
         initialSnapshot={buildSnapshot()}
@@ -229,22 +233,13 @@ describe("GeneratorIntakeHub", () => {
       />
     );
 
-    fireEvent.click(screen.getByTestId("generator-intake-overrides-toggle"));
-    fireEvent.click(screen.getByTestId("generator-intake-target-program"));
-    fireEvent.change(screen.getByTestId("generator-intake-session-count"), {
-      target: { value: "4" },
-    });
-    fireEvent.change(screen.getByTestId("generator-intake-focus-text"), {
-      target: { value: "Race-pace breathing control" },
-    });
     fireEvent.click(screen.getByTestId("generator-intake-source-toggle"));
     fireEvent.click(screen.getByTestId("generator-intake-include-goals"));
 
-    expect(screen.getByText("4 swim sessions per week")).toBeInTheDocument();
     expect(screen.getByText("4 blocks included")).toBeInTheDocument();
   });
 
-  it("shows swim sessions per week only for the multi-session program path", () => {
+  it("keeps the AI generator on the single-session path only", () => {
     render(
       <GeneratorIntakeHub
         initialSnapshot={buildSnapshot()}
@@ -253,17 +248,8 @@ describe("GeneratorIntakeHub", () => {
       />
     );
 
-    fireEvent.click(screen.getByTestId("generator-intake-overrides-toggle"));
-
     expect(screen.queryByTestId("generator-intake-session-count")).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByTestId("generator-intake-target-program"));
-
-    expect(screen.getByText("Swim sessions per week")).toBeInTheDocument();
-    expect(screen.getByTestId("generator-intake-session-count")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByTestId("generator-intake-target-session"));
-
-    expect(screen.queryByTestId("generator-intake-session-count")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("generator-intake-target-program")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("generator-intake-target-session")).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/session-generator-panel.test.tsx
+++ b/tests/unit/session-generator-panel.test.tsx
@@ -242,10 +242,13 @@ describe("SessionGeneratorPanel", () => {
     vi.clearAllMocks();
   });
 
-  it("keeps program generation deferred in the UI", () => {
+  it("shows session information controls and lets the user clear session notes", () => {
+    const onOverrideChange = vi.fn();
+    const onResetOverrides = vi.fn();
+
     render(
       <SessionGeneratorPanel
-        payload={buildPayload({ targetType: "program" })}
+        payload={buildPayload()}
         selection={{
           profile: true,
           css: true,
@@ -255,17 +258,30 @@ describe("SessionGeneratorPanel", () => {
           focus: true,
         }}
         overrides={{
-          targetType: "program",
+          targetType: "session",
           desiredSessionCount: "",
           desiredSessionMinutes: "45",
-          focusText: "",
-          constraintText: "",
+          focusText: "Breathing timing under fatigue",
+          constraintText: "Keep the first half controlled.",
         }}
+        onOverrideChange={onOverrideChange}
+        onResetOverrides={onResetOverrides}
         workoutLibrary={buildWorkoutLibrary()}
       />
     );
 
-    expect(screen.getByTestId("session-generator-program-deferred")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Session information" })).toBeInTheDocument();
+    fireEvent.change(screen.getByTestId("session-generator-focus-text"), {
+      target: { value: "Race-pace breathing control" },
+    });
+    fireEvent.change(screen.getByTestId("session-generator-constraint-text"), {
+      target: { value: "Keep kick work short." },
+    });
+    fireEvent.click(screen.getByTestId("session-generator-reset-overrides"));
+
+    expect(onOverrideChange).toHaveBeenNthCalledWith(1, "focusText", "Race-pace breathing control");
+    expect(onOverrideChange).toHaveBeenNthCalledWith(2, "constraintText", "Keep kick work short.");
+    expect(onResetOverrides).toHaveBeenCalledTimes(1);
   });
 
   it("generates and allows local editing of a draft session", async () => {
@@ -297,6 +313,8 @@ describe("SessionGeneratorPanel", () => {
           focusText: "",
           constraintText: "Keep the first half controlled.",
         }}
+        onOverrideChange={vi.fn()}
+        onResetOverrides={vi.fn()}
         workoutLibrary={buildWorkoutLibrary()}
       />
     );
@@ -388,6 +406,8 @@ describe("SessionGeneratorPanel", () => {
           focusText: "",
           constraintText: "Keep the first half controlled.",
         }}
+        onOverrideChange={vi.fn()}
+        onResetOverrides={vi.fn()}
         workoutLibrary={buildWorkoutLibrary()}
       />
     );
@@ -440,6 +460,8 @@ describe("SessionGeneratorPanel", () => {
           focusText: "",
           constraintText: "Keep the first half controlled.",
         }}
+        onOverrideChange={vi.fn()}
+        onResetOverrides={vi.fn()}
         workoutLibrary={buildWorkoutLibrary({
           selectedWorkout: buildWorkoutRecord({
             draft: {


### PR DESCRIPTION
## Summary

- User-visible changes: `/my-library/generator` now reads as a true single-session AI generator, removes the redundant setup layer, and keeps session-only notes inside the `Generate session` panel instead of splitting them across multiple sections.
- Technical changes: simplified `GeneratorIntakeHub` and `SessionGeneratorPanel`, removed visible program-only controls from this route, tightened saved-source wording, updated generator unit/e2e coverage, and hardened the dryland create-flow desktop e2e navigation fallback.
- Policy impact: no - this slice changes My Library UI/copy/tests only and does not alter auth/session/account, analytics/consent, user data-rights, or third-party processor behavior.
- Policy version note: N/A - no policy-impacting scope in this slice.
- Brief link(s): `docs/task-briefs/in-progress/2026-03-28-generator-intake-ux-clarity-and-progressive-disclosure-10-10.md`

## Scope

- In scope: AI session generator IA/copy simplification, session-only generator controls, calmer `My Library` source wording, generator unit/e2e updates, brief checkpoint updates, and dryland create-flow e2e hardening discovered during full verify.
- Out of scope: athlete-profile schema changes, new AI generation capability, multi-session program generation, and manual swim/dryland runtime behavior outside the touched generator route and related tests.

## Risk

- Main risk: UI/IA regression on `/my-library/generator` if the simplified session-only language hides a capability an advanced user expected from the old flow.
- Rollback plan: revert `da43adc` with `git revert da43adc` to restore the previous generator setup flow and the earlier dryland e2e behavior.

## Test Evidence

- Policy-impact checklist: N/A - no auth/analytics/data-rights/processor paths changed in this PR.
- `npm run typecheck`: PASS
- `npx vitest run tests/unit/generator-intake-hub.test.tsx tests/unit/session-generator-panel.test.tsx`: PASS
- `npx playwright test tests/e2e/my-library-generator-intake.spec.ts --project=desktop-chromium`: PASS
- `npx playwright test tests/e2e/my-library-dryland-builder.spec.ts --project=desktop-chromium`: PASS
- `npm run verify:pre-pr`: PASS
- `npm run verify:pre-merge`: PENDING for `da43adc` (run after required CI is green on this head)

## Checklist

- [ ] `npm run verify:pre-merge` PASS on `da43adc`
- [ ] Required CI checks green after PR-body fix rerun
- [ ] Acceptance criteria met and brief kept in sync
- [ ] Preview QA completed if this route needs an extra browser sanity pass
