### PR TITLE
fix(course): stabilize pass-criteria progress state

### DIFF
--- a/app/course/page.tsx
+++ b/app/course/page.tsx
@@ -1653,6 +1653,7 @@ function CoursePageClient() {
   );
   const showLessonPrimaryColumn = showGoalSection || showCuesSection || showCommonMistakesSection;
   const showLessonSecondaryColumn = showDrillSection || showPassOrNextCard || showExtraHelpCard;
+  const lessonContentReady = courseContentLoadState !== "loading";
   const drillBadgeLabel =
     activeLesson.drillLabel?.trim() ||
     (lessonType === "learn" ? "Learn" : lessonType === "swim" ? "Swim" : "Drill");
@@ -1665,7 +1666,7 @@ function CoursePageClient() {
   const doneGateRequired = showPassCriteria && !isLessonDone;
   const doneGateSatisfied =
     !doneGateRequired || passCriteria.every((criterion) => doneGateChecksSet.has(criterion));
-  const markDoneBlockedByGate = !isLessonDone && !doneGateSatisfied;
+  const markDoneBlockedByGate = !lessonContentReady || (!isLessonDone && !doneGateSatisfied);
   const activeLessonProgressStatus = lessonProgressStatusById[activeLesson.id] ?? "not_started";
   const activeLessonStatusMeta =
     activeLessonProgressStatus === "done"
@@ -2569,7 +2570,14 @@ function CoursePageClient() {
                     {overviewLabel.duration ? ` • ${overviewLabel.duration}` : ""}
                   </div>
                 ) : null}
-                {markDoneBlockedByGate ? (
+                {!lessonContentReady ? (
+                  <p
+                    id="course-done-gate-feedback"
+                    className="mt-1 text-[12px] font-medium text-slate-600"
+                  >
+                    Loading lesson details...
+                  </p>
+                ) : markDoneBlockedByGate ? (
                   <p
                     id="course-done-gate-feedback"
                     className="mt-1 text-[12px] font-medium text-amber-700"
@@ -3065,7 +3073,11 @@ function CoursePageClient() {
                         ) : null}
                       </div>
                       {showPassCriteria ? (
-                        doneGateRequired ? (
+                        !lessonContentReady ? (
+                          <p className="mt-2 text-[13px] leading-6 text-slate-600">
+                            Loading pass criteria...
+                          </p>
+                        ) : doneGateRequired ? (
                           <ul
                             data-testid="course-done-gate-checklist"
                             className="mt-2 space-y-2 text-[13px] leading-6 text-slate-800"

--- a/components/MenuDrawer.tsx
+++ b/components/MenuDrawer.tsx
@@ -16,6 +16,7 @@ import MobileSegmentedNav, {
 import { BRAND_USAGE } from "@/lib/brand";
 import {
   buildCourseLessonProgressStatusMap,
+  getStrongestCourseLessonProgressStatus,
   type CourseLessonProgressStatus,
 } from "@/lib/course/progress-status";
 
@@ -463,15 +464,34 @@ function CourseView({
   onSelectLesson: (lessonId: string) => void;
 }) {
   const doneLessonIdSet = useMemo(() => new Set(doneLessonIds), [doneLessonIds]);
-  const resolvedLessonProgressStatusById = useMemo(
+  const computedLessonProgressStatusById = useMemo(
     () =>
-      lessonProgressStatusById ??
       buildCourseLessonProgressStatusMap(
         modules.flatMap((module) => module.lessons),
         doneLessonIdSet,
         doneGateChecksByLessonId
       ),
-    [doneGateChecksByLessonId, doneLessonIdSet, lessonProgressStatusById, modules]
+    [doneGateChecksByLessonId, doneLessonIdSet, modules]
+  );
+  const resolvedLessonProgressStatusById = useMemo(
+    () => {
+      if (!lessonProgressStatusById) {
+        return computedLessonProgressStatusById;
+      }
+
+      const next = { ...computedLessonProgressStatusById };
+      for (const courseModule of modules) {
+        for (const lesson of courseModule.lessons) {
+          next[lesson.id] = getStrongestCourseLessonProgressStatus(
+            computedLessonProgressStatusById[lesson.id],
+            lessonProgressStatusById[lesson.id]
+          );
+        }
+      }
+
+      return next;
+    },
+    [computedLessonProgressStatusById, lessonProgressStatusById, modules]
   );
   const totalModules = modules.length;
   const totalLessons = useMemo(

--- a/lib/course/progress-status.ts
+++ b/lib/course/progress-status.ts
@@ -2,6 +2,12 @@ import type { CourseLesson } from "@/app/course/courseData";
 
 export type CourseLessonProgressStatus = "not_started" | "in_progress" | "done";
 
+const COURSE_LESSON_PROGRESS_STATUS_PRIORITY: Record<CourseLessonProgressStatus, number> = {
+  not_started: 0,
+  in_progress: 1,
+  done: 2,
+};
+
 const LEGACY_DEFAULT_PASS_CRITERIA = [
   "Complete 3 calm repetitions with the same cue.",
   "Breathing stays controlled without rushing.",
@@ -148,6 +154,22 @@ export function getCourseLessonProgressStatus(
     return "in_progress";
   }
   return "not_started";
+}
+
+export function getStrongestCourseLessonProgressStatus(
+  ...candidates: Array<CourseLessonProgressStatus | null | undefined>
+): CourseLessonProgressStatus {
+  let strongest: CourseLessonProgressStatus = "not_started";
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    if (COURSE_LESSON_PROGRESS_STATUS_PRIORITY[candidate] >
+      COURSE_LESSON_PROGRESS_STATUS_PRIORITY[strongest]) {
+      strongest = candidate;
+    }
+  }
+
+  return strongest;
 }
 
 export function buildCourseLessonProgressStatusMap(

--- a/tests/unit/course-progress-status.test.ts
+++ b/tests/unit/course-progress-status.test.ts
@@ -6,6 +6,7 @@ import {
   countSatisfiedCourseLessonCriteria,
   getCourseLessonPassCriteria,
   getCourseLessonProgressStatus,
+  getStrongestCourseLessonProgressStatus,
   normalizeCourseLessonCriteriaChecks,
   normalizeCourseLessonCriteriaCheckRecord,
 } from "@/lib/course/progress-status";
@@ -109,6 +110,16 @@ describe("course progress status helpers", () => {
       "lesson-partial": "in_progress",
       "lesson-fresh": "not_started",
     });
+  });
+
+  it("prefers the strongest progress state when reconciling stale and computed snapshots", () => {
+    expect(
+      getStrongestCourseLessonProgressStatus("not_started", "in_progress")
+    ).toBe("in_progress");
+    expect(getStrongestCourseLessonProgressStatus("in_progress", "done")).toBe("done");
+    expect(getStrongestCourseLessonProgressStatus(undefined, null, "not_started")).toBe(
+      "not_started"
+    );
   });
 
   it("rekeys checklist records onto canonical lesson ids when runtime aliases hydrate", () => {

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -766,9 +766,11 @@ describe("WorkoutBuilderHub", () => {
       );
     });
 
-    expect(screen.getByTestId("workout-editor-handoff-notice")).toHaveTextContent(
-      "Workout handoff copied."
-    );
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-editor-handoff-notice")).toHaveTextContent(
+        "Workout handoff copied."
+      );
+    });
 
     fireEvent.click(screen.getByTestId("workout-editor-handoff-download"));
 
@@ -777,15 +779,17 @@ describe("WorkoutBuilderHub", () => {
       expect(clickSpy).toHaveBeenCalledTimes(1);
     });
 
-    expect(screen.getByTestId("workout-editor-handoff-notice")).toHaveTextContent(
-      `Downloaded ${buildWorkoutHandoffFileName(
-        {
-          ...buildDraft(),
-          title: "Local handoff workout",
-        },
-        { draftState: "local_draft" }
-      )}.`
-    );
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-editor-handoff-notice")).toHaveTextContent(
+        `Downloaded ${buildWorkoutHandoffFileName(
+          {
+            ...buildDraft(),
+            title: "Local handoff workout",
+          },
+          { draftState: "local_draft" }
+        )}.`
+      );
+    });
 
     fireEvent.click(screen.getByTestId("workout-editor-garmin-export-download"));
 
@@ -794,15 +798,17 @@ describe("WorkoutBuilderHub", () => {
       expect(clickSpy).toHaveBeenCalledTimes(2);
     });
 
-    expect(screen.getByTestId("workout-editor-garmin-export-notice")).toHaveTextContent(
-      `Downloaded ${buildWorkoutGarminReadyExportFileName(
-        {
-          ...buildDraft(),
-          title: "Local handoff workout",
-        },
-        { draftState: "local_draft" }
-      )}.`
-    );
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-editor-garmin-export-notice")).toHaveTextContent(
+        `Downloaded ${buildWorkoutGarminReadyExportFileName(
+          {
+            ...buildDraft(),
+            title: "Local handoff workout",
+          },
+          { draftState: "local_draft" }
+        )}.`
+      );
+    });
     expect(revokeUrlSpy).toHaveBeenCalledTimes(0);
   });
 


### PR DESCRIPTION
## Summary

- What changed and why? This hotfix prevents a race where `/course` could hydrate authored lesson content after a learner had already started checking fallback pass criteria, which could temporarily regress lesson/menu progress back to `not_started` or expose an untruthful done-gate state. A follow-up test hardening also makes the nearby workout-builder handoff notice assertion wait for the async notice render that CI exposed.
- User-visible changes: Learners now keep a truthful `In progress` state in the course header/menu while lesson content hydrates, and `Mark as done` stays disabled with explicit loading copy until real lesson content is ready.
- Technical changes: Gate course done actions on lesson-content readiness, reconcile drawer progress using the strongest of computed versus passed-in statuses, add strongest-status unit coverage in `app/course/page.tsx`, `components/MenuDrawer.tsx`, `lib/course/progress-status.ts`, and harden the async handoff-notice assertion in `tests/unit/workout-builder-hub.test.tsx`.
- Policy impact: no (learner course-state hotfix plus adjacent test hardening only; no auth/privacy/analytics/processor policy behavior changed)
- Policy version note: N/A (no policy-governed behavior changed)

## Scope

- In scope: Stabilize learner course pass-criteria hydration and progress-state reconciliation for the already shipped course menu/pass-criteria slice, plus deterministic test hardening for the CI-exposed workout-builder handoff notice assertion.
- Out of scope: New course content, schema/API contract changes, admin workflow changes, and unrelated brand/docs work.
- Brief link(s): `docs/task-briefs/done/2026-04-03-course-menu-pass-criteria-states-10-10.md`

## Risk

- Main risk: Course progress timing could regress lesson chips or checklist unlock timing if computed and hydrated lesson states diverge again.
- Rollback plan: Revert commits `757d766` and `5457499` to restore the previous shipped course behavior if `/course` regresses.

## Test Evidence

- Policy-impact checklist: N/A (no auth/session/account, analytics/consent, data-rights, or processor policy behavior changed)
- `npm run lint:briefs` PASS (via `npm run verify:pre-pr`; changed brief lint stayed green on head `757d766`)
- `npm run lint` PASS (via `npm run verify:pre-pr` on head `757d766`)
- `npm run typecheck` PASS (via `npm run verify:pre-pr` on head `757d766`)
- `npm run test:unit` PASS (681 passed on head `757d766`)
- `npm run build` PASS (Next.js production build completed in `npm run verify:pre-pr` on head `757d766`)
- `npm run test:e2e` PASS (95 passed / 319 skipped in `npm run verify:pre-pr` on head `757d766`)
- `npm run verify:pre-pr` PASS (`757d766`)
- `npm run verify:pre-merge` PASS (`757d766`; marker `artifacts/verify-pre-merge/20260404-073304.json`)
- Targeted regression evidence: `npx vitest run tests/unit/course-progress-status.test.ts` PASS
- Targeted regression evidence: `npx vitest run tests/unit/workout-builder-hub.test.tsx -t "builds a truthful handoff preview and supports copy/download actions"` PASS
- Targeted regression evidence: `npx playwright test tests/e2e/course-pass-criteria-visibility.spec.ts --project=desktop-chromium` PASS
- [x] `npm run lint:briefs`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge`
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [x] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added
