### PR TITLE
Clarify pool swim builder field parity

### DIFF
--- a/components/my-library/workouts/CreateManualWorkoutButton.tsx
+++ b/components/my-library/workouts/CreateManualWorkoutButton.tsx
@@ -74,7 +74,6 @@ export default function CreateManualWorkoutButton({
       }
 
       router.push(buildWorkoutHref(responseBody.workout.id));
-      router.refresh();
     } catch {
       setError(
         builderMode === "pool"

--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -122,6 +122,8 @@ type PendingRemoval =
       label: string;
     };
 
+const MANUAL_POOL_SIZE_QUICK_CHOICES = [25, 50] as const;
+
 type LastRemovedBlock = {
   kind: "step" | "repeat";
   label: string;
@@ -219,33 +221,53 @@ function parseSignatureValues(value: string) {
   return value.split("|");
 }
 
-function buildStepStrokeGuidance(step: SessionDraftStep) {
+function buildStepStrokeGuidance(step: SessionDraftStep, isManualPoolMode: boolean) {
   const recommendedFocus = getRecommendedStepFocus(step);
+  const drillTypeLabel = isManualPoolMode ? "Drill type" : "Focus tag";
 
   if (step.category === "kick") {
-    return "Kick category already tags this as kick work. Use Stroke pattern for the movement pattern this set supports, and change Focus tag only when you need extra kick, pull, or drill notation.";
+    return `Kick category already tags this as kick work. Use Stroke pattern for the movement pattern this set supports, and change ${drillTypeLabel} only when you need extra kick, pull, or drill notation.`;
   }
 
   if (step.category === "drill" || step.stroke === "drill") {
-    return "Drill shell is active. Use Stroke pattern for the base movement, and use Focus tag to clarify whether the drill is general, kick, or pull.";
+    return `Drill shell is active. Use Stroke pattern for the base movement, and use ${drillTypeLabel} to clarify whether the drill is general, kick, or pull.`;
   }
 
   return recommendedFocus
-    ? `This step already suggests the ${getSessionStepDrillTypeLabel(recommendedFocus)} focus tag. Keep it unless you need a different drill, kick, or pull note.`
-    : "Use Stroke pattern for the swim pattern. Add Focus tag only when the step needs extra drill, kick, or pull notation.";
+    ? `This step already suggests the ${getSessionStepDrillTypeLabel(recommendedFocus)} ${drillTypeLabel.toLowerCase()}. Keep it unless you need a different drill, kick, or pull note.`
+    : `Use Stroke pattern for the swim pattern. Add ${drillTypeLabel} only when the step needs extra drill, kick, or pull notation.`;
 }
 
-function buildStepFocusGuidance(step: SessionDraftStep) {
+function buildStepFocusGuidance(step: SessionDraftStep, isManualPoolMode: boolean) {
   const recommendedFocus = getRecommendedStepFocus(step);
+  const drillTypeLabel = isManualPoolMode ? "Drill type" : "Focus tag";
   if (recommendedFocus === "kick") {
-    return "Recommended Focus tag: Kick. Change it only when this kick set needs a more specific drill or pull note.";
+    return `Recommended ${drillTypeLabel}: Kick. Change it only when this kick set needs a more specific drill or pull note.`;
   }
 
   if (recommendedFocus === "drill") {
-    return "Recommended Focus tag: Drill. Switch it to Kick or Pull only when this drill set needs that extra label.";
+    return `Recommended ${drillTypeLabel}: Drill. Switch it to Kick or Pull only when this drill set needs that extra label.`;
   }
 
-  return "Optional. Leave Focus tag on None unless the step needs extra drill, kick, or pull notation.";
+  return `Optional. Leave ${drillTypeLabel} on None unless the step needs extra drill, kick, or pull notation.`;
+}
+
+function getStepDurationModeEditorLabel(
+  value: SessionDraftStepDurationMode,
+  isManualPoolMode: boolean
+) {
+  if (!isManualPoolMode) {
+    return getSessionStepDurationModeLabel(value);
+  }
+
+  switch (value) {
+    case "fixed_rest":
+      return "Rest time";
+    case "lap_button":
+      return "Open swim";
+    default:
+      return getSessionStepDurationModeLabel(value);
+  }
 }
 
 function getRecommendedStepFocus(
@@ -560,6 +582,9 @@ export default function WorkoutEditor({
   const [poolLengthInput, setPoolLengthInput] = useState(() =>
     formatEditablePoolLength(draft.poolLengthM)
   );
+  const [poolSizeExplicitlyUnspecified, setPoolSizeExplicitlyUnspecified] = useState(
+    () => draft.environment === "pool" && draft.poolLengthM === null
+  );
   const [pendingRemoval, setPendingRemoval] = useState<PendingRemoval | null>(null);
   const [lastRemovedBlock, setLastRemovedBlock] = useState<LastRemovedBlock | null>(null);
   const [workoutPdfNotice, setWorkoutPdfNotice] = useState("");
@@ -619,6 +644,11 @@ export default function WorkoutEditor({
         };
   const poolLengthUsesPreset =
     typeof draft.poolLengthM === "number" && isSessionDraftPoolLengthPreset(draft.poolLengthM);
+  const parsedPoolLengthInput = parsePoolLengthInput(poolLengthInput);
+  const poolSizeInputInvalid =
+    draft.environment === "pool" &&
+    !poolSizeExplicitlyUnspecified &&
+    (poolLengthInput.trim().length === 0 || parsedPoolLengthInput === null);
   const handoffDraftState: WorkoutHandoffDraftState =
     savedWorkout && !hasUnsavedChanges ? "canonical" : "local_draft";
   const garminReadyExport = buildWorkoutGarminReadyExport(draft, {
@@ -654,19 +684,27 @@ export default function WorkoutEditor({
     selectedPoolsideFocusIds
   );
   const selectedPoolsideFocusSignature = selectedPoolsideFocusTitles.join("|");
-  const metadataSummary = buildSessionTargetSummary({
-    ...draft,
-    totalDistanceM: draftTotals.totalDistanceM ?? draft.totalDistanceM,
-    estimatedDurationMin: draftTotals.estimatedDurationMin ?? draft.estimatedDurationMin,
-  });
+  const metadataSummary = isManualPoolMode
+    ? [
+        draftTotals.totalDistanceM ? `${draftTotals.totalDistanceM}m` : null,
+        draftTotals.estimatedDurationMin ? `~${draftTotals.estimatedDurationMin} min` : null,
+        draft.poolLengthM === null ? "Pool size unspecified" : formatPoolLengthLabel(draft.poolLengthM),
+      ]
+        .filter(Boolean)
+        .join(" · ")
+    : buildSessionTargetSummary({
+        ...draft,
+        totalDistanceM: draftTotals.totalDistanceM ?? draft.totalDistanceM,
+        estimatedDurationMin: draftTotals.estimatedDurationMin ?? draft.estimatedDurationMin,
+      });
   const manualMetadataProfileSummary = `${getSessionTypeLabel(draft.sessionType)} · ${getSessionEffortLabel(draft.effort)}`;
   const metadataHeading = isManualPoolMode
-    ? "Build your pool session"
+    ? "Pool Swim"
     : isManualOpenWaterMode
       ? "Build your open water session"
       : "Build your swim session";
   const collapsedMetadataCopy = isManualPoolMode
-    ? "Open when you want to change the title, session note, pool size, strokes, or equipment."
+    ? "Open when you want to change the title, session note, or pool size."
     : isManualOpenWaterMode
       ? "Open when you want to change the title, session note, strokes, or equipment."
       : "Open when you want to change the title, session note, environment, strokes, or equipment.";
@@ -754,7 +792,8 @@ export default function WorkoutEditor({
 
   useEffect(() => {
     setPoolLengthInput(formatEditablePoolLength(draft.poolLengthM));
-  }, [draft.poolLengthM]);
+    setPoolSizeExplicitlyUnspecified(draft.environment === "pool" && draft.poolLengthM === null);
+  }, [draft.environment, draft.poolLengthM]);
 
   useEffect(() => {
     if (openStepId && !draft.steps.some((step) => step.id === openStepId)) {
@@ -1290,9 +1329,23 @@ export default function WorkoutEditor({
 
   function updateDraftPoolLengthInput(nextValue: string) {
     setPoolLengthInput(nextValue);
+    setPoolSizeExplicitlyUnspecified(false);
+
+    const trimmed = nextValue.trim();
+    if (trimmed.length === 0) {
+      return;
+    }
 
     const parsed = parsePoolLengthInput(nextValue);
-    updateDraft("poolLengthM", parsed);
+    if (parsed !== null) {
+      updateDraft("poolLengthM", parsed);
+    }
+  }
+
+  function chooseUnspecifiedPoolSize() {
+    setPoolSizeExplicitlyUnspecified(true);
+    setPoolLengthInput("");
+    updateDraft("poolLengthM", null);
   }
 
   function togglePoolsideFocusSelection(focusId: string) {
@@ -1546,7 +1599,7 @@ export default function WorkoutEditor({
             </label>
 
             <label className="text-sm text-slate-700">
-              Category
+              {isManualPoolMode ? "Step type" : "Category"}
               <select
                 value={step.category}
                 onChange={(event) =>
@@ -1591,7 +1644,7 @@ export default function WorkoutEditor({
             </label>
 
             <label className="text-sm text-slate-700">
-              Focus tag
+              {isManualPoolMode ? "Drill type" : "Focus tag"}
               <select
                 value={step.drillType ?? "none"}
                 onChange={(event) =>
@@ -1611,8 +1664,12 @@ export default function WorkoutEditor({
               </select>
             </label>
 
-            <p className="text-sm text-slate-500 md:col-span-2">{buildStepStrokeGuidance(step)}</p>
-            <p className="text-sm text-slate-500 md:col-span-2">{buildStepFocusGuidance(step)}</p>
+            <p className="text-sm text-slate-500 md:col-span-2">
+              {buildStepStrokeGuidance(step, isManualPoolMode)}
+            </p>
+            <p className="text-sm text-slate-500 md:col-span-2">
+              {buildStepFocusGuidance(step, isManualPoolMode)}
+            </p>
 
             <label className="text-sm text-slate-700">
               Equipment
@@ -1670,7 +1727,7 @@ export default function WorkoutEditor({
               >
                 {SESSION_DRAFT_STEP_DURATION_MODES.map((value) => (
                   <option key={value} value={value}>
-                    {getSessionStepDurationModeLabel(value)}
+                    {getStepDurationModeEditorLabel(value, isManualPoolMode)}
                   </option>
                 ))}
               </select>
@@ -1804,7 +1861,9 @@ export default function WorkoutEditor({
               </label>
             ) : (
               <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4 text-sm text-slate-600">
-                This step stays open until the swimmer advances with the lap button.
+                {isManualPoolMode
+                  ? "This is an open swim step. It stays open until the swimmer advances with the lap button."
+                  : "This step stays open until the swimmer advances with the lap button."}
               </div>
             )}
 
@@ -1944,7 +2003,7 @@ export default function WorkoutEditor({
             </label>
 
             <label className="text-sm text-slate-700 md:col-span-2">
-              Notes
+              {isManualPoolMode ? "Step note" : "Notes"}
               <textarea
                 value={step.notes}
                 onChange={(event) =>
@@ -2100,14 +2159,20 @@ export default function WorkoutEditor({
 
       {draft.environment === "pool" ? (
         <div className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700 md:col-span-2">
-          <p className="text-sm font-medium text-slate-900">Pool length</p>
+          <p className="text-sm font-medium text-slate-900">
+            {isManualPoolMode ? "Pool Size" : "Pool length"}
+          </p>
           <p className="mt-1 text-xs text-slate-500">
-            Choose 12.5m, 25m, or 50m, or type the exact length when you build for a less common
-            setup.
+            {isManualPoolMode
+              ? "Choose 25m, 50m, or Unspecified. Use the exact field only when you need a less common pool size."
+              : "Choose 12.5m, 25m, or 50m, or type the exact length when you build for a less common setup."}
           </p>
 
           <div className="mt-3 flex flex-wrap gap-2">
-            {SESSION_DRAFT_POOL_LENGTH_PRESETS.map((value) => {
+            {(isManualPoolMode
+              ? MANUAL_POOL_SIZE_QUICK_CHOICES
+              : SESSION_DRAFT_POOL_LENGTH_PRESETS
+            ).map((value) => {
               const isSelected = draft.poolLengthM === value;
               return (
                 <button
@@ -2124,10 +2189,24 @@ export default function WorkoutEditor({
                 </button>
               );
             })}
+
+            {isManualPoolMode ? (
+              <button
+                type="button"
+                onClick={chooseUnspecifiedPoolSize}
+                className={`inline-flex h-10 items-center justify-center rounded-full border px-3 text-sm transition ${
+                  draft.poolLengthM === null
+                    ? "border-blue-600 bg-blue-50 text-blue-700"
+                    : "border-slate-200 bg-white text-slate-700 hover:bg-slate-100"
+                }`}
+              >
+                Unspecified
+              </button>
+            ) : null}
           </div>
 
           <label className="mt-4 block text-sm text-slate-700">
-            Exact pool length (m)
+            {isManualPoolMode ? "Exact pool size (m)" : "Exact pool length (m)"}
             <input
               type="text"
               inputMode="decimal"
@@ -2139,58 +2218,73 @@ export default function WorkoutEditor({
           </label>
 
           <p className="mt-2 text-xs text-slate-500">
-            Supported range: {formatPoolLengthLabel(SESSION_DRAFT_POOL_LENGTH_MIN)} to{" "}
-            {formatPoolLengthLabel(SESSION_DRAFT_POOL_LENGTH_MAX)}.{" "}
-            {poolLengthUsesPreset
-              ? "Preset selected."
-              : draft.poolLengthM
-                ? `Custom length saved as ${formatPoolLengthLabel(draft.poolLengthM)}.`
-                : "Enter a valid pool length before saving."}
+            {poolSizeInputInvalid ? (
+              <>
+                Enter a valid pool size between {formatPoolLengthLabel(SESSION_DRAFT_POOL_LENGTH_MIN)}{" "}
+                and {formatPoolLengthLabel(SESSION_DRAFT_POOL_LENGTH_MAX)}, or choose Unspecified.
+              </>
+            ) : (
+              <>
+                Supported range: {formatPoolLengthLabel(SESSION_DRAFT_POOL_LENGTH_MIN)} to{" "}
+                {formatPoolLengthLabel(SESSION_DRAFT_POOL_LENGTH_MAX)}.{" "}
+                {draft.poolLengthM === null
+                  ? isManualPoolMode
+                    ? "Unspecified selected."
+                    : "Enter a valid pool length before saving."
+                  : poolLengthUsesPreset
+                    ? "Preset selected."
+                    : `Custom length saved as ${formatPoolLengthLabel(draft.poolLengthM)}.`}
+              </>
+            )}
           </p>
         </div>
       ) : null}
 
-      {isManualMetadataMode ? manualMetadataProfileFields : effortField}
+      {isManualPoolMode ? null : isManualMetadataMode ? manualMetadataProfileFields : effortField}
 
-      <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 md:col-span-2">
-        <legend className="px-1 text-sm font-semibold text-slate-900">Session strokes</legend>
-        <div className="mt-3 flex flex-wrap gap-3">
-          {SESSION_GENERATOR_STROKES.map((stroke) => (
-            <label key={stroke} className="inline-flex items-center gap-2 text-sm text-slate-700">
-              <input
-                type="checkbox"
-                checked={draft.allowedStrokes.includes(stroke)}
-                onChange={() => toggleDraftStroke(stroke)}
-                disabled={stepUsesAllowedStroke(stroke)}
-              />
-              {getSessionStrokeLabel(stroke)}
-            </label>
-          ))}
-        </div>
-        <p className="mt-3 text-xs text-slate-500">
-          Strokes already used on a step stay selected here until those steps change.
-        </p>
-      </fieldset>
+      {isManualPoolMode ? null : (
+        <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 md:col-span-2">
+          <legend className="px-1 text-sm font-semibold text-slate-900">Session strokes</legend>
+          <div className="mt-3 flex flex-wrap gap-3">
+            {SESSION_GENERATOR_STROKES.map((stroke) => (
+              <label key={stroke} className="inline-flex items-center gap-2 text-sm text-slate-700">
+                <input
+                  type="checkbox"
+                  checked={draft.allowedStrokes.includes(stroke)}
+                  onChange={() => toggleDraftStroke(stroke)}
+                  disabled={stepUsesAllowedStroke(stroke)}
+                />
+                {getSessionStrokeLabel(stroke)}
+              </label>
+            ))}
+          </div>
+          <p className="mt-3 text-xs text-slate-500">
+            Strokes already used on a step stay selected here until those steps change.
+          </p>
+        </fieldset>
+      )}
 
-      <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 md:col-span-2">
-        <legend className="px-1 text-sm font-semibold text-slate-900">Equipment</legend>
-        <div className="mt-3 flex flex-wrap gap-3">
-          {SESSION_GENERATOR_EQUIPMENT.map((item) => (
-            <label key={item} className="inline-flex items-center gap-2 text-sm text-slate-700">
-              <input
-                type="checkbox"
-                checked={draft.equipmentAllowlist.includes(item)}
-                onChange={() => toggleDraftEquipment(item)}
-                disabled={stepUsesEquipment(item)}
-              />
-              {getSessionEquipmentLabel(item)}
-            </label>
-          ))}
-        </div>
-        <p className="mt-3 text-xs text-slate-500">
-          Equipment used on a step stays selected here until those step details change.
-        </p>
-      </fieldset>
+      {isManualPoolMode ? null : (
+        <fieldset className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 md:col-span-2">
+          <legend className="px-1 text-sm font-semibold text-slate-900">Equipment</legend>
+          <div className="mt-3 flex flex-wrap gap-3">
+            {SESSION_GENERATOR_EQUIPMENT.map((item) => (
+              <label key={item} className="inline-flex items-center gap-2 text-sm text-slate-700">
+                <input
+                  type="checkbox"
+                  checked={draft.equipmentAllowlist.includes(item)}
+                  onChange={() => toggleDraftEquipment(item)}
+                  disabled={stepUsesEquipment(item)}
+                />
+                {getSessionEquipmentLabel(item)}
+              </label>
+            ))}
+          </div>
+          <p className="mt-3 text-xs text-slate-500">
+            Equipment used on a step stays selected here until those step details change.
+          </p>
+        </fieldset>
+      )}
     </div>
   );
 
@@ -2916,8 +3010,7 @@ export default function WorkoutEditor({
                       )}
                     </p>
                     <p className="mt-1 text-xs text-slate-600">
-                      Garmin-familiar starter scaffold: edit the repeated steps below instead of
-                      duplicating every round by hand.
+                      Edit the repeated steps below instead of duplicating every round by hand.
                     </p>
                     <p className="mt-1 text-xs text-slate-500">
                       Repeat counts currently support {SESSION_DRAFT_REPEAT_MIN}-
@@ -3083,6 +3176,7 @@ export default function WorkoutEditor({
             disabled={
               isSaving ||
               !canonicalSaveReady ||
+              poolSizeInputInvalid ||
               pendingRemoval !== null ||
               (savedWorkout ? !hasUnsavedChanges : false)
             }

--- a/docs/task-briefs/in-progress/2026-04-06-pool-swim-builder-field-parity-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-06-pool-swim-builder-field-parity-10-10.md
@@ -107,7 +107,7 @@ Critical target categories for `10/10` claim in this brief:
 | Admin editor ergonomics                       | `supporting` | Supporting only: the owner can still inspect and repeatedly edit canonical pool workouts without missing critical authoring controls.                                  | manual QA                                 |
 | Performance (CWV + payloads)                  | `supporting` | Supporting only: pool field cleanup does not materially regress `/my-library` or workout-detail responsiveness.                                                        | targeted review + verify                  |
 | Data placement and sync boundaries            | `target`     | The slice continues to write through the existing canonical workout contract and treats `poolLengthM: null` as an intentional server-canonical state for pool mode.   | brief contract + code review              |
-| Caching and invalidation strategy             | `supporting` | Supporting only: pool field cleanup keeps existing `router.refresh` and canonical save flows intact.                                                                   | code review                               |
+| Caching and invalidation strategy             | `supporting` | Supporting only: pool field cleanup preserves canonical route transitions and save invalidation without requiring an extra create-time refresh that can race navigation. | code review + targeted e2e                |
 | Reliability and failure handling              | `target`     | Invalid custom pool size input fails clearly, while `Unspecified` remains a deliberate valid state instead of looking like missing data or a broken save.             | negative-path tests + manual QA           |
 | Security and authz                            | `supporting` | Supporting only: no changed route or API weakens authenticated owner-only workout access.                                                                              | existing auth boundaries + scope review   |
 | Privacy and compliance                        | `N/A`        | N/A because this slice changes private workout-builder labels and field visibility only, not personal-data handling or public disclosure.                              | explicit scope rationale                  |
@@ -143,7 +143,8 @@ Critical target categories for `10/10` claim in this brief:
   - no new sensitive data class is added
   - this slice changes authoring semantics only
 - Cache/invalidation:
-  - existing navigation, refresh, and canonical save boundaries remain authoritative
+  - existing canonical save boundaries remain authoritative
+  - create-time entry now relies on route transition instead of an immediate extra refresh so navigation cannot be raced back to `/my-library`
 
 ## Identity And Rename Contract
 
@@ -245,3 +246,4 @@ Critical target categories for `10/10` claim in this brief:
 
 - `2026-04-06 | in progress | created follow-up pool parity brief for field/wording cleanup after PR #370/#371 closed the entry split and moved it to in-progress | next: implement pool-only field parity and validate locally`
 - `2026-04-06 | implementation + targeted validation | manual pool builder now presents Pool Swim / Pool Size with explicit Unspecified handling, hides non-parity top-level pool metadata, uses Garmin-style pool step wording, and keeps shared summaries truthful for unspecified pool size; passed npm run typecheck, targeted vitest, targeted desktop-chromium Playwright, and npm run lint:briefs:all | next: commit this slice, rerun npm run verify:pre-pr on the committed diff, then open the PR`
+- `2026-04-06 | checkpoint 5dd1922 + full gate | follow-up race fix removed create-time refresh from the manual workout entry so full-matrix Playwright no longer stalls on /my-library after a successful create; passed npm run verify:pre-pr with 96 passed / 318 skipped | next: push branch, open PR, and monitor CI`

--- a/docs/task-briefs/in-progress/2026-04-06-pool-swim-builder-field-parity-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-06-pool-swim-builder-field-parity-10-10.md
@@ -1,0 +1,247 @@
+# Task Brief: Pool Swim Builder Field Parity (10/10)
+
+## Metadata
+
+- `id`: `2026-04-06-pool-swim-builder-field-parity-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-04-06`
+- `updated`: `2026-04-06`
+
+## Goal
+
+FreeSwimming's manual `pool` builder looks and reads like a dedicated Garmin-style `Pool Swim` authoring surface at the field level, while `open water` keeps its separate non-parity flow.
+
+## Why This Brief Exists
+
+- The first parity slice already split manual entry into separate `Build pool session` and `Build open water session` actions.
+- The next most visible mismatch is no longer route structure; it is the field model and wording inside the pool builder itself.
+- Current manual `pool` editing still exposes generic FreeSwimming concepts that Garmin pool authoring does not emphasize in the same way:
+  - `Training profile`
+  - top-level `Session strokes`
+  - top-level `Equipment`
+  - `Pool length` wording instead of `Pool Size`
+  - generic step labels like `Category`, `Focus tag`, and `Notes`
+- Garmin support material for pool workouts explicitly documents pool-workout-oriented wording and choices such as:
+  - `Pool Swim`
+  - `Pool Size`
+  - `Unspecified`
+  - `Open Swim Steps`
+  - `Send-off Time`
+  - `Add Step Note`
+- This slice deliberately stops before repeat/rest parity so the field model can be tightened without combining deep builder logic changes into the same PR.
+
+## Dependencies And Boundaries
+
+- Parent parity direction:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-06-pool-swim-builder-garmin-parity-10-10.md`
+- Broader active builder parent:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md`
+- Likely implementation surfaces:
+  - `/Users/stianvikra/freeswimming/components/my-library/workouts/WorkoutEditor.tsx`
+  - `/Users/stianvikra/freeswimming/lib/session-generator-v1/shared.ts`
+  - `/Users/stianvikra/freeswimming/lib/workouts/manual.ts`
+  - `/Users/stianvikra/freeswimming/lib/workouts/shared.ts`
+  - `/Users/stianvikra/freeswimming/tests/unit/workout-builder-hub.test.tsx`
+  - `/Users/stianvikra/freeswimming/tests/unit/workouts-shared.test.ts`
+  - `/Users/stianvikra/freeswimming/tests/e2e/my-library-workout-builder.spec.ts`
+
+## Product Direction Locked By This Brief
+
+- `Pool` remains the only Garmin-parity target in the manual swim builder.
+- `Open water` remains visually and behaviorally separate and is not pulled into pool wording.
+- This slice changes visible pool-builder fields and copy before deeper repeat/rest semantics.
+- Hidden non-parity metadata may remain in the canonical draft model temporarily if:
+  - it is not shown in the manual pool UI,
+  - persistence/export stays deterministic,
+  - later slices can still remove or remap it safely.
+
+## Field-Parity Decisions Locked By This Slice
+
+1. Pool heading and framing:
+   - manual `pool` builder should present itself as `Pool Swim`, not a generic swim form.
+2. Pool size wording:
+   - `Pool length` becomes `Pool Size` in pool mode.
+   - pool quick choices should prioritize Garmin-like choices:
+     - `25m`
+     - `50m`
+     - `Unspecified`
+   - uncommon/custom pool sizes may remain available through an exact input for compatibility.
+3. Unspecified pool size:
+   - manual pool workouts may save with `poolLengthM: null`.
+   - summaries and handoff/export text must stay truthful when pool size is unspecified.
+4. Pool-only top-level cleanup:
+   - remove `Training profile` from manual pool UI.
+   - remove top-level `Session strokes` from manual pool UI.
+   - remove top-level `Equipment` from manual pool UI.
+   - leave existing open-water/general behavior alone unless a shared label change is clearly better everywhere.
+5. Step wording:
+   - `Category` becomes `Step type`.
+   - `Focus tag` becomes `Drill type`.
+   - `Notes` becomes `Step note`.
+   - `Lap button press` becomes `Open swim`.
+   - `Fixed rest` becomes `Rest time`.
+6. Explicit deferral:
+   - do not implement Garmin repeat/final-rest semantics in this slice.
+   - do not claim full parity after this slice alone.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `Product goals and IA`
+- `UX flow clarity`
+- `Business logic correctness and data integrity`
+- `Reliability and failure handling`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                                          | Evidence                                  |
+| --------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| Product goals and IA                          | `target`     | Manual `pool` editing reads as a dedicated `Pool Swim` flow and no longer exposes the most confusing non-Garmin top-level controls.                                   | manual QA + targeted tests                |
+| UX flow clarity                               | `target`     | A swimmer editing a pool workout can find `Pool Size`, understand `Unspecified`, and edit step fields without mentally translating generic FreeSwimming labels.        | manual QA + e2e                           |
+| Accessibility (a11y)                          | `target`     | Renamed pool controls remain keyboard reachable, keep explicit labels, and preserve form semantics for `Pool Size`, `Unspecified`, and the renamed step fields.       | targeted tests + manual QA                |
+| Visual design quality                         | `target`     | The pool metadata panel feels intentionally simplified rather than like a generic builder with hidden leftovers.                                                       | screenshot review + manual QA             |
+| Business logic correctness and data integrity | `target`     | Pool workouts save/load deterministically with either explicit or unspecified pool size, and hidden pool metadata does not corrupt canonical workout payloads.         | unit tests + integration review           |
+| Admin editor ergonomics                       | `supporting` | Supporting only: the owner can still inspect and repeatedly edit canonical pool workouts without missing critical authoring controls.                                  | manual QA                                 |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: pool field cleanup does not materially regress `/my-library` or workout-detail responsiveness.                                                        | targeted review + verify                  |
+| Data placement and sync boundaries            | `target`     | The slice continues to write through the existing canonical workout contract and treats `poolLengthM: null` as an intentional server-canonical state for pool mode.   | brief contract + code review              |
+| Caching and invalidation strategy             | `supporting` | Supporting only: pool field cleanup keeps existing `router.refresh` and canonical save flows intact.                                                                   | code review                               |
+| Reliability and failure handling              | `target`     | Invalid custom pool size input fails clearly, while `Unspecified` remains a deliberate valid state instead of looking like missing data or a broken save.             | negative-path tests + manual QA           |
+| Security and authz                            | `supporting` | Supporting only: no changed route or API weakens authenticated owner-only workout access.                                                                              | existing auth boundaries + scope review   |
+| Privacy and compliance                        | `N/A`        | N/A because this slice changes private workout-builder labels and field visibility only, not personal-data handling or public disclosure.                              | explicit scope rationale                  |
+| Content governance                            | `target`     | Garmin-like wording changes in pool mode stay centralized and documented so the product does not drift into undocumented half-parity copy.                             | brief decisions + code review             |
+| Admin workflow and editability                | `target`     | Pool builders can complete normal authoring without relying on hidden meaning in `Training profile`, `Session strokes`, or generic field names.                       | manual QA + targeted tests                |
+| SEO and crawlability                          | `N/A`        | N/A because authenticated My Library builder routes are private and uncrawlable by design.                                                                             | explicit scope rationale                  |
+| AI discoverability                            | `N/A`        | N/A because this slice changes no public AI-facing route, metadata, or discoverability contract.                                                                       | explicit scope rationale                  |
+| Analytics and KPI observability               | `supporting` | Supporting only: the pool/open-water split remains interpretable after field renames even without new analytics vendor instrumentation.                                | scope review                              |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, checkout, entitlement, or billing/reporting workflow changes.                                                                                  | explicit scope rationale                  |
+| Incident response and support operations      | `N/A`        | N/A because this slice does not change the builder entry actions or recovery path; no Help/Guide or runbook contract currently references the renamed internal fields. | explicit scope rationale                  |
+| Finance and reporting operations              | `N/A`        | N/A because no finance reconciliation, reporting, payouts, or subscription operations are touched.                                                                     | explicit scope rationale                  |
+| i18n operational readiness                    | `N/A`        | N/A because this slice adjusts internal English product copy only, but it must keep wording centralized rather than embedding semantics in scattered strings.          | explicit scope rationale                  |
+| Stack-fit and dependency discipline           | `target`     | Reuse the current workout stack and canonical draft model; do not add a second persistence layer or new dependency just to rename/hide pool fields.                    | dependency diff + architecture review     |
+| Testing and QA automation                     | `target`     | Coverage protects pool-only field visibility, `Unspecified` save/load behavior, and the key wording updates before PR update.                                         | unit/e2e coverage + `verify:pre-pr`       |
+| Scalability and cost efficiency               | `supporting` | Supporting only: field cleanup should reduce authoring friction without adding extra API churn or duplicate builder paths.                                             | code review + manual QA                   |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: this slice remains reversible without schema migration or destructive data backfill.                                                                   | diff review + rollback note               |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - `workout.id`
+  - canonical workout rows and saved draft payloads in the workouts table
+  - persisted `environment`, `poolLengthM`, step fields, and export/handoff payloads
+- Local-only:
+  - metadata panel open/closed state
+  - transient pool-size input text while the user types
+  - local validation and helper messaging
+- Sync policy:
+  - saves continue through the existing authenticated workout update/create flow
+  - `poolLengthM: null` is an intentional canonical value for pool workouts when the user chooses `Unspecified`
+  - field visibility changes do not create a second hidden draft entity
+- Retention and sensitivity:
+  - no new sensitive data class is added
+  - this slice changes authoring semantics only
+- Cache/invalidation:
+  - existing navigation, refresh, and canonical save boundaries remain authoritative
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - `workout.id` remains the only canonical identity.
+- Human-readable identifiers:
+  - labels such as `Pool Swim`, `Pool Size`, `Unspecified`, `Step type`, and `Step note` are mutable UI labels, not identifiers.
+- Mutability rules:
+  - workout titles remain editable in place
+  - pool-builder copy can change in place
+- Rename vs repurpose policy:
+  - this slice renames visible fields only; it does not create a new workout entity or repurpose saved IDs
+- Compatibility contract:
+  - older saved workouts that still contain session-type/effort/stroke allowlist metadata must continue to load safely
+  - hidden metadata may remain persisted until a later schema/model cleanup slice removes or remaps it explicitly
+- Observability and repair:
+  - invalid custom pool size input must surface clear save validation instead of silently coercing to a misleading value
+
+## Scope
+
+- Manual pool-builder metadata heading/copy cleanup
+- `Pool Size` wording and `Unspecified` state
+- Pool-only hiding of non-parity top-level metadata sections
+- Pool step-label wording cleanup where Garmin terminology is already documented
+- Truthful summary/handoff/export wording for unspecified pool size
+- Relevant unit + e2e coverage
+
+## Out Of Scope
+
+- Garmin repeat/final-rest behavior
+- Step-count cap enforcement
+- Yard-mode support
+- Open-water builder redesign
+- AI generator redesign
+- Schema migration or destructive data cleanup
+
+## Acceptance Criteria
+
+1. Manual pool editing surfaces itself as a dedicated `Pool Swim` builder.
+2. Manual pool builder shows `Pool Size` and offers `25m`, `50m`, and `Unspecified` quick choices.
+3. Manual pool workouts can save and reload with `poolLengthM: null` when `Unspecified` is chosen.
+4. Manual pool builder no longer shows top-level `Training profile`, `Session strokes`, or `Equipment`.
+5. Pool step editing uses the updated wording for `Step type`, `Drill type`, `Step note`, `Open swim`, and `Rest time`.
+6. Open-water builder behavior stays functionally unchanged.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run typecheck`
+- targeted `vitest` for workout builder/shared contracts
+- targeted Playwright for `/my-library/workouts`
+- `npm run verify:pre-pr`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm must be available on the machine used for validation.
+- Before PR handoff:
+  - `npm run lint:briefs`
+  - `npm run verify:pre-pr`
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3100/my-library`
+  - desktop Chromium during implementation
+- Vercel preview:
+  - PR preview URL from checks
+- Recommended follow-up matrix:
+  - desktop Chrome
+  - desktop Safari/WebKit
+  - iPhone Safari viewport
+
+## Constraints
+
+- Preserve the existing canonical workout data model for this slice.
+- Prefer pool-only UI specialization over broad shared-form rewrites.
+- Do not hide a field in pool mode unless the remaining persistence/export behavior stays deterministic.
+- Do not claim full Garmin parity in PR copy; this is a field/wording slice only.
+
+## 10/10 Quality Bar
+
+- Pool mode should feel obviously more specific and calmer than the current generic swim builder.
+- Required states stay clear:
+  - loading: unchanged existing builder loading state remains intact
+  - empty: new pool drafts still open into an editable first-step state
+  - error: invalid pool size save attempts explain the fix
+  - retry: save retry path remains unchanged
+  - offline: existing save failure UI remains truthful
+- Accessibility:
+  - renamed controls keep clear labels and keyboard access
+  - `Unspecified` pool-size action is discoverable and screen-reader legible
+- Performance:
+  - no material route-level regression on `/my-library` or workout detail
+- Business logic:
+  - `poolLengthM: null` is intentional, not a malformed state
+  - hidden pool metadata does not create silent drift in saved workouts
+
+## Checkpoint Log
+
+- `2026-04-06 | in progress | created follow-up pool parity brief for field/wording cleanup after PR #370/#371 closed the entry split and moved it to in-progress | next: implement pool-only field parity and validate locally`
+- `2026-04-06 | implementation + targeted validation | manual pool builder now presents Pool Swim / Pool Size with explicit Unspecified handling, hides non-parity top-level pool metadata, uses Garmin-style pool step wording, and keeps shared summaries truthful for unspecified pool size; passed npm run typecheck, targeted vitest, targeted desktop-chromium Playwright, and npm run lint:briefs:all | next: commit this slice, rerun npm run verify:pre-pr on the committed diff, then open the PR`

--- a/lib/workouts/shared.ts
+++ b/lib/workouts/shared.ts
@@ -1873,10 +1873,6 @@ export function normalizeSessionDraftForWorkoutPersistence(
 
   const poolLengthM = input.environment === "pool" ? normalizePoolLength(input.poolLengthM) : null;
 
-  if (input.environment === "pool" && poolLengthM === null) {
-    return { ok: false, error: "Choose a supported pool length before saving." };
-  }
-
   if (!SESSION_GENERATOR_SESSION_TYPES.includes(input.sessionType)) {
     return { ok: false, error: "Choose a supported session type before saving." };
   }
@@ -2427,6 +2423,10 @@ type WorkoutHandoffGroup =
 function buildWorkoutEnvironmentSummary(draft: SessionDraft) {
   if (draft.environment !== "pool") {
     return getSessionEnvironmentLabel(draft.environment);
+  }
+
+  if (draft.poolLengthM === null) {
+    return `${getSessionEnvironmentLabel(draft.environment)} (Unspecified)`;
   }
 
   const poolLength =

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -110,23 +110,27 @@ test.describe("my library workout builder", () => {
     await expect(page.getByTestId("workout-builder-create-pool")).toHaveCount(0);
     await expect(page.getByTestId("workout-builder-create-open-water")).toHaveCount(0);
     await expect(page.getByTestId("session-draft-title")).toBeVisible();
-    await expect(page.getByText("Build your pool session")).toBeVisible();
+    await expect(page.getByText("Pool Swim")).toBeVisible();
     await expect(page.getByText("Session note")).toBeVisible();
-    await expect(page.getByText("Pool length", { exact: true })).toBeVisible();
+    await expect(page.getByText("Pool Size", { exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Unspecified" })).toBeVisible();
     await expect(page.getByRole("group", { name: "Environment" })).toHaveCount(0);
-    await expect(page.getByTestId("workout-editor-metadata-profile-summary")).toHaveText(
-      "Endurance · Moderate"
-    );
+    await expect(page.getByText("Training profile")).toHaveCount(0);
+    await expect(page.locator("fieldset").filter({ hasText: "Session strokes" })).toHaveCount(0);
+    await expect(page.locator("fieldset").filter({ hasText: "Equipment" })).toHaveCount(0);
     await expect(page.getByRole("combobox", { name: "Session type" })).toHaveCount(0);
     await expect(page.getByRole("combobox", { name: "Effort" })).toHaveCount(0);
-    await page.getByTestId("workout-editor-metadata-profile-toggle").click();
-    await expect(page.getByTestId("workout-editor-metadata-profile-toggle")).toHaveAttribute(
-      "aria-expanded",
-      "true"
-    );
-    await expect(page.getByRole("combobox", { name: "Session type" })).toBeVisible();
-    await expect(page.getByRole("combobox", { name: "Effort" })).toBeVisible();
     await expect(page.getByTestId("session-draft-step-toggle-0")).toBeVisible();
+    await page.getByTestId("session-draft-step-toggle-0").click();
+    await expect(page.getByLabel("Step type")).toBeVisible();
+    await expect(page.getByLabel("Drill type")).toBeVisible();
+    await expect(page.getByLabel("Step note")).toBeVisible();
+    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
+      "Open swim"
+    );
+    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
+      "Rest time"
+    );
     await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
       "All builder changes are saved to the canonical workout."
     );
@@ -174,7 +178,6 @@ test.describe("my library workout builder", () => {
     );
     await savedWorkoutPdfPopup.close();
 
-    await page.getByTestId("session-draft-step-toggle-0").click();
     await page.getByTestId("session-draft-step-name-0").fill("Warmup swim");
 
     await page.getByTestId("session-draft-step-remove-0").click();
@@ -358,16 +361,8 @@ test.describe("my library workout builder", () => {
     await expect(page.getByTestId("session-draft-step-target-mode-1")).toHaveValue("target_pace");
     await expect(page.getByTestId("session-draft-step-target-pace-minutes-1")).toHaveValue("1");
     await expect(page.getByTestId("session-draft-step-target-pace-seconds-1")).toHaveValue("35");
-    await expect(
-      page.locator("fieldset").filter({ hasText: "Session strokes" }).getByRole("checkbox", {
-        name: "Backstroke",
-      })
-    ).toBeChecked();
-    await expect(
-      page.locator("fieldset").filter({ hasText: "Equipment" }).getByRole("checkbox", {
-        name: "Fins",
-      })
-    ).toBeChecked();
+    await expect(page.locator("fieldset").filter({ hasText: "Session strokes" })).toHaveCount(0);
+    await expect(page.locator("fieldset").filter({ hasText: "Equipment" })).toHaveCount(0);
 
     const workoutMatch = new URL(page.url()).pathname.match(
       /\/my-library\/workouts\/([0-9a-f-]+)$/

--- a/tests/unit/create-manual-workout-button.test.tsx
+++ b/tests/unit/create-manual-workout-button.test.tsx
@@ -4,7 +4,6 @@ import CreateManualWorkoutButton from "@/components/my-library/workouts/CreateMa
 
 const navigationState = vi.hoisted(() => ({
   push: vi.fn(),
-  refresh: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -52,7 +51,6 @@ describe("CreateManualWorkoutButton", () => {
         "/my-library/workouts/11111111-1111-4111-8111-111111111111?entry=manual-pool"
       );
     });
-    expect(navigationState.refresh).toHaveBeenCalled();
   });
 
   it("shows an inline error when manual creation fails", async () => {

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -961,7 +961,7 @@ describe("WorkoutBuilderHub", () => {
     ).toBeVisible();
   });
 
-  it("keeps training profile fields secondary for manual builder workouts", async () => {
+  it("uses pool-swim field parity for manual builder workouts", async () => {
     render(
       <WorkoutBuilderHub
         workoutLibrary={buildWorkoutLibrary({
@@ -979,24 +979,18 @@ describe("WorkoutBuilderHub", () => {
       );
     });
 
-    expect(screen.getByText("Build your pool session")).toBeVisible();
+    expect(screen.getByText("Pool Swim")).toBeVisible();
     expect(screen.getByText("Session note")).toBeVisible();
     expect(screen.queryByText("Environment")).not.toBeInTheDocument();
-    expect(screen.getByText("Pool length")).toBeVisible();
-    expect(screen.getByTestId("workout-editor-metadata-profile-summary")).toHaveTextContent(
-      "Threshold / CSS · Moderate"
-    );
+    expect(screen.getByText("Pool Size")).toBeVisible();
+    expect(screen.getByRole("button", { name: "25m" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "50m" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Unspecified" })).toBeVisible();
     expect(screen.queryByRole("combobox", { name: "Session type" })).not.toBeInTheDocument();
     expect(screen.queryByRole("combobox", { name: "Effort" })).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByTestId("workout-editor-metadata-profile-toggle"));
-
-    expect(screen.getByTestId("workout-editor-metadata-profile-toggle")).toHaveAttribute(
-      "aria-expanded",
-      "true"
-    );
-    expect(screen.getByText("Session type")).toBeVisible();
-    expect(screen.getByText("Effort")).toBeVisible();
+    expect(screen.queryByText("Training profile")).not.toBeInTheDocument();
+    expect(screen.queryByText("Session strokes")).not.toBeInTheDocument();
+    expect(screen.queryByText("Equipment")).not.toBeInTheDocument();
   });
 
   it("locks open-water manual workouts to the open-water builder surface", async () => {
@@ -1117,6 +1111,77 @@ describe("WorkoutBuilderHub", () => {
         "Recommended Focus tag: Drill. Switch it to Kick or Pull only when this drill set needs that extra label."
       )
     ).toBeVisible();
+  });
+
+  it("uses Garmin-style pool step wording inside the manual pool builder", async () => {
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: buildWorkoutRecord({ sourceKind: "manual" }),
+          recentWorkouts: [buildWorkoutSummary({ sourceKind: "manual" })],
+        })}
+        preferExpandedDetailsOnLoad
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("session-draft-step-toggle-0"));
+
+    expect(screen.getByLabelText("Step type")).toBeVisible();
+    expect(screen.getByLabelText("Drill type")).toBeVisible();
+    expect(screen.getByLabelText("Step note")).toBeVisible();
+    expect(screen.getByRole("option", { name: "Open swim" })).toBeVisible();
+    expect(screen.getByRole("option", { name: "Rest time" })).toBeVisible();
+    expect(
+      screen.getByText(
+        "Use Stroke pattern for the swim pattern. Add Drill type only when the step needs extra drill, kick, or pull notation."
+      )
+    ).toBeVisible();
+    expect(
+      screen.getByText(
+        "Optional. Leave Drill type on None unless the step needs extra drill, kick, or pull notation."
+      )
+    ).toBeVisible();
+  });
+
+  it("treats unspecified pool size as valid while invalid custom input still blocks save", async () => {
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: buildWorkoutRecord({ sourceKind: "manual" }),
+          recentWorkouts: [buildWorkoutSummary({ sourceKind: "manual" })],
+        })}
+        preferExpandedDetailsOnLoad
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    const saveButton = screen.getByRole("button", { name: "Save changes" });
+    fireEvent.change(screen.getByLabelText("Exact pool size (m)"), {
+      target: { value: "3" },
+    });
+
+    expect(screen.getByTestId("workout-editor-panel")).toHaveTextContent(
+      "Enter a valid pool size between 12.5m and 500m, or choose Unspecified."
+    );
+    expect(saveButton).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Unspecified" }));
+
+    expect(screen.getByTestId("workout-editor-panel")).toHaveTextContent("Unspecified selected.");
+    expect(saveButton).toBeEnabled();
   });
 
   it("shows recovery guidance when the requested workout is missing", () => {

--- a/tests/unit/workouts-server.test.ts
+++ b/tests/unit/workouts-server.test.ts
@@ -177,6 +177,29 @@ describe("workouts server", () => {
     expect(summary.poolLengthM).toBe(33.33);
   });
 
+  it("persists and reloads unspecified pool size for manual builder workouts", () => {
+    const unspecifiedPoolDraft: SessionDraft = {
+      ...buildDraft(),
+      title: "Unspecified pool workout",
+      titleSuggestions: ["Unspecified pool workout"],
+      poolLengthM: null,
+    };
+
+    const insert = buildWorkoutInsert("user-1", unspecifiedPoolDraft, "manual");
+    const storedRow = buildWorkoutRow({
+      source_kind: "manual",
+      title: "Unspecified pool workout",
+      title_suggestions: ["Unspecified pool workout"],
+      pool_length_m: null,
+    });
+    const editorRecord = buildWorkoutEditorRecord(storedRow);
+    const summary = buildWorkoutSummary(storedRow);
+
+    expect(insert.pool_length_m).toBeNull();
+    expect(editorRecord.draft.poolLengthM).toBeNull();
+    expect(summary.poolLengthM).toBeNull();
+  });
+
   it("persists repeat metadata and multiplies totals from grouped repeat steps", () => {
     const repeatDraft: SessionDraft = {
       ...buildDraft(),

--- a/tests/unit/workouts-shared.test.ts
+++ b/tests/unit/workouts-shared.test.ts
@@ -145,6 +145,20 @@ describe("workouts shared readiness", () => {
     });
   });
 
+  it("surfaces unspecified pool size clearly in shared workout summaries", () => {
+    const model = buildWorkoutPdfModel(
+      {
+        ...buildDraft(),
+        poolLengthM: null,
+      },
+      {
+        draftState: "canonical",
+      }
+    );
+
+    expect(model.environmentSummary).toBe("Pool (Unspecified)");
+  });
+
   it("renders the session note label in printable workout PDF html", () => {
     const html = buildWorkoutPdfHtmlDocument(buildDraft(), {
       draftState: "canonical",


### PR DESCRIPTION
## Summary

- Aligns the manual pool builder with Garmin-style field wording and pool-first metadata.
- Hides non-parity top-level pool controls (`Training profile`, `Session strokes`, `Equipment`) while keeping the canonical workout model deterministic.
- Adds explicit `Unspecified` pool-size handling and removes a create-time navigation race that could strand the flow on `/my-library`.

## Scope

- In scope:
  - `Pool Swim` / `Pool Size` framing in the manual pool builder
  - pool quick choices `25m`, `50m`, `Unspecified`
  - pool summary handling for `poolLengthM: null`
  - pool step wording updates (`Step type`, `Drill type`, `Step note`, `Open swim`, `Rest time`)
  - targeted create-flow race fix in `CreateManualWorkoutButton`
- Out of scope:
  - repeat/final-rest Garmin parity
  - yard-mode support
  - open-water builder redesign

## Validation

- `npm run lint:briefs`: PASS
- `npm run typecheck`: PASS
- `npx vitest run tests/unit/workout-builder-hub.test.tsx tests/unit/workouts-server.test.ts tests/unit/workouts-shared.test.ts`: PASS
- `npx vitest run tests/unit/create-manual-workout-button.test.tsx`: PASS
- `npx playwright test tests/e2e/my-library-workout-builder.spec.ts tests/e2e/my-library-program-export.spec.ts --project=desktop-chromium`: PASS
- `npm run verify:pre-pr`: PASS (`96 passed / 318 skipped`)
- `npm run verify:pre-merge`: pending before merge

## Risk

- Main risk: pool wording cleanup could accidentally hide or rename a control that still matters for existing canonical workouts.
- Mitigation: unit coverage for pool-only visibility and unspecified-pool behavior, plus full `verify:pre-pr`.
- Rollback: revert commits `fbc11d5`, `5dd1922`, and `104eeaf` if needed.

## Brief

- `docs/task-briefs/in-progress/2026-04-06-pool-swim-builder-field-parity-10-10.md`

## Checklist

- [x] `npm run lint:briefs`
- [x] `npm run typecheck`
- [x] `npm run test:e2e` (covered through targeted runs and `npm run verify:pre-pr`)
- [x] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must pass on current HEAD before merge)
- [ ] Local manual QA done on dev URL
- [ ] Vercel preview manual QA done
- [x] Acceptance criteria are met for this slice
- [x] Docs updated for behavior/contract changes
- [x] Changed task brief includes full 10/10 scorecard mapping
- [x] No secrets or sensitive data added
