### PR TITLE
feat(admin-notes): expand quick note route surfaces and evidence metadata

### DIFF
--- a/components/SiteChrome.tsx
+++ b/components/SiteChrome.tsx
@@ -14,8 +14,8 @@ import MobileSegmentedNav, {
 import { getMainMenuItems } from "@/components/navigation/mainMenuItems";
 import {
   getAdminPageContextLabel,
-  hasDedicatedContextNotesForPage,
   normalizeAdminPageContextRef,
+  supportsAdminPageNotesSurface,
 } from "@/lib/admin/page-note-context";
 import { createBrowserSupabaseClient } from "@/lib/supabase/browser";
 
@@ -126,17 +126,12 @@ export default function SiteChrome({ children, menu, bottomBar }: Props) {
   const isAuthRoute = pathname === "/auth/sign-in" || pathname.startsWith("/auth/");
   const isAdminRoute = pathname === "/admin" || pathname.startsWith("/admin/");
   const isLibraryRoute = pathname === "/my-library" || pathname.startsWith("/my-library/");
-  const isCheckoutRoute =
-    pathname === "/checkout/success" || pathname.startsWith("/checkout/");
+  const isCheckoutRoute = pathname === "/checkout/success" || pathname.startsWith("/checkout/");
   const isPublicRoute = !isAuthRoute && !isLibraryRoute && !isCheckoutRoute;
   const normalizedPageContextRef = normalizeAdminPageContextRef(pathname ?? "/");
   const pageContextLabel = getAdminPageContextLabel(normalizedPageContextRef);
   const showAdminPageNotes =
-    dashboardVisible &&
-    !isAdminRoute &&
-    !isAuthRoute &&
-    !isCheckoutRoute &&
-    !hasDedicatedContextNotesForPage(normalizedPageContextRef);
+    dashboardVisible && supportsAdminPageNotesSurface(normalizedPageContextRef);
 
   const hasCustomBottomBar = Boolean(bottomBar);
   const authHref = signedInEmail ? "/my-library" : "/auth/sign-in?next=%2Fmy-library";

--- a/components/admin/AdminContextNotesPanel.tsx
+++ b/components/admin/AdminContextNotesPanel.tsx
@@ -17,6 +17,8 @@ import { uploadAdminNoteFiles } from "@/lib/admin/notes-client";
 import {
   ADMIN_NOTE_ATTACHMENT_MAX_FILES,
   ADMIN_NOTE_PRIORITY_VALUES,
+  buildAdminNoteAttachmentEvidenceSummary,
+  buildAdminNoteAttachmentOrdinalLabel,
   type AdminNoteItem,
   type AdminNotePriority,
 } from "@/lib/admin/notes";
@@ -936,10 +938,20 @@ export default function AdminContextNotesPanel({
                                 />
                                 <div className="min-w-0 flex-1">
                                   <p className="text-xs font-semibold text-slate-900">
-                                    Image {index + 1}
+                                    {buildAdminNoteAttachmentOrdinalLabel(
+                                      index,
+                                      pendingImages.length
+                                    )}
                                   </p>
                                   <p className="mt-1 truncate text-[11px] text-slate-600">
                                     {image.file.name}
+                                  </p>
+                                  <p className="mt-1 text-[11px] text-slate-500">
+                                    {buildAdminNoteAttachmentEvidenceSummary({
+                                      mimeType: image.file.type,
+                                      sizeBytes: image.file.size,
+                                      locationLabel: "Staged locally",
+                                    })}
                                   </p>
                                 </div>
                               </div>

--- a/components/admin/AdminHelpCenter.tsx
+++ b/components/admin/AdminHelpCenter.tsx
@@ -18,7 +18,7 @@ type ActionGroup = {
   actions: Array<{ label: string; meaning: string }>;
 };
 
-const LAST_UPDATED = "2026-03-25";
+const LAST_UPDATED = "2026-03-31";
 
 const QUICK_ACTIONS = [
   { id: "overview", label: "Start here" },
@@ -569,12 +569,14 @@ const DAILY_PLAYBOOKS: Playbook[] = [
       "Use `Quick note` when you want to capture the issue fast from the current surface without losing context.",
       "If you still need to scroll, click, or collect a screenshot before saving, collapse `Quick note`; the page stays interactive underneath and you can reopen the same draft from the docked edge handle on the right.",
       "If you navigate to another supported admin/context surface before saving, the same draft can follow you, but it stays attached to the original locked context shown in the panel.",
+      "Page-level `Quick note` is intentionally available on supported public pages plus selected My Library hubs: `/my-library`, `goals`, `training`, `profile`, `workouts`, `dryland`, `generator`, and `security`.",
       "Use the top `Add note` section when you want full fields in place; if notes already exist it stays collapsed until you expand it again.",
       "Create note with category, priority, and context link, then copy the visible note ID if you need to reference it later.",
       "If the issue is visual, copy the screenshot or image to your clipboard first, then use `Paste image from clipboard`, or choose `Upload images` if you already have the files.",
       "You can stage up to six pre-save images on create flows, and repeated paste/upload appends instead of replacing the earlier screenshots.",
       "Remember that pasted or uploaded pre-save images stay local until note save and attachment upload both succeed; if clipboard access is blocked or no image is found, fall back to `Upload images`.",
       "After a successful Quick note save, the panel stays open and ready for another note on the same locked context so you can keep capturing without reopening it.",
+      "Saved image cards now show a stable evidence summary: image order, file type, file size, and upload date, without exposing raw storage paths.",
       `If a note title starts with \`${ADMIN_NOTE_TEST_ARTIFACT_PREFIX}\`, it is automated test residue and should clear automatically; if it stays open, use the admin-notes recovery runbook before deleting anything manually.`,
       "On mobile, the two image actions stay visible so you do not need to remember hidden paste shortcuts.",
       "Link any follow-up note instead of pasting duplicate text.",

--- a/components/admin/AdminNoteQuickCaptureLauncher.tsx
+++ b/components/admin/AdminNoteQuickCaptureLauncher.tsx
@@ -32,6 +32,8 @@ import { uploadAdminNoteFiles } from "@/lib/admin/notes-client";
 import {
   ADMIN_NOTE_ATTACHMENT_MAX_FILES,
   ADMIN_NOTE_PRIORITY_VALUES,
+  buildAdminNoteAttachmentEvidenceSummary,
+  buildAdminNoteAttachmentOrdinalLabel,
   type AdminNoteItem,
   type AdminNotePriority,
 } from "@/lib/admin/notes";
@@ -794,10 +796,20 @@ export default function AdminNoteQuickCaptureLauncher(props: Props) {
                                 />
                                 <div className="min-w-0 flex-1">
                                   <p className="text-xs font-semibold text-slate-900">
-                                    Image {index + 1}
+                                    {buildAdminNoteAttachmentOrdinalLabel(
+                                      index,
+                                      pendingImages.length
+                                    )}
                                   </p>
                                   <p className="mt-1 truncate text-[11px] text-slate-600">
                                     {image.file.name}
+                                  </p>
+                                  <p className="mt-1 text-[11px] text-slate-500">
+                                    {buildAdminNoteAttachmentEvidenceSummary({
+                                      mimeType: image.file.type,
+                                      sizeBytes: image.file.size,
+                                      locationLabel: "Staged locally",
+                                    })}
                                   </p>
                                 </div>
                               </div>

--- a/components/admin/AdminNotesManager.tsx
+++ b/components/admin/AdminNotesManager.tsx
@@ -40,6 +40,8 @@ import {
   ADMIN_NOTE_ATTACHMENT_MAX_FILES,
   ADMIN_NOTE_PRIORITY_VALUES,
   INCIDENT_NOTE_SEVERITIES,
+  buildAdminNoteAttachmentEvidenceSummary,
+  buildAdminNoteAttachmentOrdinalLabel,
   buildIncidentNoteBodyTemplate,
   sortAdminNotesByPriorityAndNewest,
   type AdminNoteItem,
@@ -233,13 +235,6 @@ function priorityBadgeClasses(priority: AdminNotePriority): string {
     default:
       return "border-slate-200 bg-slate-100 text-slate-700";
   }
-}
-
-function formatAttachmentSize(sizeBytes: number): string {
-  if (sizeBytes < 1024) return `${sizeBytes} B`;
-  const sizeKb = sizeBytes / 1024;
-  if (sizeKb < 1024) return `${sizeKb.toFixed(1)} KB`;
-  return `${(sizeKb / 1024).toFixed(1)} MB`;
 }
 
 function hasPartialContextSelection(contextType: string, contextRef: string): boolean {
@@ -1534,9 +1529,9 @@ export default function AdminNotesManager() {
 
                   {!isEditing && item.attachments.length > 0 ? (
                     <div className="mt-3 space-y-2 rounded-lg border border-slate-200 bg-white/80 p-3">
-                      <p className="text-xs font-semibold text-slate-700">Images</p>
+                      <p className="text-xs font-semibold text-slate-700">Admin-only images</p>
                       <div className="flex flex-wrap gap-3">
-                        {item.attachments.map((attachment) => (
+                        {item.attachments.map((attachment, index) => (
                           <a
                             key={attachment.id}
                             href={attachment.signed_url ?? undefined}
@@ -1557,11 +1552,21 @@ export default function AdminNotesManager() {
                               </div>
                             )}
                             <div className="space-y-1">
+                              <p className="text-[11px] font-semibold text-slate-900">
+                                {buildAdminNoteAttachmentOrdinalLabel(
+                                  index,
+                                  item.attachments.length
+                                )}
+                              </p>
                               <p className="truncate text-[11px] font-medium text-slate-700">
                                 {attachment.file_name}
                               </p>
                               <p className="text-[10px] text-slate-500">
-                                {formatAttachmentSize(attachment.size_bytes)}
+                                {buildAdminNoteAttachmentEvidenceSummary({
+                                  mimeType: attachment.mime_type,
+                                  sizeBytes: attachment.size_bytes,
+                                  createdAt: attachment.created_at,
+                                })}
                               </p>
                             </div>
                           </a>
@@ -1882,7 +1887,7 @@ export default function AdminNotesManager() {
 
                         {item.attachments.length > 0 ? (
                           <ul className="space-y-2">
-                            {item.attachments.map((attachment) => {
+                            {item.attachments.map((attachment, index) => {
                               const isDeletingAttachment = deletingAttachmentId === attachment.id;
                               return (
                                 <li
@@ -1903,11 +1908,21 @@ export default function AdminNotesManager() {
                                       </div>
                                     )}
                                     <div className="min-w-0">
+                                      <p className="text-[11px] font-semibold text-slate-900">
+                                        {buildAdminNoteAttachmentOrdinalLabel(
+                                          index,
+                                          item.attachments.length
+                                        )}
+                                      </p>
                                       <p className="truncate text-xs font-medium text-slate-700">
                                         {attachment.file_name}
                                       </p>
                                       <p className="text-[11px] text-slate-500">
-                                        {formatAttachmentSize(attachment.size_bytes)}
+                                        {buildAdminNoteAttachmentEvidenceSummary({
+                                          mimeType: attachment.mime_type,
+                                          sizeBytes: attachment.size_bytes,
+                                          createdAt: attachment.created_at,
+                                        })}
                                       </p>
                                     </div>
                                   </div>
@@ -2308,9 +2323,21 @@ export default function AdminNotesManager() {
                           className="h-14 w-14 rounded-lg object-cover"
                         />
                         <div className="min-w-0 flex-1">
-                          <p className="text-xs font-semibold text-slate-900">Image {index + 1}</p>
+                          <p className="text-xs font-semibold text-slate-900">
+                            {buildAdminNoteAttachmentOrdinalLabel(
+                              index,
+                              createPendingScreenshots.length
+                            )}
+                          </p>
                           <p className="mt-1 truncate text-[11px] text-slate-600">
                             {image.file.name}
+                          </p>
+                          <p className="mt-1 text-[11px] text-slate-500">
+                            {buildAdminNoteAttachmentEvidenceSummary({
+                              mimeType: image.file.type,
+                              sizeBytes: image.file.size,
+                              locationLabel: "Staged locally",
+                            })}
                           </p>
                         </div>
                       </div>

--- a/docs/runbooks/admin-notes-recovery.md
+++ b/docs/runbooks/admin-notes-recovery.md
@@ -5,7 +5,7 @@ Use this runbook for AW-012 workflow `A4` stale-note reconciliation edge cases.
 ## Purpose
 
 - Recover safely when note state in UI looks stale after concurrent admin edits.
-- Keep note context links and status updates deterministic across `/admin`, `/course`, and `/plans`.
+- Keep note context links and status updates deterministic across `/admin`, supported public routes, and selected `My Library` hub routes.
 - Provide a short manual walkthrough note contract for AW-012 evidence.
 
 ## Triggers
@@ -26,6 +26,7 @@ Use this runbook for AW-012 workflow `A4` stale-note reconciliation edge cases.
 2. If the failure happened in `Quick note`, first search by the visible success state or intended title in `/admin?tab=notes` before retrying so you do not create duplicates.
 3. If you still need to inspect the page before saving, collapse the quick-note draft instead of closing it; the page underneath should remain interactive, and reopening from the docked right-edge handle should preserve the current text and staged images.
 4. If you navigated to another supported admin/context surface before saving, confirm the quick-note `Locked context` card still points to the original page/item you meant to annotate before you save.
+   Supported page-level quick-note hubs now include `/my-library`, `goals`, `training`, `profile`, `workouts`, `dryland`, `generator`, and `security` in addition to the existing supported public routes.
 5. After a successful quick-note save, confirm the panel is now ready for another note on the same locked context before you continue capturing follow-up issues.
 6. In `/admin?tab=notes`, keep the `Notes` tab active and click `Refresh` to reload server-canonical rows.
 7. If the row title starts with `[E2E Admin Note Artifact]`, treat it as automated test residue:
@@ -50,6 +51,7 @@ Use this runbook for AW-012 workflow `A4` stale-note reconciliation edge cases.
 - if a pasted image preview existed but note save failed, search by `Note ID` or title before retrying paste so you do not create duplicate notes,
 - repeated paste/upload on create flows appends until the six-image cap is reached; remove only the screenshots you no longer want instead of restarting the whole draft,
 - confirm the attachment list and image count in the note row,
+- confirm each saved image card still shows its structured evidence summary (`Image X`, file type, file size, upload date),
 - if delete failed, refresh once and verify whether the image is still present before retrying,
 - if upload failed after note save, retry only after confirming you are not looking at a stale duplicate preview,
 - if the staged images were removed locally, use clipboard paste again or fall back to `Upload images`.
@@ -61,7 +63,7 @@ Use this runbook for AW-012 workflow `A4` stale-note reconciliation edge cases.
 - remove and re-add the link only if the relationship is clearly wrong.
 
 12. Re-apply only the intended delta and click `Save changes`.
-13. Confirm success notice (`Note updated.` or attachment/link success notice) and verify the same row in its contextual surface (`/course` or `/plans`) when relevant.
+13. Confirm success notice (`Note updated.` or attachment/link success notice) and verify the same row in its contextual surface (`/course`, `/plans`, or the selected `My Library` hub route) when relevant.
 14. If update still fails, create one incident note (P1/P2) with owner + next action and link it by note ID in AW-012 checkpoint evidence.
 
 ## Pass Criteria

--- a/docs/task-briefs/in-progress/2026-03-27-admin-notes-ergonomics-multi-image-and-route-surface-followup-10-10.md
+++ b/docs/task-briefs/in-progress/2026-03-27-admin-notes-ergonomics-multi-image-and-route-surface-followup-10-10.md
@@ -3,24 +3,22 @@
 ## Metadata
 
 - `id`: `2026-03-27-admin-notes-ergonomics-multi-image-and-route-surface-followup-10-10`
-- `status`: `planned`
+- `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-03-27`
-- `updated`: `2026-03-30`
+- `updated`: `2026-03-31`
 
 ## Goal
 
-Close the remaining operator-facing admin-notes ergonomics gaps after the quick-capture utility-panel rollout so notes are faster to capture, richer in evidence, and easier to keep using across real review sessions.
+Ship the remaining operator-facing admin-notes ergonomics gaps after the multi-image/save-again slice by making quick capture available on an explicit route matrix and by making saved image evidence easier to read later without changing the canonical attachment schema.
 
 ## Why This Brief Exists
 
-- Core notes workflows, quick capture, clipboard/image intake, and linking are already shipped, but real usage still exposes a smaller follow-up wave.
-- The current gaps are tightly related:
-  - only one pre-save image in quick note/contextual add note,
-  - pasting or uploading another screenshot currently replaces the staged image instead of appending it,
-  - uncertainty around what quick note should do after save,
-  - incomplete route-surface rollout for quick capture,
-  - attachment metadata/agent-readiness expectations not yet made explicit enough in operator flows.
+- Core notes workflows, quick capture, clipboard/image intake, linking, multi-image staging, and save-again behavior are now shipped, but real usage still exposes one smaller follow-up wave.
+- The remaining gaps are tightly related:
+  - quick capture/page-level notes are still missing from the intended `My Library` route matrix,
+  - saved attachment cards still underspecify evidence metadata for later human review,
+  - operator-visible evidence structure is not yet explicit enough for future agent-assisted reading even though the canonical attachment fields already exist.
 - These issues are real notes ergonomics work, but they should stay separated from the larger workout-builder UX/action batch.
 - This brief intentionally owns the operator-facing remainder so the broader admin-notes system is not reopened piecemeal without explicit scope.
 
@@ -30,10 +28,13 @@ Close the remaining operator-facing admin-notes ergonomics gaps after the quick-
   - `/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-03-21-admin-notes-workflow-v2-attachments-and-linking-10-10.md`
   - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-25-admin-notes-image-intake-simplification-and-clipboard-paste-button-10-10.md`
   - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-27-admin-notes-global-quick-capture-panel-and-manuscript-categories-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-31-admin-notes-multi-image-and-save-again-followup-10-10.md`
 - Recommended boundary decisions unless owner explicitly changes them:
   - quick note still creates a normal canonical admin note,
   - canonical note identity remains note ID + canonical route/content context,
   - quick-note draft can travel across supported surfaces, but original note context stays explicit and locked unless the user intentionally changes it,
+  - route-surface expansion in this slice is explicit and bounded to selected `My Library` hubs instead of every library/detail route,
+  - attachment metadata surfacing in this slice uses the existing canonical attachment row fields only; it does not add a new attachment schema,
   - this slice improves ergonomics and metadata clarity; it does not replace notes with a larger ticketing system.
 
 ## Admin Notes Triage Disposition
@@ -41,17 +42,17 @@ Close the remaining operator-facing admin-notes ergonomics gaps after the quick-
 Production admin notes reviewed against this brief on `2026-03-27`:
 
 - `0d1fa716-460e-406a-a68d-28c1aaae5b22` `Mulitple Screenshots`
-  - disposition: owned by this brief.
-  - reason: pre-save multi-image evidence is the clearest remaining operator gap in quick note/contextual capture, including repeated clipboard-paste or upload flows appending instead of replacing earlier staged screenshots.
+  - disposition: closed in `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-31-admin-notes-multi-image-and-save-again-followup-10-10.md`.
+  - reason: repeated pre-save image staging and append-not-replace behavior shipped in the prior slice.
 - `40b252d8-ee9f-41ed-89ca-0eb5af8bcc89` `Quick note`
-  - disposition: owned by this brief.
-  - reason: post-save reuse, top-of-page access expectations, and continued capture flow belong in the same ergonomics wave.
+  - disposition: closed in `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-03-31-admin-notes-multi-image-and-save-again-followup-10-10.md`.
+  - reason: quick-note save-again behavior shipped in the prior slice.
 - `881e222b-4c14-4a23-b677-60b0713e220f` `Admin notes quick capture route-surface expansion follow-up`
   - disposition: owned by this brief.
-  - reason: the route-surface rollout should now be handled as an explicit matrix instead of a vague future placeholder.
+  - reason: the remaining rollout should now be handled as an explicit selected-route matrix instead of a vague future placeholder.
 - `204913d0-5c97-41e8-b6f7-ab42de3bc84e` `Admin notes attachment metadata and agent-readiness follow-up`
   - disposition: owned by this brief.
-  - reason: remaining operator-visible attachment metadata and structured evidence expectations belong together with multi-image capture and route rollout so the note is not only partially covered.
+  - reason: remaining operator-visible attachment metadata and structured evidence expectations belong together with the final route rollout so the note system is not only partially covered.
 
 ## Platform 10/10 Scorecard Mapping
 
@@ -100,7 +101,7 @@ Critical target categories for `10/10` claim in this brief:
   - attachment metadata rows,
   - stored attachment object keys,
   - canonical route/content context,
-  - any persisted structured attachment metadata required for operator/agent readiness.
+  - existing attachment row fields already available for metadata surfacing (`file_name`, `mime_type`, `size_bytes`, `created_at`).
 - Local-only:
   - staged pre-save images,
   - draft title/text/priority/category inputs,
@@ -140,15 +141,24 @@ Critical target categories for `10/10` claim in this brief:
 
 ## Scope
 
-- Add pre-save multi-image support to:
-  - quick note,
-  - contextual `Add note` panels,
-  - any directly related notes-entry surface chosen in this slice.
-- Decide and implement the intended post-save quick-note behavior:
-  - stay open and clear for another capture,
-  - or offer an equally fast repeat-capture loop that does not require rebuilding the same entry flow manually.
-- Expand quick-capture route availability through an explicit route-surface matrix instead of ad hoc surface additions.
-- Improve operator-visible attachment metadata and evidence structure so the saved note is clearer for later human review and future agent-assisted reading.
+- Keep the already shipped multi-image/save-again behavior unchanged while extending route-surface coverage intentionally.
+- Expand quick-capture/page-note availability through an explicit route-surface matrix:
+  - keep existing dedicated contextual note surfaces on `/course`, `/guides/0-1000m`, `/guides/poolside`, and `/my-library/item/[slug]`,
+  - add page-level notes + quick note through `SiteChrome` on selected `My Library` hub routes:
+    - `/my-library`
+    - `/my-library/goals`
+    - `/my-library/training`
+    - `/my-library/profile`
+    - `/my-library/workouts`
+    - `/my-library/dryland`
+    - `/my-library/generator`
+    - `/my-library/security`
+- Improve operator-visible saved attachment metadata and evidence structure using existing canonical fields:
+  - image order,
+  - file type,
+  - file size,
+  - upload date,
+  - clearer copy that the evidence remains admin-only.
 - Keep Help/Guide and recovery/runbook language aligned with the final behavior.
 
 ## Out Of Scope
@@ -156,16 +166,21 @@ Critical target categories for `10/10` claim in this brief:
 - Replacing admin notes with a full issue tracker or threaded comments system.
 - Public user uploads or public note attachments.
 - Non-image attachment types as a first-class system in this slice.
+- New schema/storage columns, OCR, caption authoring, or AI extraction for attachments.
+- Dynamic `My Library` detail routes in this wave:
+  - `/my-library/programs/[programId]`
+  - `/my-library/workouts/[workoutId]`
+  - `/my-library/dryland/[sessionId]`
 - Reopening unrelated builder or course-workspace work unless a shared bug is discovered.
 
 ## Acceptance Criteria
 
-1. Quick note and contextual `Add note` can stage more than one image before save with clear limit/error handling, including repeated clipboard-paste or upload actions appending to the staged list instead of replacing the earlier screenshot unless the operator explicitly removes it.
-2. After a quick note is saved, the next-step behavior is explicit and optimized for repeated capture rather than forcing the owner to rebuild the same flow manually.
-3. Quick capture route-surface availability is documented and implemented intentionally for the chosen surfaces.
-4. Attachment metadata shown to operators is rich enough that saved evidence remains understandable later without opening raw storage details.
-5. Quick note still saves a normal canonical admin note tied to an explicit context.
-6. Help/Guide and runbook content are updated in the same PR if labels, save/reuse behavior, or route availability change.
+1. Selected `My Library` hub routes show the same page-level admin-notes surface and `Quick note` entrypoint as the supported public page surfaces, without changing dedicated contextual surfaces that already exist elsewhere.
+2. Route-surface availability is documented as an explicit matrix for this slice instead of an open-ended rollout promise.
+3. Saved attachment cards show metadata rich enough that the evidence remains understandable later without exposing raw storage details.
+4. The richer attachment metadata comes from the existing canonical attachment fields and does not require a new schema or migration.
+5. Quick note still saves a normal canonical admin note tied to an explicit context, and locked-context behavior remains truthful when moving between supported surfaces.
+6. Help/Guide and runbook content are updated in the same PR for the chosen route matrix and metadata contract.
 7. Relevant production admin notes listed above remain explicitly owned by this brief until shipped or intentionally split again.
 8. `npm run lint:briefs`, targeted validation, and `npm run verify:pre-pr` pass before PR update.
 
@@ -174,14 +189,12 @@ Critical target categories for `10/10` claim in this brief:
 - `npm run lint:briefs`
 - `npm run typecheck`
 - targeted unit tests for:
-  - staged multi-image state,
-  - post-save reset/reuse behavior,
+  - page-route availability logic,
   - attachment metadata rendering,
-  - route-surface availability logic
+  - context label/metadata fallback behavior where relevant
 - targeted e2e for:
-  - quick note multi-image capture,
-  - contextual add-note multi-image capture,
-  - route-surface persistence/reopen behavior,
+  - quick note on a newly supported `My Library` hub route,
+  - route-surface persistence/reopen behavior on the selected matrix,
   - admin help-center/update assertions
 - `npm run verify:pre-pr`
 - before merge recommendation: `npm run verify:pre-merge`
@@ -195,17 +208,18 @@ Critical target categories for `10/10` claim in this brief:
 
 - Production review:
   - `https://freeswimming.org/admin`
-  - relevant admin note entry surfaces encountered during real review work
+  - selected `My Library` hub routes reached during real review work
 - Local iteration:
-  - `http://127.0.0.1:3000/admin`
+  - `http://127.0.0.1:3000/my-library`
+  - `http://127.0.0.1:3000/my-library/goals`
 - Preview:
   - PR Vercel preview URL for the implementation branch
 
 ## Constraints
 
 - Quick note must remain understandable as a note-capture utility, not a second separate notes system.
-- Multi-image support must be bounded and clear, not an unbounded drag-and-drop bucket.
 - Route-surface expansion should be explicit and support real review workflows, not chase every possible route in one wave.
+- This slice should prefer stable `My Library` hub routes over dynamic detail-route coverage.
 - Attachment metadata should help later reading without exposing raw storage implementation details.
 
 ## 10/10 Quality Bar
@@ -216,11 +230,12 @@ Critical target categories for `10/10` claim in this brief:
   - `empty`
   - `error`
   - `retry`
-  - `success`
-  - staged image pending
-  - per-image remove/failure state
+- `success`
+- staged image pending
+- per-image remove/failure state
 - Multi-image behavior must be obvious before save and predictable after save.
 - Route-surface expansion should improve coverage without making note context ambiguous.
+- Saved attachment cards should read like structured evidence, not anonymous thumbnails.
 
 ## Help/Guide And Operator Training Contract
 
@@ -284,5 +299,7 @@ Critical target categories for `10/10` claim in this brief:
 
 ## Checkpoint Log
 
+- `2026-03-31 | working tree | shipped the remaining slice scope on branch `feat/admin-notes-route-surface-metadata-2026-03-31`: selected My Library hubs now expose page-level quick note through the shared SiteChrome surface, attachment cards/staged previews show stable evidence metadata from existing canonical fields, Help/Guide and recovery docs were updated, and `lint:briefs:all`, targeted unit/e2e, `typecheck`, and `verify:pre-pr` all passed locally | next: commit, push, open PR, and watch CI`
+- `2026-03-31 | working tree | moved the remaining admin-notes ergonomics follow-up into in-progress after the multi-image/save-again slice merged; narrowed this implementation wave to selected My Library route-surface expansion plus richer saved attachment metadata using the existing attachment contract | next: implement the route matrix in SiteChrome/page-note helpers, update attachment cards/copy/tests, and run targeted validation`
 - `2026-03-30 | working tree | refined the planned follow-up brief so repeated screenshot paste/upload append behavior is explicit in the problem statement, admin-note triage, and acceptance criteria while keeping the owned scope unchanged | next: keep this planned until the repeated-capture loop and route-surface matrix are chosen for implementation`
 - `2026-03-27 | planning | created a dedicated admin-notes ergonomics follow-up brief to own the remaining production-note batch around multi-image pre-save evidence, quick-note post-save reuse, route-surface rollout, and attachment metadata/agent-readiness expectations | next: confirm the desired repeated-capture workflow and route-surface matrix before implementation starts`

--- a/lib/admin/notes.ts
+++ b/lib/admin/notes.ts
@@ -162,6 +162,67 @@ export function compareAdminNotePriority(
   return rank[right] - rank[left];
 }
 
+export function buildAdminNoteAttachmentOrdinalLabel(index: number, total: number): string {
+  const safeIndex = Math.max(0, index) + 1;
+  const safeTotal = Math.max(1, total);
+  return safeTotal > 1 ? `Image ${safeIndex} of ${safeTotal}` : `Image ${safeIndex}`;
+}
+
+export function formatAdminNoteAttachmentSize(sizeBytes: number): string {
+  if (sizeBytes < 1024) return `${sizeBytes} B`;
+  const sizeKb = sizeBytes / 1024;
+  if (sizeKb < 1024) return `${sizeKb.toFixed(1)} KB`;
+  return `${(sizeKb / 1024).toFixed(1)} MB`;
+}
+
+export function formatAdminNoteAttachmentMimeLabel(mimeType: string): string {
+  const normalized = mimeType.trim().toLowerCase();
+  switch (normalized) {
+    case "image/png":
+      return "PNG";
+    case "image/jpeg":
+      return "JPEG";
+    case "image/webp":
+      return "WEBP";
+    case "image/gif":
+      return "GIF";
+    default: {
+      const subtype = normalized.split("/")[1] ?? normalized;
+      return subtype.toUpperCase() || "IMAGE";
+    }
+  }
+}
+
+export function formatAdminNoteAttachmentDate(createdAt: string): string {
+  const date = new Date(createdAt);
+  if (Number.isNaN(date.getTime())) {
+    return createdAt;
+  }
+  return date.toISOString().slice(0, 10);
+}
+
+export function buildAdminNoteAttachmentEvidenceSummary(params: {
+  mimeType: string;
+  sizeBytes: number;
+  createdAt?: string | null;
+  locationLabel?: string | null;
+}): string {
+  const parts = [
+    formatAdminNoteAttachmentMimeLabel(params.mimeType),
+    formatAdminNoteAttachmentSize(params.sizeBytes),
+  ];
+
+  if (params.createdAt) {
+    parts.push(`Uploaded ${formatAdminNoteAttachmentDate(params.createdAt)}`);
+  }
+
+  if (params.locationLabel) {
+    parts.push(params.locationLabel);
+  }
+
+  return parts.join(" · ");
+}
+
 export function isUuid(value: string): boolean {
   return UUID_REGEX.test(value);
 }

--- a/lib/admin/page-note-context.ts
+++ b/lib/admin/page-note-context.ts
@@ -11,6 +11,12 @@ export const ADMIN_PAGE_CONTEXT_OPTIONS: AdminPageContextOption[] = [
   { ref: "/guides/poolside", label: "Poolside guide" },
   { ref: "/my-library", label: "My Library" },
   { ref: "/my-library/goals", label: "My Library goals" },
+  { ref: "/my-library/training", label: "My Library training" },
+  { ref: "/my-library/profile", label: "My Library profile" },
+  { ref: "/my-library/workouts", label: "My Library workouts" },
+  { ref: "/my-library/dryland", label: "My Library dryland" },
+  { ref: "/my-library/generator", label: "My Library generator" },
+  { ref: "/my-library/security", label: "My Library security" },
   { ref: "/plans", label: "Plans page" },
   { ref: "/analysis", label: "Analysis page" },
   { ref: "/programs", label: "Programs page" },
@@ -24,6 +30,17 @@ export const ADMIN_PAGE_CONTEXT_OPTIONS: AdminPageContextOption[] = [
 const PAGE_LABEL_BY_REF = Object.fromEntries(
   ADMIN_PAGE_CONTEXT_OPTIONS.map((item) => [item.ref, item.label])
 ) as Record<string, string>;
+
+const ADMIN_MY_LIBRARY_PAGE_NOTE_REFS = [
+  "/my-library",
+  "/my-library/goals",
+  "/my-library/training",
+  "/my-library/profile",
+  "/my-library/workouts",
+  "/my-library/dryland",
+  "/my-library/generator",
+  "/my-library/security",
+] as const;
 
 function trimTrailingSlash(path: string): string {
   if (path === "/") return path;
@@ -56,4 +73,32 @@ export function hasDedicatedContextNotesForPage(pathname: string): boolean {
   if (normalized === "/guides/poolside") return true;
   if (normalized.startsWith("/my-library/item/")) return true;
   return false;
+}
+
+export function supportsAdminPageNotesSurface(pathname: string): boolean {
+  const normalized = normalizeAdminPageContextRef(pathname);
+
+  if (normalized === "/admin" || normalized.startsWith("/admin/")) {
+    return false;
+  }
+
+  if (normalized === "/auth/sign-in" || normalized.startsWith("/auth/")) {
+    return false;
+  }
+
+  if (normalized === "/checkout/success" || normalized.startsWith("/checkout/")) {
+    return false;
+  }
+
+  if (hasDedicatedContextNotesForPage(normalized)) {
+    return false;
+  }
+
+  if (normalized.startsWith("/my-library")) {
+    return ADMIN_MY_LIBRARY_PAGE_NOTE_REFS.includes(
+      normalized as (typeof ADMIN_MY_LIBRARY_PAGE_NOTE_REFS)[number]
+    );
+  }
+
+  return true;
 }

--- a/tests/e2e/admin-contextual-notes.spec.ts
+++ b/tests/e2e/admin-contextual-notes.spec.ts
@@ -396,4 +396,113 @@ test.describe("admin contextual notes", () => {
       panel.getByTestId("admin-context-note-item").filter({ hasText: title })
     ).toHaveCount(0);
   });
+
+  test("allowlisted admin can quick-capture page notes from my-library goals", async ({
+    page,
+  }, testInfo) => {
+    runOnceOnDesktopChromium(testInfo.project.name);
+    test.slow();
+
+    await loginAsAdminViaDevBypass(page, "/my-library/goals");
+    expect(new URL(page.url()).pathname).toBe("/my-library/goals");
+
+    const probe = await page.request.get(
+      "/api/admin/notes?contextType=page&contextRef=%2Fmy-library%2Fgoals"
+    );
+    if (!probe.ok()) {
+      test.skip(true, `Context notes API unavailable (${probe.status()}).`);
+    }
+
+    const probePayload = (await probe.json()) as { ok?: boolean; schemaReady?: boolean };
+    if (probePayload.ok && probePayload.schemaReady === false) {
+      test.skip(true, "Admin notes schema is not ready in this environment.");
+    }
+
+    const panel = page.getByTestId("admin-context-notes-panel");
+    await expect(panel).toBeVisible({ timeout: 15_000 });
+    await expect
+      .poll(async () => await panel.getByText("Loading notes…").count(), { timeout: 15_000 })
+      .toBe(0);
+
+    const unique = `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+    const title = buildAdminNoteTestArtifactTitle({
+      scope: ADMIN_CONTEXTUAL_NOTES_ARTIFACT_SCOPE,
+      label: "My Library goals quick capture",
+      unique,
+    });
+
+    await panel.getByRole("button", { name: "Quick note" }).click();
+    const quickCaptureDialog = page.getByTestId("admin-note-quick-capture-dialog");
+    await expect(quickCaptureDialog).toBeVisible({ timeout: 10_000 });
+    const createForm = page.getByTestId("admin-note-quick-capture-form");
+    await createForm.getByLabel("Title").fill(title);
+    await createForm.getByLabel("Category").fill("Operations");
+    await createForm.getByLabel("Priority").selectOption("high");
+    await createForm.getByLabel("Text").fill("Page-level admin note for My Library goals.");
+
+    let createResponse: Awaited<ReturnType<Page["waitForResponse"]>> | undefined;
+    try {
+      [createResponse] = await Promise.all([
+        page.waitForResponse(
+          (response) =>
+            response.url().includes("/api/admin/notes") && response.request().method() === "POST",
+          { timeout: 15_000 }
+        ),
+        createForm.getByRole("button", { name: "Save note" }).click(),
+      ]);
+    } catch {
+      test.skip(true, "My Library goals note create request timed out in this environment.");
+    }
+
+    if (!createResponse) {
+      return;
+    }
+
+    const createPayload = (await createResponse.json().catch(() => null)) as {
+      ok?: boolean;
+      error?: string;
+    } | null;
+    if (!createResponse.ok() || createPayload?.ok === false) {
+      const reason =
+        typeof createPayload?.error === "string"
+          ? createPayload.error
+          : `status ${createResponse.status()}`;
+      test.skip(
+        true,
+        `My Library goals note create is not write-ready in this environment (${reason}).`
+      );
+    }
+
+    await expect(quickCaptureDialog).toBeVisible({ timeout: 10_000 });
+    await expect(quickCaptureDialog.getByLabel("Title")).toHaveValue("");
+    await quickCaptureDialog.getByRole("button", { name: "Close panel" }).first().click();
+    await expect(quickCaptureDialog).toHaveCount(0);
+
+    const toggle = panel.getByTestId("admin-context-notes-toggle");
+    if ((await toggle.textContent())?.includes("Show")) {
+      await toggle.click();
+    }
+
+    const createdItem = panel
+      .getByTestId("admin-context-note-item")
+      .filter({ hasText: title })
+      .first();
+    await expect
+      .poll(
+        async () =>
+          await panel.getByTestId("admin-context-note-item").filter({ hasText: title }).count(),
+        { timeout: 15_000 }
+      )
+      .toBeGreaterThan(0);
+    await expect(createdItem).toBeVisible({ timeout: 15_000 });
+    await expect(createdItem).toContainText("High");
+
+    await toggleDoneAndWait(page, panel, title, "Note marked as done.");
+
+    page.once("dialog", (dialog) => dialog.accept());
+    await createdItem.getByRole("button", { name: "Delete" }).click();
+    await expect(
+      panel.getByTestId("admin-context-note-item").filter({ hasText: title })
+    ).toHaveCount(0);
+  });
 });

--- a/tests/e2e/admin-help-center.spec.ts
+++ b/tests/e2e/admin-help-center.spec.ts
@@ -147,6 +147,11 @@ test.describe("admin help center", () => {
     ).toBeVisible();
     await expect(
       page.getByText(
+        "Page-level `Quick note` is intentionally available on supported public pages plus selected My Library hubs: `/my-library`, `goals`, `training`, `profile`, `workouts`, `dryland`, `generator`, and `security`."
+      )
+    ).toBeVisible();
+    await expect(
+      page.getByText(
         "Create note with category, priority, and context link, then copy the visible note ID if you need to reference it later."
       )
     ).toBeVisible();
@@ -168,6 +173,11 @@ test.describe("admin help center", () => {
     await expect(
       page.getByText(
         "After a successful Quick note save, the panel stays open and ready for another note on the same locked context so you can keep capturing without reopening it."
+      )
+    ).toBeVisible();
+    await expect(
+      page.getByText(
+        "Saved image cards now show a stable evidence summary: image order, file type, file size, and upload date, without exposing raw storage paths."
       )
     ).toBeVisible();
     await expect(

--- a/tests/unit/admin-notes.test.ts
+++ b/tests/unit/admin-notes.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   ADMIN_INCIDENT_NOTE_CATEGORY_BY_SEVERITY,
+  buildAdminNoteAttachmentEvidenceSummary,
+  buildAdminNoteAttachmentOrdinalLabel,
   buildAdminNoteAttachmentStoragePath,
   buildIncidentNoteBodyTemplate,
   canonicalizeAdminNoteLinkPair,
@@ -134,6 +136,25 @@ describe("admin note attachment validation", () => {
     });
 
     expect(validated.ok).toBe(false);
+  });
+
+  it("builds deterministic evidence labels for saved and staged images", () => {
+    expect(buildAdminNoteAttachmentOrdinalLabel(0, 3)).toBe("Image 1 of 3");
+    expect(buildAdminNoteAttachmentOrdinalLabel(0, 1)).toBe("Image 1");
+    expect(
+      buildAdminNoteAttachmentEvidenceSummary({
+        mimeType: "image/png",
+        sizeBytes: 2048,
+        createdAt: "2026-03-31T14:22:11.000Z",
+      })
+    ).toBe("PNG · 2.0 KB · Uploaded 2026-03-31");
+    expect(
+      buildAdminNoteAttachmentEvidenceSummary({
+        mimeType: "image/webp",
+        sizeBytes: 1536,
+        locationLabel: "Staged locally",
+      })
+    ).toBe("WEBP · 1.5 KB · Staged locally");
   });
 });
 

--- a/tests/unit/page-note-context.test.ts
+++ b/tests/unit/page-note-context.test.ts
@@ -3,6 +3,7 @@ import {
   getAdminPageContextLabel,
   hasDedicatedContextNotesForPage,
   normalizeAdminPageContextRef,
+  supportsAdminPageNotesSurface,
 } from "@/lib/admin/page-note-context";
 
 describe("page note context helpers", () => {
@@ -14,6 +15,7 @@ describe("page note context helpers", () => {
 
   it("returns known labels and safe fallback labels", () => {
     expect(getAdminPageContextLabel("/plans")).toBe("Plans page");
+    expect(getAdminPageContextLabel("/my-library/training")).toBe("My Library training");
     expect(getAdminPageContextLabel("/unknown-path")).toBe("Page: /unknown-path");
   });
 
@@ -22,5 +24,17 @@ describe("page note context helpers", () => {
     expect(hasDedicatedContextNotesForPage("/guides/poolside")).toBe(true);
     expect(hasDedicatedContextNotesForPage("/my-library/item/guide-poolside")).toBe(true);
     expect(hasDedicatedContextNotesForPage("/plans")).toBe(false);
+  });
+
+  it("supports page-level notes on public routes and selected my-library hubs only", () => {
+    expect(supportsAdminPageNotesSurface("/plans")).toBe(true);
+    expect(supportsAdminPageNotesSurface("/my-library")).toBe(true);
+    expect(supportsAdminPageNotesSurface("/my-library/goals")).toBe(true);
+    expect(supportsAdminPageNotesSurface("/my-library/profile")).toBe(true);
+    expect(supportsAdminPageNotesSurface("/my-library/workouts")).toBe(true);
+    expect(supportsAdminPageNotesSurface("/my-library/workouts/workout-1")).toBe(false);
+    expect(supportsAdminPageNotesSurface("/my-library/item/guide-poolside")).toBe(false);
+    expect(supportsAdminPageNotesSurface("/auth/sign-in")).toBe(false);
+    expect(supportsAdminPageNotesSurface("/admin")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-03-31T17:54:01.820Z for branch `feat/admin-notes-route-surface-metadata-2026-03-31` (base ref `origin/main`).
- Latest commit: `3ec580e` - feat(admin-notes): expand quick note route surfaces and evidence metadata.
- User-visible changes: Admin-facing behavior/guardrails may change in touched admin routes or APIs.
- Technical changes: Updated 13 file(s): `components/SiteChrome.tsx`, `components/admin/AdminContextNotesPanel.tsx`, `components/admin/AdminHelpCenter.tsx`, `components/admin/AdminNoteQuickCaptureLauncher.tsx`, `components/admin/AdminNotesManager.tsx`, `... and 8 more file(s)`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-03-27-admin-notes-ergonomics-multi-image-and-route-surface-followup-10-10.md`
- Scorecard target outcomes: 13 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (2); tests (4); runtime UI/routes/components (7).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (13):
  - `components/SiteChrome.tsx`
  - `components/admin/AdminContextNotesPanel.tsx`
  - `components/admin/AdminHelpCenter.tsx`
  - `components/admin/AdminNoteQuickCaptureLauncher.tsx`
  - `components/admin/AdminNotesManager.tsx`
  - `docs/runbooks/admin-notes-recovery.md`
  - `docs/task-briefs/in-progress/2026-03-27-admin-notes-ergonomics-multi-image-and-route-surface-followup-10-10.md`
  - `lib/admin/notes.ts`
  - `... and 5 more file(s)`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `3ec580e` (`git revert 3ec580e`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **PASS** (`PW_PORT=3121 NEXT_DIST_DIR=.next-playwright-admin-notes-route-surface-verify-prepr-head SITE_LOCK_ENABLED=0 npm run verify:pre-pr` on `3ec580e`)
- `npm run verify:pre-merge`: **PENDING** for `3ec580e` (required before merge to `main`).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  - Local public verify passed on `3ec580e`.
  - Playwright public matrix: `92 passed`, `286 skipped`.
  - `lint:briefs`, `lint`, `typecheck`, `test:unit`, `build`, `test:perf:budgets`, and `test:e2e` all passed in the same run.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
