### PR TITLE
docs(briefs): close pool compatibility guards brief

### DIFF
--- a/docs/task-briefs/done/2026-04-06-pool-swim-builder-garmin-compatibility-guards-10-10.md
+++ b/docs/task-briefs/done/2026-04-06-pool-swim-builder-garmin-compatibility-guards-10-10.md
@@ -3,10 +3,10 @@
 ## Metadata
 
 - `id`: `2026-04-06-pool-swim-builder-garmin-compatibility-guards-10-10`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-04-06`
-- `updated`: `2026-04-06`
+- `updated`: `2026-04-07`
 
 ## Goal
 
@@ -211,3 +211,4 @@ Critical target categories for `10/10` claim in this brief:
 
 - `2026-04-06 | in progress | created the compatibility-guards brief after the repeat/rest slice closed; scope is now narrowed to documented Garmin step-cap and send-off truthfulness in the shared readiness layer | next: implement aggregate readiness issues, update targeted tests, and run full pre-PR verification`
 - `2026-04-06 | implementation + full gate | added pool-only Garmin compatibility review rules for authored step cap and send-off placement, updated shared readiness coverage plus builder-hub expectations, and passed npm run lint:briefs:all, targeted vitest, npm run typecheck, and full npm run verify:pre-pr (96 passed / 318 skipped); perf-budget trend recommendation remained hold (runs: 1/2, worst margin 36.2%) | next: inspect final diff, commit the slice, push the branch, and open the PR`
+- `2026-04-07 | merged to main + closeout | feature PR #376 merged to main as d3a713c after local npm run verify:pre-merge passed (96 passed / 318 skipped; private gate intentionally skipped because SITE_LOCK_ENABLED!=1) and required GitHub checks turned green; brief moved to done on the closeout branch | next: none`


### PR DESCRIPTION
## Summary

- What changed and why?
  - Moved the merged compatibility-guards brief from `in-progress` to `done` and recorded the final merge/checkpoint evidence after feature PR `#376` landed on `main`.
- User-visible changes:
  - None. This is a docs-only task-brief lifecycle closeout.
- Technical changes:
  - Renamed the brief into `docs/task-briefs/done/`
  - Updated brief `status` to `done`
  - Updated the brief `updated` date to `2026-04-07`
  - Appended the final checkpoint entry with merge commit `d3a713c` and gate evidence
- Policy impact: no (docs-only closeout; no runtime behavior change)
- Policy version note: N/A (docs-only lifecycle closeout)

## Scope

- In scope:
  - Close out `2026-04-06-pool-swim-builder-garmin-compatibility-guards-10-10`
  - Keep the brief lifecycle aligned with the already merged feature slice
- Out of scope:
  - Runtime/app code
  - UI behavior
  - additional tests beyond brief lint

## Risk

- Main risk:
  - Brief lifecycle drift if the feature is merged but the brief still reads as `in-progress`
- Rollback plan:
  - Revert this docs-only commit or move the brief back if merge status was recorded incorrectly

## Test Evidence

- Policy-impact checklist: N/A (docs-only closeout; no runtime behavior change)
- `verify:pre-pr`: NOT RUN on current closeout head `7f0c60f` (docs-only closeout PR); feature PR `#376` passed local `npm run verify:pre-pr` before merge.
- `verify:pre-merge`: NOT RUN on current closeout head `7f0c60f` (docs-only closeout PR); feature PR `#376` passed local `npm run verify:pre-merge` before merge.
- [x] `npm run lint:briefs`
  - PASS via `npm run lint:briefs:all`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be `PASS` on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)
- Feature PR reference:
  - `#376` already passed local `npm run verify:pre-pr`, local `npm run verify:pre-merge`, and required GitHub CI before merge

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [x] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [x] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
