### PR TITLE
feat: add staged admin note screenshot import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 .husky/_
 /artifacts/test-runs
 /artifacts/finance-reconciliation
+/.tmp/admin-note-imports/
 
 # next.js
 /.next/

--- a/components/admin/AdminHelpCenter.tsx
+++ b/components/admin/AdminHelpCenter.tsx
@@ -18,7 +18,7 @@ type ActionGroup = {
   actions: Array<{ label: string; meaning: string }>;
 };
 
-const LAST_UPDATED = "2026-04-02";
+const LAST_UPDATED = "2026-04-06";
 
 const QUICK_ACTIONS = [
   { id: "overview", label: "Start here" },
@@ -421,7 +421,7 @@ const BUTTON_GUIDE: ActionGroup[] = [
       {
         label: "Add images / Delete image",
         meaning:
-          "Attach admin-only screenshots or other note images, or fall back here when clipboard paste is not the best fit. Delete must remove both note metadata and the underlying stored image.",
+          "Attach admin-only screenshots or other note images, or fall back here when clipboard paste is not the best fit. If a screenshot only exists in Codex chat, save the real file under `/.tmp/admin-note-imports/` and give Codex the note ID + file path for assistant-led attachment import. Delete must remove both note metadata and the underlying stored image.",
       },
       {
         label: "Paste image from clipboard / Upload images",
@@ -574,8 +574,11 @@ const DAILY_PLAYBOOKS: Playbook[] = [
       "If the note is already saved and you forgot the screenshot, open `Edit` in the contextual notes panel and upload the image there instead of recreating the note.",
       "Saved contextual notes now show the visible note ID, an `Open in Notes` jump, and related-note titles that jump into the full queue by stable note ID.",
       "If the issue is visual, copy the screenshot or image to your clipboard first, then use `Paste image from clipboard`, or choose `Upload images` if you already have the files.",
+      "Fastest screenshot path is often: let Codex create the note first, open the direct note link, then paste or upload the screenshot yourself in Notes.",
       "You can stage up to six pre-save images on create flows, and repeated paste/upload appends instead of replacing the earlier screenshots.",
       "Remember that pasted or uploaded pre-save images stay local until note save and attachment upload both succeed; if clipboard access is blocked or no image is found, fall back to `Upload images`.",
+      "If you need Codex to perform the attachment step, the chat image is discussion-only; save the real file under `/.tmp/admin-note-imports/` and give Codex the canonical note ID plus that staged file path.",
+      "Codex-led staged imports should delete the local staging file after confirmed success and keep it in place if upload fails so recovery stays explicit.",
       "After a successful Quick note save, the panel stays open and ready for another note on the same locked context so you can keep capturing without reopening it.",
       "Saved image cards now show a stable evidence summary: image order, file type, file size, and upload date, without exposing raw storage paths.",
       `If a note title starts with \`${ADMIN_NOTE_TEST_ARTIFACT_PREFIX}\`, it is automated test residue and should clear automatically; if it stays open, use the admin-notes recovery runbook before deleting anything manually.`,
@@ -900,12 +903,14 @@ export default function AdminHelpCenter() {
           </article>
           <article className="rounded-xl border border-amber-200 bg-amber-50 p-3">
             <p className="text-sm font-semibold text-amber-900">
-              Clipboard paste is blocked or image upload fails
+              Clipboard paste is blocked, chat image is not enough, or image upload fails
             </p>
             <p className="mt-1 text-sm text-amber-800">
               Confirm the screenshot was copied first. If clipboard access is blocked or upload
-              still fails, keep the note ID, refresh Notes, and use Upload images or the admin-notes
-              recovery runbook.
+              still fails, keep the note ID, refresh Notes, and use Upload images. If the image
+              only exists in Codex chat, save the real file under `/.tmp/admin-note-imports/` and
+              give Codex the note ID + file path. Use the admin-notes recovery runbook if the
+              state is still unclear.
             </p>
           </article>
           <article className="rounded-xl border border-slate-200 bg-slate-50 p-3">

--- a/docs/runbooks/admin-notes-recovery.md
+++ b/docs/runbooks/admin-notes-recovery.md
@@ -14,6 +14,7 @@ Use this runbook for AW-012 workflow `A4` stale-note reconciliation edge cases.
 - Quick capture save fails or closes unexpectedly and you need to confirm whether a note was actually created.
 - Clipboard image paste is blocked, empty, or never stages a preview and you need to finish the note safely.
 - A pasted clipboard image never reaches preview, disappears before save, or you are unsure whether it uploaded after note save.
+- A screenshot was only shared in Codex chat and you need a real admin-note attachment without guessing whether chat or local file is canonical.
 - A contextual note panel shows outdated title/body/status after recent edits in admin.
 - You suspect duplicate/overlapping edits on the same note.
 - Image upload/delete returns an error and you are unsure whether the stored image was fully removed.
@@ -45,12 +46,17 @@ Use this runbook for AW-012 workflow `A4` stale-note reconciliation edge cases.
 
 - if contextual `Add note` is collapsed because notes already exist, expand it first before retrying image intake,
 - if the note is already saved in the contextual panel and the screenshot is missing, open `Edit` on that note and upload the image there instead of recreating the note,
+- if Codex already created the note and returned a direct `/admin?tab=notes...` link, open that exact note and paste/upload the screenshot there before creating anything new,
 - if `Paste image from clipboard` says no image was found, confirm you copied the screenshot first and retry, or use `Upload images`,
 - if clipboard access was blocked, retry from the explicit paste button after granting browser permission, or use `Upload images`,
 - if you pasted an image from clipboard and no preview ever appeared, nothing was saved; retry paste or use `Upload images`,
 - if preview existed but note save failed, search by `Note ID` or title before retrying image staging so you do not create duplicate notes,
 - if a pasted image preview existed but note save failed, search by `Note ID` or title before retrying paste so you do not create duplicate notes,
 - repeated paste/upload on create flows appends until the six-image cap is reached; remove only the screenshots you no longer want instead of restarting the whole draft,
+- if the screenshot only exists in Codex chat, that chat image is discussion-only and cannot be uploaded directly; save the real file under `/.tmp/admin-note-imports/` first if you want Codex to perform the attachment import,
+- for Codex-assisted staged imports, give Codex the canonical note ID plus the staged file path and verify the returned direct note link after import,
+- if Codex-assisted staged import reports upload failure, keep the staged file in place and retry only after confirming the target note and current attachment list,
+- if Codex-assisted staged import reports cleanup failure after upload success, do not re-import the same screenshot blindly; verify the note attachment first, then delete the staged file manually if needed,
 - confirm the attachment list and image count in the note row,
 - confirm each saved image card still shows its structured evidence summary (`Image X`, file type, file size, upload date),
 - if delete failed, refresh once and verify whether the image is still present before retrying,

--- a/docs/task-briefs/in-progress/2026-04-05-admin-notes-chat-screenshot-staging-import-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-05-admin-notes-chat-screenshot-staging-import-10-10.md
@@ -1,0 +1,264 @@
+# Task Brief: Admin Notes Chat Screenshot Staging Import (10/10)
+
+## Metadata
+
+- `id`: `2026-04-05-admin-notes-chat-screenshot-staging-import-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-04-05`
+- `updated`: `2026-04-06`
+
+## Goal
+
+FreeSwimming has a supported, cleanup-safe workflow for turning screenshots discussed in Codex chat into real admin-note attachments by staging the actual image files under `/.tmp/admin-note-imports/`, while chat-pasted images remain interpretation-only context.
+
+## Why This Brief Exists
+
+- Current session verification on `2026-04-05` established a hard boundary:
+  - Codex can see and interpret a screenshot pasted into chat,
+  - but Codex does not receive that chat image as a reliable local file/blob that can be uploaded directly into admin notes.
+- The team still needs a practical workflow now so note triage does not stall while we discuss screenshots in chat.
+- A safe staging path is simpler and more truthful than trying to scrape hidden chat internals with ad hoc scripts.
+- The desired behavior is already captured by production note `4120fac6` `Chat screenshots to admin notes attachments`, but the first honest implementation step is a staging workflow, not an assumed direct chat-image bridge.
+
+## Dependencies And Boundaries
+
+- Existing admin-note attachment foundations remain authoritative:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-03-21-admin-notes-workflow-v2-attachments-and-linking-10-10.md`
+  - `/Users/stianvikra/freeswimming/app/api/admin/notes/[id]/attachments/route.ts`
+  - `/Users/stianvikra/freeswimming/app/api/admin/notes/[id]/attachments/[attachmentId]/route.ts`
+  - `/Users/stianvikra/freeswimming/components/admin/AdminNotesManager.tsx`
+  - `/Users/stianvikra/freeswimming/components/admin/AdminContextNotesPanel.tsx`
+- This brief owns:
+  - the operator/assistant workflow contract for staged screenshot imports,
+  - the repo-local temporary staging path contract,
+  - cleanup expectations after successful attachment import,
+  - truthful documentation that chat-image interpretation and file upload are separate capabilities.
+- This brief does not own:
+  - direct binary ingestion from chat attachments,
+  - OCR or AI extraction from images,
+  - public upload behavior,
+  - storing screenshots in `app/`, `public/`, or any committed product asset path.
+- Locked decisions unless owner explicitly changes them:
+  - do not use Python or hidden chat/runtime internals to scrape pasted chat images,
+  - the staged file path is the upload source-of-truth,
+  - the same screenshot may also be pasted into chat for interpretation, but the chat copy is not the file used for upload,
+  - staged screenshots stay gitignored and should be deleted after confirmed success.
+
+## Admin Notes Triage Disposition
+
+- `4120fac6` `Chat screenshots to admin notes attachments`
+  - disposition: owned by this brief.
+  - reason: the real remaining need is a supported bridge between collaborative screenshot discussion in chat and the existing admin-note attachment system, starting with a truthful staging workflow.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Business logic correctness and data integrity`
+- `Data placement and sync boundaries`
+- `Privacy and compliance`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                                   | Evidence                                  |
+| --------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| Product goals and IA                          | `target`     | Operators understand the split between chat-image interpretation and staged-file upload without guessing which source is canonical.                             | brief contract + docs review              |
+| UX flow clarity                               | `target`     | The screenshot workflow is one explicit path: stage file, provide note ID + file path, optionally paste into chat for interpretation, then clean up on success. | brief contract + manual workflow review   |
+| Visual design quality                         | `N/A`        | N/A because this slice is primarily workflow/documentation and repo-local staging, not a new user-facing UI redesign.                                          | explicit scope rationale                  |
+| Business logic correctness and data integrity | `target`     | Admin-note attachments remain sourced from real files only, never inferred from chat markup, and staging cleanup never reports success before upload confirms.  | attachment contract + implementation test |
+| Admin editor ergonomics                       | `target`     | The owner can keep discussing screenshots in chat while giving Codex one stable file path for the real attachment action.                                      | manual QA                                 |
+| Accessibility (a11y)                          | `N/A`        | N/A because the staging-path contract itself adds no new end-user UI control; existing admin-note attachment UI remains authoritative.                         | explicit scope rationale                  |
+| Performance (CWV + payloads)                  | `N/A`        | N/A because the staging workflow should not change route payloads or Core Web Vitals.                                                                           | explicit scope rationale                  |
+| Data placement and sync boundaries            | `target`     | Chat screenshots remain conversational context only, repo-local staged files remain temporary local inputs only, and canonical note attachments remain server-owned. | data contract + code review            |
+| Caching and invalidation strategy             | `supporting` | Supporting only: attachment views should continue using existing notes refresh behavior after a staged-file import succeeds.                                   | existing attachment contract              |
+| Reliability and failure handling              | `target`     | On upload failure, the staged file is preserved and the failure is reported explicitly; on confirmed success, cleanup is deterministic.                        | workflow test + recovery notes            |
+| Security and authz                            | `target`     | Attachment uploads remain admin-only and the staging path never becomes a public asset or public URL source.                                                    | existing authz tests + scope review       |
+| Privacy and compliance                        | `target`     | Sensitive screenshots stay local and gitignored before upload, and are deleted from staging after confirmed import unless failure requires retention.          | `.gitignore` + workflow contract          |
+| Content governance                            | `supporting` | Supporting only: the note system remains canonical; this slice only clarifies how screenshot evidence enters it.                                               | linked brief + scope review               |
+| Admin workflow and editability                | `target`     | The operator can provide a note ID and staged file path without recreating the note or misusing public/product asset folders.                                  | manual QA + brief contract                |
+| SEO and crawlability                          | `N/A`        | N/A because staging files and admin-note attachments are private/admin-only concerns.                                                                           | explicit scope rationale                  |
+| AI discoverability                            | `N/A`        | N/A because this slice changes no public AI-facing metadata or crawl surface.                                                                                   | explicit scope rationale                  |
+| Analytics and KPI observability               | `N/A`        | N/A because no new analytics event is required for this narrow staging workflow contract.                                                                       | explicit scope rationale                  |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, billing, entitlement, or finance behavior changes.                                                                                      | explicit scope rationale                  |
+| Incident response and support operations      | `target`     | Recovery guidance clearly tells the operator what happens on success vs failure and where staged files are expected to live temporarily.                       | runbook/help update                       |
+| Finance and reporting operations              | `N/A`        | N/A because no billing, reconciliation, payout, or finance reporting path changes in this screenshot-staging slice.                                            | explicit scope rationale                  |
+| i18n operational readiness                    | `N/A`        | N/A because this slice adds an internal operator workflow contract only and no locale-sensitive product model.                                                  | explicit scope rationale                  |
+| Stack-fit and dependency discipline           | `target`     | Reuse the current admin-note attachment stack and repo-local filesystem; do not add scraping tools or extra upload dependencies.                               | dependency diff + architecture review     |
+| Testing and QA automation                     | `target`     | Coverage and/or deterministic validation protect the staging-path contract, cleanup semantics, and any helper used to import staged screenshots.               | tests + `npm run verify:pre-pr` evidence  |
+| Scalability and cost efficiency               | `supporting` | Supporting only: temporary staging stays bounded and local, avoiding duplicate storage or committed screenshot churn.                                          | scope review                              |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: the workflow is reversible because staged files are local-only and canonical attachment behavior stays unchanged.                             | rollback note + code review               |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - `admin_note.id`,
+  - `admin_note_attachments` rows,
+  - admin attachment storage object keys and canonical metadata.
+- Local-only:
+  - staged screenshots under `/.tmp/admin-note-imports/`,
+  - chat-pasted screenshots used only for discussion/interpretation,
+  - transient local path references shared with Codex during a session.
+- Sync policy:
+  - the owner stages a real image file locally before asking Codex to attach it,
+  - Codex may use the matching chat image for interpretation, but not as upload source,
+  - upload happens only on explicit note-targeted action,
+  - staged file deletes only after confirmed attachment success,
+  - failed uploads keep the staged file in place and return an explicit recovery message.
+- Retention and sensitivity:
+  - staged screenshots may contain sensitive operational information,
+  - staged files must remain gitignored and local-only,
+  - successful imports should clear the staged file promptly unless the owner explicitly wants to keep it.
+- Cache/invalidation:
+  - existing notes manager/context-panel refresh rules remain authoritative after attachment upload,
+  - the staging directory itself is outside app runtime caching.
+
+## Identity And Rename Contract
+
+- Canonical stable IDs:
+  - `admin_note.id` remains the canonical note identity,
+  - attachment IDs remain canonical after the upload succeeds.
+- Human-readable identifiers:
+  - local staging filenames are operator convenience only and are not canonical identity,
+  - note titles and screenshot filenames remain display metadata, not source-of-truth identity.
+- Mutability rules:
+  - a local staged filename may be renamed freely before upload,
+  - the target note ID must be explicit at upload time,
+  - the staging path must not be persisted as canonical attachment metadata unless already supported by the existing attachment schema.
+- Rename vs repurpose policy:
+  - changing a staging filename is harmless local prep,
+  - changing the target note means a new explicit upload action rather than silently retargeting an in-flight import.
+- Compatibility contract:
+  - existing attachment flows continue to work unchanged,
+  - operators who do not use chat-based collaboration can still attach screenshots through the normal UI.
+- Observability and repair:
+  - if a staged file is missing, unreadable, or upload fails, Codex must report the exact file/path failure and keep the local staging file untouched when possible.
+
+## Scope
+
+- Define `/.tmp/admin-note-imports/` as the standard repo-local staging path for screenshots that will later be attached to admin notes.
+- Keep the workflow explicit:
+  - optional chat paste for interpretation,
+  - required staged file for real upload,
+  - explicit note ID + file path as the actionable input.
+- Support two operator-approved workflows going forward:
+  - `Fast manual attachment path`:
+    - owner describes the issue in chat,
+    - Codex creates the admin note,
+    - Codex returns the direct `freeswimming.org/admin?...` note link,
+    - owner opens the note and pastes/uploads the screenshot manually in the UI.
+  - `Assisted staged-file attachment path`:
+    - owner stages a real image file under `/.tmp/admin-note-imports/`,
+    - owner gives Codex the target note ID plus file path,
+    - owner may also paste the same image in chat for interpretation,
+    - Codex imports the staged file into the note attachment flow and then deletes the local staged file after confirmed success.
+- Add repo-level protection against accidental commit of staged screenshots.
+- Document cleanup semantics:
+  - delete staged file after confirmed success,
+  - preserve on failure and explain next step.
+- Reuse the existing admin-note attachment system rather than creating a second screenshot store.
+
+## Out Of Scope
+
+- Direct binary ingestion from chat-pasted images.
+- Any workflow that depends on Python or private chat/runtime scraping.
+- Storing staging images in `app/`, `public/`, or any committed asset folder.
+- New public screenshot upload features.
+- OCR, captioning, or automatic structured extraction from screenshots.
+
+## Acceptance Criteria
+
+1. The repo defines a gitignored local staging path for admin-note screenshot imports at `/.tmp/admin-note-imports/`.
+2. The workflow explicitly states that chat screenshots may be used for interpretation, but a real staged file path is required for upload.
+3. The target admin note remains identified by canonical note ID, not by screenshot filename or chat context.
+4. The brief explicitly preserves a faster manual path where Codex creates the note first and always returns a direct admin-note link so the owner can paste the screenshot manually with minimal clicks.
+5. On confirmed staged-file upload success, the staged file is deleted; on failure, it is preserved and the failure reason is surfaced clearly.
+6. After either note creation or staged-file attachment import, Codex returns a direct `freeswimming.org` admin-notes link to the targeted note for verification.
+7. No solution in this slice depends on Python-based chat scraping, hidden chat internals, `app/`, or `public/` storage.
+8. Help/Guide or runbook copy is updated in the same implementation PR if operator workflow wording changes beyond this planning brief.
+9. `npm run lint:briefs` and relevant validation pass before any implementation PR update.
+
+## Validation
+
+- `npm run lint:briefs`
+- targeted validation for any new helper or workflow wrapper added in implementation
+- targeted admin-notes regression coverage if the import path touches attachment UI or mutation helpers
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm must be installed on the machine used for local validation.
+- Local validation runs from repo root.
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3000/admin?tab=notes`
+  - repo-local staging path `/.tmp/admin-note-imports/`
+- Preview:
+  - PR preview URL if an implementation branch changes operator-facing notes copy or workflow affordances.
+
+## Constraints
+
+- Keep the first solution truthful and boring: real file in staging, existing admin-note attachment contract, deterministic cleanup.
+- Do not present chat-image interpretation as if it were a real file-upload capability.
+- Keep screenshots local-only before upload and minimize the chance of accidental git inclusion.
+- Prefer the faster create-note-then-return-link path when the owner is happy to paste/upload the screenshot manually.
+- Use the staged-file import path only when the owner explicitly wants Codex to perform the attachment step.
+
+## 10/10 Quality Bar
+
+- The workflow should feel obvious enough that the owner never has to guess whether Codex is using the chat image or the staged file.
+- Failure states must be explicit:
+  - missing staged file,
+  - unreadable path,
+  - note-targeting mismatch,
+  - attachment upload failure,
+  - cleanup failure after successful upload.
+- Security/privacy expectations must stay explicit:
+  - local-only before upload,
+  - gitignored staging,
+  - admin-only after upload.
+
+## Help/Guide And Operator Training Contract
+
+- If implementation changes any visible operator wording or introduces a reusable helper workflow, update Help/Guide or the relevant runbook in the same PR.
+- Wording must explicitly separate:
+  - chat screenshot for discussion,
+  - staged file for attachment import.
+- Wording should also explicitly document the recommended low-friction default:
+  - Codex creates the note,
+  - Codex returns the direct note link,
+  - owner pastes/uploads the screenshot manually in the note UI.
+
+## Session Continuity And Recovery
+
+- Canonical recovery order:
+  1. `git status -sb`
+  2. `git log --oneline -n 10`
+  3. reopen this brief and continue from the latest checkpoint
+- If the working tree is dirty during implementation, summarize:
+  - which staged screenshot files were intentionally kept,
+  - which note imports were completed,
+  - which cleanup step remains.
+
+## Git Rhythm Defaults
+
+- Keep this slice small:
+  - one coherent workflow contract,
+  - one implementation pass,
+  - one validation cycle before PR update.
+
+## PR Browser Rule
+
+- Open PR/review links in Safari by default.
+
+## Checkpoint Log
+
+- `2026-04-05 | planning | captured the first truthful contract for turning chat-discussed screenshots into real admin-note attachments: staged local image is upload source-of-truth, chat image is interpretation-only, and the default low-friction path remains create-note-then-return-link for manual paste in the UI | next: implement the gitignored staging path, a helper/CLI for note-id + file-path imports, and the operator recovery wording for success/failure cleanup`
+- `2026-04-06 | in-progress | reopened the slice after the swim-session builder wave closed, verified the remaining open admin notes, and chose note 4120fac6 as the next actionable implementation because it already has a narrow, dependency-light workflow contract | next: land the staging-path protection, staged-file import helper, tests, and operator docs in one small pass`
+- `2026-04-06 | implementation | shipped the first supported staged-screenshot workflow: gitignored /.tmp/admin-note-imports/, a CLI helper for note-id + file-path imports with deterministic cleanup semantics, Help/Guide + recovery wording that separates chat interpretation from file upload, and targeted regression coverage for the new helper/docs contract | next: keep the tree clean, commit, push, open PR, and carry the slice through merge if CI stays green`
+- `2026-04-06 | validation | targeted unit/type/help checks are green, lint:briefs:all passed, the new CLI prints stable usage, and full npm run verify:pre-pr passed (95 passed / 319 skipped) in the clean worktree | next: commit, push, open PR in Safari, and monitor required CI`

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:e2e:extended": "playwright test --project=tablet-ipad-pro-11 --project=desktop-chromium --project=desktop-webkit --project=desktop-firefox",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:ui": "playwright test --ui",
+    "admin:notes:import-staged": "node ./scripts/import-admin-note-staged-attachment.mjs",
     "finance:reconcile": "node ./scripts/reconcile-finance-entitlements.mjs",
     "verify:open": "SITE_LOCK_ENABLED=0 npm run verify",
     "verify:public": "SITE_LOCK_ENABLED=0 npm run verify",

--- a/scripts/import-admin-note-staged-attachment.mjs
+++ b/scripts/import-admin-note-staged-attachment.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+
+import { readFile, unlink } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { createClient } from "@supabase/supabase-js";
+import {
+  ADMIN_NOTE_ATTACHMENT_BUCKET,
+  buildAdminNoteAttachmentStoragePath,
+  buildAdminNoteVerificationUrl,
+  normalizeAdminNoteId,
+  parseStagedAdminNoteImportArgs,
+  REPO_ROOT,
+  requireEnvValue,
+  resolveStagedAttachmentPath,
+  validateStagedAdminNoteAttachment,
+} from "./lib/admin-note-staged-import.mjs";
+
+function createAdminSupabaseClient() {
+  return createClient(
+    requireEnvValue("NEXT_PUBLIC_SUPABASE_URL", { repoRoot: REPO_ROOT }),
+    requireEnvValue("SUPABASE_SERVICE_ROLE_KEY", { repoRoot: REPO_ROOT }),
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    }
+  );
+}
+
+function printUsage() {
+  console.log(
+    [
+      "Usage:",
+      "  npm run admin:notes:import-staged -- --note-id <uuid> --file .tmp/admin-note-imports/<image>",
+      "  node ./scripts/import-admin-note-staged-attachment.mjs <uuid> .tmp/admin-note-imports/<image>",
+      "",
+      "The file must already exist under /.tmp/admin-note-imports/.",
+    ].join("\n")
+  );
+}
+
+async function removeUploadedStorageObject(supabase, storagePath) {
+  const removeResult = await supabase.storage.from(ADMIN_NOTE_ATTACHMENT_BUCKET).remove([storagePath]);
+  if (removeResult.error) {
+    console.error(
+      JSON.stringify(
+        {
+          ok: false,
+          code: "ATTACHMENT_STORAGE_ROLLBACK_FAILED",
+          storagePath,
+          error: removeResult.error.message,
+        },
+        null,
+        2
+      )
+    );
+  }
+}
+
+async function runCli() {
+  const args = parseStagedAdminNoteImportArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    return;
+  }
+
+  const noteId = normalizeAdminNoteId(args.noteId);
+  const stagedFile = await resolveStagedAttachmentPath(args.filePath, { repoRoot: REPO_ROOT });
+  const validatedAttachment = validateStagedAdminNoteAttachment({
+    fileName: path.basename(stagedFile.absolutePath),
+    sizeBytes: stagedFile.sizeBytes,
+  });
+  const supabase = createAdminSupabaseClient();
+
+  const noteResult = await supabase
+    .from("admin_notes")
+    .select("id,is_done")
+    .eq("id", noteId)
+    .maybeSingle();
+
+  if (noteResult.error) {
+    throw new Error(`Could not load target admin note: ${noteResult.error.message}`);
+  }
+
+  if (!noteResult.data) {
+    throw new Error(`Admin note was not found: ${noteId}`);
+  }
+
+  const attachmentId = crypto.randomUUID();
+  const storagePath = buildAdminNoteAttachmentStoragePath({
+    noteId,
+    attachmentId,
+    fileName: validatedAttachment.fileName,
+  });
+
+  const fileBuffer = await readFile(stagedFile.absolutePath);
+  const uploadResult = await supabase.storage
+    .from(ADMIN_NOTE_ATTACHMENT_BUCKET)
+    .upload(storagePath, fileBuffer, {
+      contentType: validatedAttachment.mimeType,
+      upsert: false,
+    });
+
+  if (uploadResult.error) {
+    throw new Error(`Could not upload staged attachment: ${uploadResult.error.message}`);
+  }
+
+  const insertResult = await supabase
+    .from("admin_note_attachments")
+    .insert({
+      id: attachmentId,
+      note_id: noteId,
+      file_name: validatedAttachment.fileName,
+      mime_type: validatedAttachment.mimeType,
+      size_bytes: validatedAttachment.sizeBytes,
+      storage_path: storagePath,
+      created_by: null,
+    })
+    .select("id,note_id,file_name,mime_type,size_bytes,storage_path")
+    .maybeSingle();
+
+  if (insertResult.error) {
+    await removeUploadedStorageObject(supabase, storagePath);
+    throw new Error(`Could not save attachment metadata: ${insertResult.error.message}`);
+  }
+
+  const verificationUrl = buildAdminNoteVerificationUrl({
+    noteId,
+    isDone: noteResult.data.is_done,
+  });
+
+  try {
+    await unlink(stagedFile.absolutePath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(
+      JSON.stringify(
+        {
+          ok: false,
+          code: "STAGED_FILE_CLEANUP_FAILED",
+          attachmentImported: true,
+          noteId,
+          attachmentId,
+          verificationUrl,
+          stagedFilePath: stagedFile.repoRelativePath,
+          error: message,
+        },
+        null,
+        2
+      )
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        noteId,
+        attachmentId,
+        fileName: validatedAttachment.fileName,
+        mimeType: validatedAttachment.mimeType,
+        sizeBytes: validatedAttachment.sizeBytes,
+        stagedFilePath: stagedFile.repoRelativePath,
+        stagedFileDeleted: true,
+        verificationUrl,
+      },
+      null,
+      2
+    )
+  );
+}
+
+runCli().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(
+    JSON.stringify(
+      {
+        ok: false,
+        error: message,
+      },
+      null,
+      2
+    )
+  );
+  process.exitCode = 1;
+});

--- a/scripts/lib/admin-note-staged-import.mjs
+++ b/scripts/lib/admin-note-staged-import.mjs
@@ -1,0 +1,224 @@
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, realpath, stat } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+export const ADMIN_NOTE_ATTACHMENT_BUCKET = "admin-note-attachments";
+export const ADMIN_NOTE_ATTACHMENT_MAX_BYTES = 5 * 1024 * 1024;
+export const ADMIN_NOTE_IMPORT_STAGING_DIR = ".tmp/admin-note-imports";
+export const ADMIN_NOTE_ALLOWED_ATTACHMENT_MIME_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+];
+export const ADMIN_NOTES_BASE_URL = "https://freeswimming.org";
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const EXTENSION_TO_MIME_TYPE = new Map([
+  [".png", "image/png"],
+  [".jpg", "image/jpeg"],
+  [".jpeg", "image/jpeg"],
+  [".webp", "image/webp"],
+  [".gif", "image/gif"],
+]);
+const ENV_FILE_NAMES = [".env.local", ".env"];
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = path.resolve(SCRIPT_DIR, "..", "..");
+
+function normalizeString(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function isUuid(value) {
+  return UUID_REGEX.test(value);
+}
+
+export function normalizeAdminNoteId(value) {
+  const noteId = normalizeString(value).toLowerCase();
+  if (!isUuid(noteId)) {
+    throw new Error("A valid admin note ID is required.");
+  }
+  return noteId;
+}
+
+export function sanitizeAttachmentFileName(fileName) {
+  const baseName = normalizeString(fileName)
+    .normalize("NFKD")
+    .replace(/[^\x00-\x7F]/g, "")
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 80);
+
+  return baseName || "attachment";
+}
+
+export function inferAdminNoteAttachmentMimeType(fileName) {
+  const extension = path.extname(normalizeString(fileName)).toLowerCase();
+  return EXTENSION_TO_MIME_TYPE.get(extension) ?? null;
+}
+
+export function validateStagedAdminNoteAttachment(params) {
+  const fileName = sanitizeAttachmentFileName(params.fileName);
+  const mimeType = inferAdminNoteAttachmentMimeType(fileName);
+  const sizeBytes = Number.isFinite(params.sizeBytes) ? Math.trunc(params.sizeBytes) : 0;
+
+  if (!mimeType || !ADMIN_NOTE_ALLOWED_ATTACHMENT_MIME_TYPES.includes(mimeType)) {
+    throw new Error("Only PNG, JPEG, WEBP, and GIF images are allowed.");
+  }
+
+  if (sizeBytes <= 0) {
+    throw new Error("Attachment file is empty.");
+  }
+
+  if (sizeBytes > ADMIN_NOTE_ATTACHMENT_MAX_BYTES) {
+    throw new Error(
+      `Attachments must be ${Math.round(ADMIN_NOTE_ATTACHMENT_MAX_BYTES / (1024 * 1024))} MB or smaller.`
+    );
+  }
+
+  return {
+    fileName,
+    mimeType,
+    sizeBytes,
+  };
+}
+
+export function buildAdminNoteAttachmentStoragePath(params) {
+  const safeFileName = sanitizeAttachmentFileName(params.fileName);
+  return `notes/${params.noteId}/${params.attachmentId}-${safeFileName}`;
+}
+
+export function buildAdminNoteVerificationUrl(params) {
+  const searchParams = new URLSearchParams([
+    ["tab", "notes"],
+    ["notesQuery", normalizeAdminNoteId(params.noteId)],
+    ["notesStatus", params.isDone ? "done" : "open"],
+  ]);
+  return `${ADMIN_NOTES_BASE_URL}/admin?${searchParams.toString()}`;
+}
+
+export function readEnvFileValue(name, options = {}) {
+  const repoRoot = options.repoRoot ?? REPO_ROOT;
+  for (const fileName of ENV_FILE_NAMES) {
+    const filePath = path.join(repoRoot, fileName);
+    if (!existsSync(filePath)) continue;
+
+    for (const line of readFileSync(filePath, "utf8").split(/\r?\n/)) {
+      if (!line.startsWith(`${name}=`)) continue;
+
+      let value = line.slice(name.length + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+
+      if (value) return value;
+    }
+  }
+
+  return null;
+}
+
+export function requireEnvValue(name, options = {}) {
+  const env = options.env ?? process.env;
+  const value = normalizeString(env[name] ?? "") || readEnvFileValue(name, options);
+  if (!value) {
+    throw new Error(`${name} is required for staged admin-note attachment import.`);
+  }
+  return value;
+}
+
+export async function ensureAdminNoteImportStagingDir(options = {}) {
+  const repoRoot = options.repoRoot ?? REPO_ROOT;
+  const stagingDir = path.resolve(repoRoot, ADMIN_NOTE_IMPORT_STAGING_DIR);
+  await mkdir(stagingDir, { recursive: true });
+  return realpath(stagingDir);
+}
+
+export async function resolveStagedAttachmentPath(filePath, options = {}) {
+  const repoRoot = options.repoRoot ?? REPO_ROOT;
+  const resolvedRepoRoot = await realpath(repoRoot).catch(() => path.resolve(repoRoot));
+  const rawPath = normalizeString(filePath);
+  if (!rawPath) {
+    throw new Error("A staged screenshot file path is required.");
+  }
+
+  const stagingDir = await ensureAdminNoteImportStagingDir({ repoRoot });
+  const candidatePath = path.isAbsolute(rawPath)
+    ? path.resolve(rawPath)
+    : path.resolve(repoRoot, rawPath);
+
+  let absolutePath;
+  try {
+    absolutePath = await realpath(candidatePath);
+  } catch {
+    throw new Error(`Staged file was not found: ${rawPath}`);
+  }
+
+  const withinStagingDir =
+    absolutePath.startsWith(`${stagingDir}${path.sep}`) && absolutePath !== stagingDir;
+  if (!withinStagingDir) {
+    throw new Error(`Staged file must live under ${ADMIN_NOTE_IMPORT_STAGING_DIR}.`);
+  }
+
+  const fileStat = await stat(absolutePath);
+  if (!fileStat.isFile()) {
+    throw new Error(`Staged path is not a file: ${rawPath}`);
+  }
+
+  return {
+    absolutePath,
+    repoRelativePath: path.relative(resolvedRepoRoot, absolutePath) || rawPath,
+    sizeBytes: fileStat.size,
+  };
+}
+
+export function parseStagedAdminNoteImportArgs(argv) {
+  const options = {
+    noteId: "",
+    filePath: "",
+    help: false,
+  };
+  const positionals = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+      continue;
+    }
+    if (arg === "--note-id" || arg === "-n") {
+      options.noteId = argv[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
+    if (arg === "--file" || arg === "-f") {
+      options.filePath = argv[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--note-id=")) {
+      options.noteId = arg.slice("--note-id=".length);
+      continue;
+    }
+    if (arg.startsWith("--file=")) {
+      options.filePath = arg.slice("--file=".length);
+      continue;
+    }
+    positionals.push(arg);
+  }
+
+  if (!options.noteId && positionals[0]) {
+    options.noteId = positionals[0];
+  }
+  if (!options.filePath && positionals[1]) {
+    options.filePath = positionals[1];
+  }
+
+  return options;
+}

--- a/tests/e2e/admin-help-center.spec.ts
+++ b/tests/e2e/admin-help-center.spec.ts
@@ -167,12 +167,27 @@ test.describe("admin help center", () => {
     ).toBeVisible();
     await expect(
       page.getByText(
+        "Fastest screenshot path is often: let Codex create the note first, open the direct note link, then paste or upload the screenshot yourself in Notes."
+      )
+    ).toBeVisible();
+    await expect(
+      page.getByText(
         "You can stage up to six pre-save images on create flows, and repeated paste/upload appends instead of replacing the earlier screenshots."
       )
     ).toBeVisible();
     await expect(
       page.getByText(
         "Remember that pasted or uploaded pre-save images stay local until note save and attachment upload both succeed; if clipboard access is blocked or no image is found, fall back to `Upload images`."
+      )
+    ).toBeVisible();
+    await expect(
+      page.getByText(
+        "If you need Codex to perform the attachment step, the chat image is discussion-only; save the real file under `/.tmp/admin-note-imports/` and give Codex the canonical note ID plus that staged file path."
+      )
+    ).toBeVisible();
+    await expect(
+      page.getByText(
+        "Codex-led staged imports should delete the local staging file after confirmed success and keep it in place if upload fails so recovery stays explicit."
       )
     ).toBeVisible();
     await expect(
@@ -195,6 +210,8 @@ test.describe("admin help center", () => {
         "On mobile, the two image actions stay visible so you do not need to remember hidden paste shortcuts."
       )
     ).toBeVisible();
-    await expect(page.getByText("Clipboard paste is blocked or image upload fails")).toBeVisible();
+    await expect(
+      page.getByText("Clipboard paste is blocked, chat image is not enough, or image upload fails")
+    ).toBeVisible();
   });
 });

--- a/tests/unit/admin-note-staged-import.test.ts
+++ b/tests/unit/admin-note-staged-import.test.ts
@@ -1,0 +1,119 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildAdminNoteAttachmentStoragePath as buildAppAttachmentStoragePath,
+  validateAdminNoteAttachment,
+} from "@/lib/admin/notes";
+import {
+  ADMIN_NOTE_ATTACHMENT_MAX_BYTES,
+  ADMIN_NOTE_IMPORT_STAGING_DIR,
+  buildAdminNoteAttachmentStoragePath as buildScriptAttachmentStoragePath,
+  buildAdminNoteVerificationUrl,
+  resolveStagedAttachmentPath,
+  validateStagedAdminNoteAttachment,
+} from "../../scripts/lib/admin-note-staged-import.mjs";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((tempRoot) =>
+      rm(tempRoot, {
+        recursive: true,
+        force: true,
+      })
+    )
+  );
+});
+
+async function createTempRepo() {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "admin-note-staged-import-"));
+  tempRoots.push(tempRoot);
+  await mkdir(path.join(tempRoot, ADMIN_NOTE_IMPORT_STAGING_DIR), { recursive: true });
+  return tempRoot;
+}
+
+describe("admin note staged import helper", () => {
+  it("matches the app attachment validation rules for supported and unsupported files", () => {
+    const pngInput = {
+      fileName: "Skjermbilde 01.PNG",
+      sizeBytes: 128_000,
+    };
+
+    const appPng = validateAdminNoteAttachment({
+      fileName: pngInput.fileName,
+      mimeType: "image/png",
+      sizeBytes: pngInput.sizeBytes,
+    });
+    expect(appPng.ok).toBe(true);
+    if (!appPng.ok) {
+      throw new Error(appPng.error);
+    }
+    expect(validateStagedAdminNoteAttachment(pngInput)).toEqual(appPng.value);
+
+    expect(() =>
+      validateStagedAdminNoteAttachment({
+        fileName: "notes.txt",
+        sizeBytes: 10,
+      })
+    ).toThrow("Only PNG, JPEG, WEBP, and GIF images are allowed.");
+
+    expect(() =>
+      validateStagedAdminNoteAttachment({
+        fileName: "huge.png",
+        sizeBytes: ADMIN_NOTE_ATTACHMENT_MAX_BYTES + 1,
+      })
+    ).toThrow("Attachments must be 5 MB or smaller.");
+  });
+
+  it("uses the same storage-path contract as the app route", () => {
+    const params = {
+      noteId: "123e4567-e89b-42d3-a456-426614174000",
+      attachmentId: "123e4567-e89b-42d3-a456-426614174111",
+      fileName: "Skjermbilde 01.PNG",
+    };
+
+    expect(buildScriptAttachmentStoragePath(params)).toBe(buildAppAttachmentStoragePath(params));
+  });
+
+  it("builds direct admin verification links for open and done notes", () => {
+    expect(
+      buildAdminNoteVerificationUrl({
+        noteId: "123E4567-E89B-42D3-A456-426614174000",
+        isDone: false,
+      })
+    ).toBe(
+      "https://freeswimming.org/admin?tab=notes&notesQuery=123e4567-e89b-42d3-a456-426614174000&notesStatus=open"
+    );
+
+    expect(
+      buildAdminNoteVerificationUrl({
+        noteId: "123e4567-e89b-42d3-a456-426614174000",
+        isDone: true,
+      })
+    ).toBe(
+      "https://freeswimming.org/admin?tab=notes&notesQuery=123e4567-e89b-42d3-a456-426614174000&notesStatus=done"
+    );
+  });
+
+  it("accepts files inside the staging directory and rejects files outside it", async () => {
+    const repoRoot = await createTempRepo();
+    const stagedFile = path.join(repoRoot, ADMIN_NOTE_IMPORT_STAGING_DIR, "capture.png");
+    const outsideFile = path.join(repoRoot, "capture.png");
+    await writeFile(stagedFile, "png");
+    await writeFile(outsideFile, "png");
+
+    await expect(
+      resolveStagedAttachmentPath(".tmp/admin-note-imports/capture.png", { repoRoot })
+    ).resolves.toMatchObject({
+      repoRelativePath: ".tmp/admin-note-imports/capture.png",
+      sizeBytes: 3,
+    });
+
+    await expect(
+      resolveStagedAttachmentPath("./capture.png", { repoRoot })
+    ).rejects.toThrow("Staged file must live under .tmp/admin-note-imports.");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a supported CLI workflow for Codex-assisted admin-note screenshot imports from `/.tmp/admin-note-imports/`, while keeping chat-pasted images interpretation-only.
- Updates admin `Help/Guide` and the admin-notes recovery runbook so operators can choose the fastest truthful path: note link + manual paste/upload, or staged-file import by note ID + file path.
- Adds coverage for the new workflow contract with a dedicated staged-import unit test and updated admin Help/Guide e2e assertions.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor policy scope changed).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-04-05-admin-notes-chat-screenshot-staging-import-10-10.md`
- Scorecard target outcomes: 12 target scorecard categories are defined in the linked brief.

## Scope

- In scope: gitignored staging path protection, staged screenshot import CLI/helper, operator wording for success/failure cleanup, and test coverage for the new workflow contract.
- Out of scope: direct binary ingestion from chat, OCR/extraction, public uploads, or storing staged screenshots in `app/` or `public/`.
- Changed files (9):
  - `.gitignore`
  - `components/admin/AdminHelpCenter.tsx`
  - `docs/runbooks/admin-notes-recovery.md`
  - `docs/task-briefs/in-progress/2026-04-05-admin-notes-chat-screenshot-staging-import-10-10.md`
  - `package.json`
  - `scripts/import-admin-note-staged-attachment.mjs`
  - `scripts/lib/admin-note-staged-import.mjs`
  - `tests/e2e/admin-help-center.spec.ts`
  - `tests/unit/admin-note-staged-import.test.ts`

## Risk

- Main risk: the service-role CLI helper could drift from the existing attachment-route contract or report cleanup ambiguities after successful upload if the local staged file cannot be deleted.
- Rollback plan: revert `9494cff` (`git revert 9494cff`) to restore the previous no-CLI attachment workflow and prior operator wording.

## Test Evidence

- `npm run verify:pre-pr`: **PASS** for `9494cff` in `/tmp/freeswimming-admin-notes-chat-staging-2026-04-06`.
- `npm run verify:pre-merge`: **PASS** for `9494cff` (`artifacts/verify-pre-merge/20260406-025151.json`, private-gate step skipped because `SITE_LOCK_ENABLED!=1`).
- Additional targeted checks:
  - `npm run lint:briefs:all`: **PASS**
  - `npx vitest run tests/unit/admin-note-staged-import.test.ts`: **PASS**
  - `npm run typecheck`: **PASS**
  - `npx playwright test tests/e2e/admin-help-center.spec.ts --project=desktop-chromium`: **PASS**
  - `npm run admin:notes:import-staged -- --help`: **PASS**
- Key verify summary:
  - `689` unit tests passed.
  - `95` Playwright tests passed and `319` were intentionally skipped by project/runtime guards.
  - `build` and perf budgets passed inside `npm run verify:pre-pr`.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added
