### PR TITLE
feat(admin-notes): expand my-library detail route quick capture

### DIFF
--- a/components/admin/AdminHelpCenter.tsx
+++ b/components/admin/AdminHelpCenter.tsx
@@ -18,7 +18,7 @@ type ActionGroup = {
   actions: Array<{ label: string; meaning: string }>;
 };
 
-const LAST_UPDATED = "2026-03-31";
+const LAST_UPDATED = "2026-04-02";
 
 const QUICK_ACTIONS = [
   { id: "overview", label: "Start here" },
@@ -569,7 +569,7 @@ const DAILY_PLAYBOOKS: Playbook[] = [
       "Use `Quick note` when you want a lightweight admin note from the current surface without losing context.",
       "If you still need to scroll, click, or collect a screenshot before saving, collapse `Quick note`; the page stays interactive underneath and you can reopen the same draft from the docked edge handle on the right.",
       "If you navigate to another supported admin/context surface before saving, the same draft can follow you, but it stays attached to the original locked context shown in the panel.",
-      "Page-level `Quick note` is intentionally available on supported public pages plus selected My Library hubs: `/my-library`, `goals`, `training`, `profile`, `workouts`, `dryland`, `generator`, and `security`, plus saved swim-session detail pages under `/my-library/workouts/<id>`.",
+      "Page-level `Quick note` is intentionally available on supported public pages plus selected My Library hubs: `/my-library`, `goals`, `training`, `profile`, `workouts`, `dryland`, `generator`, and `security`, plus saved detail routes under `/my-library/workouts/<id>`, `/my-library/dryland/<id>`, and `/my-library/programs/<id>`.",
       "Use the top `Add note` section when you want full fields in place; if notes already exist it stays collapsed until you expand it again.",
       "If the note is already saved and you forgot the screenshot, open `Edit` in the contextual notes panel and upload the image there instead of recreating the note.",
       "Create note with category, priority, and context link, then copy the visible note ID if you need to reference it later.",

--- a/docs/task-briefs/done/2026-04-01-admin-notes-existing-note-images-and-quick-note-copy-10-10.md
+++ b/docs/task-briefs/done/2026-04-01-admin-notes-existing-note-images-and-quick-note-copy-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-04-01-admin-notes-existing-note-images-and-quick-note-copy-10-10`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-04-01`
 - `updated`: `2026-04-02`
@@ -285,3 +285,11 @@ Critical target categories for `10/10` claim in this brief:
 - `2026-04-01 | working tree | created the first in-progress child slice under the production admin-notes umbrella, focused on contextual existing-note image recovery plus quick-note copy simplification | next: implement contextual attachment edit parity, update docs/tests, and run targeted validation`
 - `2026-04-02 | 1f960e4 | implemented contextual existing-note image upload/delete parity, simplified quick-note copy/actions, updated Help/Guide + recovery wording, and passed targeted desktop Chromium admin-notes coverage plus full npm run verify:pre-pr | next: commit the validated slice, push the worktree branch, and open/update the PR`
 - `2026-04-02 | 99ae6a3 | hardened contextual attachment delete state against stale hydrated responses, added a unit regression covering stale delete payloads, and passed isolated Playwright repros plus full npm run verify:pre-merge in a clean PR worktree | next: commit the regression fix, push the branch, and recheck PR status`
+- `2026-04-02 | a43722c | PR #337 merged to main; the slice shipped existing-note image recovery, calmer quick-note copy/actions, help/runbook updates, and delete-state hardening | next: move this brief to done and continue with the narrower route-surface expansion follow-up`
+
+## Completion Record
+
+- `PR`: `#337`
+- `merge`: `2026-04-02`
+- `merge_commit`: `a43722ceeb9391e632675cbf277815692d2937db`
+- `result`: `merged to main`

--- a/docs/task-briefs/in-progress/2026-04-01-production-admin-notes-remaining-work-umbrella-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-01-production-admin-notes-remaining-work-umbrella-10-10.md
@@ -440,6 +440,7 @@ Critical target categories for `10/10` claim in this umbrella:
 
 ## Checkpoint Log
 
+- `2026-04-02 | 2008230 | PR #338 merged the builder/my-library flow slice on main after PR #337 had already landed the existing-note images + quick-note calmness slice; remaining admin-notes system work is now narrowed to route-surface expansion plus later metadata/agent-readiness decisions | next: execute the detail-route expansion child slice for saved dryland/program routes`
 - `2026-04-02 | feat/swim-session-builder-flow-cleanup-2026-04-02 | child execution started under the umbrella through the builder/my-library slice covering swim-session flow consolidation, My Swim Sessions naming, Edit labels, reduced pool-length presets, calmer detail-route copy, and workout-detail Quick note route support without removing any manual builder input fields; targeted vitest + targeted desktop-chromium playwright are green, with the new workout-detail admin-notes e2e currently environment-skipped on write readiness | next: run npm run verify:pre-pr for this slice, then commit/push/open PR and keep the umbrella in-progress`
 - `2026-04-01 | working tree | re-triaged live production admin notes, closed 8 already-shipped notes, deleted 1 obsolete note by owner request, and created one umbrella brief for the remaining 23-note backlog | next: keep this planned until the first child execution slice is chosen`
 

--- a/docs/task-briefs/in-progress/2026-04-02-admin-notes-my-library-detail-route-expansion-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-02-admin-notes-my-library-detail-route-expansion-10-10.md
@@ -1,0 +1,263 @@
+# Task Brief: Admin Notes My Library Detail Route Expansion (10/10)
+
+## Metadata
+
+- `id`: `2026-04-02-admin-notes-my-library-detail-route-expansion-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-04-02`
+- `updated`: `2026-04-02`
+
+## Goal
+
+Allowlisted admins can use page-level `Quick note` on the remaining saved My Library detail routes that still lack it, with stable contextual labels, aligned Help/Guide copy, and regression coverage.
+
+## Why This Brief Exists
+
+- The `2026-04-01` live triage left one explicit admin-notes system follow-up open:
+  - `881e222b-4c14-4a23-b677-60b0713e220f` `Admin notes quick capture route-surface expansion follow-up`
+- Since then, two child slices landed on `main`:
+  - PR `#337` recovered screenshots on existing contextual notes and simplified quick-note copy.
+  - PR `#338` enabled page-level `Quick note` on `/my-library/workouts/[workoutId]` while consolidating the swim-session builder flow.
+- The remaining high-value gap is now narrower:
+  - saved dryland detail routes under `/my-library/dryland/[sessionId]`,
+  - saved program detail routes under `/my-library/programs/[programId]`.
+- This slice intentionally finishes the remaining My Library detail-route expansion before any broader route-sprawl or attachment-metadata redesign.
+
+## Dependencies And Boundaries
+
+- Existing admin-notes foundations remain authoritative:
+  - `components/SiteChrome.tsx`
+  - `lib/admin/page-note-context.ts`
+  - `components/admin/AdminContextNotesPanel.tsx`
+  - `components/admin/AdminHelpCenter.tsx`
+  - `tests/e2e/admin-contextual-notes.spec.ts`
+  - `tests/unit/page-note-context.test.ts`
+- Parent umbrella owner:
+  - `docs/task-briefs/in-progress/2026-04-01-production-admin-notes-remaining-work-umbrella-10-10.md`
+- Already-shipped child lineage to consume rather than reopen:
+  - `docs/task-briefs/done/2026-04-01-admin-notes-existing-note-images-and-quick-note-copy-10-10.md`
+- This slice owns:
+  - My Library detail-route surface expansion for saved dryland/program routes,
+  - stable context labels for those routes,
+  - Help/Guide wording updates for the newly-supported surfaces,
+  - targeted unit/e2e coverage.
+- This slice does not own:
+  - new attachment metadata, OCR, or agent-readiness schema work,
+  - unrelated public-route expansion,
+  - any removal of manual builder input fields.
+
+## Admin Notes Triage Disposition
+
+- `881e222b-4c14-4a23-b677-60b0713e220f` `Admin notes quick capture route-surface expansion follow-up`
+  - disposition: owned by this brief.
+  - reason: the remaining concrete product gap is missing page-level notes on the last saved My Library detail builders.
+- `204913d0-5c97-41e8-b6f7-ab42de3bc84e` `Admin notes attachment metadata and agent-readiness follow-up`
+  - disposition: out of scope for this slice.
+  - reason: route availability can land now without reopening attachment schema/policy work.
+- `95f2361c-925d-42e3-a7e5-553410faec88` `Add screenshots to admin notes`
+  - disposition: already shipped in PR `#337`.
+- `85fb1d9f-efd9-4aa5-8bfe-7ab35c989b43` `Quick notes - Less is more`
+  - disposition: already shipped in PR `#337`.
+- `24bc6866-1b4e-41b1-9e4f-ae803bf06ca3` `Quick Note`
+  - disposition: already shipped in PR `#337`.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Business logic correctness and data integrity`
+- `Admin workflow and editability`
+- `Reliability and failure handling`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                             | Evidence                                           |
+| --------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| Product goals and IA                          | `target`     | Saved My Library detail builders that still need lightweight operator capture expose the same page-level notes contract as the already-supported workout detail route. | UI review + code review + help copy                |
+| UX flow clarity                               | `target`     | Allowlisted admins can discover and use `Quick note` on the added detail routes without generic fallback labeling or route-specific confusion.            | manual QA + targeted unit/e2e                      |
+| Visual design quality                         | `supporting` | Supporting only: added route surfaces reuse the existing quick-note visual language without introducing route-specific UI drift.                           | preview review + diff review                       |
+| Business logic correctness and data integrity | `target`     | New detail-route contexts normalize to deterministic canonical refs and labels, and notes saved from those routes resolve back to the correct page context. | unit tests + targeted e2e + code review            |
+| Admin editor ergonomics                       | `target`     | Operators can capture page notes from saved dryland/program detail routes without detouring to `/admin` or losing route context.                          | workflow QA + targeted e2e                         |
+| Accessibility (a11y)                          | `supporting` | Supporting only: the same launcher semantics, focus handling, and labels remain intact on the new route surfaces.                                         | existing launcher tests + targeted e2e             |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: route-surface expansion adds no material payload or rendering regression beyond the existing admin overlay contract.                      | `verify:pre-pr` + diff review                      |
+| Data placement and sync boundaries            | `target`     | Page-note route context remains server-canonical only after save; draft text and collapsed/open UI state stay local-only.                                 | brief contract + code review + tests               |
+| Caching and invalidation strategy             | `target`     | Newly-supported route contexts show saved notes deterministically after save without stale generic labels or missing route association.                    | targeted e2e + integration review                  |
+| Reliability and failure handling              | `target`     | Unsupported/admin/auth routes remain blocked while newly-supported detail routes behave the same as other valid page-note surfaces.                        | unit tests + protected-route assertions            |
+| Security and authz                            | `target`     | Page-level notes on these detail routes remain admin-only and continue to fail closed for unauthenticated or unauthorized flows.                           | existing authz coverage + targeted e2e             |
+| Privacy and compliance                        | `supporting` | Supporting only: newly-supported route labels do not expose private user data beyond the existing admin-only route-context contract.                       | code review + scope rationale                      |
+| Content governance                            | `supporting` | Supporting only: Help/Guide text lists the newly-supported routes and stays aligned with the actual route allowlist.                                       | docs update + automated help assertion             |
+| Admin workflow and editability                | `target`     | The same quick-capture/edit/review workflow works on workout, dryland, and program detail routes without hidden route exceptions.                          | workflow QA + targeted e2e                         |
+| SEO and crawlability                          | `N/A`        | N/A because this slice only changes admin-only note surfaces and internal help text, not public crawl/index behavior.                                     | explicit scope rationale                           |
+| AI discoverability                            | `N/A`        | N/A because this slice changes no public AI-facing route, metadata, or schema contract.                                                                   | explicit scope rationale                           |
+| Analytics and KPI observability               | `supporting` | Supporting only: expanded route-surface usage remains inferable through existing note context refs even without new analytics events.                       | code review + scope rationale                      |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, entitlement, catalog, or billing logic changes in this route-surface slice.                                                       | explicit scope rationale                           |
+| Incident response and support operations      | `target`     | Help/Guide describes the newly-supported dryland/program detail routes in the same PR that changes availability.                                           | docs update + automated help assertion             |
+| Finance and reporting operations              | `N/A`        | N/A because this slice changes no reconciliation, reporting, payout, or finance-support behavior.                                                         | explicit scope rationale                           |
+| i18n operational readiness                    | `N/A`        | N/A because this slice reuses existing structural labels and introduces no locale-blocking formatting or routing logic.                                   | explicit scope rationale                           |
+| Stack-fit and dependency discipline           | `target`     | Reuse existing page-note context helpers, SiteChrome surfacing, and contextual notes flows without adding dependencies or a second routing system.         | dependency diff + architecture review              |
+| Testing and QA automation                     | `target`     | Coverage protects page-note context labels/allowlist plus dryland/program detail quick-capture flows, and the slice passes `npm run verify:pre-pr`.      | targeted tests + `verify:pre-pr`                   |
+| Scalability and cost efficiency               | `supporting` | Supporting only: this slice expands two deterministic route checks and introduces no new storage, schema, or unbounded query path.                         | diff review + route review                         |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: the route-allowlist change is reversible without data migration or cross-system rollback.                                                 | PR summary + rollback note                         |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - `admin_notes` rows,
+  - canonical page-context refs saved with note context,
+  - saved dryland/program/workout entity IDs already present in route paths.
+- Local-only:
+  - quick-note draft text,
+  - launcher open/collapsed state,
+  - transient success/error notices.
+- Sync policy:
+  - route support is determined from canonical normalized path rules,
+  - note save writes against the current normalized page ref only after explicit operator submission,
+  - help text and tests must stay aligned with the route allowlist in the same slice.
+- Retention and sensitivity:
+  - page-route refs remain admin-only note metadata,
+  - no new private payload fields or attachment data are introduced.
+- Cache/invalidation:
+  - contextual panel reads should reflect the correct route label and context immediately after save on the supported routes.
+
+## Identity And Rename Contract
+
+- Canonical stable IDs:
+  - `admin_note.id` remains the note identity,
+  - route-path context ref remains the canonical page-surface identity for contextual notes,
+  - `programId`, `sessionId`, and `workoutId` remain the entity identifiers already used by the saved detail routes.
+- Human-readable identifiers:
+  - `My Library swim session detail`, `My Library dryland session detail`, and `My Library program detail` are editable display labels only.
+- Mutability rules:
+  - route labels may change in copy,
+  - normalized route refs remain the source-of-truth for saved contextual notes,
+  - the slice must not repurpose one route label to point at a different canonical route family.
+- Rename vs repurpose policy:
+  - add a new explicit label mapping when a new detail-route family becomes supported,
+  - do not overload generic `Page: /...` fallback text for a first-class supported route.
+- Compatibility contract:
+  - existing workout-detail notes keep their current route label and behavior,
+  - unsupported routes remain unsupported unless explicitly added to the allowlist.
+- Observability and repair:
+  - unit/e2e coverage must detect missing labels or missing support on the intended detail routes.
+
+## Scope
+
+- Expand page-level admin-note support to:
+  - `/my-library/dryland/[sessionId]`
+  - `/my-library/programs/[programId]`
+- Add stable context labels for the new route families.
+- Update Help/Guide wording so the documented route list matches the actual supported surfaces.
+- Add/update targeted unit and e2e coverage for the new route contexts.
+- Update umbrella/checkpoint docs so the prior admin-notes child brief is recorded as done and this route-expansion slice is the active successor.
+
+## Out Of Scope
+
+- New attachment metadata, OCR, agent-readiness policy, or schema changes.
+- Any route expansion beyond the saved dryland/program detail routes in this slice.
+- Public-route quick-note expansion.
+- Removing any manual builder/session/program input fields.
+- Reworking the full contextual note editor beyond what is already on `main`.
+
+## Acceptance Criteria
+
+1. Allowlisted admins see the page-level admin-notes surface on `/my-library/dryland/[sessionId]` and `/my-library/programs/[programId]`.
+2. Notes saved from those routes use stable labels instead of generic `Page: /...` fallback labels.
+3. Existing unsupported routes remain unsupported.
+4. Help/Guide explicitly lists the newly-supported detail routes.
+5. `npm run lint:briefs`, targeted tests, and `npm run verify:pre-pr` pass before PR update.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run typecheck`
+- targeted `vitest`:
+  - `tests/unit/page-note-context.test.ts`
+- targeted `playwright`:
+  - `tests/e2e/admin-contextual-notes.spec.ts --project=desktop-chromium`
+  - `tests/e2e/admin-help-center.spec.ts --project=desktop-chromium`
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm must be installed on the machine used for local validation.
+- Local validation runs from repo root.
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3000/my-library/dryland/<sessionId>`
+  - `http://127.0.0.1:3000/my-library/programs/<programId>`
+  - `http://127.0.0.1:3000/admin?tab=help`
+- Preview:
+  - PR Vercel preview URL after branch push
+- Recommended matrix:
+  - desktop Chromium
+  - desktop Safari/WebKit
+
+## Constraints
+
+- Keep route expansion limited to the saved dryland/program detail routes.
+- Reuse the existing page-note context helpers and contextual panel behavior instead of inventing a second route-switching mechanism.
+- Do not reopen screenshot recovery or quick-note copy simplification in this PR unless directly needed for the new routes.
+
+## 10/10 Quality Bar
+
+- The admin should not need to remember route exceptions between saved workout, dryland, and program detail builders.
+- The primary `Quick note` path should appear exactly where the existing supported detail-route contract would make an operator expect it.
+- Required states remain explicit:
+  - `supported`
+  - `unsupported`
+  - `loading`
+  - `save success`
+  - `error`
+  - `retry`
+- Added route support must not regress auth-blocked/admin-blocked route rules.
+
+## Help/Guide And Operator Training Contract
+
+- Required:
+  - update Help/Guide route-availability wording in the same PR,
+  - keep route examples aligned with the actual allowlist,
+  - update at least one automated assertion for the changed help contract.
+
+## Security, Privacy, and Compliance
+
+- Newly-supported detail routes must remain admin-only note surfaces.
+- Unauthorized note mutations must continue to fail closed.
+- The slice must not surface new private user fields or attachment details in route labels.
+
+## Observability And KPI Contract
+
+- Useful future signals if instrumentation expands later:
+  - quick-note create by route family,
+  - contextual note usage on saved workout/dryland/program detail routes.
+- Success KPI for this slice:
+  - operators can use the same page-level note workflow across all saved My Library detail builders that are intentionally supported today.
+
+## Session Continuity And Recovery
+
+- Canonical source of truth:
+  - git branch
+  - this brief path
+- Recovery protocol:
+  1. `git status -sb`
+  2. `git log --oneline -n 10`
+  3. reopen this brief and continue from the latest checkpoint note
+
+## Git Rhythm Defaults
+
+- Commit + push after each validated implementation step for this slice.
+- Open/update PR after one coherent validated route-expansion vertical slice.
+
+## PR Browser Rule
+
+- Default PR create/review/merge links open in Safari.
+
+## Checkpoint Log
+
+- `2026-04-02 | working tree | created the second admin-notes child slice under the production umbrella to finish My Library detail-route quick-note expansion for saved dryland/program routes after PRs #337 and #338 landed on main | next: implement route-label/allowlist updates, add targeted tests, and run targeted validation`
+- `2026-04-02 | working tree | implemented saved dryland/program detail-route support, added stable context labels, updated Help/Guide route documentation, moved the prior admin-notes child brief to done, and passed targeted vitest, targeted desktop Chromium Playwright, and full npm run verify:pre-pr (95 passed, 319 skipped, 0 failed) after replacing the local worktree node_modules symlink with a physical copy for Turbopack compatibility | next: stage tracked source/brief files only, commit, push, open PR, and monitor CI`

--- a/lib/admin/page-note-context.ts
+++ b/lib/admin/page-note-context.ts
@@ -66,6 +66,12 @@ export function getAdminPageContextLabel(ref: string): string {
   if (normalized.startsWith("/my-library/workouts/")) {
     return "My Library swim session detail";
   }
+  if (normalized.startsWith("/my-library/dryland/")) {
+    return "My Library dryland session detail";
+  }
+  if (normalized.startsWith("/my-library/programs/")) {
+    return "My Library program detail";
+  }
   return `Page: ${normalized}`;
 }
 
@@ -98,6 +104,14 @@ export function supportsAdminPageNotesSurface(pathname: string): boolean {
   }
 
   if (normalized.startsWith("/my-library/workouts/")) {
+    return true;
+  }
+
+  if (normalized.startsWith("/my-library/dryland/")) {
+    return true;
+  }
+
+  if (normalized.startsWith("/my-library/programs/")) {
     return true;
   }
 

--- a/tests/e2e/admin-contextual-notes.spec.ts
+++ b/tests/e2e/admin-contextual-notes.spec.ts
@@ -2,6 +2,7 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { buildAdminNoteTestArtifactTitle } from "@/lib/admin/admin-note-test-artifacts";
 import { resolveCanonicalCourseLessonRuntimeId } from "@/lib/course/runtime-id-manifest";
+import { buildManualDrylandStarterDraft } from "@/lib/dryland/manual";
 import { buildManualWorkoutEmptyDraft } from "@/lib/workouts/manual";
 import { cleanupAdminNoteTestArtifacts } from "@/tests/e2e/admin-note-test-artifact-cleanup";
 
@@ -124,6 +125,100 @@ async function ensureContextCreateFormOpen(page: Page, panel: ReturnType<Page["g
   await expect(createForm.getByLabel("Category")).toBeVisible({ timeout: 15_000 });
 
   return createForm;
+}
+
+async function expectPageQuickCaptureFlow(
+  page: Page,
+  contextPath: string,
+  title: string,
+  body: string
+) {
+  const probe = await page.request.get(
+    `/api/admin/notes?contextType=page&contextRef=${encodeURIComponent(contextPath)}`
+  );
+  if (!probe.ok()) {
+    test.skip(true, `Context notes API unavailable (${probe.status()}).`);
+  }
+
+  const probePayload = (await probe.json()) as { ok?: boolean; schemaReady?: boolean };
+  if (probePayload.ok && probePayload.schemaReady === false) {
+    test.skip(true, "Admin notes schema is not ready in this environment.");
+  }
+
+  const panel = page.getByTestId("admin-context-notes-panel");
+  await expect(panel).toBeVisible({ timeout: 15_000 });
+  await expect
+    .poll(async () => await panel.getByText("Loading notes…").count(), { timeout: 15_000 })
+    .toBe(0);
+
+  await panel.getByRole("button", { name: "Quick note" }).click();
+  const quickCaptureDialog = page.getByTestId("admin-note-quick-capture-dialog");
+  await expect(quickCaptureDialog).toBeVisible({ timeout: 10_000 });
+  const createForm = page.getByTestId("admin-note-quick-capture-form");
+  await createForm.getByLabel("Title").fill(title);
+  await createForm.getByLabel("Category").fill("Operations");
+  await createForm.getByLabel("Priority").selectOption("high");
+  await createForm.getByLabel("Text").fill(body);
+
+  let createResponse: Awaited<ReturnType<Page["waitForResponse"]>> | undefined;
+  try {
+    [createResponse] = await Promise.all([
+      page.waitForResponse(
+        (response) =>
+          response.url().includes("/api/admin/notes") && response.request().method() === "POST",
+        { timeout: 15_000 }
+      ),
+      createForm.getByRole("button", { name: "Save note" }).click(),
+    ]);
+  } catch {
+    test.skip(true, "Page-level note create request timed out in this environment.");
+  }
+
+  if (!createResponse) {
+    return;
+  }
+
+  const createPayload = (await createResponse.json().catch(() => null)) as {
+    ok?: boolean;
+    error?: string;
+  } | null;
+  if (!createResponse.ok() || createPayload?.ok === false) {
+    const reason =
+      typeof createPayload?.error === "string"
+        ? createPayload.error
+        : `status ${createResponse.status()}`;
+    test.skip(
+      true,
+      `Page-level note create is not write-ready in this environment (${reason}).`
+    );
+  }
+
+  await expect(quickCaptureDialog).toBeVisible({ timeout: 10_000 });
+  await expect(quickCaptureDialog.getByLabel("Title")).toHaveValue("");
+  await quickCaptureDialog.getByRole("button", { name: "Close panel" }).first().click();
+  await expect(quickCaptureDialog).toHaveCount(0);
+
+  const toggle = panel.getByTestId("admin-context-notes-toggle");
+  if ((await toggle.textContent())?.includes("Show")) {
+    await toggle.click();
+  }
+
+  const createdItem = panel.getByTestId("admin-context-note-item").filter({ hasText: title }).first();
+  await expect
+    .poll(
+      async () =>
+        await panel.getByTestId("admin-context-note-item").filter({ hasText: title }).count(),
+      { timeout: 15_000 }
+    )
+    .toBeGreaterThan(0);
+  await expect(createdItem).toBeVisible({ timeout: 15_000 });
+  await expect(createdItem).toContainText("High");
+
+  await toggleDoneAndWait(page, panel, title, "Note marked as done.");
+
+  page.once("dialog", (dialog) => dialog.accept());
+  await createdItem.getByRole("button", { name: "Delete" }).click();
+  await expect(panel.getByTestId("admin-context-note-item").filter({ hasText: title })).toHaveCount(0);
 }
 
 test.describe("admin contextual notes", () => {
@@ -627,107 +722,144 @@ test.describe("admin contextual notes", () => {
     try {
       await loginAsAdminViaDevBypass(page, workoutPath);
       expect(new URL(page.url()).pathname).toBe(workoutPath);
-
-      const probe = await page.request.get(
-        `/api/admin/notes?contextType=page&contextRef=${encodeURIComponent(workoutPath)}`
-      );
-      if (!probe.ok()) {
-        test.skip(true, `Context notes API unavailable (${probe.status()}).`);
-      }
-
-      const probePayload = (await probe.json()) as { ok?: boolean; schemaReady?: boolean };
-      if (probePayload.ok && probePayload.schemaReady === false) {
-        test.skip(true, "Admin notes schema is not ready in this environment.");
-      }
-
-      const panel = page.getByTestId("admin-context-notes-panel");
-      await expect(panel).toBeVisible({ timeout: 15_000 });
-      await expect
-        .poll(async () => await panel.getByText("Loading notes…").count(), { timeout: 15_000 })
-        .toBe(0);
-
       const unique = `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
       const title = buildAdminNoteTestArtifactTitle({
         scope: ADMIN_CONTEXTUAL_NOTES_ARTIFACT_SCOPE,
         label: "Swim session detail quick capture",
         unique,
       });
-
-      await panel.getByRole("button", { name: "Quick note" }).click();
-      const quickCaptureDialog = page.getByTestId("admin-note-quick-capture-dialog");
-      await expect(quickCaptureDialog).toBeVisible({ timeout: 10_000 });
-      const createForm = page.getByTestId("admin-note-quick-capture-form");
-      await createForm.getByLabel("Title").fill(title);
-      await createForm.getByLabel("Category").fill("Operations");
-      await createForm.getByLabel("Priority").selectOption("high");
-      await createForm.getByLabel("Text").fill("Page-level admin note for swim-session detail.");
-
-      let createResponse: Awaited<ReturnType<Page["waitForResponse"]>> | undefined;
-      try {
-        [createResponse] = await Promise.all([
-          page.waitForResponse(
-            (response) =>
-              response.url().includes("/api/admin/notes") && response.request().method() === "POST",
-            { timeout: 15_000 }
-          ),
-          createForm.getByRole("button", { name: "Save note" }).click(),
-        ]);
-      } catch {
-        test.skip(true, "Swim-session detail note create request timed out in this environment.");
-      }
-
-      if (!createResponse) {
-        return;
-      }
-
-      const createPayload = (await createResponse.json().catch(() => null)) as {
-        ok?: boolean;
-        error?: string;
-      } | null;
-      if (!createResponse.ok() || createPayload?.ok === false) {
-        const reason =
-          typeof createPayload?.error === "string"
-            ? createPayload.error
-            : `status ${createResponse.status()}`;
-        test.skip(
-          true,
-          `Swim-session detail note create is not write-ready in this environment (${reason}).`
-        );
-      }
-
-      await expect(quickCaptureDialog).toBeVisible({ timeout: 10_000 });
-      await expect(quickCaptureDialog.getByLabel("Title")).toHaveValue("");
-      await quickCaptureDialog.getByRole("button", { name: "Close panel" }).first().click();
-      await expect(quickCaptureDialog).toHaveCount(0);
-
-      const toggle = panel.getByTestId("admin-context-notes-toggle");
-      if ((await toggle.textContent())?.includes("Show")) {
-        await toggle.click();
-      }
-
-      const createdItem = panel
-        .getByTestId("admin-context-note-item")
-        .filter({ hasText: title })
-        .first();
-      await expect
-        .poll(
-          async () =>
-            await panel.getByTestId("admin-context-note-item").filter({ hasText: title }).count(),
-          { timeout: 15_000 }
-        )
-        .toBeGreaterThan(0);
-      await expect(createdItem).toBeVisible({ timeout: 15_000 });
-      await expect(createdItem).toContainText("High");
-
-      await toggleDoneAndWait(page, panel, title, "Note marked as done.");
-
-      page.once("dialog", (dialog) => dialog.accept());
-      await createdItem.getByRole("button", { name: "Delete" }).click();
-      await expect(
-        panel.getByTestId("admin-context-note-item").filter({ hasText: title })
-      ).toHaveCount(0);
+      await expectPageQuickCaptureFlow(
+        page,
+        workoutPath,
+        title,
+        "Page-level admin note for swim-session detail."
+      );
     } finally {
       await page.request.delete(`/api/my-library/workouts/${workoutId}`).catch(() => null);
     }
+  });
+
+  test("allowlisted admin can quick-capture page notes from dryland detail route", async ({
+    page,
+  }, testInfo) => {
+    runOnceOnDesktopChromium(testInfo.project.name);
+    test.slow();
+
+    await loginAsAdminViaDevBypass(page, "/my-library");
+    expect(new URL(page.url()).pathname).toBe("/my-library");
+
+    const drylandCreateResponse = await page.request.post("/api/my-library/dryland", {
+      headers: {
+        "content-type": "application/json",
+      },
+      data: JSON.stringify({
+        sourceKind: "manual",
+        sessionKind: "strength",
+        draft: buildManualDrylandStarterDraft("strength"),
+      }),
+    });
+
+    if (!drylandCreateResponse.ok()) {
+      test.skip(true, `Dryland create API unavailable (${drylandCreateResponse.status()}).`);
+    }
+
+    const drylandCreatePayload = (await drylandCreateResponse.json().catch(() => null)) as {
+      ok?: boolean;
+      error?: string;
+      session?: { id?: string };
+    } | null;
+
+    if (!drylandCreatePayload?.ok || typeof drylandCreatePayload.session?.id !== "string") {
+      const reason =
+        typeof drylandCreatePayload?.error === "string"
+          ? drylandCreatePayload.error
+          : "missing dryland session id";
+      test.skip(true, `Dryland detail setup is not write-ready in this environment (${reason}).`);
+    }
+
+    const sessionId = drylandCreatePayload?.session?.id;
+    if (typeof sessionId !== "string") {
+      test.skip(true, "Dryland detail setup did not return a stable session id.");
+    }
+    const drylandPath = `/my-library/dryland/${sessionId}`;
+
+    try {
+      await loginAsAdminViaDevBypass(page, drylandPath);
+      expect(new URL(page.url()).pathname).toBe(drylandPath);
+
+      const unique = `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+      const title = buildAdminNoteTestArtifactTitle({
+        scope: ADMIN_CONTEXTUAL_NOTES_ARTIFACT_SCOPE,
+        label: "Dryland detail quick capture",
+        unique,
+      });
+
+      await expectPageQuickCaptureFlow(
+        page,
+        drylandPath,
+        title,
+        "Page-level admin note for dryland detail."
+      );
+    } finally {
+      await page.request.delete(`/api/my-library/dryland/${sessionId}`).catch(() => null);
+    }
+  });
+
+  test("allowlisted admin can quick-capture page notes from program detail route", async ({
+    page,
+  }, testInfo) => {
+    runOnceOnDesktopChromium(testInfo.project.name);
+    test.slow();
+
+    await loginAsAdminViaDevBypass(page, "/my-library");
+    expect(new URL(page.url()).pathname).toBe("/my-library");
+
+    const programCreateResponse = await page.request.post("/api/my-library/programs", {
+      headers: {
+        "content-type": "application/json",
+      },
+      data: JSON.stringify({}),
+    });
+
+    if (!programCreateResponse.ok()) {
+      test.skip(true, `Program create API unavailable (${programCreateResponse.status()}).`);
+    }
+
+    const programCreatePayload = (await programCreateResponse.json().catch(() => null)) as {
+      ok?: boolean;
+      error?: string;
+      program?: { id?: string };
+    } | null;
+
+    if (!programCreatePayload?.ok || typeof programCreatePayload.program?.id !== "string") {
+      const reason =
+        typeof programCreatePayload?.error === "string"
+          ? programCreatePayload.error
+          : "missing program id";
+      test.skip(true, `Program detail setup is not write-ready in this environment (${reason}).`);
+    }
+
+    const programId = programCreatePayload?.program?.id;
+    if (typeof programId !== "string") {
+      test.skip(true, "Program detail setup did not return a stable program id.");
+    }
+    const programPath = `/my-library/programs/${programId}`;
+
+    await loginAsAdminViaDevBypass(page, programPath);
+    expect(new URL(page.url()).pathname).toBe(programPath);
+
+    const unique = `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+    const title = buildAdminNoteTestArtifactTitle({
+      scope: ADMIN_CONTEXTUAL_NOTES_ARTIFACT_SCOPE,
+      label: "Program detail quick capture",
+      unique,
+    });
+
+    await expectPageQuickCaptureFlow(
+      page,
+      programPath,
+      title,
+      "Page-level admin note for program detail."
+    );
   });
 });

--- a/tests/e2e/admin-help-center.spec.ts
+++ b/tests/e2e/admin-help-center.spec.ts
@@ -147,7 +147,7 @@ test.describe("admin help center", () => {
     ).toBeVisible();
     await expect(
       page.getByText(
-        "Page-level `Quick note` is intentionally available on supported public pages plus selected My Library hubs: `/my-library`, `goals`, `training`, `profile`, `workouts`, `dryland`, `generator`, and `security`, plus saved swim-session detail pages under `/my-library/workouts/<id>`."
+        "Page-level `Quick note` is intentionally available on supported public pages plus selected My Library hubs: `/my-library`, `goals`, `training`, `profile`, `workouts`, `dryland`, `generator`, and `security`, plus saved detail routes under `/my-library/workouts/<id>`, `/my-library/dryland/<id>`, and `/my-library/programs/<id>`."
       )
     ).toBeVisible();
     await expect(

--- a/tests/unit/page-note-context.test.ts
+++ b/tests/unit/page-note-context.test.ts
@@ -19,6 +19,12 @@ describe("page note context helpers", () => {
     expect(getAdminPageContextLabel("/my-library/workouts/workout-1")).toBe(
       "My Library swim session detail"
     );
+    expect(getAdminPageContextLabel("/my-library/dryland/session-1")).toBe(
+      "My Library dryland session detail"
+    );
+    expect(getAdminPageContextLabel("/my-library/programs/program-1")).toBe(
+      "My Library program detail"
+    );
     expect(getAdminPageContextLabel("/unknown-path")).toBe("Page: /unknown-path");
   });
 
@@ -29,13 +35,15 @@ describe("page note context helpers", () => {
     expect(hasDedicatedContextNotesForPage("/plans")).toBe(false);
   });
 
-  it("supports page-level notes on public routes and selected my-library hubs only", () => {
+  it("supports page-level notes on public routes, selected my-library hubs, and saved builder detail routes", () => {
     expect(supportsAdminPageNotesSurface("/plans")).toBe(true);
     expect(supportsAdminPageNotesSurface("/my-library")).toBe(true);
     expect(supportsAdminPageNotesSurface("/my-library/goals")).toBe(true);
     expect(supportsAdminPageNotesSurface("/my-library/profile")).toBe(true);
     expect(supportsAdminPageNotesSurface("/my-library/workouts")).toBe(true);
     expect(supportsAdminPageNotesSurface("/my-library/workouts/workout-1")).toBe(true);
+    expect(supportsAdminPageNotesSurface("/my-library/dryland/session-1")).toBe(true);
+    expect(supportsAdminPageNotesSurface("/my-library/programs/program-1")).toBe(true);
     expect(supportsAdminPageNotesSurface("/my-library/item/guide-poolside")).toBe(false);
     expect(supportsAdminPageNotesSurface("/auth/sign-in")).toBe(false);
     expect(supportsAdminPageNotesSurface("/admin")).toBe(false);


### PR DESCRIPTION
## Summary

- What changed and why? Expand page-level admin notes quick capture so saved My Library dryland and program detail routes match the existing workout detail/admin-notes recovery flow.
- User-visible changes: allowlisted admins can open `Quick note` directly from `/my-library/dryland/<id>` and `/my-library/programs/<id>`, with matching Help/Guide coverage.
- Technical changes: update `lib/admin/page-note-context.ts`, `components/admin/AdminHelpCenter.tsx`, and route-surface unit/e2e coverage for the new contextual note labels and allowlist rules.
- Policy impact: no (this slice does not change auth/session/account, analytics/consent, privacy rights, or third-party processor policy behavior).
- Policy version note: N/A (no policy contract changed in this slice).

## Scope

- In scope: admin-notes quick-capture support for saved My Library dryland and program detail routes, Help/Guide text, task-brief lifecycle updates, and automated coverage.
- Out of scope: new manual builder inputs, unrelated My Library IA/copy work, admin-notes attachment metadata follow-ups, and live admin-note content cleanup.

## Risk

- Main risk: route-surface expansion could accidentally over-match unsupported My Library paths or drift from Help/Guide wording.
- Rollback plan: revert `e67dd88` to restore the previous route allowlist and Help/Guide contract.

## Test Evidence

- Policy-impact checklist: N/A (no policy-impact paths or release-review obligations changed; see `docs/checklists/policy-impact-release-review.md` for the gate definition).
- `npm run lint:briefs:all`: PASS
- `npx vitest run tests/unit/page-note-context.test.ts`: PASS
- `npx playwright test tests/e2e/admin-contextual-notes.spec.ts tests/e2e/admin-help-center.spec.ts --project=desktop-chromium --reporter=line`: PASS
- `npm run typecheck`: PASS
- `npm run verify:pre-pr`: PASS
- `npm run verify:pre-merge`: PASS on `e67dd88` (`artifacts/verify-pre-merge/20260402-165255.json`)
- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be `PASS` on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)
- Brief link(s): `docs/task-briefs/in-progress/2026-04-02-admin-notes-my-library-detail-route-expansion-10-10.md`, `docs/task-briefs/in-progress/2026-04-01-production-admin-notes-remaining-work-umbrella-10-10.md`

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/339`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
