### PR TITLE
feat(my-library): simplify training focus and notes IA

### DIFF
--- a/app/my-library/training/page.tsx
+++ b/app/my-library/training/page.tsx
@@ -69,11 +69,8 @@ export default async function MyLibraryTrainingPage({ searchParams }: Props) {
               </p>
               <h1 className="mt-2 text-3xl font-bold text-slate-900">Focus & Notes</h1>
               <p className="mt-2 max-w-[64ch] text-sm text-slate-600">
-                Keep multiple swim focuses open when needed, choose one primary cue when other My
-                Library surfaces need a single current focus, and capture what you notice in the
-                pool so you can come back with answers or clear next actions after the session.
-                Saved goals can prefill the next step here without becoming the same thing as your
-                focus or notes.
+                Keep today&apos;s cue clear, keep supporting focuses nearby, and save quick notes
+                from the pool without turning this page into a wall of setup text.
               </p>
             </div>
             <div className="flex flex-wrap gap-2">

--- a/components/my-library/training/TrainingContextHub.tsx
+++ b/components/my-library/training/TrainingContextHub.tsx
@@ -144,6 +144,58 @@ function getPrefillMessage(
     : `${goalTitle} was selected from Goals for your next ${workflowLabel}. Start in the highlighted ${workflowLabel} form below.`;
 }
 
+function hasFocusDraftContent(draft: FocusDraft) {
+  return (
+    draft.title.trim().length > 0 ||
+    draft.details.trim().length > 0 ||
+    draft.goalId.trim().length > 0
+  );
+}
+
+function hasNoteDraftContent(draft: NoteDraft) {
+  return (
+    draft.body.trim().length > 0 ||
+    draft.goalId.trim().length > 0 ||
+    draft.focusId.trim().length > 0
+  );
+}
+
+function getFocusComposerSummary(draft: FocusDraft, goalTitle: string | null) {
+  if (draft.title.trim().length > 0) {
+    return `Draft ready: ${draft.title.trim()}`;
+  }
+
+  if (draft.details.trim().length > 0) {
+    return `Draft detail saved: ${getPreviewText(draft.details, "", 80)}`;
+  }
+
+  if (goalTitle) {
+    return `Selected goal: ${goalTitle}`;
+  }
+
+  return "Open when you want to capture the next cue for the pool.";
+}
+
+function getNoteComposerSummary(
+  draft: NoteDraft,
+  goalTitle: string | null,
+  focusTitle: string | null
+) {
+  if (draft.body.trim().length > 0) {
+    return `Draft ready: ${getPreviewText(draft.body, "", 90)}`;
+  }
+
+  if (focusTitle) {
+    return `Selected focus: ${focusTitle}`;
+  }
+
+  if (goalTitle) {
+    return `Selected goal: ${goalTitle}`;
+  }
+
+  return "Open when you want to save an observation or question.";
+}
+
 export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill }: Props) {
   const [snapshot, setSnapshot] = useState(initialSnapshot);
   const [isOnline, setIsOnline] = useState(true);
@@ -168,6 +220,8 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
   const [showFocusHistory, setShowFocusHistory] = useState(false);
   const [pendingNoteCreate, setPendingNoteCreate] = useState(false);
   const [pendingNoteSaveId, setPendingNoteSaveId] = useState<string | null>(null);
+  const [showFocusComposer, setShowFocusComposer] = useState(true);
+  const [showNoteComposer, setShowNoteComposer] = useState(true);
 
   useEffect(() => {
     setIsOnline(readNavigatorOnlineState());
@@ -175,10 +229,14 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
     const restoredNoteDraft = getStorageValue(NOTE_DRAFT_STORAGE_KEY, getDefaultNoteDraft());
     const nextFocusDraft = { ...restoredFocusDraft };
     const nextNoteDraft = { ...restoredNoteDraft };
+    const restoredFocusHasDraft = hasFocusDraftContent(restoredFocusDraft);
+    const restoredNoteHasDraft = hasNoteDraftContent(restoredNoteDraft);
 
     let nextSelectedGoalId = "";
     let nextContextMessage = "";
     let nextPreferredWorkflowIntent: WorkflowIntent | null = null;
+    let nextShowFocusComposer = restoredFocusHasDraft || initialSnapshot.openFocuses.length === 0;
+    let nextShowNoteComposer = restoredNoteHasDraft || initialSnapshot.recentNotes.length === 0;
 
     if (initialGoalPrefill?.goalId) {
       const prefilledGoal = initialSnapshot.goalOptions.find(
@@ -187,13 +245,7 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
 
       if (prefilledGoal) {
         nextPreferredWorkflowIntent = initialGoalPrefill.intent;
-        const hadExistingLocalDraft =
-          restoredFocusDraft.title.trim().length > 0 ||
-          restoredFocusDraft.details.trim().length > 0 ||
-          restoredFocusDraft.goalId.trim().length > 0 ||
-          restoredNoteDraft.body.trim().length > 0 ||
-          restoredNoteDraft.goalId.trim().length > 0 ||
-          restoredNoteDraft.focusId.trim().length > 0;
+        const hadExistingLocalDraft = restoredFocusHasDraft || restoredNoteHasDraft;
 
         nextSelectedGoalId = prefilledGoal.id;
         if (!nextFocusDraft.goalId) {
@@ -208,6 +260,11 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
           initialGoalPrefill.intent,
           hadExistingLocalDraft
         );
+        if (initialGoalPrefill.intent === "focus") {
+          nextShowFocusComposer = true;
+        } else {
+          nextShowNoteComposer = true;
+        }
       } else {
         nextContextMessage =
           "The goal selected from Goals is no longer available. Pick another goal below.";
@@ -219,6 +276,8 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
     setSelectedGoalId(nextSelectedGoalId);
     setPreferredWorkflowIntent(nextPreferredWorkflowIntent);
     setContextMessage(nextContextMessage);
+    setShowFocusComposer(nextShowFocusComposer);
+    setShowNoteComposer(nextShowNoteComposer);
     setClientReady(true);
 
     function onOnline() {
@@ -235,7 +294,13 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
       window.removeEventListener("online", onOnline);
       window.removeEventListener("offline", onOffline);
     };
-  }, [initialGoalPrefill?.goalId, initialGoalPrefill?.intent, initialSnapshot.goalOptions]);
+  }, [
+    initialGoalPrefill?.goalId,
+    initialGoalPrefill?.intent,
+    initialSnapshot.goalOptions,
+    initialSnapshot.openFocuses.length,
+    initialSnapshot.recentNotes.length,
+  ]);
 
   useEffect(() => {
     setStorageValue(FOCUS_DRAFT_STORAGE_KEY, focusDraft);
@@ -270,6 +335,7 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
     setActionSuccess("");
 
     if (intent === "focus") {
+      setShowFocusComposer(true);
       setFocusDraft((prev) => ({ ...prev, goalId: goal.id }));
       setContextMessage(
         `${goal.title} is selected for your next focus. Start in the highlighted focus form below.`
@@ -277,6 +343,7 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
       return;
     }
 
+    setShowNoteComposer(true);
     setNoteDraft((prev) => ({ ...prev, goalId: goal.id }));
     setContextMessage(
       `${goal.title} is selected for your next note. Start in the highlighted note form below.`
@@ -415,6 +482,10 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
       }
 
       setSnapshot(payload.snapshot);
+      if (editingFocusId === focusId) {
+        setEditingFocusId(null);
+        setFocusEditState(null);
+      }
       setActionSuccess(
         action === "complete"
           ? "Focus marked completed."
@@ -639,6 +710,223 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
     editingNote && noteEditState
       ? noteEditState.body.trim() || editingNote.body
       : (snapshot.recentNotes[0]?.body ?? null);
+  const primaryOpenFocus = snapshot.openFocuses.find((focus) => focus.isPrimary) ?? null;
+  const nonPrimaryOpenFocuses = snapshot.openFocuses.filter((focus) => !focus.isPrimary);
+  const focusDraftHasContent = hasFocusDraftContent(focusDraft);
+  const noteDraftHasContent = hasNoteDraftContent(noteDraft);
+  const focusComposerSummary = getFocusComposerSummary(
+    focusDraft,
+    focusDraft.goalId ? (goalOptionById.get(focusDraft.goalId)?.title ?? null) : null
+  );
+  const noteComposerSummary = getNoteComposerSummary(
+    noteDraft,
+    noteDraft.goalId ? (goalOptionById.get(noteDraft.goalId)?.title ?? null) : null,
+    noteDraft.focusId
+      ? (focusOptions.find((focus) => focus.id === noteDraft.focusId)?.title ?? null)
+      : null
+  );
+
+  function renderFocusCard(focus: TrainingFocusView, options?: { featured?: boolean }) {
+    const isEditing = editingFocusId === focus.id && focusEditState !== null;
+    const isStatusPending = pendingFocusActionId === focus.id;
+    const isSavePending = pendingFocusSaveId === focus.id;
+
+    return (
+      <article
+        key={focus.id}
+        data-testid={`training-focus-card-${focus.id}`}
+        className={`rounded-2xl border p-4 ${
+          options?.featured
+            ? "border-white/90 bg-white/90 shadow-[0_10px_30px_rgba(16,24,40,0.06)]"
+            : "border-slate-200 bg-slate-50/50"
+        }`}
+      >
+        <div className="flex flex-wrap items-center gap-2">
+          <h4 className="text-sm font-semibold text-slate-900">
+            {isEditing ? focusEditState.title || focus.title : focus.title}
+          </h4>
+          <span className="inline-flex rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-600">
+            {focus.statusLabel}
+          </span>
+          {focus.isPrimary ? (
+            <span className="inline-flex rounded-full border border-emerald-200 bg-white px-3 py-1 text-xs font-semibold text-emerald-700">
+              Primary
+            </span>
+          ) : null}
+        </div>
+
+        {isEditing ? (
+          <div className="mt-4 space-y-4">
+            <label className="block">
+              <span className="text-sm font-medium text-slate-700">Focus title</span>
+              <input
+                value={focusEditState.title}
+                onChange={(e) =>
+                  setFocusEditState((prev) => (prev ? { ...prev, title: e.target.value } : prev))
+                }
+                className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500"
+              />
+            </label>
+
+            <label className="block">
+              <span className="text-sm font-medium text-slate-700">Optional detail</span>
+              <textarea
+                value={focusEditState.details}
+                onChange={(e) =>
+                  setFocusEditState((prev) => (prev ? { ...prev, details: e.target.value } : prev))
+                }
+                rows={3}
+                className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500"
+              />
+            </label>
+
+            <label className="block">
+              <span className="text-sm font-medium text-slate-700">Optional linked goal</span>
+              <select
+                data-testid={`training-focus-edit-goal-select-${focus.id}`}
+                value={focusEditState.goalId}
+                onChange={(e) =>
+                  setFocusEditState((prev) => (prev ? { ...prev, goalId: e.target.value } : prev))
+                }
+                className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500"
+              >
+                <option value="">No linked goal</option>
+                {snapshot.goalOptions.map((goal) => (
+                  <option key={goal.id} value={goal.id}>
+                    {goal.title} ({goal.statusLabel})
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => void saveFocus(focus.id)}
+                disabled={isSavePending}
+                className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isSavePending ? "Saving..." : "Save focus"}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setEditingFocusId(null);
+                  setFocusEditState(null);
+                }}
+                className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+              >
+                Cancel
+              </button>
+              {focus.isPrimary ? (
+                <button
+                  type="button"
+                  data-testid={`training-focus-clear-primary-${focus.id}`}
+                  onClick={() => void updateFocusStatus(focus.id, "clear_primary")}
+                  disabled={isStatusPending}
+                  className="inline-flex h-10 items-center justify-center rounded-xl border border-emerald-200 bg-white px-4 text-sm font-medium text-emerald-700 transition hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isStatusPending ? "Saving..." : "Remove primary"}
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  data-testid={`training-focus-set-primary-${focus.id}`}
+                  onClick={() => void updateFocusStatus(focus.id, "set_primary")}
+                  disabled={isStatusPending}
+                  className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-4 text-sm font-medium text-blue-700 transition hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isStatusPending ? "Saving..." : "Set primary"}
+                </button>
+              )}
+              <button
+                type="button"
+                data-testid={`training-focus-complete-${focus.id}`}
+                onClick={() => void updateFocusStatus(focus.id, "complete")}
+                disabled={isStatusPending}
+                className="inline-flex h-10 items-center justify-center rounded-xl bg-emerald-600 px-4 text-sm font-semibold text-white transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isStatusPending ? "Saving..." : "Mark completed"}
+              </button>
+              <button
+                type="button"
+                data-testid={`training-focus-archive-${focus.id}`}
+                onClick={() => void updateFocusStatus(focus.id, "archive")}
+                disabled={isStatusPending}
+                className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Archive
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <p className="mt-2 text-sm text-slate-700">
+              {focus.details ?? "No extra detail saved for this focus yet."}
+            </p>
+            {focus.goalTitle ? (
+              <p className="mt-2 text-xs text-slate-600">Goal: {focus.goalTitle}</p>
+            ) : null}
+            <div className="mt-4 flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => openFocusEditor(focus)}
+                className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+              >
+                Edit focus
+              </button>
+              {focus.isPrimary ? (
+                <>
+                  <button
+                    type="button"
+                    data-testid={`training-focus-clear-primary-${focus.id}`}
+                    onClick={() => void updateFocusStatus(focus.id, "clear_primary")}
+                    disabled={isStatusPending}
+                    className="inline-flex h-10 items-center justify-center rounded-xl border border-emerald-200 bg-white px-4 text-sm font-medium text-emerald-700 transition hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {isStatusPending ? "Saving..." : "Remove primary"}
+                  </button>
+                  <button
+                    type="button"
+                    data-testid={`training-focus-complete-${focus.id}`}
+                    onClick={() => void updateFocusStatus(focus.id, "complete")}
+                    disabled={isStatusPending}
+                    className="inline-flex h-10 items-center justify-center rounded-xl bg-emerald-600 px-4 text-sm font-semibold text-white transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {isStatusPending ? "Saving..." : "Mark completed"}
+                  </button>
+                  <button
+                    type="button"
+                    data-testid={`training-focus-archive-${focus.id}`}
+                    onClick={() => void updateFocusStatus(focus.id, "archive")}
+                    disabled={isStatusPending}
+                    className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    Archive
+                  </button>
+                </>
+              ) : (
+                <button
+                  type="button"
+                  data-testid={`training-focus-set-primary-${focus.id}`}
+                  onClick={() => void updateFocusStatus(focus.id, "set_primary")}
+                  disabled={isStatusPending}
+                  className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-4 text-sm font-medium text-blue-700 transition hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isStatusPending ? "Saving..." : "Set primary"}
+                </button>
+              )}
+            </div>
+            {!focus.isPrimary ? (
+              <p className="mt-3 text-xs text-slate-500">
+                Complete or archive from Edit focus when this cue is done.
+              </p>
+            ) : null}
+          </>
+        )}
+      </article>
+    );
+  }
 
   return (
     <div
@@ -702,7 +990,7 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
       ) : null}
 
       <section className="rounded-2xl border border-blue-100 bg-blue-50/60 p-5">
-        <h2 className="text-base font-semibold text-slate-900">How these work together</h2>
+        <h2 className="text-base font-semibold text-slate-900">Today at a glance</h2>
         <div className="mt-3 grid gap-3 md:grid-cols-3">
           <a
             href="#training-goals-section"
@@ -716,7 +1004,7 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
             <p className="mt-2 text-sm text-slate-700">
               {overviewGoal
                 ? `Current goal context${overviewGoal.statusLabel ? ` • ${overviewGoal.statusLabel}` : ""}`
-                : "Choose a goal below when you want to connect long-term direction to today’s work."}
+                : "Choose a goal below when you want a little longer-term context."}
             </p>
           </a>
           <a
@@ -737,7 +1025,7 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
                   ? "Primary focus for the rest of My Library."
                   : selectedFocus
                     ? "Current focus cue shown from your open focus list."
-                    : "Add the next technical or tactical cue you want to carry into the pool."}
+                    : "Add the next cue you want to carry into the pool."}
             </p>
           </a>
           <a
@@ -767,12 +1055,10 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
       >
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <h2 className="text-lg font-semibold text-slate-900">
-              Turn a goal into today&apos;s work
-            </h2>
+            <h2 className="text-lg font-semibold text-slate-900">Start from a goal</h2>
             <p className="mt-2 text-sm text-slate-600">
-              Goals stay long-term. Use one here to prefill the next focus or note without
-              re-selecting it everywhere.
+              Goals stay long-term. Use one here when you want the next focus or note to start with
+              the right context.
             </p>
           </div>
           {selectedGoal ? (
@@ -868,10 +1154,9 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
       >
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <h2 className="text-lg font-semibold text-slate-900">Open focuses</h2>
+            <h2 className="text-lg font-semibold text-slate-900">Focus</h2>
             <p className="mt-2 text-sm text-slate-600">
-              Keep several current training cues open. Choose one as your primary focus when My
-              Library needs one clear cue elsewhere.
+              Keep the main cue clear and keep supporting focuses close by when you still need them.
             </p>
           </div>
           <button
@@ -897,6 +1182,19 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
                   You have {snapshot.openFocuses.length} open focuses and no primary focus selected
                   yet. Pick one below before other My Library surfaces try to use a single current
                   cue.
+                </p>
+              </div>
+            ) : primaryOpenFocus ? (
+              <div className="rounded-2xl border border-emerald-200 bg-emerald-50/40 p-5">
+                <div className="flex flex-wrap items-center gap-2">
+                  <h3 className="text-base font-semibold text-slate-900">Primary focus</h3>
+                  <span className="inline-flex rounded-full border border-emerald-200 bg-white px-3 py-1 text-xs font-semibold text-emerald-700">
+                    Used across My Library
+                  </span>
+                </div>
+                <p className="mt-2 text-sm text-slate-700">
+                  Keep one clear cue here when other My Library surfaces need a single current
+                  focus.
                 </p>
               </div>
             ) : selectedFocus ? (
@@ -939,29 +1237,44 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
             ) : null}
           </div>
 
-          <form
-            onSubmit={createFocus}
-            data-testid="training-focus-form"
-            data-goal-intent-highlight={preferredWorkflowIntent === "focus" ? "true" : "false"}
+          <div
             className={`rounded-2xl border p-5 transition ${
               preferredWorkflowIntent === "focus"
                 ? "border-blue-300 bg-blue-50/60 shadow-[0_12px_36px_rgba(37,99,235,0.08)]"
                 : "border-slate-200 bg-slate-50/60"
             }`}
           >
-            <div className="flex flex-wrap items-center gap-2">
-              <h3 className="text-base font-semibold text-slate-900">Add a new open focus</h3>
-              {preferredWorkflowIntent === "focus" ? (
-                <span
-                  data-testid="training-focus-intent-badge"
-                  className="inline-flex rounded-full border border-blue-200 bg-white px-3 py-1 text-xs font-semibold text-blue-700"
-                >
-                  From Goals
-                </span>
-              ) : null}
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <h3 className="text-base font-semibold text-slate-900">Add focus</h3>
+                {preferredWorkflowIntent === "focus" ? (
+                  <span
+                    data-testid="training-focus-intent-badge"
+                    className="inline-flex rounded-full border border-blue-200 bg-white px-3 py-1 text-xs font-semibold text-blue-700"
+                  >
+                    From Goals
+                  </span>
+                ) : null}
+              </div>
+              <button
+                type="button"
+                data-testid="training-focus-form-toggle"
+                aria-expanded={showFocusComposer}
+                aria-controls="training-focus-form"
+                onClick={() => setShowFocusComposer((prev) => !prev)}
+                className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+              >
+                {showFocusComposer
+                  ? "Collapse"
+                  : focusDraftHasContent
+                    ? "Resume draft"
+                    : "Add focus"}
+              </button>
             </div>
             <p className="mt-2 text-sm text-slate-600">
-              Saving a new focus will never auto-complete or auto-archive the ones you already have.
+              {showFocusComposer
+                ? "Saving a new focus will never auto-complete or auto-archive the ones you already have."
+                : focusComposerSummary}
             </p>
             {preferredWorkflowIntent === "focus" ? (
               <p className="mt-2 text-sm font-medium text-blue-700">
@@ -977,227 +1290,93 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
                 </span>
               </p>
             ) : null}
-            <div className="mt-4 space-y-4">
-              <label className="block">
-                <span className="text-sm font-medium text-slate-700">Focus title</span>
-                <input
-                  value={focusDraft.title}
-                  onChange={(e) => setFocusDraft((prev) => ({ ...prev, title: e.target.value }))}
-                  placeholder="Exhale calmly before turning to breathe"
-                  className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-blue-500"
-                />
-              </label>
-
-              <label className="block">
-                <span className="text-sm font-medium text-slate-700">Optional detail</span>
-                <textarea
-                  value={focusDraft.details}
-                  onChange={(e) => setFocusDraft((prev) => ({ ...prev, details: e.target.value }))}
-                  rows={3}
-                  placeholder="What do you want to watch for in the next session?"
-                  className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-blue-500"
-                />
-              </label>
-
-              <label className="block">
-                <span className="text-sm font-medium text-slate-700">Optional linked goal</span>
-                <select
-                  data-testid="training-focus-goal-select"
-                  value={focusDraft.goalId}
-                  onChange={(e) => setFocusDraft((prev) => ({ ...prev, goalId: e.target.value }))}
-                  className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500"
-                >
-                  <option value="">No linked goal</option>
-                  {snapshot.goalOptions.map((goal) => (
-                    <option key={goal.id} value={goal.id}>
-                      {goal.title} ({goal.statusLabel})
-                    </option>
-                  ))}
-                </select>
-              </label>
-
-              <button
-                type="submit"
-                disabled={!snapshot.schemaReady || pendingFocusCreate}
-                className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+            {showFocusComposer ? (
+              <form
+                id="training-focus-form"
+                onSubmit={createFocus}
+                data-testid="training-focus-form"
+                data-goal-intent-highlight={preferredWorkflowIntent === "focus" ? "true" : "false"}
+                className="mt-4 space-y-4"
               >
-                {pendingFocusCreate ? "Saving..." : "Save open focus"}
-              </button>
-            </div>
-          </form>
+                <label className="block">
+                  <span className="text-sm font-medium text-slate-700">Focus title</span>
+                  <input
+                    value={focusDraft.title}
+                    onChange={(e) => setFocusDraft((prev) => ({ ...prev, title: e.target.value }))}
+                    placeholder="Exhale calmly before turning to breathe"
+                    className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-blue-500"
+                  />
+                </label>
+
+                <label className="block">
+                  <span className="text-sm font-medium text-slate-700">Optional detail</span>
+                  <textarea
+                    value={focusDraft.details}
+                    onChange={(e) =>
+                      setFocusDraft((prev) => ({ ...prev, details: e.target.value }))
+                    }
+                    rows={3}
+                    placeholder="What do you want to watch for in the next session?"
+                    className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-blue-500"
+                  />
+                </label>
+
+                <label className="block">
+                  <span className="text-sm font-medium text-slate-700">Optional linked goal</span>
+                  <select
+                    data-testid="training-focus-goal-select"
+                    value={focusDraft.goalId}
+                    onChange={(e) => setFocusDraft((prev) => ({ ...prev, goalId: e.target.value }))}
+                    className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500"
+                  >
+                    <option value="">No linked goal</option>
+                    {snapshot.goalOptions.map((goal) => (
+                      <option key={goal.id} value={goal.id}>
+                        {goal.title} ({goal.statusLabel})
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <button
+                  type="submit"
+                  disabled={!snapshot.schemaReady || pendingFocusCreate}
+                  className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {pendingFocusCreate ? "Saving..." : "Save open focus"}
+                </button>
+              </form>
+            ) : null}
+          </div>
         </div>
 
-        {snapshot.openFocuses.length > 0 ? (
+        {primaryOpenFocus ? (
+          <div className="mt-5 space-y-5">
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-600">
+                Primary focus
+              </h3>
+              <div className="mt-3">{renderFocusCard(primaryOpenFocus, { featured: true })}</div>
+            </div>
+
+            {nonPrimaryOpenFocuses.length > 0 ? (
+              <div>
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-600">
+                  Other open focuses
+                </h3>
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  {nonPrimaryOpenFocuses.map((focus) => renderFocusCard(focus))}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        ) : snapshot.openFocuses.length > 0 ? (
           <div className="mt-5">
             <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-600">
               Open focus list
             </h3>
             <div className="mt-3 grid gap-3 md:grid-cols-2">
-              {snapshot.openFocuses.map((focus) => {
-                const isEditing = editingFocusId === focus.id && focusEditState !== null;
-                const isStatusPending = pendingFocusActionId === focus.id;
-                const isSavePending = pendingFocusSaveId === focus.id;
-
-                return (
-                  <article
-                    key={focus.id}
-                    data-testid={`training-focus-card-${focus.id}`}
-                    className={`rounded-2xl border p-4 ${
-                      focus.isPrimary
-                        ? "border-emerald-200 bg-emerald-50/40"
-                        : "border-slate-200 bg-slate-50/50"
-                    }`}
-                  >
-                    <div className="flex flex-wrap items-center gap-2">
-                      <h4 className="text-sm font-semibold text-slate-900">
-                        {isEditing ? focusEditState.title || focus.title : focus.title}
-                      </h4>
-                      <span className="inline-flex rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-600">
-                        {focus.statusLabel}
-                      </span>
-                      {focus.isPrimary ? (
-                        <span className="inline-flex rounded-full border border-emerald-200 bg-white px-3 py-1 text-xs font-semibold text-emerald-700">
-                          Primary
-                        </span>
-                      ) : null}
-                    </div>
-
-                    {isEditing ? (
-                      <div className="mt-4 space-y-4">
-                        <label className="block">
-                          <span className="text-sm font-medium text-slate-700">Focus title</span>
-                          <input
-                            value={focusEditState.title}
-                            onChange={(e) =>
-                              setFocusEditState((prev) =>
-                                prev ? { ...prev, title: e.target.value } : prev
-                              )
-                            }
-                            className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500"
-                          />
-                        </label>
-
-                        <label className="block">
-                          <span className="text-sm font-medium text-slate-700">
-                            Optional detail
-                          </span>
-                          <textarea
-                            value={focusEditState.details}
-                            onChange={(e) =>
-                              setFocusEditState((prev) =>
-                                prev ? { ...prev, details: e.target.value } : prev
-                              )
-                            }
-                            rows={3}
-                            className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500"
-                          />
-                        </label>
-
-                        <label className="block">
-                          <span className="text-sm font-medium text-slate-700">
-                            Optional linked goal
-                          </span>
-                          <select
-                            data-testid={`training-focus-edit-goal-select-${focus.id}`}
-                            value={focusEditState.goalId}
-                            onChange={(e) =>
-                              setFocusEditState((prev) =>
-                                prev ? { ...prev, goalId: e.target.value } : prev
-                              )
-                            }
-                            className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500"
-                          >
-                            <option value="">No linked goal</option>
-                            {snapshot.goalOptions.map((goal) => (
-                              <option key={goal.id} value={goal.id}>
-                                {goal.title} ({goal.statusLabel})
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-
-                        <div className="flex flex-wrap gap-2">
-                          <button
-                            type="button"
-                            onClick={() => void saveFocus(focus.id)}
-                            disabled={isSavePending}
-                            className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
-                          >
-                            {isSavePending ? "Saving..." : "Save focus"}
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => {
-                              setEditingFocusId(null);
-                              setFocusEditState(null);
-                            }}
-                            className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
-                          >
-                            Cancel
-                          </button>
-                        </div>
-                      </div>
-                    ) : (
-                      <>
-                        <p className="mt-2 text-sm text-slate-700">
-                          {focus.details ?? "No extra detail saved for this focus yet."}
-                        </p>
-                        {focus.goalTitle ? (
-                          <p className="mt-2 text-xs text-slate-600">Goal: {focus.goalTitle}</p>
-                        ) : null}
-                        <div className="mt-4 flex flex-wrap gap-2">
-                          <button
-                            type="button"
-                            onClick={() => openFocusEditor(focus)}
-                            className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
-                          >
-                            Edit focus
-                          </button>
-                          {focus.isPrimary ? (
-                            <button
-                              type="button"
-                              data-testid={`training-focus-clear-primary-${focus.id}`}
-                              onClick={() => void updateFocusStatus(focus.id, "clear_primary")}
-                              disabled={isStatusPending}
-                              className="inline-flex h-10 items-center justify-center rounded-xl border border-emerald-200 bg-white px-4 text-sm font-medium text-emerald-700 transition hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-60"
-                            >
-                              {isStatusPending ? "Saving..." : "Remove primary"}
-                            </button>
-                          ) : (
-                            <button
-                              type="button"
-                              data-testid={`training-focus-set-primary-${focus.id}`}
-                              onClick={() => void updateFocusStatus(focus.id, "set_primary")}
-                              disabled={isStatusPending}
-                              className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-4 text-sm font-medium text-blue-700 transition hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-60"
-                            >
-                              {isStatusPending ? "Saving..." : "Set primary"}
-                            </button>
-                          )}
-                          <button
-                            type="button"
-                            data-testid={`training-focus-complete-${focus.id}`}
-                            onClick={() => void updateFocusStatus(focus.id, "complete")}
-                            disabled={isStatusPending}
-                            className="inline-flex h-10 items-center justify-center rounded-xl bg-emerald-600 px-4 text-sm font-semibold text-white transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
-                          >
-                            {isStatusPending ? "Saving..." : "Mark completed"}
-                          </button>
-                          <button
-                            type="button"
-                            data-testid={`training-focus-archive-${focus.id}`}
-                            onClick={() => void updateFocusStatus(focus.id, "archive")}
-                            disabled={isStatusPending}
-                            className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-                          >
-                            Archive
-                          </button>
-                        </div>
-                      </>
-                    )}
-                  </article>
-                );
-              })}
+              {snapshot.openFocuses.map((focus) => renderFocusCard(focus))}
             </div>
           </div>
         ) : null}
@@ -1249,7 +1428,8 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
           <div>
             <h2 className="text-lg font-semibold text-slate-900">Notes</h2>
             <p className="mt-2 text-sm text-slate-600">
-              Save observations and questions while they are fresh, then answer or close them later.
+              Keep short observations and questions close to the training moment, then answer or
+              close them later.
             </p>
           </div>
           <div className="flex flex-wrap gap-3 text-sm">
@@ -1264,27 +1444,41 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
           </div>
         </div>
 
-        <form
-          onSubmit={createNote}
-          data-testid="training-note-form"
-          data-goal-intent-highlight={preferredWorkflowIntent === "note" ? "true" : "false"}
+        <div
           className={`mt-5 rounded-2xl border p-5 transition ${
             preferredWorkflowIntent === "note"
               ? "border-blue-300 bg-blue-50/60 shadow-[0_12px_36px_rgba(37,99,235,0.08)]"
               : "border-slate-200 bg-slate-50/60"
           }`}
         >
-          <div className="flex flex-wrap items-center gap-2">
-            <h3 className="text-base font-semibold text-slate-900">Add a note</h3>
-            {preferredWorkflowIntent === "note" ? (
-              <span
-                data-testid="training-note-intent-badge"
-                className="inline-flex rounded-full border border-blue-200 bg-white px-3 py-1 text-xs font-semibold text-blue-700"
-              >
-                From Goals
-              </span>
-            ) : null}
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="text-base font-semibold text-slate-900">Add note</h3>
+              {preferredWorkflowIntent === "note" ? (
+                <span
+                  data-testid="training-note-intent-badge"
+                  className="inline-flex rounded-full border border-blue-200 bg-white px-3 py-1 text-xs font-semibold text-blue-700"
+                >
+                  From Goals
+                </span>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              data-testid="training-note-form-toggle"
+              aria-expanded={showNoteComposer}
+              aria-controls="training-note-form"
+              onClick={() => setShowNoteComposer((prev) => !prev)}
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+            >
+              {showNoteComposer ? "Collapse" : noteDraftHasContent ? "Resume draft" : "Add note"}
+            </button>
           </div>
+          <p className="mt-2 text-sm text-slate-600">
+            {showNoteComposer
+              ? "Use this for a quick observation or a question you want to answer later."
+              : noteComposerSummary}
+          </p>
           {preferredWorkflowIntent === "note" ? (
             <p className="mt-2 text-sm font-medium text-blue-700">
               This is the recommended next step for the selected goal. Use it for an observation or
@@ -1299,85 +1493,95 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
               </span>
             </p>
           ) : null}
-          <div className="mt-4 grid gap-4 lg:grid-cols-2">
-            <label className="block">
-              <span className="text-sm font-medium text-slate-700">Type</span>
-              <select
-                value={noteDraft.noteType}
-                onChange={(e) =>
-                  setNoteDraft((prev) => ({
-                    ...prev,
-                    noteType: e.target.value as NoteDraft["noteType"],
-                  }))
-                }
-                className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500"
-              >
-                <option value="observation">{getTrainingNoteTypeLabel("observation")}</option>
-                <option value="question">{getTrainingNoteTypeLabel("question")}</option>
-              </select>
-            </label>
-
-            <label className="block">
-              <span className="text-sm font-medium text-slate-700">Optional linked goal</span>
-              <select
-                data-testid="training-note-goal-select"
-                value={noteDraft.goalId}
-                onChange={(e) => setNoteDraft((prev) => ({ ...prev, goalId: e.target.value }))}
-                className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500"
-              >
-                <option value="">No linked goal</option>
-                {snapshot.goalOptions.map((goal) => (
-                  <option key={goal.id} value={goal.id}>
-                    {goal.title} ({goal.statusLabel})
-                  </option>
-                ))}
-              </select>
-            </label>
-          </div>
-
-          <label className="mt-4 block">
-            <span className="text-sm font-medium text-slate-700">
-              {noteDraft.noteType === "question" ? "Question" : "Observation"}
-            </span>
-            <textarea
-              value={noteDraft.body}
-              onChange={(e) => setNoteDraft((prev) => ({ ...prev, body: e.target.value }))}
-              rows={4}
-              placeholder={
-                noteDraft.noteType === "question"
-                  ? "What do you want to check later?"
-                  : "What did you notice in the pool?"
-              }
-              className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-blue-500"
-            />
-          </label>
-
-          <label className="mt-4 block">
-            <span className="text-sm font-medium text-slate-700">Optional linked focus</span>
-            <select
-              value={noteDraft.focusId}
-              onChange={(e) => setNoteDraft((prev) => ({ ...prev, focusId: e.target.value }))}
-              className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500"
+          {showNoteComposer ? (
+            <form
+              id="training-note-form"
+              onSubmit={createNote}
+              data-testid="training-note-form"
+              data-goal-intent-highlight={preferredWorkflowIntent === "note" ? "true" : "false"}
+              className="mt-4"
             >
-              <option value="">No linked focus</option>
-              {focusOptions.map((focus) => (
-                <option key={focus.id} value={focus.id}>
-                  {focus.title}
-                  {focus.isPrimary ? " (Primary)" : ""}
-                  {` (${focus.statusLabel})`}
-                </option>
-              ))}
-            </select>
-          </label>
+              <div className="grid gap-4 lg:grid-cols-2">
+                <label className="block">
+                  <span className="text-sm font-medium text-slate-700">Type</span>
+                  <select
+                    value={noteDraft.noteType}
+                    onChange={(e) =>
+                      setNoteDraft((prev) => ({
+                        ...prev,
+                        noteType: e.target.value as NoteDraft["noteType"],
+                      }))
+                    }
+                    className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500"
+                  >
+                    <option value="observation">{getTrainingNoteTypeLabel("observation")}</option>
+                    <option value="question">{getTrainingNoteTypeLabel("question")}</option>
+                  </select>
+                </label>
 
-          <button
-            type="submit"
-            disabled={!snapshot.schemaReady || pendingNoteCreate}
-            className="mt-4 inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {pendingNoteCreate ? "Saving..." : "Save note"}
-          </button>
-        </form>
+                <label className="block">
+                  <span className="text-sm font-medium text-slate-700">Optional linked goal</span>
+                  <select
+                    data-testid="training-note-goal-select"
+                    value={noteDraft.goalId}
+                    onChange={(e) => setNoteDraft((prev) => ({ ...prev, goalId: e.target.value }))}
+                    className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500"
+                  >
+                    <option value="">No linked goal</option>
+                    {snapshot.goalOptions.map((goal) => (
+                      <option key={goal.id} value={goal.id}>
+                        {goal.title} ({goal.statusLabel})
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+
+              <label className="mt-4 block">
+                <span className="text-sm font-medium text-slate-700">
+                  {noteDraft.noteType === "question" ? "Question" : "Observation"}
+                </span>
+                <textarea
+                  value={noteDraft.body}
+                  onChange={(e) => setNoteDraft((prev) => ({ ...prev, body: e.target.value }))}
+                  rows={4}
+                  placeholder={
+                    noteDraft.noteType === "question"
+                      ? "What do you want to check later?"
+                      : "What did you notice in the pool?"
+                  }
+                  className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-blue-500"
+                />
+              </label>
+
+              <label className="mt-4 block">
+                <span className="text-sm font-medium text-slate-700">Optional linked focus</span>
+                <select
+                  value={noteDraft.focusId}
+                  onChange={(e) => setNoteDraft((prev) => ({ ...prev, focusId: e.target.value }))}
+                  className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-500"
+                >
+                  <option value="">No linked focus</option>
+                  {focusOptions.map((focus) => (
+                    <option key={focus.id} value={focus.id}>
+                      {focus.title}
+                      {focus.isPrimary ? " (Primary)" : ""}
+                      {` (${focus.statusLabel})`}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <button
+                type="submit"
+                disabled={!snapshot.schemaReady || pendingNoteCreate}
+                className="mt-4 inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {pendingNoteCreate ? "Saving..." : "Save note"}
+              </button>
+            </form>
+          ) : null}
+        </div>
 
         {snapshot.recentNotes.length === 0 ? (
           <div className="mt-5 rounded-2xl border border-dashed border-slate-300 bg-slate-50/70 p-6">

--- a/docs/runbooks/core-flow-incident-response.md
+++ b/docs/runbooks/core-flow-incident-response.md
@@ -49,6 +49,8 @@ Additional `My Library` sub-route checks:
   - confirm `Use as focus` and `Add note` links include a canonical `goalId` query param,
   - confirm opening the linked training route preselects the intended goal without mutating the goal row,
   - confirm existing local focus/note draft text is preserved when goal-prefill is applied.
+  - confirm collapsed `Add focus` / `Add note` composers reopen with the same local draft text and linked goal context still intact.
+  - confirm non-primary open focuses still expose complete/archive actions through `Edit focus`, even though the default card surface is calmer.
 - `/my-library/generator`
   - confirm `/api/my-library/generator-intake` returns owner-scoped `200` or fail-closed `401`,
   - confirm `/api/my-library/generator/session-draft` returns owner-scoped `200` for session target, `401` for unauthenticated reads, and explicit `422` when program target is chosen in this slice,

--- a/docs/task-briefs/done/2026-03-30-passkey-first-sign-in-and-admin-site-lock-unlock-10-10.md
+++ b/docs/task-briefs/done/2026-03-30-passkey-first-sign-in-and-admin-site-lock-unlock-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-03-30-passkey-first-sign-in-and-admin-site-lock-unlock-10-10`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-03-30`
 - `updated`: `2026-03-30`
@@ -194,3 +194,4 @@ Critical target categories for `10/10` claim in this brief:
 - `2026-03-30 | working tree | confirmed current provider-native Supabase WebAuthn support in this stack is session-bound MFA/step-up, not a standalone unauthenticated passkey sign-in primitive; updated /auth/sign-in to a passkey-aware email-code flow with explicit device support status, less email-heavy copy, and honest recovery framing instead of a fake passkey button | validation: npm run typecheck, npx vitest run tests/unit/auth-passkey-readiness-card.test.tsx tests/unit/sign-in-ui-state.test.ts tests/unit/sign-in-request.test.ts, npx playwright test tests/e2e/auth-sign-in-ux.spec.ts --project=desktop-chromium | next: run npm run verify:pre-pr on this slice, then open PR if green`
 - `2026-03-30 | working tree | owner chose the recommended phased rollout over true passkey-first entry: keep email-code bootstrap, then guide newly signed-in users toward adding a passkey on the current device from My Library > Account & Security; next slice now owns My Library onboarding clarity and security-page setup guidance so the recommended path is obvious in-product | next: implement the onboarding card and setup callout, then rerun targeted tests + verify:pre-pr`
 - `2026-03-30 | working tree | live iPhone validation exposed that current hosted Supabase auth does not support the promised passkey flow in this product path; cleanup slice now removes false passkey/setup promises, restores truthful email-code + preview-password guidance, and records real passkeys as a future architecture decision instead of an environment-toggle assumption | next: update tests/brief/runbooks to the honest contract, rerun targeted auth suites, then run full verify:pre-pr`
+- `2026-03-30 | 1db55c1 | merged via PR #325 after required CI checks passed; auth truthfulness cleanup is now on main and this brief moves to done | next: use the done auth contract as the baseline for later real-passkeys decision and rollout planning`

--- a/docs/task-briefs/in-progress/2026-03-30-my-library-training-focus-goals-notes-ia-simplification-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-30-my-library-training-focus-goals-notes-ia-simplification-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-03-30-my-library-training-focus-goals-notes-ia-simplification-10-10`
-- `status`: `planned`
+- `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-03-30`
 - `updated`: `2026-03-30`
@@ -213,7 +213,6 @@ Critical target categories for `10/10` claim in this brief:
 ## Validation
 
 - `npm run lint:briefs`
-- `npm run lint:briefs:all` while this planned brief is still untracked
 - `npm run lint`
 - `npm run typecheck`
 - targeted unit tests for:
@@ -331,3 +330,5 @@ Critical target categories for `10/10` claim in this brief:
 
 - `2026-03-30 | working tree | aligned this planned brief with the current repo execution defaults so validation, automation ownership, and Safari QA expectations are explicit before implementation starts | next: keep the slice planned until the route simplification work is scheduled`
 - `2026-03-30 | planning | created a dedicated training-route follow-up brief after production notes showed that /my-library/training still feels too verbose and action-dense even though the underlying goals/focus/notes model is sound; locked scope to calmer IA, collapsible composers, and primary-first focus presentation without schema change | next: implement route simplification, update tests/docs, and validate with verify:pre-pr`
+- `2026-03-30 | working tree | implementation started on branch \`feat/my-library-training-ia-simplification-2026-03-30\`; brief moved to in-progress and lifecycle-aligned with the already-merged auth cleanup so this slice can focus on calmer training IA, collapsible composers, and primary-first focus actions | next: ship the training route UI changes, update tests/runbook coverage, then run lint:briefs + verify:pre-pr before PR handoff`
+- `2026-03-30 | working tree | shipped calmer /my-library/training IA locally: shorter hero/bridge copy, collapsible Add focus/Add note composers with preserved drafts, primary-first focus grouping, and calmer non-primary action surfaces; updated incident-response runbook plus unit + targeted Playwright coverage, then passed \`npm run lint:briefs:all\`, \`npm run typecheck\`, \`npx vitest run tests/unit/training-context-hub.test.tsx\`, \`npx playwright test tests/e2e/my-library-training-context.spec.ts --project=desktop-chromium\`, and full \`npm run verify:pre-pr\` | next: commit, push branch, open PR, and monitor CI`

--- a/docs/task-briefs/planned/2026-03-30-clerk-passkeys-paying-members-first-10-10.md
+++ b/docs/task-briefs/planned/2026-03-30-clerk-passkeys-paying-members-first-10-10.md
@@ -35,7 +35,7 @@ Ship a production-safe first real passkey rollout using Clerk for paying subscri
 ## Dependencies And Boundaries
 
 - This brief depends on [2026-03-30-real-passkeys-architecture-decision-and-rollout-gate-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/planned/2026-03-30-real-passkeys-architecture-decision-and-rollout-gate-10-10.md) being explicitly accepted with `Clerk` still chosen.
-- Current truthful auth behavior remains owned by [2026-03-30-passkey-first-sign-in-and-admin-site-lock-unlock-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-03-30-passkey-first-sign-in-and-admin-site-lock-unlock-10-10.md) until this rollout actually starts.
+- Current truthful auth behavior baseline was established by [2026-03-30-passkey-first-sign-in-and-admin-site-lock-unlock-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-30-passkey-first-sign-in-and-admin-site-lock-unlock-10-10.md) and stays the live contract until this rollout actually starts.
 - This brief owns:
   - provider-specific member migration planning,
   - identity/entitlement linkage rules,

--- a/docs/task-briefs/planned/2026-03-30-real-passkeys-architecture-decision-and-rollout-gate-10-10.md
+++ b/docs/task-briefs/planned/2026-03-30-real-passkeys-architecture-decision-and-rollout-gate-10-10.md
@@ -82,12 +82,12 @@ Choose a production-safe path for real passkeys on freeswimming.org, with explic
 ## Admin Notes Triage Disposition
 
 - This is a planned decision brief, not a new implementation slice.
-- It inherits the same-day auth/security production-note review already recorded in [2026-03-30-passkey-first-sign-in-and-admin-site-lock-unlock-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-03-30-passkey-first-sign-in-and-admin-site-lock-unlock-10-10.md): no open production admin note was found to directly own passkey, WebAuthn, sign-in, or site-lock auth scope at that review time.
+- It inherits the same-day auth/security production-note review already recorded in [2026-03-30-passkey-first-sign-in-and-admin-site-lock-unlock-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-30-passkey-first-sign-in-and-admin-site-lock-unlock-10-10.md): no open production admin note was found to directly own passkey, WebAuthn, sign-in, or site-lock auth scope at that review time.
 - Before any implementation starts under this planned brief, production admin-note triage must be rerun against the live queue and recorded explicitly in the implementation brief.
 
 ## Dependencies And Boundaries
 
-- Current truthful auth copy and live UX remain owned by [2026-03-30-passkey-first-sign-in-and-admin-site-lock-unlock-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-03-30-passkey-first-sign-in-and-admin-site-lock-unlock-10-10.md).
+- Current truthful auth copy and live UX baseline were established by [2026-03-30-passkey-first-sign-in-and-admin-site-lock-unlock-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-30-passkey-first-sign-in-and-admin-site-lock-unlock-10-10.md).
 - This brief owns:
   - architecture comparison,
   - security/recovery/rollback decision criteria,

--- a/tests/e2e/my-library-training-context.spec.ts
+++ b/tests/e2e/my-library-training-context.spec.ts
@@ -176,12 +176,12 @@ test.describe("my library training context", () => {
 
     await expect(page.getByTestId("training-context-selected-goal")).toContainText(goalTitle);
     await expect(page.getByTestId("training-focus-goal-select")).toHaveValue(goalId!);
-    await expect(page.getByTestId("training-note-goal-select")).toHaveValue(goalId!);
     await expect(page.getByTestId("training-focus-form")).toHaveAttribute(
       "data-goal-intent-highlight",
       "true"
     );
     await expect(page.getByTestId("training-focus-intent-badge")).toBeVisible();
+    await expect(page.getByTestId("training-note-form-toggle")).toBeVisible();
 
     await page.getByTestId(`training-goal-context-use-note-${goalId}`).click();
     await expect(page.getByTestId("training-note-goal-select")).toHaveValue(goalId!);
@@ -225,7 +225,6 @@ test.describe("my library training context", () => {
     await waitForTrainingContextClientReady(page);
 
     await expect(page.getByTestId("training-context-selected-goal")).toContainText(goalTitle);
-    await expect(page.getByTestId("training-focus-goal-select")).toHaveValue(goalId);
     await expect(page.getByTestId("training-note-goal-select")).toHaveValue(goalId);
     await expect(page.getByTestId("training-note-form")).toHaveAttribute(
       "data-goal-intent-highlight",
@@ -233,7 +232,54 @@ test.describe("my library training context", () => {
     );
     await expect(page.getByTestId("training-note-intent-badge")).toBeVisible();
     await expect(page.getByText(/was selected from Goals for your next note\./i)).toBeVisible();
+    if (
+      (await page.getByTestId("training-focus-form-toggle").getAttribute("aria-expanded")) !==
+      "true"
+    ) {
+      await page.getByTestId("training-focus-form-toggle").click();
+    }
+    await expect(page.getByTestId("training-focus-goal-select")).toHaveValue(goalId);
 
     await archiveCreatedGoalIfNeeded(page, createdGoalTitle, goalId);
+  });
+
+  test("keeps focus and note drafts when the composers are collapsed and reopened", async ({
+    page,
+  }, testInfo) => {
+    runOnceOnDesktopChromium(testInfo.project.name);
+
+    await loginToMyLibraryViaDevBypass(page);
+    await page.goto("/my-library/training", { waitUntil: "domcontentloaded", timeout: 60_000 });
+    await expect(page.getByRole("heading", { name: "Focus & Notes", level: 1 })).toBeVisible();
+    await waitForTrainingContextClientReady(page);
+
+    if (
+      (await page.getByTestId("training-focus-form-toggle").getAttribute("aria-expanded")) !==
+      "true"
+    ) {
+      await page.getByTestId("training-focus-form-toggle").click();
+    }
+    await page.getByLabel("Focus title").fill("Hold the line into the catch");
+    await page.getByTestId("training-focus-form-toggle").click();
+    await expect(page.getByText("Draft ready: Hold the line into the catch")).toBeVisible();
+    await page.getByTestId("training-focus-form-toggle").click();
+    await expect(page.getByLabel("Focus title")).toHaveValue("Hold the line into the catch");
+
+    if (
+      (await page.getByTestId("training-note-form-toggle").getAttribute("aria-expanded")) !== "true"
+    ) {
+      await page.getByTestId("training-note-form-toggle").click();
+    }
+    await page
+      .getByRole("textbox", { name: "Observation" })
+      .fill("Breathing stayed calmer after the second rep.");
+    await page.getByTestId("training-note-form-toggle").click();
+    await expect(
+      page.getByText("Draft ready: Breathing stayed calmer after the second rep.")
+    ).toBeVisible();
+    await page.getByTestId("training-note-form-toggle").click();
+    await expect(page.getByRole("textbox", { name: "Observation" })).toHaveValue(
+      "Breathing stayed calmer after the second rep."
+    );
   });
 });

--- a/tests/unit/training-context-hub.test.tsx
+++ b/tests/unit/training-context-hub.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import TrainingContextHub from "@/components/my-library/training/TrainingContextHub";
 import type { TrainingContextSnapshot, TrainingFocusView } from "@/lib/training-context/server";
@@ -87,16 +87,14 @@ describe("TrainingContextHub", () => {
     vi.unstubAllGlobals();
   });
 
-  it("renders open focuses and notes as separate sections", () => {
+  it("renders calmer focus and notes sections", () => {
     render(<TrainingContextHub initialSnapshot={buildSnapshot()} />);
 
-    expect(screen.getByRole("heading", { name: "Open focuses" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Focus" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Notes" })).toBeInTheDocument();
-    expect(screen.getByTestId("training-focus-card-focus-1")).toHaveTextContent(
-      "Longer exhale in the water"
-    );
-    expect(screen.getByText(/Keep several current training cues open\./i)).toBeInTheDocument();
-    expect(screen.getByText("Primary focus")).toBeInTheDocument();
+    expect(screen.getByTestId("training-focus-card-focus-1")).toHaveTextContent("Primary");
+    expect(screen.getByText(/Keep the main cue clear/i)).toBeInTheDocument();
+    expect(screen.getAllByText("Primary focus").length).toBeGreaterThan(0);
   });
 
   it("opens question editing with answer field", () => {
@@ -196,6 +194,13 @@ describe("TrainingContextHub", () => {
       "true"
     );
     expect(screen.getByTestId("training-note-intent-badge")).toBeInTheDocument();
+    expect(screen.queryByTestId("training-focus-form")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("training-focus-form-toggle"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("training-focus-goal-select")).toHaveValue("goal-1");
+    });
     expect(screen.getByTestId("training-focus-form")).toHaveAttribute(
       "data-goal-intent-highlight",
       "false"
@@ -256,6 +261,104 @@ describe("TrainingContextHub", () => {
       "Longer exhale in the water"
     );
     expect(screen.getByTestId("training-overview-card-notes")).toHaveTextContent("Latest note");
+  });
+
+  it("collapses and reopens focus and note drafts without losing text", async () => {
+    render(<TrainingContextHub initialSnapshot={buildSnapshot()} />);
+
+    expect(screen.queryByTestId("training-focus-form")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("training-note-form")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("training-focus-form-toggle"));
+    fireEvent.change(screen.getByPlaceholderText("Exhale calmly before turning to breathe"), {
+      target: { value: "Hold the line on every catch" },
+    });
+    fireEvent.click(screen.getByTestId("training-focus-form-toggle"));
+
+    expect(screen.queryByTestId("training-focus-form")).not.toBeInTheDocument();
+    expect(screen.getByText("Draft ready: Hold the line on every catch")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Resume draft",
+      })
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("training-focus-form-toggle"));
+    expect(screen.getByDisplayValue("Hold the line on every catch")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("training-note-form-toggle"));
+    fireEvent.change(screen.getByPlaceholderText("What did you notice in the pool?"), {
+      target: { value: "Breathing felt calmer after the second 100." },
+    });
+    fireEvent.click(screen.getByTestId("training-note-form-toggle"));
+
+    expect(screen.queryByTestId("training-note-form")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Draft ready: Breathing felt calmer after the second 100.")
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("training-note-form-toggle"));
+    expect(
+      screen.getByDisplayValue("Breathing felt calmer after the second 100.")
+    ).toBeInTheDocument();
+  });
+
+  it("groups secondary focuses and keeps complete/archive behind edit for non-primary cards", () => {
+    const primary = buildFocus({
+      id: "focus-1",
+      title: "Longer exhale in the water",
+      isPrimary: true,
+    });
+    const secondary = buildFocus({
+      id: "focus-2",
+      title: "Patient catch timing",
+      isPrimary: false,
+      goalId: null,
+      goalTitle: null,
+    });
+
+    render(
+      <TrainingContextHub
+        initialSnapshot={buildSnapshot({
+          activeFocus: primary,
+          primaryFocus: primary,
+          openFocuses: [primary, secondary],
+        })}
+      />
+    );
+
+    expect(screen.getAllByText("Primary focus").length).toBeGreaterThan(0);
+    expect(screen.getByRole("heading", { name: "Other open focuses" })).toBeInTheDocument();
+    expect(screen.getByTestId("training-focus-card-focus-2")).toHaveTextContent(
+      "Patient catch timing"
+    );
+    expect(
+      within(screen.getByTestId("training-focus-card-focus-2")).queryByRole("button", {
+        name: "Mark completed",
+      })
+    ).not.toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("training-focus-card-focus-2")).queryByRole("button", {
+        name: "Archive",
+      })
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      within(screen.getByTestId("training-focus-card-focus-2")).getByRole("button", {
+        name: "Edit focus",
+      })
+    );
+
+    expect(
+      within(screen.getByTestId("training-focus-card-focus-2")).getByRole("button", {
+        name: "Mark completed",
+      })
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("training-focus-card-focus-2")).getByRole("button", {
+        name: "Archive",
+      })
+    ).toBeInTheDocument();
   });
 
   it("edits an open focus inline and saves the updated snapshot", async () => {


### PR DESCRIPTION
## Summary

- Simplifies `/my-library/training` so the route feels calmer and less over-explanatory without changing the underlying goals/focus/notes model.
- Adds collapsible `Add focus` and `Add note` composers that preserve unsaved drafts across collapse/reopen.
- Reworks open focuses into a primary-first hierarchy and moves non-primary status churn behind `Edit focus`.
- Updates the active My Library brief, lifecycle status for the already-merged auth brief, related planned passkey brief links, and the incident-response runbook coverage for the new UI behavior.

## Scope

- In scope:
  - shorter training-route hero/bridge copy
  - collapsible focus/note composers with deterministic open defaults
  - primary-first focus grouping and calmer non-primary action surface
  - targeted unit/e2e coverage and related brief/runbook updates
- Out of scope:
  - schema or migration changes
  - goals-page IA cleanup
  - admin notes quick-capture / multi-image work
  - real passkeys / Clerk rollout work
- Changed files (9):
  - `app/my-library/training/page.tsx`
  - `components/my-library/training/TrainingContextHub.tsx`
  - `docs/runbooks/core-flow-incident-response.md`
  - `docs/task-briefs/done/2026-03-30-passkey-first-sign-in-and-admin-site-lock-unlock-10-10.md`
  - `docs/task-briefs/in-progress/2026-03-30-my-library-training-focus-goals-notes-ia-simplification-10-10.md`
  - `docs/task-briefs/planned/2026-03-30-clerk-passkeys-paying-members-first-10-10.md`
  - `docs/task-briefs/planned/2026-03-30-real-passkeys-architecture-decision-and-rollout-gate-10-10.md`
  - `tests/e2e/my-library-training-context.spec.ts`
  - `tests/unit/training-context-hub.test.tsx`

## Risk

- Main risk: regressions in composer-open defaults, goal-prefill routing, or focus action availability on `/my-library/training`.
- Guardrails in this PR: preserved canonical write flows, added targeted unit/e2e coverage for collapse/reopen and focus hierarchy behavior, and passed both local release gates plus required CI.
- Rollback plan: revert `b55c148` to restore the prior training-route behavior.

## Test Evidence

- `npm run lint:briefs:all`: PASS
- `npm run typecheck`: PASS
- `npx vitest run tests/unit/training-context-hub.test.tsx`: PASS
- `PW_PORT=3100 NEXT_DIST_DIR=.next-playwright SITE_LOCK_ENABLED=0 npx playwright test tests/e2e/my-library-training-context.spec.ts --project=desktop-chromium`: PASS
- `npm run verify:pre-pr`: PASS
- `npm run verify:pre-merge`: PASS
- Required CI checks on PR #326: PASS
- Perf budget trend recommendation: `hold`
- Local manual QA: `http://127.0.0.1:3100/my-library/training` via local dev bypass in Chromium; verified route copy (`Today at a glance`, `Start from a goal`), both composer toggles, and draft preservation across collapse/reopen for focus + note.
- Local manual QA note: the dev-bypass account used here had no existing primary/open focus data, so the primary/secondary grouping was covered by automated tests rather than visible manual data on this run.
- Vercel preview sanity: `https://freeswimming-pq4tgrm1p-stian-vikras-projects.vercel.app/my-library/training` correctly redirected to `/preview-access?next=%2Fmy-library%2Ftraining` with expected private-gate messaging.
- Vercel preview limitation: authenticated training-route UI was not directly exercisable in preview because the environment is private and local-only `dev/login` bypass is unavailable there.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`)

- [x] `npm run lint:briefs`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] `npm run test:e2e` (via `npm run verify:pre-merge`)
- [x] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge` (PASS on current HEAD before merge)
- [x] Local manual QA done on dev URL
- [ ] Vercel preview manual QA done (preview sanity verified; authenticated route QA unavailable in preview because the environment is private)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [x] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL: `https://github.com/stianvikra/freeswimming/pull/326`
- [x] Required checks are green
- [x] Local QA completed
- [ ] Preview authenticated-route QA blocked by private-gate/no preview dev bypass; preview access-gate sanity completed instead
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d feat/my-library-training-ia-simplification-2026-03-30`
- [ ] Optional: `git fetch --prune`
