### PR TITLE
docs(briefs): close pre-merge regression hardening brief

### DIFF
--- a/docs/task-briefs/done/2026-04-04-pre-merge-playwright-regression-hardening-10-10.md
+++ b/docs/task-briefs/done/2026-04-04-pre-merge-playwright-regression-hardening-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-04-04-pre-merge-playwright-regression-hardening`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-04-04`
 - `updated`: `2026-04-04`


### PR DESCRIPTION
## Summary

- Close the final merged hotfix brief so repository lifecycle state matches shipped work.
- User-visible changes: None; this PR only updates brief lifecycle placement and metadata.
- Technical changes:
  - move `docs/task-briefs/in-progress/2026-04-04-pre-merge-playwright-regression-hardening-10-10.md` to `docs/task-briefs/done/2026-04-04-pre-merge-playwright-regression-hardening-10-10.md`
  - update the brief `status` metadata from `in-progress` to `done`
- Policy impact: no (docs lifecycle cleanup only; no auth, privacy, analytics, or processor contract changed)
- Policy version note: N/A (no policy-impacting scope)

## Scope

- In scope:
  - final lifecycle closeout for the merged pre-merge regression hardening brief
  - keeping `docs/task-briefs` aligned with actual merge state
- Out of scope:
  - no runtime, product, API, schema, or test-behavior changes
  - no new feature work or policy changes

## Risk

- Main risk: Minimal; the only realistic risk is marking the wrong brief state if the closeout target were incorrect.
- Rollback plan: revert `0f43f57` to restore the brief to its prior path/state.

## Test Evidence

- Policy-impact checklist: N/A (`docs/checklists/policy-impact-release-review.md`; docs lifecycle cleanup only)
- `npm run lint:briefs:all`: PASS on `0f43f57`
- `npm run verify:pre-pr`: PASS on `0f43f57`
- `npm run verify:pre-merge`: PASS on `0f43f57`
- [x] `npm run lint:briefs:all`
- [x] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge`
- [ ] Local manual QA done on dev URL (N/A: docs-only lifecycle cleanup)
- [ ] Vercel preview manual QA done (N/A: docs-only lifecycle cleanup)
- [ ] QA covered relevant matrix for this change (N/A beyond automation gates)

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [x] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added

## Brief link(s)

- `docs/task-briefs/done/2026-04-04-pre-merge-playwright-regression-hardening-10-10.md`
