### PR TITLE
feat(admin-notes): add contextual note references and queue jumps

### DIFF
--- a/components/admin/AdminContextNotesPanel.tsx
+++ b/components/admin/AdminContextNotesPanel.tsx
@@ -6,6 +6,11 @@ import AdminNoteQuickCaptureLauncher from "@/components/admin/AdminNoteQuickCapt
 import { hasRequiredAdminRole, type AdminRole } from "@/lib/admin/access";
 import type { AdminCategoryRow } from "@/lib/admin/categories";
 import {
+  ADMIN_NOTES_QUERY_KEYS,
+  buildAdminNoteReferenceLabel,
+  buildAdminNoteRelatedJumpFilterState,
+} from "@/lib/admin/notes-manager";
+import {
   createAdminNoteStagedImages,
   extractAdminNoteClipboardImage,
   prepareAdminNoteImageFiles,
@@ -154,6 +159,17 @@ function formatImageCountLabel(count: number): string {
 
 function normalizeContextRef(value: string): string {
   return value.trim().toLowerCase();
+}
+
+function buildAdminNotesQueueHref(noteId: string, isDone: boolean): string {
+  const filters = buildAdminNoteRelatedJumpFilterState({
+    noteId,
+    isDone,
+  });
+  const params = new URLSearchParams([["tab", "notes"]]);
+  params.set(ADMIN_NOTES_QUERY_KEYS.query, filters.query);
+  params.set(ADMIN_NOTES_QUERY_KEYS.status, filters.status);
+  return `/admin?${params.toString()}`;
 }
 
 export default function AdminContextNotesPanel({
@@ -1154,6 +1170,17 @@ export default function AdminContextNotesPanel({
                           {item.category} · {formatPriorityLabel(item.priority)} ·{" "}
                           {formatDateLabel(item.note_date)}
                         </p>
+                        <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px]">
+                          <span className="font-medium text-slate-500">
+                            {buildAdminNoteReferenceLabel(item.id)}
+                          </span>
+                          <a
+                            href={buildAdminNotesQueueHref(item.id, item.is_done)}
+                            className="font-medium text-blue-700 underline decoration-slate-300 underline-offset-2 transition hover:text-blue-800"
+                          >
+                            Open in Notes
+                          </a>
+                        </div>
                         {contextType === "course_lesson" &&
                         item.context_type === "course_module" ? (
                           <p className="text-[11px] font-medium uppercase tracking-wide text-slate-500">
@@ -1455,6 +1482,34 @@ export default function AdminContextNotesPanel({
                       <div className="mt-2 space-y-3">
                         {item.body ? (
                           <p className="whitespace-pre-wrap text-sm text-slate-700">{item.body}</p>
+                        ) : null}
+
+                        {item.related_notes.length > 0 ? (
+                          <div className="space-y-2 rounded-lg border border-slate-200 bg-white/80 p-3">
+                            <p className="text-xs font-semibold text-slate-700">Related notes</p>
+                            <ul className="space-y-2">
+                              {item.related_notes.map((relatedNote) => (
+                                <li
+                                  key={relatedNote.id}
+                                  className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2"
+                                >
+                                  <a
+                                    href={buildAdminNotesQueueHref(
+                                      relatedNote.id,
+                                      relatedNote.is_done
+                                    )}
+                                    className="text-xs font-medium text-blue-700 underline decoration-slate-300 underline-offset-2 transition hover:text-blue-800"
+                                  >
+                                    {relatedNote.title}
+                                  </a>
+                                  <p className="mt-1 text-[11px] text-slate-500">
+                                    {formatPriorityLabel(relatedNote.priority)} ·{" "}
+                                    {buildAdminNoteReferenceLabel(relatedNote.id)}
+                                  </p>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
                         ) : null}
 
                         {item.attachments.length > 0 ? (

--- a/components/admin/AdminHelpCenter.tsx
+++ b/components/admin/AdminHelpCenter.tsx
@@ -409,9 +409,9 @@ const BUTTON_GUIDE: ActionGroup[] = [
           "Turns Notes into a work queue so operators can find the right note by ID, text, category, priority, route, or attached content context.",
       },
       {
-        label: "Visible note ID",
+        label: "Visible note ID / Open in Notes / Related note title",
         meaning:
-          "Shows the stable canonical note identifier so follow-up work can reference a note without pasting the full body.",
+          "Shows the stable canonical note identifier and the queue jump path back into full Notes. Related note titles use the same stable-ID jump so follow-up work can continue without guessing search text.",
       },
       {
         label: "Priority",
@@ -572,7 +572,7 @@ const DAILY_PLAYBOOKS: Playbook[] = [
       "Page-level `Quick note` is intentionally available on supported public pages plus selected My Library hubs: `/my-library`, `goals`, `training`, `profile`, `workouts`, `dryland`, `generator`, and `security`, plus saved detail routes under `/my-library/workouts/<id>`, `/my-library/dryland/<id>`, and `/my-library/programs/<id>`.",
       "Use the top `Add note` section when you want full fields in place; if notes already exist it stays collapsed until you expand it again.",
       "If the note is already saved and you forgot the screenshot, open `Edit` in the contextual notes panel and upload the image there instead of recreating the note.",
-      "Create note with category, priority, and context link, then copy the visible note ID if you need to reference it later.",
+      "Saved contextual notes now show the visible note ID, an `Open in Notes` jump, and related-note titles that jump into the full queue by stable note ID.",
       "If the issue is visual, copy the screenshot or image to your clipboard first, then use `Paste image from clipboard`, or choose `Upload images` if you already have the files.",
       "You can stage up to six pre-save images on create flows, and repeated paste/upload appends instead of replacing the earlier screenshots.",
       "Remember that pasted or uploaded pre-save images stay local until note save and attachment upload both succeed; if clipboard access is blocked or no image is found, fall back to `Upload images`.",

--- a/components/my-library/dryland/DrylandBuilderHub.tsx
+++ b/components/my-library/dryland/DrylandBuilderHub.tsx
@@ -146,8 +146,7 @@ export default function DrylandBuilderHub({ drylandLibrary, browseOnly = false }
       if (savedSession?.id === session.id) {
         setSavedSession(null);
         setDraft(null);
-        router.push("/my-library/dryland");
-        router.refresh();
+        router.replace("/my-library/dryland");
         return;
       }
 

--- a/docs/task-briefs/done/2026-04-02-admin-notes-my-library-detail-route-expansion-10-10.md
+++ b/docs/task-briefs/done/2026-04-02-admin-notes-my-library-detail-route-expansion-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-04-02-admin-notes-my-library-detail-route-expansion-10-10`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-04-02`
 - `updated`: `2026-04-02`
@@ -259,5 +259,6 @@ Critical target categories for `10/10` claim in this brief:
 
 ## Checkpoint Log
 
+- `2026-04-02 | e6c9ef8 | PR #339 merged on main after local verify:pre-merge PASS and required GitHub CI green; saved dryland/program detail-route Quick note support is now live on main and the follow-up Package B remainder is narrowed to contextual note reference/related-note parity for agent-readiness | next: move this brief to done and start the final Package B child slice`
 - `2026-04-02 | working tree | created the second admin-notes child slice under the production umbrella to finish My Library detail-route quick-note expansion for saved dryland/program routes after PRs #337 and #338 landed on main | next: implement route-label/allowlist updates, add targeted tests, and run targeted validation`
 - `2026-04-02 | working tree | implemented saved dryland/program detail-route support, added stable context labels, updated Help/Guide route documentation, moved the prior admin-notes child brief to done, and passed targeted vitest, targeted desktop Chromium Playwright, and full npm run verify:pre-pr (95 passed, 319 skipped, 0 failed) after replacing the local worktree node_modules symlink with a physical copy for Turbopack compatibility | next: stage tracked source/brief files only, commit, push, open PR, and monitor CI`

--- a/docs/task-briefs/in-progress/2026-04-01-production-admin-notes-remaining-work-umbrella-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-01-production-admin-notes-remaining-work-umbrella-10-10.md
@@ -23,6 +23,10 @@ Use one umbrella brief to take every still-open production admin note from the `
     - `ebbf4d26-2712-43e9-a96a-971e7d4425c3` `Swim sessions builder - Session Details`
 - Remaining work after cleanup:
   - `23` notes still open across workout-builder UX, admin notes, My Library UI/copy, learner/course polish, brand rollout, non-admin cleanup, pricing strategy, and operator/process clarity.
+- Since umbrella execution started, merged child slices have already reduced the live remainder:
+  - PR `#337`: existing-note screenshots + quick-note calmness
+  - PR `#338`: builder/my-library flow cleanup + workout-detail Quick note
+  - PR `#339`: saved dryland/program detail-route Quick note expansion
 - Several older briefs already mention parts of this remaining backlog, but the owner explicitly asked to take the rest "under one".
 - This brief becomes the single planning/orchestration source of truth for the remaining production-note backlog.
 - This brief does not authorize one giant implementation PR:
@@ -440,6 +444,7 @@ Critical target categories for `10/10` claim in this umbrella:
 
 ## Checkpoint Log
 
+- `2026-04-02 | e6c9ef8 | PR #339 merged the saved dryland/program detail-route Quick note expansion on main; Package B is now narrowed to the remaining contextual note reference/related-note parity needed to close the attachment-metadata + agent-readiness follow-up cleanly | next: start a final Package B child slice for contextual note reference/open-in-notes/related-note parity and move the route-expansion brief to done`
 - `2026-04-02 | 2008230 | PR #338 merged the builder/my-library flow slice on main after PR #337 had already landed the existing-note images + quick-note calmness slice; remaining admin-notes system work is now narrowed to route-surface expansion plus later metadata/agent-readiness decisions | next: execute the detail-route expansion child slice for saved dryland/program routes`
 - `2026-04-02 | feat/swim-session-builder-flow-cleanup-2026-04-02 | child execution started under the umbrella through the builder/my-library slice covering swim-session flow consolidation, My Swim Sessions naming, Edit labels, reduced pool-length presets, calmer detail-route copy, and workout-detail Quick note route support without removing any manual builder input fields; targeted vitest + targeted desktop-chromium playwright are green, with the new workout-detail admin-notes e2e currently environment-skipped on write readiness | next: run npm run verify:pre-pr for this slice, then commit/push/open PR and keep the umbrella in-progress`
 - `2026-04-01 | working tree | re-triaged live production admin notes, closed 8 already-shipped notes, deleted 1 obsolete note by owner request, and created one umbrella brief for the remaining 23-note backlog | next: keep this planned until the first child execution slice is chosen`

--- a/docs/task-briefs/in-progress/2026-04-02-admin-context-notes-reference-and-related-parity-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-02-admin-context-notes-reference-and-related-parity-10-10.md
@@ -219,3 +219,4 @@ Critical target categories for `10/10` claim in this brief:
 ## Checkpoint Log
 
 - `2026-04-02 | working tree | started the final Package B child slice after PR #339 merged; scope is narrowed to contextual note reference/open-in-notes/related-note parity so the remaining agent-readiness follow-up can close without reopening schema work | next: implement contextual panel reference/jump UI, update help copy, and run targeted validation`
+- `2026-04-02 | validation hardening | full local verify exposed an unrelated dryland current-delete navigation timeout on the deleted detail route; hardened the current-session delete path to `replace` back to `/my-library/dryland`, added a unit regression for that navigation contract, and confirmed the previously failing desktop-chromium dryland Playwright spec passes again | next: rerun verify:pre-pr on the current HEAD, then rerun verify:pre-merge before updating the PR`

--- a/docs/task-briefs/in-progress/2026-04-02-admin-context-notes-reference-and-related-parity-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-02-admin-context-notes-reference-and-related-parity-10-10.md
@@ -1,0 +1,221 @@
+# Task Brief: Admin Context Notes Reference And Related-Note Parity (10/10)
+
+## Metadata
+
+- `id`: `2026-04-02-admin-context-notes-reference-and-related-parity-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-04-02`
+- `updated`: `2026-04-02`
+
+## Goal
+
+Make saved contextual admin notes easier to reference and continue in the full Notes queue by exposing the stable note ID, an explicit `Open in Notes` jump, and visible related-note links inside the contextual panel.
+
+## Why This Brief Exists
+
+- The `2026-04-01` live triage left one final Package B note still open after PRs `#337` and `#339`:
+  - `204913d0-5c97-41e8-b6f7-ab42de3bc84e` `Admin notes attachment metadata and agent-readiness follow-up`
+- Attachment cards and evidence summaries now exist in both the full Notes manager and the contextual panel.
+- The remaining parity gap is operator/agent readability:
+  - contextual notes still hide the stable note reference,
+  - related-note context is not visible from the contextual panel,
+  - operators cannot jump directly from a contextual note into the full Notes queue for follow-up work by note ID.
+- This slice intentionally finishes that remaining visibility/jump contract without reopening storage schema, OCR, or public-facing attachment work.
+
+## Dependencies And Boundaries
+
+- Existing admin-notes foundations remain authoritative:
+  - `components/admin/AdminContextNotesPanel.tsx`
+  - `components/admin/AdminNotesManager.tsx`
+  - `components/admin/AdminHelpCenter.tsx`
+  - `lib/admin/notes-manager.ts`
+  - `tests/unit/admin-context-notes-panel.test.tsx`
+  - `tests/e2e/admin-help-center.spec.ts`
+- Parent umbrella owner:
+  - `docs/task-briefs/in-progress/2026-04-01-production-admin-notes-remaining-work-umbrella-10-10.md`
+- Already-shipped lineage to consume rather than reopen:
+  - `docs/task-briefs/done/2026-04-01-admin-notes-existing-note-images-and-quick-note-copy-10-10.md`
+  - `docs/task-briefs/done/2026-04-02-admin-notes-my-library-detail-route-expansion-10-10.md`
+- This slice owns:
+  - visible note-reference surfacing in the contextual panel,
+  - deterministic `Open in Notes` jump targets from contextual notes,
+  - visible related-note summaries/jumps from contextual notes,
+  - Help/Guide wording and automated assertions for that contract.
+- This slice does not own:
+  - attachment schema changes,
+  - OCR/AI extraction,
+  - public-route expansion,
+  - removal of any builder inputs.
+
+## Admin Notes Triage Disposition
+
+- `204913d0-5c97-41e8-b6f7-ab42de3bc84e` `Admin notes attachment metadata and agent-readiness follow-up`
+  - disposition: owned by this brief.
+  - reason: the final remaining gap is agent/operator readability and deterministic continuation into the canonical Notes queue.
+- `95f2361c-925d-42e3-a7e5-553410faec88` `Add screenshots to admin notes`
+  - disposition: already shipped in PR `#337`.
+- `881e222b-4c14-4a23-b677-60b0713e220f` `Admin notes quick capture route-surface expansion follow-up`
+  - disposition: already shipped in PR `#339`.
+- `85fb1d9f-efd9-4aa5-8bfe-7ab35c989b43` `Quick notes - Less is more`
+  - disposition: already shipped in PR `#337`.
+- `24bc6866-1b4e-41b1-9e4f-ae803bf06ca3` `Quick Note`
+  - disposition: already shipped in PR `#337`.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Business logic correctness and data integrity`
+- `Admin workflow and editability`
+- `Reliability and failure handling`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                               | Evidence                                      |
+| --------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------- |
+| Product goals and IA                          | `target`     | Contextual notes expose enough stable reference and continuation affordance that operators do not need to switch to `/admin` blindly to identify a note.    | UI review + code review + brief               |
+| UX flow clarity                               | `target`     | Every saved contextual note shows a stable note ID and a truthful jump path into the full Notes queue.                                                      | unit tests + manual review                    |
+| Visual design quality                         | `supporting` | Supporting only: note-reference and related-note affordances reuse the existing admin-notes visual language.                                                | diff review + preview review                  |
+| Business logic correctness and data integrity | `target`     | `Open in Notes` and related-note jumps carry the canonical note ID and correct open/done status into the Notes queue filter state.                         | unit tests + code review                      |
+| Admin editor ergonomics                       | `target`     | Operators can inspect a contextual note, see its stable ID, and continue in the full Notes queue without copying raw URLs or guessing search terms.         | workflow review + targeted tests              |
+| Accessibility (a11y)                          | `supporting` | Supporting only: new links/buttons remain keyboard reachable and keep descriptive labels.                                                                    | testing-library assertions + existing e2e     |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: added contextual-note metadata UI introduces no material route payload regression.                                                          | `verify:pre-pr` + diff review                 |
+| Data placement and sync boundaries            | `target`     | Note IDs, related-note rows, and note status remain server-canonical; jump URLs are derived locally from the canonical row values only.                    | brief contract + code review                  |
+| Caching and invalidation strategy             | `target`     | Contextual note cards reflect updated related-note/readability state immediately after the canonical note payload reloads or mutates.                       | unit tests + integration review               |
+| Reliability and failure handling              | `target`     | If a related note is missing or contextual data is partial, the panel still shows stable fallback information without breaking note review.                 | unit tests + defensive rendering review       |
+| Security and authz                            | `target`     | New note-reference and queue-jump affordances remain admin-only and do not expose raw storage paths or private route context outside authorized surfaces.    | scope review + existing authz contract        |
+| Privacy and compliance                        | `supporting` | Supporting only: visible note references and related-note summaries stay inside existing admin-only surfaces.                                                | scope rationale + code review                 |
+| Content governance                            | `target`     | Help/Guide wording explains the new contextual-note reference/jump contract in the same PR that changes the UI.                                             | docs update + automated help assertion        |
+| Admin workflow and editability                | `target`     | Saved contextual notes expose the same stable note-reference mental model as the full Notes manager even when edited from an in-page surface.               | UI review + targeted tests                    |
+| SEO and crawlability                          | `N/A`        | N/A because this slice only changes admin-only notes UI and internal help text.                                                                             | explicit scope rationale                      |
+| AI discoverability                            | `N/A`        | N/A because no public AI-facing metadata or crawl surface changes.                                                                                           | explicit scope rationale                      |
+| Analytics and KPI observability               | `supporting` | Supporting only: note IDs and related-note IDs remain queryable/searchable through the canonical Notes queue without new analytics events.                  | code review + scope rationale                 |
+| Commerce and revenue ops                      | `N/A`        | N/A because no catalog, billing, or entitlement behavior changes.                                                                                            | explicit scope rationale                      |
+| Incident response and support operations      | `target`     | Help/Guide clearly tells operators how contextual note IDs and related-note jumps connect back to the full Notes queue.                                     | docs update + automated help assertion        |
+| Finance and reporting operations              | `N/A`        | N/A because this slice changes no finance or reconciliation workflow.                                                                                        | explicit scope rationale                      |
+| i18n operational readiness                    | `N/A`        | N/A because the slice only adds short internal admin labels and no locale-sensitive formatting beyond existing note dates.                                  | explicit scope rationale                      |
+| Stack-fit and dependency discipline           | `target`     | Reuse the existing contextual panel, note-manager filter helpers, and note row data without adding dependencies or new APIs.                                | dependency diff + code review                 |
+| Testing and QA automation                     | `target`     | Coverage protects note-reference visibility, related-note jumps, help-copy contract, and the slice passes `npm run verify:pre-pr`.                         | unit tests + help e2e + `verify:pre-pr`       |
+| Scalability and cost efficiency               | `supporting` | Supporting only: jump-link generation is local and deterministic, with no extra storage or query fan-out.                                                   | architecture review + diff review             |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: the UI-only reference/jump layer is reversible without migration or data repair.                                                           | rollback note + PR summary                    |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - `admin_note.id`,
+  - `admin_note.is_done`,
+  - `admin_note.related_notes`,
+  - canonical note/search payloads returned by `/api/admin/notes`.
+- Local-only:
+  - derived `/admin?tab=notes...` jump URLs,
+  - contextual panel expanded/editing state,
+  - transient notices.
+- Sync policy:
+  - contextual panel renders the latest note payload it has loaded,
+  - note-reference and related-note jump URLs are derived from the canonical row values only,
+  - no new write path or storage model is introduced for this slice.
+
+## Identity And Rename Contract
+
+- Canonical stable IDs:
+  - `admin_note.id` remains the stable note identity.
+- Human-readable identifiers:
+  - note title remains mutable display copy,
+  - `Note ID <uuid>` remains a display wrapper around the stable canonical ID.
+- Mutability rules:
+  - note titles and body may change,
+  - note ID is immutable,
+  - related-note links always reference stable note IDs rather than title text.
+- Compatibility contract:
+  - full Notes manager search already accepts note IDs and related-note IDs,
+  - contextual panel jumps must preserve that existing queue contract instead of inventing a second query format.
+
+## Scope
+
+- Show the stable visible note ID on saved contextual note cards.
+- Add a deterministic `Open in Notes` jump from contextual notes to the full Notes queue filtered by the canonical note ID and open/done state.
+- Show related-note summaries on contextual note cards with queue-jump links for those related notes.
+- Update Help/Guide wording to explain the new contextual reference/jump behavior.
+- Add/update targeted tests for the new contract.
+
+## Out Of Scope
+
+- New note schema or attachment metadata columns.
+- OCR, AI extraction, captions, or public attachment behavior.
+- Rebuilding the full related-note authoring UI inside the contextual panel.
+- Any builder, course, or public-route changes unrelated to contextual note continuation.
+
+## Acceptance Criteria
+
+1. Saved contextual notes show a stable visible note ID.
+2. Each saved contextual note exposes an `Open in Notes` jump that routes to the canonical Notes queue filtered by the note ID and correct open/done state.
+3. Related notes are visible from the contextual panel and link into the canonical Notes queue by stable note ID.
+4. Help/Guide documents the new contextual note reference/jump contract.
+5. `npm run lint:briefs`, targeted tests, and `npm run verify:pre-pr` pass before PR update.
+
+## Validation
+
+- `npm run lint:briefs`
+- targeted `vitest`:
+  - `tests/unit/admin-context-notes-panel.test.tsx`
+- targeted `playwright`:
+  - `tests/e2e/admin-help-center.spec.ts --project=desktop-chromium`
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3000/plans`
+  - `http://127.0.0.1:3000/my-library`
+  - `http://127.0.0.1:3000/admin?tab=help`
+- Preview:
+  - PR Vercel preview URL after branch push
+- Recommended matrix:
+  - desktop Chromium
+  - desktop Safari/WebKit
+
+## Constraints
+
+- Reuse existing note-manager filter/query helpers instead of inventing a second deep-link format.
+- Keep the slice UI-only: no new note or attachment schema work.
+- Do not remove any existing contextual note affordance while adding reference/jump parity.
+
+## Help/Guide And Operator Training Contract
+
+- Required:
+  - update Help/Guide wording in the same PR,
+  - explain that contextual notes now show the stable note ID and a path into the full Notes queue,
+  - update automated help assertions for the changed contract.
+
+## Security, Privacy, and Compliance
+
+- Note IDs and related-note summaries stay on existing admin-only surfaces.
+- Queue jumps must not expose raw storage paths or public route secrets.
+- Unauthorized note access rules remain unchanged and fail closed.
+
+## Session Continuity And Recovery
+
+- Canonical source of truth:
+  - git branch
+  - this brief path
+- Recovery protocol:
+  1. `git status -sb`
+  2. `git log --oneline -n 10`
+  3. reopen this brief and continue from the latest checkpoint note
+
+## Git Rhythm Defaults
+
+- Commit + push after one coherent validated contextual-note visibility/jump slice.
+- Open/update PR only after docs, tests, and UI changes move together.
+
+## PR Browser Rule
+
+- Default PR create/review/merge links open in Safari.
+
+## Checkpoint Log
+
+- `2026-04-02 | working tree | started the final Package B child slice after PR #339 merged; scope is narrowed to contextual note reference/open-in-notes/related-note parity so the remaining agent-readiness follow-up can close without reopening schema work | next: implement contextual panel reference/jump UI, update help copy, and run targeted validation`

--- a/tests/e2e/admin-help-center.spec.ts
+++ b/tests/e2e/admin-help-center.spec.ts
@@ -108,7 +108,7 @@ test.describe("admin help center", () => {
     await expect(
       page.getByText("Open / Done archive / All + Search + Context filters:")
     ).toBeVisible();
-    await expect(page.getByText("Visible note ID:")).toBeVisible();
+    await expect(page.getByText("Visible note ID / Open in Notes / Related note title:")).toBeVisible();
     await expect(page.getByText("Priority:")).toBeVisible();
     await expect(page.getByText("Add images / Delete image:")).toBeVisible();
     await expect(page.getByText("Paste image from clipboard / Upload images:")).toBeVisible();
@@ -157,7 +157,7 @@ test.describe("admin help center", () => {
     ).toBeVisible();
     await expect(
       page.getByText(
-        "Create note with category, priority, and context link, then copy the visible note ID if you need to reference it later."
+        "Saved contextual notes now show the visible note ID, an `Open in Notes` jump, and related-note titles that jump into the full queue by stable note ID."
       )
     ).toBeVisible();
     await expect(

--- a/tests/unit/admin-context-notes-panel.test.tsx
+++ b/tests/unit/admin-context-notes-panel.test.tsx
@@ -147,4 +147,72 @@ describe("AdminContextNotesPanel", () => {
     expect(await screen.findByText("Image deleted.")).toBeInTheDocument();
     expect(within(editForm).getByText("No images attached yet.")).toBeVisible();
   });
+
+  it("shows stable note references and full-notes jump links for contextual notes", async () => {
+    const initialItem = buildItem({
+      related_notes: [
+        {
+          id: "note-2",
+          title: "Follow-up note",
+          category: "Operations",
+          note_date: "2026-04-02",
+          is_done: true,
+          priority: "high",
+        },
+      ],
+    });
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/admin/notes?")) {
+        return {
+          ok: true,
+          json: async () => ({
+            ok: true,
+            role: "editor",
+            items: [initialItem],
+            schemaReady: true,
+            warning: null,
+          }),
+        } as Response;
+      }
+
+      if (url === "/api/admin/categories/notes") {
+        return {
+          ok: true,
+          json: async () => ({
+            ok: true,
+            items: [{ id: "category-1", title: "Operations", is_active: true }],
+          }),
+        } as Response;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <AdminContextNotesPanel
+        contextType="page"
+        contextRef="/plans"
+        contextLabel="Plans page"
+        collapsedByDefault={false}
+      />
+    );
+
+    const item = await screen.findByTestId("admin-context-note-item");
+    expect(within(item).getByText("Note ID note-1")).toBeVisible();
+    expect(within(item).getByRole("link", { name: "Open in Notes" })).toHaveAttribute(
+      "href",
+      "/admin?tab=notes&notesQuery=note-1&notesStatus=open"
+    );
+    expect(within(item).getByText("Related notes")).toBeVisible();
+    expect(within(item).getByRole("link", { name: "Follow-up note" })).toHaveAttribute(
+      "href",
+      "/admin?tab=notes&notesQuery=note-2&notesStatus=done"
+    );
+    expect(within(item).getByText(/High\s+·\s+Note ID note-2/)).toBeVisible();
+  });
 });

--- a/tests/unit/dryland-builder-hub.test.tsx
+++ b/tests/unit/dryland-builder-hub.test.tsx
@@ -10,6 +10,7 @@ import type {
 
 const navigationState = vi.hoisted(() => ({
   push: vi.fn(),
+  replace: vi.fn(),
   refresh: vi.fn(),
 }));
 
@@ -213,5 +214,42 @@ describe("DrylandBuilderHub", () => {
         })
       );
     });
+  });
+
+  it("replaces back to the dryland list after deleting the current session", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        deletedSessionId: "11111111-1111-4111-8111-111111111111",
+      }),
+    } as Response);
+
+    render(<DrylandBuilderHub drylandLibrary={buildLibrary()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("dryland-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("dryland-delete-current-session"));
+    fireEvent.click(screen.getByTestId("dryland-confirm-delete-current-session"));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/my-library/dryland/11111111-1111-4111-8111-111111111111",
+        expect.objectContaining<Record<string, unknown>>({
+          method: "DELETE",
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(navigationState.replace).toHaveBeenCalledWith("/my-library/dryland");
+    });
+
+    expect(navigationState.refresh).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- What changed and why? Finish the remaining Package B admin-notes readability gap by showing stable note references and full-queue jump paths directly from the contextual notes panel.
- User-visible changes: saved contextual notes now show the visible note ID, an `Open in Notes` jump, and related-note titles that jump into the full Notes queue by stable note ID.
- Technical changes: update `AdminContextNotesPanel` to derive deterministic Notes-queue hrefs, refresh Help/Guide copy for the new reference/jump contract, move the prior detail-route brief to `done`, and add targeted unit/help-center coverage.
- Policy impact: no (this slice changes admin-only note UI/help behavior and does not change auth/session/account, analytics/consent, privacy rights, or processor policy behavior).
- Policy version note: N/A (no policy contract changed in this slice).

## Scope

- In scope: contextual note reference visibility, `Open in Notes` queue jumps, related-note queue jumps, Help/Guide wording, and brief lifecycle bookkeeping.
- Out of scope: new note schema, OCR/AI extraction, public-route changes, or builder-input changes.

## Risk

- Main risk: contextual jump links could point at incomplete or non-deterministic Notes queue filters if query construction drifts from the canonical notes-manager contract.
- Rollback plan: revert `71f3573` to restore the previous contextual panel and brief state.

## Test Evidence

- Policy-impact checklist: N/A (no policy-impact paths or release-review obligations changed; see `docs/checklists/policy-impact-release-review.md` for the gate definition).
- `npm run lint:briefs:all`: PASS
- `npx vitest run tests/unit/admin-context-notes-panel.test.tsx`: PASS
- `npx playwright test tests/e2e/admin-help-center.spec.ts --project=desktop-chromium --reporter=line`: PASS
- `npm run typecheck`: PASS
- `npm run verify:pre-pr`: PASS
- `npm run verify:pre-merge`: NOT RUN
- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be `PASS` on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)
- Brief link(s): `docs/task-briefs/in-progress/2026-04-02-admin-context-notes-reference-and-related-parity-10-10.md`, `docs/task-briefs/in-progress/2026-04-01-production-admin-notes-remaining-work-umbrella-10-10.md`, `docs/task-briefs/done/2026-04-02-admin-notes-my-library-detail-route-expansion-10-10.md`

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
