### PR TITLE
Clarify workout builder metadata panel

### DIFF
--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -547,6 +547,8 @@ export default function WorkoutEditor({
   const draftTotals = computeSessionDraftDerivedTotals(draft);
   const garminReadiness = buildWorkoutGarminReadinessReport(draft);
   const stepGroups = buildStepRenderGroups(draft.steps);
+  const showCalmBuilderLayout = copyVariant === "default";
+  const isManualMetadataMode = showCalmBuilderLayout && savedWorkout?.sourceKind === "manual";
   const [openStepId, setOpenStepId] = useState<string | null>(null);
   const [poolLengthInput, setPoolLengthInput] = useState(() =>
     formatEditablePoolLength(draft.poolLengthM)
@@ -562,6 +564,7 @@ export default function WorkoutEditor({
   const [metadataOpen, setMetadataOpen] = useState(
     () => forceMetadataOpenOnLoad || !(savedWorkout && copyVariant === "default")
   );
+  const [manualMetadataProfileOpen, setManualMetadataProfileOpen] = useState(false);
   const [poolsidePrintStyle, setPoolsidePrintStyle] = useState<WorkoutPoolsidePrintStyle>("color");
   const [selectedPoolsideFocusIds, setSelectedPoolsideFocusIds] = useState<string[]>(() =>
     getDefaultWorkoutPoolsideFocusIds(trainingFocusOptions)
@@ -571,7 +574,6 @@ export default function WorkoutEditor({
     garminExport: false,
     handoff: false,
   });
-  const showCalmBuilderLayout = copyVariant === "default";
   const [supportToolsOpen, setSupportToolsOpen] = useState(() => copyVariant !== "default");
   const savedWorkoutId = savedWorkout?.id ?? null;
   const trainingFocusIdSignature = trainingFocusOptions.map((focus) => focus.id).join("|");
@@ -650,6 +652,7 @@ export default function WorkoutEditor({
     totalDistanceM: draftTotals.totalDistanceM ?? draft.totalDistanceM,
     estimatedDurationMin: draftTotals.estimatedDurationMin ?? draft.estimatedDurationMin,
   });
+  const manualMetadataProfileSummary = `${getSessionTypeLabel(draft.sessionType)} · ${getSessionEffortLabel(draft.effort)}`;
   const poolsideFocusSummary =
     trainingFocusOptions.length === 0
       ? "No open focuses are available right now. The poolside note will print without a focus section."
@@ -745,6 +748,10 @@ export default function WorkoutEditor({
   useEffect(() => {
     setSupportToolsOpen(!showCalmBuilderLayout);
   }, [savedWorkoutId, showCalmBuilderLayout]);
+
+  useEffect(() => {
+    setManualMetadataProfileOpen(false);
+  }, [savedWorkoutId, isManualMetadataMode]);
 
   useEffect(() => {
     if (!pendingRemoval) return;
@@ -1939,6 +1946,80 @@ export default function WorkoutEditor({
     );
   }
 
+  const sessionTypeField = (
+    <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
+      Session type
+      <select
+        value={draft.sessionType}
+        onChange={(event) =>
+          updateDraft("sessionType", event.target.value as SessionDraft["sessionType"])
+        }
+        className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+      >
+        {SESSION_GENERATOR_SESSION_TYPES.map((value) => (
+          <option key={value} value={value}>
+            {getSessionTypeLabel(value)}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+
+  const effortField = (
+    <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
+      Effort
+      <select
+        value={draft.effort}
+        onChange={(event) => updateDraft("effort", event.target.value as SessionDraft["effort"])}
+        className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+      >
+        {SESSION_GENERATOR_EFFORT_PRESETS.map((value) => (
+          <option key={value} value={value}>
+            {getSessionEffortLabel(value)}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+
+  const manualMetadataProfileFields = (
+    <div className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 md:col-span-2">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-medium text-slate-900">Training profile</p>
+          <p className="mt-1 text-xs text-slate-500">
+            These labels shape summaries and export context. Change them when this session needs a
+            different training emphasis.
+          </p>
+          {!manualMetadataProfileOpen ? (
+            <p
+              data-testid="workout-editor-metadata-profile-summary"
+              className="mt-2 text-sm font-medium text-slate-900"
+            >
+              {manualMetadataProfileSummary}
+            </p>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={() => setManualMetadataProfileOpen((current) => !current)}
+          aria-expanded={manualMetadataProfileOpen}
+          data-testid="workout-editor-metadata-profile-toggle"
+          className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+        >
+          {manualMetadataProfileOpen ? "Hide profile" : "Edit profile"}
+        </button>
+      </div>
+
+      {manualMetadataProfileOpen ? (
+        <div className="mt-4 grid gap-4 md:grid-cols-2">
+          {sessionTypeField}
+          {effortField}
+        </div>
+      ) : null}
+    </div>
+  );
+
   const metadataFields = (
     <div className="grid gap-4 md:grid-cols-2">
       <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
@@ -1952,28 +2033,13 @@ export default function WorkoutEditor({
         />
       </label>
 
-      <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
-        Session type
-        <select
-          value={draft.sessionType}
-          onChange={(event) =>
-            updateDraft("sessionType", event.target.value as SessionDraft["sessionType"])
-          }
-          className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-        >
-          {SESSION_GENERATOR_SESSION_TYPES.map((value) => (
-            <option key={value} value={value}>
-              {getSessionTypeLabel(value)}
-            </option>
-          ))}
-        </select>
-      </label>
+      {isManualMetadataMode ? null : sessionTypeField}
 
       <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700 md:col-span-2">
-        Description
+        Session note
         <p className="mt-2 text-xs text-slate-500">
-          Optional. Use this for the whole-workout purpose, pacing intent, or one short coaching
-          note that applies across the session.
+          Optional. Use this for the whole-session purpose or one short coaching note that applies
+          across the session.
         </p>
         <textarea
           value={draft.description}
@@ -2062,20 +2128,7 @@ export default function WorkoutEditor({
         </div>
       ) : null}
 
-      <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700">
-        Effort
-        <select
-          value={draft.effort}
-          onChange={(event) => updateDraft("effort", event.target.value as SessionDraft["effort"])}
-          className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-        >
-          {SESSION_GENERATOR_EFFORT_PRESETS.map((value) => (
-            <option key={value} value={value}>
-              {getSessionEffortLabel(value)}
-            </option>
-          ))}
-        </select>
-      </label>
+      {isManualMetadataMode ? manualMetadataProfileFields : effortField}
 
       <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 md:col-span-2">
         <legend className="px-1 text-sm font-semibold text-slate-900">Session strokes</legend>
@@ -2686,12 +2739,12 @@ export default function WorkoutEditor({
                 Session details
               </p>
               <h3 className="mt-2 text-base font-semibold text-slate-900">
-                Title through equipment
+                Build your swim session
               </h3>
               <p className="mt-1 text-sm text-slate-600">
                 {metadataOpen
-                  ? "Core session details stay here while the workout steps remain the primary editing surface."
-                  : "Collapsed while you work on the session itself. Open anytime to change title, environment, or equipment."}
+                  ? "Keep the top-level setup here while you shape the workout steps below."
+                  : "Open when you want to change the title, session note, environment, strokes, or equipment."}
               </p>
               {!metadataOpen ? (
                 <p

--- a/docs/task-briefs/done/2026-04-05-swim-session-builder-metadata-panel-clarity-10-10.md
+++ b/docs/task-briefs/done/2026-04-05-swim-session-builder-metadata-panel-clarity-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-04-05-swim-session-builder-metadata-panel-clarity-10-10`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-04-05`
 - `updated`: `2026-04-05`
@@ -209,4 +209,5 @@ Critical target categories for `10/10` claim in this brief:
 
 - `2026-04-05 | planning | created a dedicated follow-up brief after the create-vs-edit builder slice shipped; closed prod notes 0655d28e and f271ea91 as covered, kept 2d2cb8af open for its metadata-panel residual, and grouped that residual with new prod note 172c63c6 so the next slice can focus only on manual-builder metadata labels, field visibility, and truthfulness | next: implement the metadata-panel cleanup, then decide with code/test evidence whether Session type, Description, and Effort should stay visible in the manual builder`
 - `2026-04-05 | in-progress | started implementation in a clean worktree from origin/main; confirmed Session type and Effort are still part of the canonical handoff/PDF/export contract, so this slice will simplify the manual-builder presentation without removing those fields from the stored workout model | next: land the metadata-panel UI/test changes, then run lint:briefs, targeted tests, and verify:pre-pr`
-- `2026-04-05 | in-progress | implementation + local validation complete in feature worktree: manual-builder metadata now uses calmer copy, the Description field is presented as Session note, manual sessions keep Session type + Effort behind a secondary Training profile toggle, and user-visible handoff/PDF output matches the renamed note label; passed lint:briefs:all, targeted vitest, targeted Playwright for /my-library/workouts create flow, typecheck, and full npm run verify:pre-pr (95 passed / 319 skipped) | next: commit, push, open PR, and wait for CI before merge`
+- `2026-04-05 | implementation + local validation | manual-builder metadata now uses calmer copy, the Description field is presented as Session note, manual sessions keep Session type + Effort behind a secondary Training profile toggle, and user-visible handoff/PDF output matches the renamed note label; passed lint:briefs:all, targeted vitest, targeted Playwright for /my-library/workouts create flow, typecheck, and full npm run verify:pre-pr (95 passed / 319 skipped) | next: commit, push, open PR, and wait for CI before merge`
+- `2026-04-05 | brief closeout staged for merge | moved this child brief from in-progress to done after PR #357 reached all-green required checks and local npm run verify:pre-merge passed for the metadata-panel slice | next: merge PR #357 to main, then close the remaining admin notes owned by this brief`

--- a/docs/task-briefs/in-progress/2026-04-05-swim-session-builder-metadata-panel-clarity-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-05-swim-session-builder-metadata-panel-clarity-10-10.md
@@ -1,0 +1,212 @@
+# Task Brief: Swim Session Builder Metadata Panel Clarity (10/10)
+
+## Metadata
+
+- `id`: `2026-04-05-swim-session-builder-metadata-panel-clarity-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-04-05`
+- `updated`: `2026-04-05`
+
+## Goal
+
+The manual swim-session builder keeps only truthful, necessary metadata controls visible, with calmer copy and labels that match how coaches actually author a session.
+
+## Why This Brief Exists
+
+- The create-vs-edit builder slice shipped on `2026-04-05`, and that removed the biggest entry confusion.
+- The remaining friction is now concentrated inside the metadata panel of the manual builder:
+  - the heading `Title through equipment` is awkward,
+  - the collapsed helper copy still reads like leftover scaffolding,
+  - open production note `2d2cb8af` still asks for the duplicate builder-shell copy to be removed,
+  - new production note `172c63c6` asks whether `Session type`, `Description`, and `Effort` are actually needed in the manual builder at all.
+- This is a smaller and safer next slice than reopening builder entry IA again.
+
+## Dependencies And Boundaries
+
+- Parent builder brief that remains authoritative for the broader swim-session wave:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md`
+- Recently shipped builder entry clarity slice:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-05-swim-session-builder-create-vs-edit-clarity-10-10.md`
+- Primary implementation files likely touched:
+  - `/Users/stianvikra/freeswimming/components/my-library/workouts/WorkoutEditor.tsx`
+  - `/Users/stianvikra/freeswimming/components/my-library/workouts/WorkoutBuilderHub.tsx`
+  - `/Users/stianvikra/freeswimming/tests/unit/workout-builder-hub.test.tsx`
+  - `/Users/stianvikra/freeswimming/tests/e2e/my-library-workout-builder.spec.ts`
+- Relevant contract review surfaces before hiding/removing fields:
+  - existing manual workout draft shape and canonical workout persistence,
+  - Garmin/export adapters and any builder assumptions around session metadata,
+  - generated-session flow if it reuses the same editor component.
+
+## Admin Notes Triage Disposition
+
+- `172c63c6-1e6c-4c70-ac6a-0a2cd45e601e` `Session Builder items`
+  - disposition: owned by this brief.
+  - reason: this is the clearest expression of the remaining manual-builder metadata-panel work.
+- `2d2cb8af-b65b-48c0-8d7d-0e5d9cd58daf` `Swim session builder`
+  - disposition: partially still open and owned by this brief.
+  - reason: most shell-level copy was already removed, but the metadata-panel heading and collapsed helper copy still match the note's remaining complaint.
+- `0655d28e-8fa8-4077-8d20-0bc34309671c` `Swim session builder`
+  - disposition: closed on `2026-04-05`.
+  - reason: the latest-saved chooser and `Continue latest saved session` wording no longer exist after the three-action overview shipped.
+- `f271ea91-a7f7-4687-937f-6e6f64e68b27` `Swim session builder edit-entry clarity`
+  - disposition: closed on `2026-04-05`.
+  - reason: create-vs-edit boundaries, manual-vs-AI split, and copy-removal requests were shipped in the overview/create-vs-edit slice.
+  - note: `Delete current draft` was intentionally not adopted because the current model still edits a canonical saved workout row, so `Delete session` remains more truthful than `draft`.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Business logic correctness and data integrity`
+- `Admin workflow and editability`
+- `Testing and QA automation`
+- `Product goals and IA`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                                                   | Evidence                                  |
+| --------------------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| Product goals and IA                          | `target`     | Manual builder metadata reads like one coherent authoring surface, with labels and visible controls that match the owner's real manual-session workflow.                        | copy review + manual QA + e2e             |
+| UX flow clarity                               | `target`     | The metadata panel no longer contains awkward or scaffolding-like wording, and hidden/removed fields do not leave the user unsure what belongs in session setup.               | manual QA + targeted e2e                  |
+| Visual design quality                         | `target`     | The metadata panel feels calmer and more intentional after heading/helper-copy cleanup and any unnecessary field removal.                                                      | screenshot review + manual QA             |
+| Business logic correctness and data integrity | `target`     | Any field removed or hidden from the manual UI is either proven unnecessary for canonical save/export behavior or safely preserved behind the existing data contract.          | code review + unit tests + export review  |
+| Admin editor ergonomics                       | `target`     | The owner can start a manual session and understand the top metadata block immediately without reading explanatory filler text.                                               | timed manual QA + e2e                     |
+| Accessibility (a11y)                          | `supporting` | Supporting only: metadata toggles, labels, and any remaining fields stay keyboard- and screen-reader-friendly.                                                                 | targeted tests + code review              |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: metadata cleanup does not materially regress `/my-library/workouts/[workoutId]` responsiveness or payload.                                                   | typecheck + targeted review               |
+| Data placement and sync boundaries            | `target`     | The brief explicitly states whether metadata changes are UI-only or schema-affecting, and manual-builder edits still save through the current canonical workout boundary.      | brief contract + implementation review    |
+| Caching and invalidation strategy             | `supporting` | Supporting only: metadata changes continue to use the current save + refresh path without adding a second sync layer.                                                          | integration review                        |
+| Reliability and failure handling              | `target`     | Save/delete/error states remain truthful if fields are hidden, renamed, or re-ordered; no partial-state confusion is introduced.                                              | unit/e2e coverage + manual QA             |
+| Security and authz                            | `supporting` | Supporting only: owner-scoped workout routes and APIs remain unchanged.                                                                                                          | existing auth boundaries                  |
+| Privacy and compliance                        | `N/A`        | N/A because this slice changes authenticated builder UI labels/fields, not privacy or disclosure policy.                                                                       | explicit scope rationale                  |
+| Content governance                            | `supporting` | Supporting only: renamed fields and helper text must stay aligned with the canonical workout model and any downstream export semantics.                                        | copy review + contract review             |
+| Admin workflow and editability                | `target`     | Manual authors can set up a workout with less ambiguity at the top of the editor, and field visibility matches real authoring needs.                                          | manual QA + targeted tests                |
+| SEO and crawlability                          | `N/A`        | N/A because this is an authenticated My Library surface with no public crawl contract.                                                                                          | explicit scope rationale                  |
+| AI discoverability                            | `N/A`        | N/A because this slice does not change public AI entry metadata or public AI-facing routes.                                                                                     | explicit scope rationale                  |
+| Analytics and KPI observability               | `supporting` | Supporting only: any field-visibility change should still leave session creation/edit behavior interpretable through existing route-level usage patterns.                       | scope review                              |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, entitlement, billing, or subscription workflow changes.                                                                                                 | explicit scope rationale                  |
+| Incident response and support operations      | `supporting` | Supporting only: if builder-field meaning changes, related Help/Guide or runbook guidance must stay truthful or be marked N/A explicitly.                                      | docs impact review                        |
+| Finance and reporting operations              | `N/A`        | N/A because no billing, payout, reconciliation, or finance reporting path changes in this slice.                                                                                | explicit scope rationale                  |
+| i18n operational readiness                    | `N/A`        | N/A because this slice changes internal English builder copy only and does not alter localization architecture.                                                                 | explicit scope rationale                  |
+| Stack-fit and dependency discipline           | `target`     | Reuse the current workout-editor component and canonical workout stack; do not add new dependencies or parallel metadata persistence.                                         | dependency diff + architecture review     |
+| Testing and QA automation                     | `target`     | Coverage protects metadata heading/copy, field visibility decisions, and any builder-save/export invariants affected by metadata changes.                                      | unit/e2e coverage + `verify:pre-pr`       |
+| Scalability and cost efficiency               | `supporting` | Supporting only: metadata simplification should reduce operator friction without increasing save churn or duplicative builder branching.                                        | code review + manual QA                   |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: the slice stays reversible through a normal UI/copy rollback and should not require a destructive migration.                                                  | rollback note + diff review               |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - `workout.id`,
+  - the canonical workout draft payload stored through the current workouts table,
+  - any metadata fields already persisted on that draft.
+- Local-only:
+  - metadata-panel open/closed UI state,
+  - transient inline save/delete error messages,
+  - any local presentation-only field grouping or helper text.
+- Sync policy:
+  - this slice should prefer UI-only simplification first,
+  - if `Session type`, `Description`, or `Effort` stay required for save/export correctness, they may stay in the canonical draft contract even if their presentation changes,
+  - if a field is removed from the manual UI entirely, the brief must document why that does not break canonical save, generated-session edit continuity, or export behavior.
+- Retention and sensitivity:
+  - no new private data class is introduced,
+  - the slice only changes how existing workout metadata is presented and, if justified, edited.
+- Cache/invalidation:
+  - existing save and route-refresh behavior remains authoritative,
+  - no second local draft store is introduced.
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - `workout.id` remains the only canonical swim-session identity.
+- Human-readable identifiers:
+  - metadata labels such as `Session details`, `Build your swim session`, `Session note`, and field labels are mutable UI copy, not identifiers.
+- Mutability rules:
+  - UI labels may change in place,
+  - underlying canonical field names should stay stable unless a separate explicit data-contract slice changes them.
+- Rename vs repurpose policy:
+  - preferred path is to rename or hide presentation affordances before changing the underlying schema,
+  - if `Description` becomes `Session note`, it should remain the same stored field unless a dedicated schema brief decides otherwise.
+- Compatibility contract:
+  - saved workouts, exports, and generated-session editing must keep working against the current workout entity and route contract.
+- Observability and repair:
+  - any removed or hidden field that affects export or generated-session edit behavior must be covered by deterministic tests or explicit fallback mapping.
+
+## Scope
+
+- Rework the manual-builder metadata panel heading and helper text so it no longer says `Title through equipment` or uses filler copy that reads like scaffolding.
+- Review whether these controls should remain visible in the manual builder:
+  - `Session type`
+  - `Description`
+  - `Effort`
+- If one or more of those controls remain:
+  - rename or reposition them so they read truthfully for manual authoring.
+- If one or more of those controls are hidden or removed from the manual UI:
+  - preserve canonical save/export behavior and document the reason clearly in implementation.
+- Update targeted tests for the chosen metadata-panel contract.
+
+## Out Of Scope
+
+- Reopening the create-vs-edit or manual-vs-AI entry architecture.
+- Changing the delete-action truthfulness back to a `draft` label without a new underlying draft model.
+- Reworking the AI generator intake flow beyond any editor-field coupling that must remain compatible.
+- Introducing a new workout schema, migration, or separate local-only draft entity unless a later brief explicitly approves it.
+- Reworking dryland builder metadata in this slice.
+
+## Acceptance Criteria
+
+1. The metadata panel no longer uses the heading `Title through equipment`.
+2. The collapsed metadata helper copy is removed or rewritten so it sounds intentional and truthful.
+3. The brief's chosen contract for `Session type`, `Description`, and `Effort` is reflected in the manual builder UI.
+4. Any field hidden or removed from the manual builder is proven unnecessary for canonical save/export behavior, or a safe compatibility mapping is kept.
+5. The manual builder still opens, saves, and exports correctly after metadata-panel cleanup.
+6. Targeted tests and `npm run verify:pre-pr` pass before PR update.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run typecheck`
+- targeted `vitest`:
+  - `tests/unit/workout-builder-hub.test.tsx`
+  - any additional unit tests needed for metadata-field visibility or export compatibility
+- targeted `playwright`:
+  - `tests/e2e/my-library-workout-builder.spec.ts --project=desktop-chromium`
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm must be installed on the machine used for local validation.
+- Local validation runs from repo root.
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3000/my-library`
+  - `http://127.0.0.1:3000/my-library/workouts/<id>`
+- Preview:
+  - PR preview URL after branch push
+
+## Constraints
+
+- Keep the slice small and truthful.
+- Do not remove fields from the manual builder just because they feel noisy; first confirm whether canonical save/export or generated-session edit flow depends on them.
+- Prefer UI simplification and copy cleanup before schema changes.
+- If external Garmin documentation is needed to justify a removal, treat that as supporting evidence, not an excuse to guess.
+
+## 10/10 Quality Bar
+
+- A coach opening the manual builder should understand the metadata block at a glance.
+- The top metadata section should feel purposeful, not like leftover implementation copy.
+- Any remaining field in manual builder should earn its place by supporting real manual authoring or proven downstream contract needs.
+- Required states stay clear:
+  - loading: existing builder readiness/loading states stay intact,
+  - empty: no-session state remains truthful,
+  - error: save/delete failures still explain what happened,
+  - retry: existing retry path remains the normal save-again flow.
+
+## Checkpoint Log
+
+- `2026-04-05 | planning | created a dedicated follow-up brief after the create-vs-edit builder slice shipped; closed prod notes 0655d28e and f271ea91 as covered, kept 2d2cb8af open for its metadata-panel residual, and grouped that residual with new prod note 172c63c6 so the next slice can focus only on manual-builder metadata labels, field visibility, and truthfulness | next: implement the metadata-panel cleanup, then decide with code/test evidence whether Session type, Description, and Effort should stay visible in the manual builder`
+- `2026-04-05 | in-progress | started implementation in a clean worktree from origin/main; confirmed Session type and Effort are still part of the canonical handoff/PDF/export contract, so this slice will simplify the manual-builder presentation without removing those fields from the stored workout model | next: land the metadata-panel UI/test changes, then run lint:briefs, targeted tests, and verify:pre-pr`
+- `2026-04-05 | in-progress | implementation + local validation complete in feature worktree: manual-builder metadata now uses calmer copy, the Description field is presented as Session note, manual sessions keep Session type + Effort behind a secondary Training profile toggle, and user-visible handoff/PDF output matches the renamed note label; passed lint:briefs:all, targeted vitest, targeted Playwright for /my-library/workouts create flow, typecheck, and full npm run verify:pre-pr (95 passed / 319 skipped) | next: commit, push, open PR, and wait for CI before merge`

--- a/lib/workouts/shared.ts
+++ b/lib/workouts/shared.ts
@@ -578,7 +578,7 @@ export function buildWorkoutHandoffText(
   }
 
   if (draft.description) {
-    lines.push(`- Description: ${draft.description}`);
+    lines.push(`- Session note: ${draft.description}`);
   }
 
   if (draft.warnings.length > 0) {
@@ -1367,7 +1367,7 @@ function buildStandardWorkoutPdfHtmlDocument(model: WorkoutPdfModel, fontUrl: st
             model.description
               ? `
                 <section class="notice notice-neutral">
-                  <h2>Description</h2>
+                  <h2>Session note</h2>
                   <p>${escapeHtml(model.description)}</p>
                 </section>
               `

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -109,6 +109,20 @@ test.describe("my library workout builder", () => {
     await expect(page.getByRole("link", { name: "AI-generated session" })).toHaveCount(0);
     await expect(page.getByTestId("workout-builder-create-manual")).toHaveCount(0);
     await expect(page.getByTestId("session-draft-title")).toBeVisible();
+    await expect(page.getByText("Build your swim session")).toBeVisible();
+    await expect(page.getByText("Session note")).toBeVisible();
+    await expect(page.getByTestId("workout-editor-metadata-profile-summary")).toHaveText(
+      "Endurance · Moderate"
+    );
+    await expect(page.getByRole("combobox", { name: "Session type" })).toHaveCount(0);
+    await expect(page.getByRole("combobox", { name: "Effort" })).toHaveCount(0);
+    await page.getByTestId("workout-editor-metadata-profile-toggle").click();
+    await expect(page.getByTestId("workout-editor-metadata-profile-toggle")).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+    await expect(page.getByRole("combobox", { name: "Session type" })).toBeVisible();
+    await expect(page.getByRole("combobox", { name: "Effort" })).toBeVisible();
     await expect(page.getByTestId("session-draft-step-toggle-0")).toBeVisible();
     await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
       "All builder changes are saved to the canonical workout."
@@ -249,7 +263,7 @@ test.describe("my library workout builder", () => {
     await page.getByTestId("workout-editor-poolside-style-ink-saver").click();
     await expect(
       page.getByText(
-        "Optional. Use this for the whole-workout purpose, pacing intent, or one short coaching note that applies across the session."
+        "Optional. Use this for the whole-session purpose or one short coaching note that applies across the session."
       )
     ).toBeVisible();
     await expect(page.getByTestId("workout-builder-save")).toBeEnabled();

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -941,7 +941,7 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.getByTestId("session-draft-title")).toHaveValue("Accepted threshold workout");
   });
 
-  it("shows whole-workout guidance for the description field", async () => {
+  it("shows calmer session-note guidance in the metadata panel", async () => {
     render(<WorkoutBuilderHub workoutLibrary={buildWorkoutLibrary()} />);
 
     await waitFor(() => {
@@ -952,12 +952,66 @@ describe("WorkoutBuilderHub", () => {
     });
 
     openWorkoutMetadataPanel();
-    expect(screen.getByText("Description")).toBeVisible();
+    expect(screen.getByText("Session note")).toBeVisible();
     expect(
       screen.getByText(
-        "Optional. Use this for the whole-workout purpose, pacing intent, or one short coaching note that applies across the session."
+        "Optional. Use this for the whole-session purpose or one short coaching note that applies across the session."
       )
     ).toBeVisible();
+  });
+
+  it("keeps training profile fields secondary for manual builder workouts", async () => {
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: buildWorkoutRecord({ sourceKind: "manual" }),
+          recentWorkouts: [buildWorkoutSummary({ sourceKind: "manual" })],
+        })}
+        preferExpandedDetailsOnLoad
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    expect(screen.getByText("Build your swim session")).toBeVisible();
+    expect(screen.getByText("Session note")).toBeVisible();
+    expect(screen.getByTestId("workout-editor-metadata-profile-summary")).toHaveTextContent(
+      "Threshold / CSS · Moderate"
+    );
+    expect(screen.queryByRole("combobox", { name: "Session type" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("combobox", { name: "Effort" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("workout-editor-metadata-profile-toggle"));
+
+    expect(screen.getByTestId("workout-editor-metadata-profile-toggle")).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+    expect(screen.getByText("Session type")).toBeVisible();
+    expect(screen.getByText("Effort")).toBeVisible();
+  });
+
+  it("keeps training profile fields visible for AI-origin workouts", async () => {
+    render(
+      <WorkoutBuilderHub workoutLibrary={buildWorkoutLibrary()} preferExpandedDetailsOnLoad />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    expect(screen.getByText("Build your swim session")).toBeVisible();
+    expect(screen.getByRole("combobox", { name: "Session type" })).toBeVisible();
+    expect(screen.getByRole("combobox", { name: "Effort" })).toBeVisible();
+    expect(screen.queryByTestId("workout-editor-metadata-profile-toggle")).not.toBeInTheDocument();
   });
 
   it("shows clearer kick and drill taxonomy guidance inside the step form", async () => {

--- a/tests/unit/workouts-shared.test.ts
+++ b/tests/unit/workouts-shared.test.ts
@@ -111,6 +111,7 @@ describe("workouts shared readiness", () => {
     expect(text).toContain("Title: Garmin readiness draft");
     expect(text).toContain("Garmin/export readiness: Ready");
     expect(text).toContain("Session type: Threshold / CSS");
+    expect(text).toContain("Session note: Readiness coverage for workout builder handoff.");
     expect(text).toContain("1. Warmup swim");
     expect(text).toContain("Warmup · 400m · Freestyle · Easy");
   });
@@ -142,6 +143,16 @@ describe("workouts shared readiness", () => {
       title: "Warmup swim",
       summary: "Warmup · 400m · Freestyle · Easy",
     });
+  });
+
+  it("renders the session note label in printable workout PDF html", () => {
+    const html = buildWorkoutPdfHtmlDocument(buildDraft(), {
+      draftState: "canonical",
+      variant: "standard",
+    });
+
+    expect(html).toContain("<h2>Session note</h2>");
+    expect(html).toContain("Readiness coverage for workout builder handoff.");
   });
 
   it("builds a canonical garmin-ready export payload with deterministic workout metadata", () => {


### PR DESCRIPTION
## Summary
- What changed and why? Clarify the swim-session builder metadata panel so the top of the editor reads like a purposeful authoring surface instead of leftover scaffolding.
- User-visible changes: The metadata panel now says Build your swim session, presents the stored Description field as Session note, and manual-origin sessions tuck Session type + Effort behind a secondary Training profile toggle.
- Technical changes: Updated metadata rendering in components/my-library/workouts/WorkoutEditor.tsx, aligned user-visible handoff/PDF labels in lib/workouts/shared.ts, expanded workout-builder unit/e2e coverage, and moved docs/task-briefs/done/2026-04-05-swim-session-builder-metadata-panel-clarity-10-10.md into done before merge.
- Policy impact: no (authenticated workout-builder UI/copy only; no auth, privacy, analytics, or processor policy contract changed)
- Policy version note: N/A (no policy document or legal text changed)

## Scope
- In scope: manual swim-session builder metadata heading/helper copy cleanup, Session note wording, Training profile toggle for manual-origin sessions, targeted tests, and brief checkpoint updates.
- Out of scope: create-vs-edit IA, AI generator intake architecture, schema changes, Garmin contract rewrites, and admin-note closeout.

## Risk
- Main risk: Manual-origin sessions now make Session type and Effort less prominent, so users could miss those settings if the Training profile summary/toggle becomes unclear.
- Rollback plan: Revert commits `b991258` and `88a0499`, or revert the eventual squash merge commit on `main`.

## Test Evidence
- Policy-impact checklist: N/A (no policy-impact surface changed)
- `npm run lint:briefs`: PASS (`npm run lint:briefs:all` passed after moving the brief to done)
- `npm run lint`: PASS
- `npm run typecheck`: PASS
- `npm run test:unit`: PASS
- `npm run build`: PASS
- `npm run test:e2e`: PASS (full public Playwright matrix passed as part of both local verification gates)
- `npm run verify:pre-pr`: PASS (`95 passed / 319 skipped`)
- `npm run verify:pre-merge`: PASS (`95 passed / 319 skipped`; private-gate step skipped because `SITE_LOCK_ENABLED!=1`; head `88a04999`)
- Local manual QA done on dev URL: NOT RUN
- Vercel preview manual QA done: NOT RUN
- QA covered relevant matrix for this change: PASS (mobile, tablet, desktop browsers covered through Playwright in local verification)

## UI Evidence
- [ ] Screenshot(s) attached (if UI changed)
- [x] Mobile behavior checked (if UI changed)

## Checklist
- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [x] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added

## Owner Merge Step
- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/357`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)
- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d feat/swim-session-builder-metadata-panel-clarity-2026-04-05`
- [ ] Optional: `git fetch --prune`
