### PR TITLE
feat(workouts): add pool device execution truthfulness guards

### DIFF
--- a/docs/task-briefs/in-progress/2026-04-07-pool-swim-builder-compatible-device-execution-truthfulness-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-07-pool-swim-builder-compatible-device-execution-truthfulness-10-10.md
@@ -1,0 +1,243 @@
+# Task Brief: Pool Swim Builder Compatible-Device Execution Truthfulness (10/10)
+
+## Metadata
+
+- `id`: `2026-04-07-pool-swim-builder-compatible-device-execution-truthfulness-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-04-07`
+- `updated`: `2026-04-07`
+
+## Goal
+
+FreeSwimming's manual `pool` builder should stay truthful about Garmin pool-workout behaviors that still vary by device or personal CSS state, so readiness/handoff/PDF/export stop reading as universally execution-safe when Garmin's own support material documents important caveats.
+
+## Why This Brief Exists
+
+- The pool parity wave already shipped:
+  - separate `pool` and `open water` manual entry,
+  - pool field parity,
+  - repeat/final-rest parity,
+  - documented compatibility guards for step count and send-off placement,
+  - supported stroke/drill cleanup,
+  - equipment truthfulness,
+  - step-authoring wording parity,
+  - output/execution wording parity.
+- `origin/main` now describes pool workouts more clearly, but it still overstates one class of readiness:
+  - some pool features are documented by Garmin as full-featured only on compatible devices,
+  - CSS-relative pool targets depend on the device's CSS behavior,
+  - `Unspecified` pool size is not a completely identical execution path across pool-swim watches.
+- The current readiness layer treats these shapes as fully `ready`, which is too optimistic when the target watch may simplify or reinterpret the authored workout.
+- Garmin support material we already rely on documents three execution-truthfulness gaps that should now surface before handoff:
+  - `Unspecified` pool size is only partially compatible across pool-swim watches; fully compatible devices keep step distances as authored, while older devices can convert distances for yard pools,
+  - compatible devices can use the last rest interval in a repeat block, while older devices always skip the final rest,
+  - compatible devices automatically adjust CSS-relative send-off and pace targets when CSS changes, and use `2:00/100m` if no CSS is set.
+
+## Dependencies And Boundaries
+
+- Parent parity direction:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-06-pool-swim-builder-garmin-parity-10-10.md`
+- Shipped prerequisite slices:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-06-pool-swim-builder-garmin-compatibility-guards-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-06-pool-swim-builder-repeat-rest-parity-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-07-pool-swim-builder-supported-strokes-and-drills-parity-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-07-pool-swim-builder-equipment-compatibility-truthfulness-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-07-pool-swim-builder-output-execution-parity-10-10.md`
+- Primary implementation surfaces:
+  - `/Users/stianvikra/freeswimming/lib/workouts/shared.ts`
+  - `/Users/stianvikra/freeswimming/tests/unit/workouts-shared.test.ts`
+  - `/Users/stianvikra/freeswimming/tests/unit/workout-builder-hub.test.tsx`
+  - `/Users/stianvikra/freeswimming/tests/e2e/my-library-workout-builder.spec.ts`
+- Official parity references:
+  - Garmin Support: `Pool Swim Workout Enhancements`
+  - Garmin Support: `Using Pool Swim Workouts`
+
+## Product Direction Locked By This Brief
+
+- This slice is `pool`-only device/execution truthfulness work.
+- `Open water` keeps its current separate non-parity path and must not inherit these pool-specific device cautions.
+- This slice stays in the shared readiness/support-output layer:
+  - readiness status,
+  - handoff text,
+  - printable PDF review details,
+  - Garmin-ready JSON diagnostics.
+- Do not add a device picker, per-watch profile, or save-blocking validation in this slice.
+- Prefer explicit `review` details over silent optimism when Garmin documents that older devices or missing CSS setup can change execution.
+
+## Execution Truthfulness Decisions Locked By This Slice
+
+1. `Unspecified` pool size:
+   - pool drafts with `poolLengthM: null` enter Garmin/export `review` state.
+   - the review detail must explain:
+     - Garmin documents `Unspecified` as partially compatible across pool-swim watches,
+     - fully compatible devices keep authored step distances as entered,
+     - older devices may convert the distance in yard pools.
+2. Repeat blocks that keep the last rest:
+   - pool repeat blocks ending in a rest step and using `Use last rest interval` enter Garmin/export `review` state.
+   - the review detail must explain:
+     - Garmin documents this behavior on compatible devices,
+     - older devices skip the last rest interval instead.
+3. CSS-relative pool steps:
+   - pool drafts using `CSS target pace` or `CSS send-off` enter Garmin/export `review` state.
+   - the review detail must explain:
+     - Garmin documents that compatible devices auto-adjust these targets when CSS changes,
+     - Garmin devices use `2:00/100m` if no CSS is set,
+     - FreeSwimming previews use the workout's current CSS baseline and therefore need final watch confirmation before handoff.
+4. Scope limit:
+   - no schema change,
+   - no device-picker UI,
+   - no new save-blocking validation,
+   - no reopening of already-shipped equipment/send-off-count rules.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `Product goals and IA`
+- `UX flow clarity`
+- `Business logic correctness and data integrity`
+- `Reliability and failure handling`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                                   | Evidence                                |
+| --------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| Product goals and IA                          | `target`     | Pool readiness stops implying universal watch behavior for `Unspecified` pool size, `Use last rest interval`, and CSS-relative targets when Garmin documents caveats. | source review + targeted tests          |
+| UX flow clarity                               | `target`     | A swimmer can tell from the readiness panel why a pool workout needs device/CSS review without reverse-engineering Garmin support docs.                         | targeted tests + manual QA              |
+| Accessibility (a11y)                          | `supporting` | Supporting only: readiness details remain plain text, keyboard reachable, and screen-reader legible inside the existing support panel.                          | code review + existing test harness     |
+| Visual design quality                         | `supporting` | Supporting only: the new truthfulness details fit the existing support surfaces without adding noisy new chrome.                                                | screenshot review + manual QA           |
+| Business logic correctness and data integrity | `target`     | Pool readiness/export diagnostics deterministically flag the documented device/CSS caveats while preserving the same canonical saved workout payload.            | unit tests + integration review         |
+| Admin editor ergonomics                       | `target`     | The owner can keep editing the same workout while understanding which pool features need final device confirmation before Garmin handoff.                        | targeted tests + manual QA              |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: aggregate readiness checks remain linear in step count and do not materially regress `/my-library` or workout-detail responsiveness.            | verify + targeted review                |
+| Data placement and sync boundaries            | `target`     | Device/CSS truthfulness stays derived from the canonical draft and introduces no extra persisted compatibility state or shadow output model.                     | brief contract + code review            |
+| Caching and invalidation strategy             | `supporting` | Supporting only: readiness continues deriving from the current draft/save flow with no new cache invalidation rules.                                            | integration review                      |
+| Reliability and failure handling              | `target`     | Out-of-contract pool execution assumptions fail closed into `review` state with explicit reasons instead of looking universally handoff-ready.                  | negative-path tests + manual QA         |
+| Security and authz                            | `supporting` | Supporting only: no route/API permission boundary changes.                                                                                                       | scope review                            |
+| Privacy and compliance                        | `N/A`        | N/A because this slice changes owner-scoped workout guidance only and introduces no new sensitive data path or disclosure contract.                              | explicit scope rationale                |
+| Content governance                            | `target`     | Device/CSS caveats stay centralized in one audited readiness contract instead of drifting between builder, handoff text, PDF, and export JSON.                  | brief decisions + code review           |
+| Admin workflow and editability                | `target`     | Save/reopen/edit flows remain intact while the support layer becomes more truthful about device-level pool execution caveats.                                   | unit coverage + manual QA               |
+| SEO and crawlability                          | `N/A`        | N/A because authenticated My Library builder routes remain private and uncrawlable.                                                                             | explicit scope rationale                |
+| AI discoverability                            | `N/A`        | N/A because this slice changes no public route, metadata, or AI-facing discoverability contract.                                                               | explicit scope rationale                |
+| Analytics and KPI observability               | `supporting` | Supporting only: readiness summaries remain inspectable without adding new analytics instrumentation.                                                            | scope review                            |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, billing, entitlement, checkout, or subscription reporting behavior changes.                                                             | explicit scope rationale                |
+| Incident response and support operations      | `supporting` | Supporting only: handoff/PDF/export review language should make device/CSS caveats diagnosable during support triage.                                          | support output review                   |
+| Finance and reporting operations              | `N/A`        | N/A because no finance reconciliation, payouts, billing, or operator reporting flow changes.                                                                    | explicit scope rationale                |
+| i18n operational readiness                    | `N/A`        | N/A because this slice adjusts internal English compatibility messaging only and must keep the semantics centralized for later localization work.                | explicit scope rationale                |
+| Stack-fit and dependency discipline           | `target`     | Reuse the existing workout readiness/export helper stack; do not add new dependencies or a per-device configuration system in this slice.                       | dependency diff + architecture review   |
+| Testing and QA automation                     | `target`     | Targeted coverage protects `Unspecified` pool size, `Use last rest interval`, and CSS-relative pool warnings before PR update, and `npm run verify:pre-pr` passes. | unit/e2e coverage + `verify:pre-pr`     |
+| Scalability and cost efficiency               | `supporting` | Supporting only: the new guards remain a small deterministic derived check with no extra writes or route duplication.                                           | code review                             |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: the slice stays reversible as a shared-logic/readiness change with no schema migration.                                                        | diff review + rollback note             |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - `workout.id`
+  - canonical workout draft rows and their persisted step arrays
+- Local-only:
+  - support panel open/closed state
+  - transient unsaved edits before canonical save
+- Sync policy:
+  - device/CSS cautions derive from the current draft state both before and after save
+  - no extra save mutation or background sync path is introduced
+  - reopening a saved workout recomputes the same readiness result from the canonical draft payload
+- Retention and sensitivity:
+  - no new sensitive data class
+  - no new persisted compatibility metadata
+- Cache/invalidation:
+  - existing `router.refresh` and canonical save boundaries remain authoritative
+  - readiness stays computed from current in-memory draft or loaded canonical draft
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - `workout.id` remains the only canonical workout identity.
+- Human-readable identifiers:
+  - labels such as `Unspecified`, `Use last rest interval`, `CSS send-off`, and the review copy are mutable UI wording, not identifiers.
+- Mutability rules:
+  - step layout and support copy remain editable in place.
+- Rename vs repurpose policy:
+  - changing a workout to remove a device/CSS caution is an in-place edit to the same workout.
+- Compatibility contract:
+  - older saved workouts that already use these shapes must still load safely and now show truthful review-state guidance instead of false universal readiness.
+- Observability and repair:
+  - review-state diagnostics must stay explicit enough that the owner can repair or confirm the workout without reading code.
+
+## Scope
+
+- Add pool-only Garmin readiness issues for:
+  - `Unspecified` pool size,
+  - repeat blocks that keep the last rest interval,
+  - CSS-relative pace/send-off steps.
+- Keep handoff/PDF/export diagnostics truthful by reusing the shared readiness report.
+- Update targeted unit/component/e2e coverage for the new device/CSS review details.
+
+## Out Of Scope
+
+- New schema fields or migrations
+- Device-picker or per-watch configuration UI
+- New save-blocking validation
+- Open-water compatibility redesign
+- Reopening already-shipped step-cap or send-off placement rules
+- Rewording the broader pool editor again
+
+## Acceptance Criteria
+
+1. Pool drafts with `Unspecified` pool size enter Garmin/export `review` state with an explicit partial-compatibility detail.
+2. Pool repeat blocks that keep the last rest interval enter Garmin/export `review` state with an explicit older-device fallback detail.
+3. Pool drafts using `CSS target pace` or `CSS send-off` enter Garmin/export `review` state with an explicit CSS/device-baseline detail.
+4. Existing save/load flows still work for reviewed workouts.
+5. Handoff text, PDF review notice, and Garmin-ready export diagnostics include the same device/CSS issues from the shared readiness report.
+6. Open-water behavior stays unchanged in this slice.
+
+## Validation
+
+- `npm run lint:briefs:all`
+- `npm run typecheck`
+- targeted `vitest`
+  - `tests/unit/workouts-shared.test.ts`
+  - `tests/unit/workout-builder-hub.test.tsx`
+- targeted Playwright
+  - `tests/e2e/my-library-workout-builder.spec.ts --project=desktop-chromium`
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm must be available on the machine used for validation.
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3100/my-library`
+  - desktop Chromium during implementation
+- Vercel preview:
+  - PR preview URL from checks
+
+## Constraints
+
+- Keep the slice additive and backward-compatible.
+- Prefer source-backed execution truthfulness over new unsupported device claims.
+- Do not imply a per-watch compatibility engine that the product does not actually have.
+
+## 10/10 Quality Bar
+
+- The new details should feel specific and useful, not like vague legalese.
+- Required states:
+  - loading: unchanged existing builder loading behavior
+  - empty: unchanged fallback state
+  - error: device/CSS caveats surface as review details, not route crashes
+  - retry/offline: existing save failure behavior remains unchanged
+- Accessibility:
+  - compatibility details remain visible plain text inside the existing support panels
+  - no extra click is required to preserve semantic meaning in exported outputs
+- Performance:
+  - readiness checks remain cheap relative to existing derived totals
+- Business logic:
+  - identical draft inputs always produce identical readiness/export diagnostics
+  - save/reopen must not erase or invent device/CSS cautions
+
+## Checkpoint Log
+
+- `2026-04-07 | a1183c2 | added pool-only readiness truthfulness guards for Unspecified pool size, use-last-rest repeat blocks, and CSS-relative targets in the shared Garmin/export layer; refreshed shared + hub tests; local validation passed via lint:briefs:all, typecheck, targeted vitest, targeted Playwright, and verify:pre-pr (96 passed / 318 skipped) | next: commit, push, open PR, and monitor CI`
+- `2026-04-07 | in progress | created a dedicated compatible-device execution truthfulness slice after the wording/output parity wave closed; the next source-backed Garmin gap is no longer labels, but pool features whose execution still varies by device or CSS baseline (`Unspecified` pool size, `Use last rest interval`, and CSS-relative targets) | next: update shared readiness logic, refresh targeted tests, and run the pre-PR gate`

--- a/docs/task-briefs/in-progress/2026-04-07-pool-swim-builder-compatible-device-execution-truthfulness-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-07-pool-swim-builder-compatible-device-execution-truthfulness-10-10.md
@@ -239,5 +239,6 @@ Critical target categories for `10/10` claim in this brief:
 
 ## Checkpoint Log
 
+- `2026-04-07 | pending commit | hardened the mobile install-prompt Playwright spec to stub deterministic course content and jump to a canonical lesson id so pre-merge no longer depends on the current published-course dataset; local `npm run verify:pre-merge` passed (`96 passed / 318 skipped`) | next: commit, push, refresh PR checks, and merge when CI is green`
 - `2026-04-07 | a1183c2 | added pool-only readiness truthfulness guards for Unspecified pool size, use-last-rest repeat blocks, and CSS-relative targets in the shared Garmin/export layer; refreshed shared + hub tests; local validation passed via lint:briefs:all, typecheck, targeted vitest, targeted Playwright, and verify:pre-pr (96 passed / 318 skipped) | next: commit, push, open PR, and monitor CI`
 - `2026-04-07 | in progress | created a dedicated compatible-device execution truthfulness slice after the wording/output parity wave closed; the next source-backed Garmin gap is no longer labels, but pool features whose execution still varies by device or CSS baseline (`Unspecified` pool size, `Use last rest interval`, and CSS-relative targets) | next: update shared readiness logic, refresh targeted tests, and run the pre-PR gate`

--- a/lib/workouts/shared.ts
+++ b/lib/workouts/shared.ts
@@ -2159,18 +2159,148 @@ function buildWorkoutGarminReadinessIssues(
 function buildWorkoutGarminAggregateReadinessIssues(
   draft: SessionDraft
 ): WorkoutGarminReadinessIssue[] {
-  if (draft.environment !== "pool" || draft.steps.length <= WORKOUT_GARMIN_POOL_MAX_STEP_COUNT) {
+  if (draft.environment !== "pool") {
     return [];
   }
 
-  return [
-    {
+  const issues: WorkoutGarminReadinessIssue[] = [];
+
+  if (draft.steps.length > WORKOUT_GARMIN_POOL_MAX_STEP_COUNT) {
+    issues.push({
       id: "draft-pool-step-cap",
       stepId: WORKOUT_GARMIN_DRAFT_ISSUE_STEP_ID,
       stepIndex: -1,
       detail: `This Pool Swim draft currently has ${draft.steps.length} authored steps. Garmin pool workouts top out at ${WORKOUT_GARMIN_POOL_MAX_STEP_COUNT} workout steps, so consolidate the set before Garmin/export handoff.`,
-    },
-  ];
+    });
+  }
+
+  const unspecifiedPoolSizeIssue = buildWorkoutGarminPoolUnspecifiedPoolSizeIssue(draft);
+  if (unspecifiedPoolSizeIssue) {
+    issues.push(unspecifiedPoolSizeIssue);
+  }
+
+  const repeatEndingRestCompatibilityIssue =
+    buildWorkoutGarminPoolRepeatEndingRestCompatibilityIssue(draft);
+  if (repeatEndingRestCompatibilityIssue) {
+    issues.push(repeatEndingRestCompatibilityIssue);
+  }
+
+  const cssCompatibilityIssue = buildWorkoutGarminPoolCssCompatibilityIssue(draft);
+  if (cssCompatibilityIssue) {
+    issues.push(cssCompatibilityIssue);
+  }
+
+  return issues;
+}
+
+function buildWorkoutGarminPoolUnspecifiedPoolSizeIssue(
+  draft: SessionDraft
+): WorkoutGarminReadinessIssue | null {
+  if (draft.environment !== "pool" || draft.poolLengthM !== null) {
+    return null;
+  }
+
+  return {
+    id: "draft-pool-size-unspecified-compatibility",
+    stepId: WORKOUT_GARMIN_DRAFT_ISSUE_STEP_ID,
+    stepIndex: -1,
+    detail:
+      "This Pool Swim draft uses Unspecified pool size. Garmin documents that setting as partially compatible across pool-swim watches: fully compatible devices keep the authored step distances as entered, while older devices may convert the distance in yard pools. Confirm the target watch before Garmin/export handoff.",
+  };
+}
+
+function buildWorkoutGarminPoolRepeatEndingRestCompatibilityIssue(
+  draft: SessionDraft
+): WorkoutGarminReadinessIssue | null {
+  if (draft.environment !== "pool") {
+    return null;
+  }
+
+  const useLastRestGroups = buildWorkoutHandoffGroups(draft.steps)
+    .filter((group): group is Extract<WorkoutHandoffGroup, { kind: "repeat" }> => group.kind === "repeat")
+    .filter(
+      (group) =>
+        group.repeatCount !== null &&
+        group.repeatCount > 1 &&
+        group.repeatEndingRestMode === "use_last_rest" &&
+        Boolean(group.entries.at(-1) && isSessionDraftRepeatEndingRestStep(group.entries.at(-1)!.step))
+    )
+    .map((group) => {
+      const firstEntry = group.entries[0];
+      return firstEntry
+        ? `repeat block starting at ${buildWorkoutStepReadinessLabel(firstEntry.step, firstEntry.index)}`
+        : null;
+    })
+    .filter((value): value is string => Boolean(value));
+
+  if (useLastRestGroups.length === 0) {
+    return null;
+  }
+
+  return {
+    id: "draft-pool-repeat-ending-rest-compatible-device-review",
+    stepId: WORKOUT_GARMIN_DRAFT_ISSUE_STEP_ID,
+    stepIndex: -1,
+    detail: `This Pool Swim draft keeps the last rest interval in ${joinWorkoutIssueReferences(
+      useLastRestGroups
+    )}. Garmin documents that compatible devices can use the last rest interval in a repeat block, but older watches skip the final rest instead. Confirm the target watch before Garmin/export handoff.`,
+  };
+}
+
+function buildWorkoutGarminPoolCssCompatibilityIssue(
+  draft: SessionDraft
+): WorkoutGarminReadinessIssue | null {
+  if (draft.environment !== "pool") {
+    return null;
+  }
+
+  const cssReferences = draft.steps.flatMap((step, index) => {
+    const stepLabel = buildWorkoutStepReadinessLabel(step, index);
+    const references: string[] = [];
+
+    if (step.targetMode === "css_target_pace") {
+      references.push(`${stepLabel} (CSS target pace)`);
+    }
+
+    if (step.durationMode === "css_send_off") {
+      references.push(`${stepLabel} (CSS send-off)`);
+    }
+
+    return references;
+  });
+
+  if (cssReferences.length === 0) {
+    return null;
+  }
+
+  const currentCssBaselineLabel = `${
+    draft.usedCssPaceLabel ?? formatClockDurationLabelFromSeconds(draft.basePaceSecondsPer100m)
+  }/100m`;
+
+  return {
+    id: "draft-pool-css-compatible-device-review",
+    stepId: WORKOUT_GARMIN_DRAFT_ISSUE_STEP_ID,
+    stepIndex: -1,
+    detail: `This Pool Swim draft uses CSS-relative pacing in ${joinWorkoutIssueReferences(
+      cssReferences
+    )}. Garmin documents that compatible devices auto-adjust CSS-relative send-off times and pace targets when CSS changes, and use 2:00/100m if no CSS is set. FreeSwimming previews currently use ${currentCssBaselineLabel} as the workout CSS baseline, so confirm the final watch target before Garmin/export handoff.`,
+  };
+}
+
+function joinWorkoutIssueReferences(values: string[]) {
+  if (values.length === 0) {
+    return "";
+  }
+
+  if (values.length === 1) {
+    return values[0];
+  }
+
+  if (values.length === 2) {
+    return `${values[0]} and ${values[1]}`;
+  }
+
+  return `${values.slice(0, -1).join(", ")}, and ${values[values.length - 1]}`;
 }
 
 function buildWorkoutGarminSendOffCompatibilityIssue(

--- a/tests/e2e/install-prompt.spec.ts
+++ b/tests/e2e/install-prompt.spec.ts
@@ -1,10 +1,47 @@
 import { expect, test, type Page } from "@playwright/test";
+import { COURSE_MODULES } from "../../app/course/courseData";
+import { resolveCanonicalCourseLessonRuntimeId } from "../../lib/course/runtime-id-manifest";
 import { isMobileProject } from "./project-guards";
 
 const UNSUPPORTED_BROWSER_MESSAGE =
   "Install is not available in this browser yet. For best support, use Safari, Chrome, or Edge.";
 const INSTALL_SUCCESS_MESSAGE =
   "App installed. You can open FreeSwimming from your Dock, Start menu, or home screen.";
+const INSTALL_PROMPT_LESSON_ID =
+  resolveCanonicalCourseLessonRuntimeId("mod3-l1") ?? "mod3-l1";
+
+async function stubPublishedCourseContent(page: Page) {
+  await page.route("**/api/course/content*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        modules: COURSE_MODULES,
+        preview: {
+          enabled: false,
+          mode: "published",
+        },
+      }),
+    });
+  });
+}
+
+async function gotoInstallPromptLesson(page: Page) {
+  await page.goto(`/course?lesson=${encodeURIComponent(INSTALL_PROMPT_LESSON_ID)}`, {
+    waitUntil: "domcontentloaded",
+    timeout: 60_000,
+  });
+  await waitForCoursePageToSettle(page);
+  await expect(page.getByTestId("course-page")).toHaveAttribute(
+    "data-active-lesson-id",
+    INSTALL_PROMPT_LESSON_ID
+  );
+}
+
+test.beforeEach(async ({ page }) => {
+  await stubPublishedCourseContent(page);
+});
 
 async function waitForCoursePageToSettle(page: Page) {
   const compilingIndicator = page.getByText("Compiling", { exact: true });
@@ -26,8 +63,7 @@ async function waitForCoursePageToSettle(page: Page) {
 }
 
 async function openMainMenuFromCourse(page: Page) {
-  await page.goto("/course?lesson=mod3-l1", { waitUntil: "domcontentloaded", timeout: 60_000 });
-  await waitForCoursePageToSettle(page);
+  await gotoInstallPromptLesson(page);
 
   const lessonsToggle = page.getByTestId("course-nav-lessons");
   const drawer = page.getByRole("dialog", { name: "Navigation menu" });
@@ -403,8 +439,7 @@ test("first successful mark-as-done can trigger contextual install prompt once",
   );
   test.slow();
 
-  await page.goto("/course?lesson=mod3-l1", { waitUntil: "domcontentloaded", timeout: 60_000 });
-  await waitForCoursePageToSettle(page);
+  await gotoInstallPromptLesson(page);
   const markDoneButton = page.getByTestId("course-mark-done-button");
   await expect(markDoneButton).toBeVisible();
   await dismissSwipeHintIfPresent(page);
@@ -443,8 +478,7 @@ test("contextual install prompt shows success confirmation after accepted instal
   );
   test.slow();
 
-  await page.goto("/course?lesson=mod3-l1", { waitUntil: "domcontentloaded", timeout: 60_000 });
-  await waitForCoursePageToSettle(page);
+  await gotoInstallPromptLesson(page);
   const markDoneButton = page.getByTestId("course-mark-done-button");
   await expect(markDoneButton).toBeVisible();
   await dismissSwipeHintIfPresent(page);
@@ -485,8 +519,7 @@ test("guest sees free-account backup prompt after completing three lessons", asy
     localStorage.removeItem("fs_course_done_lessons");
     localStorage.removeItem("fs_course_backup_prompt_dismissed_at");
   });
-  await page.goto("/course?lesson=mod3-l1", { waitUntil: "domcontentloaded", timeout: 60_000 });
-  await waitForCoursePageToSettle(page);
+  await gotoInstallPromptLesson(page);
   await dismissSwipeHintIfPresent(page);
 
   await satisfyDoneGateIfPresent(page);

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -304,7 +304,7 @@ describe("WorkoutBuilderHub", () => {
       "Unsaved changes stay local until you save this workout."
     );
     expect(screen.getByTestId("workout-editor-support-tools-status")).toHaveTextContent(
-      "2 review items"
+      "4 review items"
     );
     openSupportToolsPanel();
     expect(screen.getByTestId("workout-editor-garmin-readiness")).toHaveAttribute(
@@ -312,17 +312,29 @@ describe("WorkoutBuilderHub", () => {
       "review"
     );
     expect(screen.getByTestId("workout-editor-garmin-readiness-summary")).toHaveTextContent(
-      "Review 2 Garmin/export mapping details before you treat this workout as handoff-ready."
+      "Review 4 Garmin/export mapping details before you treat this workout as handoff-ready."
     );
     fireEvent.click(screen.getByTestId("workout-editor-garmin-readiness-toggle"));
-    expect(screen.getByTestId("workout-editor-garmin-readiness-issue-0")).toHaveTextContent("Fins");
-    expect(screen.getByTestId("workout-editor-garmin-readiness-issue-0")).toHaveTextContent(
+    expect(screen.getByTestId("workout-editor-garmin-readiness")).toHaveTextContent(
+      "last rest interval"
+    );
+    expect(screen.getByTestId("workout-editor-garmin-readiness")).toHaveTextContent(
+      "older watches skip the final rest instead"
+    );
+    expect(screen.getByTestId("workout-editor-garmin-readiness")).toHaveTextContent(
+      "CSS-relative pacing"
+    );
+    expect(screen.getByTestId("workout-editor-garmin-readiness")).toHaveTextContent(
+      "2:00/100m if no CSS is set"
+    );
+    expect(screen.getByTestId("workout-editor-garmin-readiness")).toHaveTextContent("Fins");
+    expect(screen.getByTestId("workout-editor-garmin-readiness")).toHaveTextContent(
       "Manual Garmin translation is still required"
     );
-    expect(screen.getByTestId("workout-editor-garmin-readiness-issue-1")).toHaveTextContent(
+    expect(screen.getByTestId("workout-editor-garmin-readiness")).toHaveTextContent(
       "CSS send-off"
     );
-    expect(screen.getByTestId("workout-editor-garmin-readiness-issue-1")).toHaveTextContent(
+    expect(screen.getByTestId("workout-editor-garmin-readiness")).toHaveTextContent(
       "open rest instead"
     );
     fireEvent.click(screen.getByTestId("workout-editor-garmin-export-toggle"));
@@ -1233,6 +1245,25 @@ describe("WorkoutBuilderHub", () => {
 
     expect(screen.getByTestId("workout-editor-panel")).toHaveTextContent("Unspecified selected.");
     expect(saveButton).toBeEnabled();
+    expect(screen.getByTestId("workout-editor-support-tools-status")).toHaveTextContent(
+      "1 review item"
+    );
+
+    openSupportToolsPanel();
+    expect(screen.getByTestId("workout-editor-garmin-readiness")).toHaveAttribute(
+      "data-readiness-status",
+      "review"
+    );
+    expect(screen.getByTestId("workout-editor-garmin-readiness-summary")).toHaveTextContent(
+      "Review 1 Garmin/export mapping detail before you treat this workout as handoff-ready."
+    );
+    fireEvent.click(screen.getByTestId("workout-editor-garmin-readiness-toggle"));
+    expect(screen.getByTestId("workout-editor-garmin-readiness")).toHaveTextContent(
+      "Unspecified pool size"
+    );
+    expect(screen.getByTestId("workout-editor-garmin-readiness")).toHaveTextContent(
+      "yard pools"
+    );
   });
 
   it("shows recovery guidance when the requested workout is missing", () => {

--- a/tests/unit/workouts-shared.test.ts
+++ b/tests/unit/workouts-shared.test.ts
@@ -155,6 +155,69 @@ describe("workouts shared readiness", () => {
     expect(report.issues[0]?.detail).toContain("100 workout steps");
   });
 
+  it("reports review when a pool workout uses unspecified pool size", () => {
+    const report = buildWorkoutGarminReadinessReport({
+      ...buildDraft(),
+      poolLengthM: null,
+    });
+
+    expect(report.status).toBe("review");
+    expect(report.summary).toBe(
+      "Review 1 Garmin/export mapping detail before you treat this workout as handoff-ready."
+    );
+    expect(report.issues).toHaveLength(1);
+    expect(report.issues[0]?.detail).toContain("Unspecified pool size");
+    expect(report.issues[0]?.detail).toContain("partially compatible across pool-swim watches");
+    expect(report.issues[0]?.detail).toContain("yard pools");
+  });
+
+  it("reports review when a pool repeat block keeps the last rest interval", () => {
+    const report = buildWorkoutGarminReadinessReport({
+      ...buildDraft(),
+      steps: [
+        {
+          id: "step-1",
+          category: "main",
+          name: "Repeat swim",
+          stroke: "freestyle",
+          intensity: "moderate",
+          durationMode: "distance",
+          distanceM: 100,
+          timeMin: null,
+          targetSummary: "Hold the line.",
+          notes: "",
+          repeatGroupId: "repeat-1",
+          repeatCount: 4,
+          repeatEndingRestMode: "use_last_rest",
+        },
+        {
+          id: "step-2",
+          category: "rest",
+          name: "Repeat rest",
+          stroke: "choice",
+          intensity: "easy",
+          durationMode: "send_off",
+          distanceM: null,
+          timeMin: 2,
+          targetSummary: "Reset before the next round.",
+          notes: "",
+          repeatGroupId: "repeat-1",
+          repeatCount: 4,
+          repeatEndingRestMode: "use_last_rest",
+        },
+      ],
+    });
+
+    expect(report.status).toBe("review");
+    expect(report.summary).toBe(
+      "Review 1 Garmin/export mapping detail before you treat this workout as handoff-ready."
+    );
+    expect(report.issues).toHaveLength(1);
+    expect(report.issues[0]?.detail).toContain("last rest interval");
+    expect(report.issues[0]?.detail).toContain("Step 1 (Repeat swim)");
+    expect(report.issues[0]?.detail).toContain("older watches skip the final rest instead");
+  });
+
   it("reports review when send-off time is not authored as a rest after a distance-based swim step", () => {
     const report = buildWorkoutGarminReadinessReport({
       ...buildDraft(),
@@ -196,7 +259,7 @@ describe("workouts shared readiness", () => {
     expect(report.issues[0]?.detail).toContain("is not a distance-based swim step");
   });
 
-  it("keeps valid CSS send-off rest usage ready when it follows a distance-based swim step", () => {
+  it("reports review for CSS-relative pool timing even when the send-off placement itself is valid", () => {
     const report = buildWorkoutGarminReadinessReport({
       ...buildDraft(),
       steps: [
@@ -228,9 +291,15 @@ describe("workouts shared readiness", () => {
       ],
     });
 
-    expect(report.status).toBe("ready");
-    expect(report.summary).toBe("Ready for the planned Garmin/export handoff.");
-    expect(report.issues).toEqual([]);
+    expect(report.status).toBe("review");
+    expect(report.summary).toBe(
+      "Review 1 Garmin/export mapping detail before you treat this workout as handoff-ready."
+    );
+    expect(report.issues).toHaveLength(1);
+    expect(report.issues[0]?.detail).toContain("CSS-relative pacing");
+    expect(report.issues[0]?.detail).toContain("Step 2 (CSS send-off rest) (CSS send-off)");
+    expect(report.issues[0]?.detail).toContain("2:00/100m if no CSS is set");
+    expect(report.issues[0]?.detail).toContain("2:08/100m as the workout CSS baseline");
   });
 
   it("builds a canonical handoff text export with workout metadata and steps", () => {
@@ -525,6 +594,8 @@ describe("workouts shared readiness", () => {
     expect(text).toContain("Source: Local draft");
     expect(text).toContain("Garmin/export readiness: Review");
     expect(text).toContain("Review before export/send");
+    expect(text).toContain("last rest interval");
+    expect(text).toContain("older watches skip the final rest instead");
     expect(text).toContain("IM by round");
     expect(text).toContain("Pull");
     expect(text).toContain("Fins");
@@ -582,8 +653,12 @@ describe("workouts shared readiness", () => {
       "freeswimming-review-export-draft-garmin-ready-draft.json"
     );
     expect(exportPayload.diagnostics.status).toBe("review");
-    expect(exportPayload.diagnostics.issueCount).toBe(1);
+    expect(exportPayload.diagnostics.issueCount).toBe(2);
+    expect(exportPayload.diagnostics.issues[0]?.detail).toContain("last rest interval");
     expect(exportPayload.diagnostics.issues[0]?.detail).toContain(
+      "older watches skip the final rest instead"
+    );
+    expect(exportPayload.diagnostics.issues[1]?.detail).toContain(
       "Garmin's documented swim-workout builder does not list a matching equipment field"
     );
     expect(exportPayload.blocks).toHaveLength(1);
@@ -753,8 +828,10 @@ describe("workouts shared readiness", () => {
     expect(html).toContain("Source: Local draft");
     expect(html).toContain("Review print draft");
     expect(html).toContain(
-      "Review 1 Garmin/export mapping detail before you treat this workout as handoff-ready."
+      "Review 2 Garmin/export mapping details before you treat this workout as handoff-ready."
     );
+    expect(html).toContain("last rest interval");
+    expect(html).toContain("older watches skip the final rest instead");
     expect(html).toContain("Manual Garmin translation is still required.");
     expect(html).toContain("Repeat block");
     expect(html).toContain("Repeat review swim");


### PR DESCRIPTION
## Summary

- What changed and why? This slice adds pool-only Garmin/export `review` guards where execution still varies by device or CSS state, and it hardens the install-prompt E2E fixture so the release gate no longer depends on whatever published course dataset happens to be live.
- User-visible changes: Pool workouts now surface truthful review warnings for `Unspecified` pool size, repeat blocks that keep the last rest interval, and CSS-relative targets anywhere the shared readiness/support output is shown.
- Technical changes: Updated `lib/workouts/shared.ts`, refreshed `tests/unit/workouts-shared.test.ts` and `tests/unit/workout-builder-hub.test.tsx`, hardened `tests/e2e/install-prompt.spec.ts` with stubbed course content plus canonical lesson routing, and recorded the checkpoint in `docs/task-briefs/in-progress/2026-04-07-pool-swim-builder-compatible-device-execution-truthfulness-10-10.md`.
- Policy impact: no - this changes workout compatibility guidance and test determinism only; no auth, privacy, billing, consent, or processor contract changes.
- Policy version note: N/A - no policy document or release-review contract changed in this slice.
- Brief link(s): `docs/task-briefs/in-progress/2026-04-07-pool-swim-builder-compatible-device-execution-truthfulness-10-10.md`

## Scope

- In scope: pool-only shared readiness/export truthfulness for `Unspecified` pool size, `Use last rest interval`, and CSS-relative targets, plus the install-prompt test hardening needed to keep the required merge gate deterministic.
- Out of scope: device-picker UI, schema changes, open-water parity work, or new save-blocking validation.

## Risk

- Main risk: over-flagging normal pool workflows as `review` instead of only the device/CSS-sensitive shapes Garmin documents, or accidentally making install-prompt coverage less representative while stabilizing it.
- Rollback plan: revert `3e7dffa` and `05bcceb` to restore the prior readiness contract and the previous install-prompt spec behavior.

## Test Evidence

- Policy-impact checklist: N/A - no policy-impact path or release-review checklist category changed in this PR.
- `npm run verify:pre-pr`: PASS (`96 passed / 318 skipped`)
- `npm run verify:pre-merge`: PASS on HEAD `05bcceb` (`96 passed / 318 skipped`)
- `npm run lint:briefs:all`: PASS
- `npm run lint`: PASS (covered in the full local pre-merge gate)
- `npm run typecheck`: PASS
- `npm run test:unit`: PASS
- `npm run build`: PASS
- `npm run test:e2e`: PASS (`96 passed / 318 skipped` in the full local pre-merge gate)
- `npx vitest run tests/unit/workouts-shared.test.ts tests/unit/workout-builder-hub.test.tsx`: PASS
- `npx playwright test tests/e2e/my-library-workout-builder.spec.ts --project=desktop-chromium`: PASS
- `npx playwright test tests/e2e/install-prompt.spec.ts --project=mobile-iphone-13-pro-max --grep "contextual install prompt shows success confirmation after accepted install"`: PASS
- Local manual QA done on dev URL (list URL + browser/device in PR description): NOT RUN - relied on targeted Playwright plus full `verify:pre-merge` for this slice.
- Vercel preview manual QA done (paste preview URL + browser/device in PR description): PENDING - optional spot-check after required CI returns green.
- QA covered relevant matrix for this change: PASS via full `npm run verify:pre-merge` across mobile, tablet, and desktop browser projects.

- [x] `npm run lint:briefs`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge` (must be `PASS` on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [x] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [x] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL: https://github.com/stianvikra/freeswimming/pull/386
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d feat/pool-swim-builder-execution-device-parity-2026-04-07`
- [ ] Optional: `git fetch --prune`
