### PR TITLE
Clarify pool step authoring parity wording

### DIFF
--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -231,18 +231,19 @@ function parseSignatureValues(value: string) {
 function buildStepStrokeGuidance(step: SessionDraftStep, isManualPoolMode: boolean) {
   const recommendedFocus = getRecommendedStepFocus(step);
   const drillTypeLabel = isManualPoolMode ? "Drill type" : "Focus tag";
+  const strokeLabel = isManualPoolMode ? "Stroke" : "Stroke pattern";
 
   if (step.category === "kick") {
-    return `Kick category already tags this as kick work. Use Stroke pattern for the movement pattern this set supports, and change ${drillTypeLabel} only when you need extra kick, pull, or drill notation.`;
+    return `Kick category already tags this as kick work. Use ${strokeLabel} for the movement pattern this set supports, and change ${drillTypeLabel} only when you need extra kick, pull, or drill notation.`;
   }
 
   if (step.category === "drill" || step.stroke === "drill") {
-    return `Drill shell is active. Use Stroke pattern for the base movement, and use ${drillTypeLabel} to clarify whether the drill is general, kick, or pull.`;
+    return `Drill shell is active. Use ${strokeLabel} for the base movement, and use ${drillTypeLabel} to clarify whether the drill is general, kick, or pull.`;
   }
 
   return recommendedFocus
     ? `This step already suggests the ${getSessionStepDrillTypeLabel(recommendedFocus)} ${drillTypeLabel.toLowerCase()}. Keep it unless you need a different drill, kick, or pull note.`
-    : `Use Stroke pattern for the swim pattern. Add ${drillTypeLabel} only when the step needs extra drill, kick, or pull notation.`;
+    : `Use ${strokeLabel} for the swim pattern. Add ${drillTypeLabel} only when the step needs extra drill, kick, or pull notation.`;
 }
 
 function buildStepFocusGuidance(step: SessionDraftStep, isManualPoolMode: boolean) {
@@ -268,12 +269,36 @@ function getStepDurationModeEditorLabel(
   }
 
   switch (value) {
+    case "distance":
+      return "Distance swim";
+    case "time":
+      return "Time-based swim";
     case "fixed_rest":
       return "Rest time";
     case "lap_button":
       return "Open swim";
+    case "css_send_off":
+      return "CSS send-off";
     default:
       return getSessionStepDurationModeLabel(value);
+  }
+}
+
+function getStepTargetModeEditorLabel(
+  value: NonNullable<SessionDraftStep["targetMode"]>,
+  isManualPoolMode: boolean
+) {
+  if (!isManualPoolMode) {
+    return getSessionStepTargetModeLabel(value);
+  }
+
+  switch (value) {
+    case "effort":
+      return "Effort cue";
+    case "css_target_pace":
+      return "CSS target pace";
+    default:
+      return getSessionStepTargetModeLabel(value);
   }
 }
 
@@ -1669,7 +1694,7 @@ export default function WorkoutEditor({
             </label>
 
             <label className="text-sm text-slate-700">
-              Stroke pattern
+              {isManualPoolMode ? "Stroke" : "Stroke pattern"}
               <select
                 value={step.stroke ?? "choice"}
                 onChange={(event) => {
@@ -1762,7 +1787,7 @@ export default function WorkoutEditor({
             </label>
 
             <label className="text-sm text-slate-700">
-              Duration mode
+              {isManualPoolMode ? "Step timing" : "Duration mode"}
               <select
                 value={step.durationMode}
                 onChange={(event) =>
@@ -1833,7 +1858,11 @@ export default function WorkoutEditor({
               </div>
             ) : step.durationMode === "time" || step.durationMode === "fixed_rest" ? (
               <label className="text-sm text-slate-700">
-                {step.durationMode === "fixed_rest" ? "Rest time (min)" : "Time (min)"}
+                {step.durationMode === "fixed_rest"
+                  ? "Rest time (min)"
+                  : isManualPoolMode
+                    ? "Swim time (min)"
+                    : "Time (min)"}
                 <input
                   type="text"
                   inputMode="numeric"
@@ -1917,7 +1946,7 @@ export default function WorkoutEditor({
             )}
 
             <label className="text-sm text-slate-700">
-              Target mode
+              {isManualPoolMode ? "Target" : "Target mode"}
               <select
                 value={step.targetMode ?? "none"}
                 onChange={(event) =>
@@ -1943,7 +1972,7 @@ export default function WorkoutEditor({
               >
                 {SESSION_DRAFT_STEP_TARGET_MODES.map((value) => (
                   <option key={value} value={value}>
-                    {getSessionStepTargetModeLabel(value)}
+                    {getStepTargetModeEditorLabel(value, isManualPoolMode)}
                   </option>
                 ))}
               </select>
@@ -2037,9 +2066,10 @@ export default function WorkoutEditor({
             ) : null}
 
             <label className="text-sm text-slate-700 md:col-span-2">
-              Target notes
+              {isManualPoolMode ? "Target summary" : "Target notes"}
               <input
                 type="text"
+                aria-label={isManualPoolMode ? "Target summary" : "Target notes"}
                 value={step.targetSummary}
                 onChange={(event) =>
                   updateDraftStep(step.id, (current) => ({
@@ -2049,11 +2079,18 @@ export default function WorkoutEditor({
                 }
                 className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
               />
+              {isManualPoolMode ? (
+                <p className="mt-2 text-xs text-slate-500">
+                  Optional short cue for the interval summary. Use Step note for the Garmin-style
+                  step note.
+                </p>
+              ) : null}
             </label>
 
             <label className="text-sm text-slate-700 md:col-span-2">
               {isManualPoolMode ? "Step note" : "Notes"}
               <textarea
+                aria-label={isManualPoolMode ? "Step note" : "Notes"}
                 value={step.notes}
                 onChange={(event) =>
                   updateDraftStep(step.id, (current) => ({
@@ -2064,6 +2101,11 @@ export default function WorkoutEditor({
                 rows={3}
                 className="mt-2 block w-full rounded-xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
               />
+              {isManualPoolMode ? (
+                <p className="mt-2 text-xs text-slate-500">
+                  Closest match to Garmin Add Step Note for this pool step.
+                </p>
+              ) : null}
             </label>
           </div>
         ) : null}

--- a/docs/task-briefs/in-progress/2026-04-07-pool-swim-builder-step-authoring-parity-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-07-pool-swim-builder-step-authoring-parity-10-10.md
@@ -1,0 +1,239 @@
+# Task Brief: Pool Swim Builder Step Authoring Parity (10/10)
+
+## Metadata
+
+- `id`: `2026-04-07-pool-swim-builder-step-authoring-parity-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-04-07`
+- `updated`: `2026-04-07`
+
+## Goal
+
+FreeSwimming's manual `pool` step editor should read like a dedicated Garmin-style pool workout authoring surface by tightening the remaining generic labels around stroke, timing, targets, and step notes without rewriting the canonical draft model.
+
+## Why This Brief Exists
+
+- The pool parity wave already shipped:
+  - separate `Build pool session` and `Build open water session` entry,
+  - pool field-level wording cleanup,
+  - repeat/final-rest parity,
+  - documented compatibility guards,
+  - supported stroke/drill readiness mapping,
+  - truthful equipment review wording.
+- `origin/main` now shows a half-completed pool step editor:
+  - `Step type`, `Drill type`, `Open swim`, `Rest time`, and `Step note` are already present in pool mode,
+  - but pool mode still exposes generic labels such as `Stroke pattern`, `Duration mode`, `Target mode`, and `Target notes`.
+- Garmin's documented pool-workout creator language is more specific around:
+  - swim/open/time/rest step timing,
+  - send-off timing,
+  - stroke/drill separation,
+  - and `Add Step Note`.
+- This slice exists to finish that remaining wording pass in the pool-only step editor without destabilizing saved workouts.
+
+## Dependencies And Boundaries
+
+- Parent parity direction:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-06-pool-swim-builder-garmin-parity-10-10.md`
+- Shipped prerequisite slices:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-06-pool-swim-builder-field-parity-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-06-pool-swim-builder-repeat-rest-parity-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-06-pool-swim-builder-garmin-compatibility-guards-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-07-pool-swim-builder-supported-strokes-and-drills-parity-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-07-pool-swim-builder-equipment-compatibility-truthfulness-10-10.md`
+- Primary implementation surfaces:
+  - `/Users/stianvikra/freeswimming/components/my-library/workouts/WorkoutEditor.tsx`
+  - `/Users/stianvikra/freeswimming/tests/unit/workout-builder-hub.test.tsx`
+  - `/Users/stianvikra/freeswimming/tests/e2e/my-library-workout-builder.spec.ts`
+- Official parity references:
+  - Garmin Support: `Pool Swim Workout Enhancements`
+  - Garmin Support: `Using Pool Swim Workouts`
+
+## Product Direction Locked By This Brief
+
+- This slice is `pool`-only wording/authoring parity work.
+- `Open water` must keep the current separate non-parity path and generic labels in this slice.
+- The canonical workout draft schema stays unchanged.
+- The builder may keep non-Garmin-supporting fields internally where needed, but the pool editor should describe them in Garmin-familiar language wherever a direct wording fit exists.
+- This slice favors truthful UI terminology and small contextual help over hidden transformation or aggressive field removal.
+
+## Step Authoring Decisions Locked By This Slice
+
+1. Pool stroke wording:
+   - the pool step editor should say `Stroke`, not `Stroke pattern`.
+   - helper copy should use the same wording.
+2. Pool timing wording:
+   - the pool step editor should say `Step timing`, not `Duration mode`.
+   - manual pool options should read as explicit pool step/timing concepts:
+     - `Distance swim`
+     - `Time-based swim`
+     - `Rest time`
+     - `Open swim`
+     - `Send-off time`
+     - `CSS send-off`
+   - pool time-entry labels should distinguish swim time from rest time.
+3. Pool target wording:
+   - the pool step editor should say `Target`, not `Target mode`.
+   - any remaining target-choice labels should read like pool-authoring cues, not generic engine modes.
+4. Step note truthfulness:
+   - the visible pool note field should remain `Step note`.
+   - the adjacent summary field should stop pretending to be a second note surface and instead read as a short summary/cue field.
+   - pool UI copy should make it clear that `Step note` is the closest match to Garmin's documented `Add Step Note`.
+5. Scope limit:
+   - do not remove canonical fields from persisted workout drafts in this slice.
+   - do not add migrations or change API payload versions.
+   - do not rewrite repeat logic or Garmin readiness logic again here.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `Product goals and IA`
+- `UX flow clarity`
+- `Business logic correctness and data integrity`
+- `Reliability and failure handling`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                                     | Evidence                              |
+| --------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
+| Product goals and IA                          | `target`     | Pool step editing surfaces explicit swim-workout wording so a Garmin-familiar swimmer no longer has to mentally translate generic builder terms.                 | manual QA + targeted tests            |
+| UX flow clarity                               | `target`     | Pool step labels and helper copy distinguish stroke, timing, target, and step-note intent clearly without adding more clicks or hidden sub-flows.               | targeted tests + manual QA            |
+| Accessibility (a11y)                          | `supporting` | Supporting only: renamed labels remain text-first, screen-reader legible, and tied to existing form controls.                                                    | label review + existing test harness  |
+| Visual design quality                         | `supporting` | Supporting only: the step form still feels like the same editor and does not add noisy chrome for this wording pass.                                             | screenshot review + manual QA         |
+| Business logic correctness and data integrity | `target`     | Pool step wording changes do not alter canonical payload shape, save semantics, or the persisted meaning of existing step fields.                                | unit coverage + code review           |
+| Admin editor ergonomics                       | `target`     | The owner can keep authoring pool steps quickly because the wording matches the intended swim-workout mental model more closely.                                 | manual QA + targeted tests            |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: this slice stays in existing editor surfaces and does not materially change route payload or interaction cost.                                  | targeted review + verify              |
+| Data placement and sync boundaries            | `target`     | The pool editor still writes to the same canonical workout draft shape with no alternate local-only step-authoring contract.                                     | brief contract + code review          |
+| Caching and invalidation strategy             | `supporting` | Supporting only: no new cache boundaries are introduced because this is a client/editor wording slice on the existing save flow.                                 | scope review                          |
+| Reliability and failure handling              | `target`     | Older saved workouts still load safely and keep the same editable values even though the pool editor labels become more specific.                                | regression tests + manual QA          |
+| Security and authz                            | `supporting` | Supporting only: no auth boundary, route permission, or secret handling changes.                                                                                  | scope review                          |
+| Privacy and compliance                        | `N/A`        | N/A because this slice changes private workout-builder wording only and introduces no new personal-data path or disclosure behavior.                             | explicit scope rationale              |
+| Content governance                            | `target`     | Garmin-like pool-step terminology stays centralized in one audited editor contract rather than drifting between UI labels and tests.                             | brief decisions + code review         |
+| Admin workflow and editability                | `target`     | Pool-step editing stays reversible and familiar while internal field meaning remains intact under the renamed labels.                                            | unit coverage + manual QA             |
+| SEO and crawlability                          | `N/A`        | N/A because authenticated My Library builder routes remain private and uncrawlable.                                                                               | explicit scope rationale              |
+| AI discoverability                            | `N/A`        | N/A because this slice changes no public metadata, public route, or AI-facing discoverability contract.                                                          | explicit scope rationale              |
+| Analytics and KPI observability               | `supporting` | Supporting only: no analytics contract changes are needed because this slice is wording and helper-copy only.                                                    | scope review                          |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, entitlement, billing, or purchase workflow changes.                                                                                       | explicit scope rationale              |
+| Incident response and support operations      | `N/A`        | N/A because no Help/Guide or runbook currently references these internal pool-step labels directly, so this slice does not change operator recovery procedures. | explicit scope rationale              |
+| Finance and reporting operations              | `N/A`        | N/A because no finance reconciliation, payout, billing, or reporting behavior changes.                                                                            | explicit scope rationale              |
+| i18n operational readiness                    | `N/A`        | N/A because this slice adjusts centralized English pool-step wording only and keeps later localization work possible.                                             | explicit scope rationale              |
+| Stack-fit and dependency discipline           | `target`     | Reuse the existing pool/editor component and shared draft helpers; do not add a new dependency or alternate editor path.                                         | dependency diff + architecture review |
+| Testing and QA automation                     | `target`     | Targeted unit/e2e coverage protects the renamed pool step labels and helper text before PR update, and `npm run verify:pre-pr` passes on the final diff.        | tests + `verify:pre-pr`               |
+| Scalability and cost efficiency               | `supporting` | Supporting only: the slice remains a small wording/editor pass with no extra writes, queries, or background jobs.                                                | code review                           |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: the slice stays fully reversible as a UI/text-only change with no schema migration.                                                             | diff review + rollback note           |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - `workout.id`
+  - canonical saved workout drafts and their step arrays
+- Local-only:
+  - current editor open/closed step state
+  - transient unsaved field edits before save
+- Sync policy:
+  - renamed pool labels map onto the same canonical draft fields as before
+  - save/reopen must preserve the exact same stored values
+  - no background conversion job or hidden migration runs in this slice
+- Retention and sensitivity:
+  - no new sensitive data class
+  - no new persisted parity metadata
+- Cache/invalidation:
+  - existing save/refresh boundaries remain authoritative
+  - label changes must not create new invalidation rules
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - `workout.id` remains the only stable workout identity.
+- Human-readable identifiers:
+  - labels such as `Step timing`, `Stroke`, `Target`, `Target summary`, and `Step note` are mutable UI wording, not canonical identifiers.
+- Mutability rules:
+  - pool editor wording can change in place.
+  - persisted step values retain their current canonical enum/value identities in this slice.
+- Rename vs repurpose policy:
+  - label changes are in-place wording refinements, not a repurposing of the saved workout entity.
+- Compatibility contract:
+  - old saved workouts remain editable without any migration.
+
+## Scope
+
+- Finish the remaining Garmin-style wording cleanup inside the manual `pool` step editor.
+- Tighten pool-only helper copy around stroke, drill type, timing, target, and step note semantics.
+- Keep existing saved drafts compatible and keep open-water wording unchanged.
+- Update targeted unit/e2e assertions that cover manual `pool` step authoring labels.
+
+## Out Of Scope
+
+- Schema changes or new migrations
+- New save-blocking validation rules
+- Repeat/rest behavior changes
+- Garmin readiness/export diagnostic rewrites
+- Open-water authoring redesign
+- Removal of canonical fields from the draft model
+
+## Acceptance Criteria
+
+1. Manual `pool` step editing says `Stroke`, `Step timing`, `Target`, `Target summary`, and `Step note`.
+2. Manual `pool` timing options use explicit pool-step wording: `Distance swim`, `Time-based swim`, `Rest time`, `Open swim`, `Send-off time`, and `CSS send-off`.
+3. Manual `pool` helper copy uses the same pool-step terms consistently and explains `Step note` as the closest match to Garmin's documented step-note concept.
+4. Open-water and non-pool manual flows keep their current generic wording in this slice.
+5. Existing save/reopen behavior and canonical payload shape stay unchanged.
+6. Targeted unit/e2e coverage protects the new pool-step wording.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run typecheck`
+- targeted `vitest`
+  - `tests/unit/workout-builder-hub.test.tsx`
+- targeted Playwright
+  - `tests/e2e/my-library-workout-builder.spec.ts --project=desktop-chromium`
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm must be available on the validation machine.
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3100/my-library`
+  - desktop Chromium during implementation
+- Vercel preview:
+  - PR preview URL from checks
+
+## Constraints
+
+- Keep the slice additive and backward-compatible.
+- Prefer pool-only wording branches over shared label churn when open-water still uses the generic builder.
+- Do not imply stronger Garmin parity than the documented sources support.
+
+## Help/Guide And Operator Training Contract
+
+- `N/A` for this slice because no Help/Guide or runbook contract currently cites the internal pool-step labels being renamed here.
+- If implementation uncovers a public/operator-facing help surface that already names these labels, update it in the same PR before merge.
+
+## 10/10 Quality Bar
+
+- Pool step editing should feel intentionally specific, not partially renamed.
+- Required states:
+  - loading: unchanged existing builder loading behavior
+  - empty: the first pool step still opens/editors safely
+  - error: invalid saved drafts still fail through existing safe boundaries, not new wording-only crashes
+  - retry/offline: existing save failure behavior remains unchanged
+- Accessibility:
+  - renamed labels remain attached to the same controls
+  - helper text remains visible plain text rather than tooltip-only
+- Performance:
+  - wording changes stay cheap and local to the existing step editor
+- Business logic:
+  - identical pool draft data produces identical saved payloads before and after this slice
+  - label changes must not silently rewrite existing step values
+
+## Checkpoint Log
+
+- `2026-04-07 | in progress | created a dedicated step-authoring parity slice after confirming on origin/main that entry split, field parity, repeat/rest, compatibility guards, stroke/drill readiness, and equipment truthfulness were already closed; the remaining visible Garmin gap is the pool-only step-editor wording around stroke, timing, targets, and step-note semantics | next: update WorkoutEditor pool labels/helper text, refresh targeted tests, and run pre-PR verification`
+- `2026-04-07 | implementation + full pre-PR gate | tightened the manual pool step editor around the remaining Garmin-like wording (`Stroke`, `Step timing`, `Target`, `Target summary`, clarified `Step note`, and explicit pool timing option labels), updated targeted unit/e2e coverage, passed npm run lint:briefs:all, npm run typecheck, targeted vitest, targeted desktop-chromium Playwright, and a full npm run verify:pre-pr (96 passed / 318 skipped); the worktree had to use local copy-on-write copies of node_modules and .env.local because Turbopack rejected symlinks outside the worktree root during build | next: inspect final diff, commit, push, and open the PR`

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -123,14 +123,38 @@ test.describe("my library workout builder", () => {
     await expect(page.getByTestId("session-draft-step-toggle-0")).toBeVisible();
     await page.getByTestId("session-draft-step-toggle-0").click();
     await expect(page.getByLabel("Step type")).toBeVisible();
+    await expect(page.getByLabel("Stroke")).toBeVisible();
     await expect(page.getByLabel("Drill type")).toBeVisible();
-    await expect(page.getByLabel("Step note")).toBeVisible();
+    await expect(page.getByLabel("Step timing")).toBeVisible();
+    await expect(page.getByRole("combobox", { name: "Target" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Target summary" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Step note" })).toBeVisible();
+    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
+      "Distance swim"
+    );
+    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
+      "Time-based swim"
+    );
     await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
       "Open swim"
     );
     await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
       "Rest time"
     );
+    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
+      "Send-off time"
+    );
+    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
+      "CSS send-off"
+    );
+    await expect(
+      page.getByText(
+        "Optional short cue for the interval summary. Use Step note for the Garmin-style step note."
+      )
+    ).toBeVisible();
+    await expect(
+      page.getByText("Closest match to Garmin Add Step Note for this pool step.")
+    ).toBeVisible();
     await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
       "All builder changes are saved to the canonical workout."
     );

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -1169,19 +1169,35 @@ describe("WorkoutBuilderHub", () => {
     fireEvent.click(screen.getByTestId("session-draft-step-toggle-0"));
 
     expect(screen.getByLabelText("Step type")).toBeVisible();
+    expect(screen.getByLabelText("Stroke")).toBeVisible();
     expect(screen.getByLabelText("Drill type")).toBeVisible();
+    expect(screen.getByLabelText("Step timing")).toBeVisible();
+    expect(screen.getByLabelText("Target")).toBeVisible();
+    expect(screen.getByLabelText("Target summary")).toBeVisible();
     expect(screen.getByLabelText("Step note")).toBeVisible();
+    expect(screen.getByRole("option", { name: "Distance swim" })).toBeVisible();
+    expect(screen.getByRole("option", { name: "Time-based swim" })).toBeVisible();
     expect(screen.getByRole("option", { name: "Open swim" })).toBeVisible();
     expect(screen.getByRole("option", { name: "Rest time" })).toBeVisible();
+    expect(screen.getByRole("option", { name: "Send-off time" })).toBeVisible();
+    expect(screen.getByRole("option", { name: "CSS send-off" })).toBeVisible();
     expect(
       screen.getByText(
-        "Use Stroke pattern for the swim pattern. Add Drill type only when the step needs extra drill, kick, or pull notation."
+        "Use Stroke for the swim pattern. Add Drill type only when the step needs extra drill, kick, or pull notation."
       )
     ).toBeVisible();
     expect(
       screen.getByText(
         "Optional. Leave Drill type on None unless the step needs extra drill, kick, or pull notation."
       )
+    ).toBeVisible();
+    expect(
+      screen.getByText(
+        "Optional short cue for the interval summary. Use Step note for the Garmin-style step note."
+      )
+    ).toBeVisible();
+    expect(
+      screen.getByText("Closest match to Garmin Add Step Note for this pool step.")
     ).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-04-07T10:13:40.226Z for branch `feat/pool-swim-builder-step-authoring-parity-2026-04-07` (base ref `origin/main`).
- Latest commit: `0a7545c` - Clarify pool step authoring parity wording.
- User-visible changes: User/admin runtime behavior may change on touched routes/components.
- Technical changes: Updated 4 file(s): `components/my-library/workouts/WorkoutEditor.tsx`, `docs/task-briefs/in-progress/2026-04-07-pool-swim-builder-step-authoring-parity-10-10.md`, `tests/e2e/my-library-workout-builder.spec.ts`, `tests/unit/workout-builder-hub.test.tsx`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-04-07-pool-swim-builder-step-authoring-parity-10-10.md`
- Scorecard target outcomes: 10 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (1); tests (2); runtime UI/routes/components (1).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (4):
  - `components/my-library/workouts/WorkoutEditor.tsx`
  - `docs/task-briefs/in-progress/2026-04-07-pool-swim-builder-step-authoring-parity-10-10.md`
  - `tests/e2e/my-library-workout-builder.spec.ts`
  - `tests/unit/workout-builder-hub.test.tsx`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `0a7545c` (`git revert 0a7545c`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **NOT RUN** (run locally before pushing PR updates).
- `npm run verify:pre-merge`: **PASS** for `0a7545c` (2026-04-07T10:13:25Z, mode: skipped).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  - No local verify log found in `artifacts/test-runs/latest`.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
