### PR TITLE
polish pool builder owner note 3A29FEAE

### DIFF
--- a/components/my-library/workouts/WorkoutBuilderHub.tsx
+++ b/components/my-library/workouts/WorkoutBuilderHub.tsx
@@ -216,22 +216,6 @@ export default function WorkoutBuilderHub({
                 My Swim Sessions
               </Link>
             ) : null}
-            {savedWorkout ? (
-              <button
-                type="button"
-                onClick={() => {
-                  setPendingCurrentDelete(true);
-                  setPendingDeleteWorkoutId(null);
-                  setError("");
-                  setSuccess("");
-                }}
-                disabled={deletingWorkoutId === savedWorkout.id}
-                data-testid="workout-builder-delete-current-workout"
-                className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-700 transition hover:bg-rose-50 active:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {deletingWorkoutId === savedWorkout.id ? "Deleting..." : "Delete session"}
-              </button>
-            ) : null}
           </div>
         </div>
       )}
@@ -420,6 +404,13 @@ export default function WorkoutBuilderHub({
               showLoadedBanner={false}
               showPdfPanel={false}
               forceMetadataOpenOnLoad={preferExpandedDetailsOnLoad}
+              onRequestDeleteCurrent={() => {
+                setPendingCurrentDelete(true);
+                setPendingDeleteWorkoutId(null);
+                setError("");
+                setSuccess("");
+              }}
+              isDeletingCurrent={deletingWorkoutId === savedWorkout.id}
               recentWorkoutsDescription="Edit another saved session when you want to switch what you are working on."
               workoutHrefBuilder={(workoutId) => `/my-library/workouts/${workoutId}`}
               saveButtonTestId="workout-builder-save"

--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -2182,6 +2182,7 @@ export default function WorkoutEditor({
             <label className="text-sm text-slate-700 md:col-span-2">
               {isManualPoolMode ? "Step note" : "Notes"}
               <AutoGrowingTextarea
+                aria-label={isManualPoolMode ? "Step note" : "Notes"}
                 value={step.notes}
                 onChange={(event) =>
                   updateDraftStep(step.id, (current) => ({
@@ -2302,6 +2303,7 @@ export default function WorkoutEditor({
           </p>
         )}
         <AutoGrowingTextarea
+          aria-label="Session note"
           value={draft.description}
           onChange={(event) => updateDraft("description", event.target.value)}
           data-testid="session-draft-description"

--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState, type TextareaHTMLAttributes } from "react";
 import { BRAND_FONT_PUBLIC_PATH, BRAND_PDF_LOGO_PATH } from "@/lib/brand";
 import { useAutoDismissNotice } from "@/components/my-library/workouts/useAutoDismissNotice";
 import {
@@ -96,6 +96,8 @@ type Props = {
   showPdfPanel?: boolean;
   copyVariant?: "default" | "generator";
   forceMetadataOpenOnLoad?: boolean;
+  onRequestDeleteCurrent?: (() => void) | null;
+  isDeletingCurrent?: boolean;
 };
 
 type StepRenderEntry = {
@@ -139,10 +141,59 @@ type LastRemovedBlock = {
   restoreOpenStepId: string | null;
 };
 
+type AutoGrowingTextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  value: string;
+  minRows?: number;
+};
+
 type SupportSectionKey = "readiness" | "garminExport" | "handoff";
 
 const CUSTOM_DISTANCE_VALUE = "custom";
 const EMPTY_WORKOUT_POOLSIDE_FOCUS_OPTIONS: WorkoutPoolsideFocusOption[] = [];
+
+function syncAutoGrowingTextareaHeight(node: HTMLTextAreaElement, minRows: number) {
+  node.style.height = "auto";
+  const computedLineHeight = Number.parseFloat(window.getComputedStyle(node).lineHeight || "0");
+  const minimumHeight =
+    Number.isFinite(computedLineHeight) && computedLineHeight > 0
+      ? computedLineHeight * minRows + 24
+      : 44;
+  node.style.height = `${Math.max(node.scrollHeight, minimumHeight)}px`;
+}
+
+function AutoGrowingTextarea({
+  value,
+  minRows = 1,
+  className,
+  onInput,
+  style,
+  ...props
+}: AutoGrowingTextareaProps) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    if (!textareaRef.current) return;
+    syncAutoGrowingTextareaHeight(textareaRef.current, minRows);
+  }, [minRows, value]);
+
+  return (
+    <textarea
+      {...props}
+      ref={textareaRef}
+      value={value}
+      rows={minRows}
+      onInput={(event) => {
+        syncAutoGrowingTextareaHeight(event.currentTarget, minRows);
+        onInput?.(event);
+      }}
+      className={className}
+      style={{
+        ...style,
+        overflowY: "hidden",
+      }}
+    />
+  );
+}
 
 function buildStepId(index: number) {
   return `step-${Date.now()}-${index}`;
@@ -410,20 +461,31 @@ function formatClockDurationLabel(valueMinutes: number | null | undefined) {
   return formatClockDurationLabelFromSeconds(getClockTotalSeconds(valueMinutes));
 }
 
-function buildStepRemovalLabel(step: SessionDraftStep, fallbackIndex: number) {
+function buildStepRemovalLabel(
+  step: SessionDraftStep,
+  fallbackIndex: number,
+  options?: {
+    isManualPoolMode?: boolean;
+    basePaceSecondsPer100m?: number;
+  }
+) {
+  if (options?.isManualPoolMode && typeof options.basePaceSecondsPer100m === "number") {
+    return buildManualPoolStepSummary(step, options.basePaceSecondsPer100m);
+  }
+
   return (
     step.name.trim() || `${getSessionStepCategoryLabel(step.category)} step ${fallbackIndex + 1}`
   );
 }
 
-function buildStepSummary(
+function buildStepContextLabel(
   step: SessionDraftStep,
-  basePaceSecondsPer100m: number,
-  environment: SessionGeneratorEnvironment
+  options?: {
+    environment?: SessionGeneratorEnvironment | null;
+  }
 ) {
-  const structuredTarget = buildSessionStepStructuredTargetLabel(step, basePaceSecondsPer100m);
   const contextParts =
-    environment === "pool" && step.category === "rest"
+    options?.environment === "pool" && step.category === "rest"
       ? []
       : [getSessionStepStrokeLabel(step.stroke)];
 
@@ -444,15 +506,50 @@ function buildStepSummary(
     contextParts.push(getSessionStepEquipmentLabel(step.equipment));
   }
 
+  return contextParts.join(" · ");
+}
+
+function buildStepSummary(
+  step: SessionDraftStep,
+  basePaceSecondsPer100m: number,
+  environment: SessionGeneratorEnvironment
+) {
+  const structuredTarget = buildSessionStepStructuredTargetLabel(step, basePaceSecondsPer100m);
+
   return [
     buildWorkoutStepDurationOutputSummary(step, basePaceSecondsPer100m, {
       environment,
     }),
-    contextParts.join(" · "),
+    buildStepContextLabel(step, { environment }),
     structuredTarget ?? getSessionEffortLabel(step.intensity),
   ]
     .filter(Boolean)
     .join(" · ");
+}
+
+function buildManualPoolStepSummary(step: SessionDraftStep, basePaceSecondsPer100m: number) {
+  const structuredTarget = buildSessionStepStructuredTargetLabel(step, basePaceSecondsPer100m);
+
+  return [
+    buildWorkoutStepDurationOutputSummary(step, basePaceSecondsPer100m, {
+      environment: "pool",
+    }),
+    buildStepContextLabel(step, { environment: "pool" }),
+    structuredTarget,
+  ]
+    .filter(Boolean)
+    .join(" · ") || `${getSessionStepCategoryLabel(step.category)} step`;
+}
+
+function syncManualPoolEditableStep(
+  step: SessionDraftStep,
+  basePaceSecondsPer100m: number
+): SessionDraftStep {
+  return {
+    ...step,
+    name: buildManualPoolStepSummary(step, basePaceSecondsPer100m).slice(0, 120),
+    targetSummary: "",
+  };
 }
 
 function buildRepeatSummary(
@@ -594,6 +691,8 @@ export default function WorkoutEditor({
   showPdfPanel = true,
   copyVariant = "default",
   forceMetadataOpenOnLoad = false,
+  onRequestDeleteCurrent = null,
+  isDeletingCurrent = false,
 }: Props) {
   const draftTotals = computeSessionDraftDerivedTotals(draft);
   const garminReadiness = buildWorkoutGarminReadinessReport(draft);
@@ -919,9 +1018,14 @@ export default function WorkoutEditor({
   }, [savedWorkoutId]);
 
   function syncDraftSelections(nextDraft: SessionDraft) {
+    const nextSteps = isManualPoolMode
+      ? nextDraft.steps.map((step) =>
+          syncManualPoolEditableStep(step, nextDraft.basePaceSecondsPer100m)
+        )
+      : nextDraft.steps;
     const requiredStrokes = Array.from(
       new Set(
-        nextDraft.steps
+        nextSteps
           .map((step) => step.stroke)
           .filter((stroke): stroke is SessionGeneratorStroke =>
             SESSION_GENERATOR_STROKES.includes(stroke as SessionGeneratorStroke)
@@ -930,7 +1034,7 @@ export default function WorkoutEditor({
     );
     const requiredEquipment = Array.from(
       new Set(
-        nextDraft.steps
+        nextSteps
           .map((step) => step.equipment)
           .filter((value): value is (typeof SESSION_GENERATOR_EQUIPMENT)[number] =>
             SESSION_GENERATOR_EQUIPMENT.includes(
@@ -942,6 +1046,7 @@ export default function WorkoutEditor({
 
     return {
       ...nextDraft,
+      steps: nextSteps,
       allowedStrokes: Array.from(new Set([...nextDraft.allowedStrokes, ...requiredStrokes])),
       equipmentAllowlist: Array.from(
         new Set([...nextDraft.equipmentAllowlist, ...requiredEquipment])
@@ -1129,7 +1234,10 @@ export default function WorkoutEditor({
     setPendingRemoval({
       kind: "step",
       stepId,
-      label: buildStepRemovalLabel(step, stepIndex),
+      label: buildStepRemovalLabel(step, stepIndex, {
+        isManualPoolMode,
+        basePaceSecondsPer100m: draft.basePaceSecondsPer100m,
+      }),
       repeatGroupId: step.repeatGroupId ?? null,
     });
   }
@@ -1525,6 +1633,9 @@ export default function WorkoutEditor({
     const isOpen = openStepId === step.id;
     const toggleLabel = isOpen ? "Done" : "Edit step";
     const panelId = `session-draft-step-panel-${step.id}`;
+    const stepTitle = isManualPoolMode
+      ? buildManualPoolStepSummary(step, draft.basePaceSecondsPer100m)
+      : step.name || getSessionStepCategoryLabel(step.category);
 
     return (
       <article
@@ -1544,16 +1655,16 @@ export default function WorkoutEditor({
                 ? `Repeat step ${options?.repeatStepNumber ?? 1}`
                 : `Step ${index + 1}`}
             </p>
-            <p className="mt-1 text-sm font-medium text-slate-900">
-              {step.name || getSessionStepCategoryLabel(step.category)}
-            </p>
+            <p className="mt-1 text-sm font-medium text-slate-900">{stepTitle}</p>
             <p className="mt-1 text-xs font-medium text-slate-600">
               {getSessionStepCategoryLabel(step.category)}
             </p>
-            <p className="mt-2 text-xs text-slate-600">
-              {buildStepSummary(step, draft.basePaceSecondsPer100m, draft.environment)}
-            </p>
-            {step.targetSummary ? (
+            {!isManualPoolMode ? (
+              <p className="mt-2 text-xs text-slate-600">
+                {buildStepSummary(step, draft.basePaceSecondsPer100m, draft.environment)}
+              </p>
+            ) : null}
+            {!isManualPoolMode && step.targetSummary ? (
               <p className="mt-1 text-xs text-slate-500">{step.targetSummary}</p>
             ) : null}
             {step.notes ? <p className="mt-1 text-xs text-slate-400">{step.notes}</p> : null}
@@ -1634,21 +1745,23 @@ export default function WorkoutEditor({
 
         {isOpen ? (
           <div id={panelId} className="mt-4 grid gap-4 md:grid-cols-2">
-            <label className="text-sm text-slate-700">
-              Step name
-              <input
-                type="text"
-                value={step.name}
-                onChange={(event) =>
-                  updateDraftStep(step.id, (current) => ({
-                    ...current,
-                    name: event.target.value,
-                  }))
-                }
-                data-testid={`session-draft-step-name-${index}`}
-                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-              />
-            </label>
+            {isManualPoolMode ? null : (
+              <label className="text-sm text-slate-700">
+                Step name
+                <input
+                  type="text"
+                  value={step.name}
+                  onChange={(event) =>
+                    updateDraftStep(step.id, (current) => ({
+                      ...current,
+                      name: event.target.value,
+                    }))
+                  }
+                  data-testid={`session-draft-step-name-${index}`}
+                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                />
+              </label>
+            )}
 
             <label className="text-sm text-slate-700">
               {isManualPoolMode ? "Step type" : "Category"}
@@ -1716,12 +1829,16 @@ export default function WorkoutEditor({
               </select>
             </label>
 
-            <p className="text-sm text-slate-500 md:col-span-2">
-              {buildStepStrokeGuidance(step, isManualPoolMode)}
-            </p>
-            <p className="text-sm text-slate-500 md:col-span-2">
-              {buildStepFocusGuidance(step, isManualPoolMode)}
-            </p>
+            {isManualPoolMode ? null : (
+              <>
+                <p className="text-sm text-slate-500 md:col-span-2">
+                  {buildStepStrokeGuidance(step, isManualPoolMode)}
+                </p>
+                <p className="text-sm text-slate-500 md:col-span-2">
+                  {buildStepFocusGuidance(step, isManualPoolMode)}
+                </p>
+              </>
+            )}
 
             <label className="text-sm text-slate-700">
               Equipment
@@ -1744,25 +1861,27 @@ export default function WorkoutEditor({
               </select>
             </label>
 
-            <label className="text-sm text-slate-700">
-              Effort cue
-              <select
-                value={step.intensity}
-                onChange={(event) =>
-                  updateDraftStep(step.id, (current) => ({
-                    ...current,
-                    intensity: event.target.value as SessionDraft["effort"],
-                  }))
-                }
-                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-              >
-                {SESSION_GENERATOR_EFFORT_PRESETS.map((value) => (
-                  <option key={value} value={value}>
-                    {getSessionEffortLabel(value)}
-                  </option>
-                ))}
-              </select>
-            </label>
+            {isManualPoolMode ? null : (
+              <label className="text-sm text-slate-700">
+                Effort cue
+                <select
+                  value={step.intensity}
+                  onChange={(event) =>
+                    updateDraftStep(step.id, (current) => ({
+                      ...current,
+                      intensity: event.target.value as SessionDraft["effort"],
+                    }))
+                  }
+                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                >
+                  {SESSION_GENERATOR_EFFORT_PRESETS.map((value) => (
+                    <option key={value} value={value}>
+                      {getSessionEffortLabel(value)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
 
             <label className="text-sm text-slate-700">
               {isManualPoolMode ? "Step timing" : "Duration mode"}
@@ -2043,32 +2162,26 @@ export default function WorkoutEditor({
               </label>
             ) : null}
 
-            <label className="text-sm text-slate-700 md:col-span-2">
-              {isManualPoolMode ? "Target summary" : "Target notes"}
-              <input
-                type="text"
-                aria-label={isManualPoolMode ? "Target summary" : "Target notes"}
-                value={step.targetSummary}
-                onChange={(event) =>
-                  updateDraftStep(step.id, (current) => ({
-                    ...current,
-                    targetSummary: event.target.value,
-                  }))
-                }
-                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-              />
-              {isManualPoolMode ? (
-                <p className="mt-2 text-xs text-slate-500">
-                  Optional short cue for the interval summary. Use Step note for the Garmin-style
-                  step note.
-                </p>
-              ) : null}
-            </label>
+            {isManualPoolMode ? null : (
+              <label className="text-sm text-slate-700 md:col-span-2">
+                Target notes
+                <input
+                  type="text"
+                  value={step.targetSummary}
+                  onChange={(event) =>
+                    updateDraftStep(step.id, (current) => ({
+                      ...current,
+                      targetSummary: event.target.value,
+                    }))
+                  }
+                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                />
+              </label>
+            )}
 
             <label className="text-sm text-slate-700 md:col-span-2">
               {isManualPoolMode ? "Step note" : "Notes"}
-              <textarea
-                aria-label={isManualPoolMode ? "Step note" : "Notes"}
+              <AutoGrowingTextarea
                 value={step.notes}
                 onChange={(event) =>
                   updateDraftStep(step.id, (current) => ({
@@ -2076,8 +2189,8 @@ export default function WorkoutEditor({
                     notes: event.target.value,
                   }))
                 }
-                rows={3}
-                className="mt-2 block w-full rounded-xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                minRows={isManualPoolMode ? 1 : 3}
+                className="mt-2 block w-full resize-y rounded-xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
               />
               {isManualPoolMode ? (
                 <p className="mt-2 text-xs text-slate-500">
@@ -2182,16 +2295,18 @@ export default function WorkoutEditor({
 
       <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700 md:col-span-2">
         Session note
-        <p className="mt-2 text-xs text-slate-500">
-          Optional. Use this for the whole-session purpose or one short coaching note that applies
-          across the session.
-        </p>
-        <textarea
+        {isManualPoolMode ? null : (
+          <p className="mt-2 text-xs text-slate-500">
+            Optional. Use this for the whole-session purpose or one short coaching note that
+            applies across the session.
+          </p>
+        )}
+        <AutoGrowingTextarea
           value={draft.description}
           onChange={(event) => updateDraft("description", event.target.value)}
           data-testid="session-draft-description"
-          rows={4}
-          className="mt-2 block w-full rounded-xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+          minRows={isManualPoolMode ? 1 : 4}
+          className="mt-2 block w-full resize-y rounded-xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
         />
       </label>
 
@@ -2231,13 +2346,14 @@ export default function WorkoutEditor({
           <p className="text-sm font-medium text-slate-900">
             {isManualPoolMode ? "Pool Size" : "Pool length"}
           </p>
-          <p className="mt-1 text-xs text-slate-500">
-            {isManualPoolMode
-              ? "Choose 25m, 50m, or Unspecified. Use the exact field only when you need a less common pool size."
-              : "Choose 12.5m, 25m, or 50m, or type the exact length when you build for a less common setup."}
-          </p>
+          {isManualPoolMode ? null : (
+            <p className="mt-1 text-xs text-slate-500">
+              Choose 12.5m, 25m, or 50m, or type the exact length when you build for a less common
+              setup.
+            </p>
+          )}
 
-          <div className="mt-3 flex flex-wrap gap-2">
+          <div className={`${isManualPoolMode ? "mt-0" : "mt-3"} flex flex-wrap gap-2`}>
             {(isManualPoolMode
               ? MANUAL_POOL_SIZE_QUICK_CHOICES
               : SESSION_DRAFT_POOL_LENGTH_PRESETS
@@ -2924,11 +3040,9 @@ export default function WorkoutEditor({
                 Session details
               </p>
               <h3 className="mt-2 text-base font-semibold text-slate-900">{metadataHeading}</h3>
-              <p className="mt-1 text-sm text-slate-600">
-                {metadataOpen
-                  ? "Keep the top-level setup here while you shape the workout steps below."
-                  : collapsedMetadataCopy}
-              </p>
+              {metadataOpen ? null : (
+                <p className="mt-1 text-sm text-slate-600">{collapsedMetadataCopy}</p>
+              )}
               {!metadataOpen ? (
                 <p
                   data-testid="workout-editor-metadata-summary"
@@ -2938,15 +3052,28 @@ export default function WorkoutEditor({
                 </p>
               ) : null}
             </div>
-            <button
-              type="button"
-              onClick={() => setMetadataOpen((current) => !current)}
-              aria-expanded={metadataOpen}
-              data-testid="workout-editor-metadata-toggle"
-              className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
-            >
-              {metadataOpen ? "Hide details" : "Show details"}
-            </button>
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setMetadataOpen((current) => !current)}
+                aria-expanded={metadataOpen}
+                data-testid="workout-editor-metadata-toggle"
+                className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+              >
+                {metadataOpen ? "Hide details" : "Show details"}
+              </button>
+              {savedWorkout && onRequestDeleteCurrent ? (
+                <button
+                  type="button"
+                  onClick={onRequestDeleteCurrent}
+                  disabled={isDeletingCurrent}
+                  data-testid="workout-builder-delete-current-workout"
+                  className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-700 transition hover:bg-rose-50 active:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isDeletingCurrent ? "Deleting..." : "Delete session"}
+                </button>
+              ) : null}
+            </div>
           </div>
 
           {metadataOpen ? <div className="mt-4">{metadataFields}</div> : null}
@@ -2957,7 +3084,9 @@ export default function WorkoutEditor({
 
       <div className="rounded-2xl border border-slate-200 bg-white p-4">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <h3 className="text-base font-semibold text-slate-900">Editable draft steps</h3>
+          <h3 className="text-base font-semibold text-slate-900">
+            {isManualPoolMode ? "Session builder" : "Editable draft steps"}
+          </h3>
           <div className="flex flex-wrap gap-2">
             <button
               type="button"
@@ -3079,13 +3208,17 @@ export default function WorkoutEditor({
                         group.repeatEndingRestMode
                       )}
                     </p>
-                    <p className="mt-1 text-xs text-slate-600">
-                      Edit the repeated steps below instead of duplicating every round by hand.
-                    </p>
-                    <p className="mt-1 text-xs text-slate-500">
-                      Repeat counts currently support {SESSION_DRAFT_REPEAT_MIN}-
-                      {SESSION_DRAFT_REPEAT_MAX} rounds per block.
-                    </p>
+                    {isManualPoolMode ? null : (
+                      <>
+                        <p className="mt-1 text-xs text-slate-600">
+                          Edit the repeated steps below instead of duplicating every round by hand.
+                        </p>
+                        <p className="mt-1 text-xs text-slate-500">
+                          Repeat counts currently support {SESSION_DRAFT_REPEAT_MIN}-
+                          {SESSION_DRAFT_REPEAT_MAX} rounds per block.
+                        </p>
+                      </>
+                    )}
                   </div>
                   <div className="flex flex-wrap items-end gap-2">
                     <label className="text-sm text-slate-700">

--- a/docs/task-briefs/in-progress/2026-04-07-pool-builder-owner-note-3a29feae-step-detail-polish-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-07-pool-builder-owner-note-3a29feae-step-detail-polish-10-10.md
@@ -1,0 +1,226 @@
+# Task Brief: Pool Builder Owner Note 3A29FEAE Step And Detail Polish (10/10)
+
+## Metadata
+
+- `id`: `2026-04-07-pool-builder-owner-note-3a29feae-step-detail-polish-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-04-07`
+- `updated`: `2026-04-07`
+
+## Goal
+
+The pool session builder removes the remaining small authoring seams from owner note `3A29FEAE-C00D-4088-B72F-C265F8253CA2` so step editing feels calmer, more Garmin-familiar in semantics, and less cluttered during real manual workout building.
+
+## Why This Brief Exists
+
+- The pool Garmin-parity wave shipped on `main` on `2026-04-06`, but live manual use immediately surfaced smaller builder-polish issues inside the saved-session editor.
+- Owner note `3A29FEAE-C00D-4088-B72F-C265F8253CA2` groups a coherent set of low-risk, high-frequency friction points on `/my-library/workouts/8082725f-26de-4efe-876f-9e84148bba45`.
+- The note is not asking for a new Garmin implementation slice. It is asking for owner-led polish on top of the shipped pool builder:
+  - calmer copy,
+  - better delete placement,
+  - one-line expandable note fields,
+  - removal of pool-only redundant or unclear step fields.
+- This is safer to handle as one bounded child brief now than to scatter the note into more micro-fixes while manual builder review is still active.
+
+## Dependencies And Boundaries
+
+- Parent builder live-review brief:
+  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md`
+- Recently shipped pool builder lineage that stays authoritative:
+  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/docs/task-briefs/done/2026-04-06-pool-swim-builder-field-parity-10-10.md`
+  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/docs/task-briefs/done/2026-04-06-pool-swim-builder-repeat-rest-parity-10-10.md`
+  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/docs/task-briefs/done/2026-04-06-pool-swim-builder-garmin-parity-10-10.md`
+- Metadata-panel lineage that this slice builds on:
+  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/docs/task-briefs/done/2026-04-05-swim-session-builder-metadata-panel-clarity-10-10.md`
+- Parked follow-up that must remain parked in this chat:
+  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/docs/task-briefs/planned/2026-04-07-pool-swim-builder-garmin-follow-up-map-10-10.md`
+- Primary implementation files likely touched:
+  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/components/my-library/workouts/WorkoutEditor.tsx`
+  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/components/my-library/workouts/WorkoutBuilderHub.tsx`
+  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/tests/unit/workout-builder-hub.test.tsx`
+  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/tests/e2e/my-library-workout-builder.spec.ts`
+- Boundary decisions for this brief:
+  - no new Garmin slice,
+  - no open-water contract decisions,
+  - no schema migration,
+  - no broad export/handoff redesign beyond what is required to keep hidden pool-only fields truthful.
+
+## Admin Notes Triage Disposition
+
+- `3a29feae-c00d-4088-b72f-c265f8253ca2` `Swim Session Builder`
+  - disposition: owned by this brief.
+  - reason: the note is one coherent pool-builder polish bundle on the saved-session route and can be implemented safely without reopening broader builder architecture.
+  - scope adopted from the note:
+    - remove the top metadata helper sentence,
+    - move `Delete session` beside the details toggle,
+    - make `Session note` one-line by default with auto-growth,
+    - remove the manual-pool `Pool Size` helper copy,
+    - remove manual-pool `Step name`,
+    - rename `Editable draft steps` to `Session builder`,
+    - remove the manual-pool stroke/drill helper copy,
+    - make `Step note` one-line by default with auto-growth,
+    - remove repeat helper copy,
+    - remove the duplicate top-level `Effort cue`,
+    - remove manual-pool `Target notes`.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `Product goals and IA`
+- `UX flow clarity`
+- `Business logic correctness and data integrity`
+- `Admin workflow and editability`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                                   | Evidence                                     |
+| --------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| Product goals and IA                          | `target`     | The saved pool builder reads as one coherent session-authoring surface, with step labels/actions that match real manual coaching jobs without leftover filler.  | manual QA + code review + targeted e2e       |
+| UX flow clarity                               | `target`     | Pool step editing shows only one obvious control for each authoring concept, and session/delete actions are visible where the owner expects them.               | targeted e2e + manual QA                     |
+| Visual design quality                         | `target`     | The metadata header, repeat cards, and pool step editor feel calmer after helper-copy removal and note-field density reduction.                                | screenshot review + manual QA                |
+| Business logic correctness and data integrity | `target`     | Hiding `Step name` and `Target notes` from the pool UI does not leave stale hidden labels in save/export flows; pool step titles remain generated truthfully. | unit tests + implementation review           |
+| Admin editor ergonomics                       | `target`     | High-frequency pool session edits require fewer unnecessary fields and less scrolling while preserving clear destructive-action placement.                      | timed manual QA + targeted e2e               |
+| Accessibility (a11y)                          | `supporting` | Supporting only: moved buttons, renamed sections, and auto-growing note fields remain labeled, keyboard reachable, and screen-reader compatible.               | code review + targeted tests                 |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: the route remains within current builder expectations and this slice adds no heavy client dependency.                                          | dependency diff + typecheck                  |
+| Data placement and sync boundaries            | `target`     | The brief explicitly keeps the canonical workout draft as server truth while limiting this slice to presentation and safe pool-step compatibility mapping.      | brief contract + code review                 |
+| Caching and invalidation strategy             | `supporting` | Supporting only: save/delete still reuse the existing builder refresh path with no second draft store or extra cache layer.                                    | implementation review                        |
+| Reliability and failure handling              | `target`     | Save/delete/removal flows stay deterministic after control movement and pool-only field removal; no new dead-end or hidden-state failure path is introduced.   | unit/e2e coverage + manual QA                |
+| Security and authz                            | `supporting` | Supporting only: this slice keeps the current authenticated owner-only workout route and action boundaries unchanged.                                           | existing auth boundaries + scope review      |
+| Privacy and compliance                        | `N/A`        | N/A because this slice changes only owner-facing pool-builder UI and note density, not sensitive-data policy or disclosure.                                    | explicit scope rationale                     |
+| Content governance                            | `supporting` | Supporting only: copy and labels must stay aligned with the shipped pool builder contract and not imply unsupported Garmin or open-water behavior.             | copy review + brief alignment                |
+| Admin workflow and editability                | `target`     | The owner can reopen a saved pool session and edit steps/details with fewer redundant controls and clearer destructive-action placement.                        | manual QA + targeted tests                   |
+| SEO and crawlability                          | `N/A`        | N/A because `/my-library/workouts/[workoutId]` is an authenticated owner surface with no public crawl contract.                                                | explicit scope rationale                     |
+| AI discoverability                            | `N/A`        | N/A because this slice changes no public route, metadata, or AI-facing document surface.                                                                       | explicit scope rationale                     |
+| Analytics and KPI observability               | `supporting` | Supporting only: session-edit and delete behavior stays observable through existing route-level builder usage without new event dependencies.                   | scope review                                 |
+| Commerce and revenue ops                      | `N/A`        | N/A because no entitlement, billing, pricing, or revenue path changes.                                                                                          | explicit scope rationale                     |
+| Incident response and support operations      | `N/A`        | N/A because this slice is limited to owner-facing builder copy/layout polish and does not change runbook-worthy failure or support workflows.                  | explicit scope rationale                     |
+| Finance and reporting operations              | `N/A`        | N/A because no finance, reconciliation, or reporting flow changes in this builder polish slice.                                                                 | explicit scope rationale                     |
+| i18n operational readiness                    | `N/A`        | N/A because this slice adjusts internal English builder copy only and does not change localization architecture or locale routing.                              | explicit scope rationale                     |
+| Stack-fit and dependency discipline           | `target`     | Reuse the current workout-builder stack and component model; do not add new dependencies or a second step-storage contract.                                    | dependency diff + architecture review        |
+| Testing and QA automation                     | `target`     | Unit and e2e coverage protect the new pool-builder visibility contract, delete placement, and hidden-field compatibility rules.                                | targeted tests + `verify:pre-pr`            |
+| Scalability and cost efficiency               | `supporting` | Supporting only: the slice reduces operator friction without adding extra fetch churn, polling, or preview generation cost.                                     | code review                                  |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: the slice is reversible through normal UI/component rollback with no schema drift.                                                             | diff review + rollback note                 |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - `workout.id`,
+  - the saved workout draft payload in the existing workouts table,
+  - canonical step arrays, notes, and builder metadata already persisted through the current workout save route.
+- Local-only:
+  - metadata-panel open/closed state,
+  - pending delete confirmation state,
+  - note field height/auto-grow presentation,
+  - local undo/removal presentation state.
+- Sync policy:
+  - canonical save still occurs only through the existing `PATCH /api/my-library/workouts/[id]` flow,
+  - this brief does not add a second draft entity or local-only persisted step model,
+  - for manual pool editing, hidden `step.name` and `targetSummary` values may remain in the stored draft schema for compatibility, but the editor must keep them synchronized to generated pool-step titles and cleared target-summary values so hidden stale copy does not leak into downstream save/export surfaces.
+- Retention and sensitivity:
+  - no new sensitive data class is introduced,
+  - note text remains owner-authored workout content under the existing retention model.
+- Cache/invalidation:
+  - current route refresh and recent-workout summary updates remain authoritative after save/delete.
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - `workout.id` remains the only canonical identity for saved swim sessions.
+- Human-readable identifiers:
+  - session title and visible step summaries are editable or generated display strings, not stable identifiers.
+- Mutability rules:
+  - session title and note fields remain editable in place,
+  - pool step display titles become generated from canonical step fields in the builder instead of hand-authored `Step name` input,
+  - workout deletion still removes the saved workout entity instead of repurposing it.
+- Rename vs repurpose policy:
+  - step-summary display changes are presentation cleanup on the same step entity,
+  - no new step identity or alias model is introduced in this slice.
+- Compatibility contract:
+  - existing saved workouts still load through the same route and draft contract,
+  - hidden `step.name` stays schema-compatible for now, but the manual pool editor must stop depending on it as a user-authored field.
+- Observability and repair:
+  - if a hidden legacy field would become stale, the pool editor should overwrite it with generated step naming before save rather than leave invisible drift.
+
+## Scope
+
+- Move the saved-session `Delete session` action from the top route header into the metadata/details header beside the details toggle.
+- Remove the open metadata helper sentence that reads like scaffolding.
+- Rename the pool step section heading from `Editable draft steps` to `Session builder`.
+- Remove these controls or helper blocks from the manual pool editor only:
+  - `Step name`,
+  - the duplicate top-level `Effort cue`,
+  - `Target notes`,
+  - stroke/drill helper paragraphs,
+  - repeat helper copy,
+  - manual `Pool Size` helper copy.
+- Make these fields one-line by default with auto-growth while typing:
+  - `Session note`,
+  - `Step note`.
+- Keep pool-step visible titles/summaries truthful after `Step name` removal by generating them from canonical step fields.
+- Update targeted tests for the new manual-pool builder contract.
+
+## Out Of Scope
+
+- Starting a new Garmin slice or reopening the parked Garmin follow-up brief.
+- Any open-water builder contract or layout decisions.
+- Schema migration or permanent removal of `step.name` / `targetSummary` from stored workout drafts.
+- Broad export, PDF, handoff, or API redesign beyond the compatibility mapping required by this note.
+- Dryland or AI-generated builder changes beyond shared-component compatibility.
+
+## Acceptance Criteria
+
+1. The saved pool builder shows `Delete session` beside the details toggle instead of beside `My Swim Sessions`.
+2. The pool metadata panel no longer shows the sentence `Keep the top-level setup here while you shape the workout steps below.`
+3. The pool builder section is labeled `Session builder`.
+4. Manual pool step editing no longer shows `Step name`, the duplicate top `Effort cue`, or `Target notes`.
+5. Manual pool `Session note` and `Step note` start as one-line textareas and grow while typing.
+6. Hidden legacy pool fields do not leave stale generic step names or target-summary copy in the current save/export contract.
+7. Targeted tests and `npm run verify:pre-pr` pass before PR update.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run typecheck`
+- targeted `vitest`:
+  - `tests/unit/workout-builder-hub.test.tsx`
+- targeted `playwright`:
+  - `tests/e2e/my-library-workout-builder.spec.ts --project=desktop-chromium`
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm must be installed on the machine used for local validation.
+- Local validation runs from repo root.
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3000/my-library/workouts/<id>`
+- Preview:
+  - PR preview URL after branch push
+
+## Constraints
+
+- Keep this slice explicitly pool-only.
+- Prefer truthful UI cleanup and compatibility mapping over deeper schema changes.
+- Do not introduce a broader "same as Garmin visually" goal; this is about calmer FreeSwimming-native UI with Garmin-familiar semantics where already shipped.
+- Do not break the current canonical save route or downstream export surfaces while removing visible fields.
+
+## 10/10 Quality Bar
+
+- A coach reopening a saved pool session should understand the page structure without filler text.
+- The step editor should show only one control per pool authoring concept where possible.
+- Hidden compatibility fields must not leak stale or generic labels into save/export behavior.
+- Required states remain clear:
+  - loading: current client-ready/canonical-save readiness states remain unchanged,
+  - empty: no-session state remains truthful,
+  - error: save/delete failures still explain what happened,
+  - retry: existing save-again/delete-again flow remains the recovery path.
+
+## Checkpoint Log
+
+- `2026-04-07 | planning | created a dedicated child brief from owner note 3A29FEAE on the shipped pool builder route; scoped it to UI/detail polish only, explicitly kept the parked Garmin follow-up out of scope, and documented that hidden pool step fields must stay compatibility-safe without turning this into a schema migration | next: implement the pool-builder UI cleanup, update targeted tests, and run lint:briefs + targeted validation + verify:pre-pr`

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -149,18 +149,15 @@ test.describe("my library workout builder", () => {
     await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
       "CSS send-off"
     );
-    await expect(page.getByLabel("Step name")).toHaveCount(0);
-    await expect(page.getByLabel("Effort cue")).toHaveCount(0);
-    await expect(page.getByLabel("Target summary")).toHaveCount(0);
-    await expect(page.getByLabel("Target notes")).toHaveCount(0);
-    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
-      "CSS send-off"
-    );
+    await expect(page.locator("label").filter({ hasText: /^Step name$/ })).toHaveCount(0);
+    await expect(page.locator("label").filter({ hasText: /^Effort cue$/ })).toHaveCount(0);
+    await expect(page.locator("label").filter({ hasText: /^Target summary$/ })).toHaveCount(0);
+    await expect(page.locator("label").filter({ hasText: /^Target notes$/ })).toHaveCount(0);
     await expect(
       page.getByText(
         "Optional short cue for the interval summary. Use Step note for the Garmin-style step note."
       )
-    ).toBeVisible();
+    ).toHaveCount(0);
     await expect(
       page.getByText("Closest match to Garmin Add Step Note for this pool step.")
     ).toBeVisible();
@@ -253,7 +250,6 @@ test.describe("my library workout builder", () => {
     await page.getByTestId("session-draft-step-target-mode-1").selectOption("target_pace");
     await page.getByTestId("session-draft-step-target-pace-minutes-1").fill("1");
     await page.getByTestId("session-draft-step-target-pace-seconds-1").fill("35");
-    await page.getByLabel("Target summary").fill("Hold 1:35 and leave on the red top.");
     await page.getByLabel("Step note").fill("Leave on the top and count strokes.");
     await page.getByTestId("session-draft-title").fill(uniqueTitle);
     await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
@@ -289,9 +285,6 @@ test.describe("my library workout builder", () => {
     );
     await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(
       "Final rest skipped"
-    );
-    await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(
-      "Target summary: Hold 1:35 and leave on the red top."
     );
     await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(
       "Step note: Leave on the top and count strokes."

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -122,12 +122,14 @@ test.describe("my library workout builder", () => {
     await expect(page.getByRole("combobox", { name: "Effort" })).toHaveCount(0);
     await expect(page.getByTestId("session-draft-step-toggle-0")).toBeVisible();
     await page.getByTestId("session-draft-step-toggle-0").click();
+    await expect(
+      page.getByTestId("workout-editor-panel").getByRole("heading", { name: "Session builder" })
+    ).toBeVisible();
     await expect(page.getByLabel("Step type")).toBeVisible();
     await expect(page.getByLabel("Stroke")).toBeVisible();
     await expect(page.getByLabel("Drill type")).toBeVisible();
     await expect(page.getByLabel("Step timing")).toBeVisible();
     await expect(page.getByRole("combobox", { name: "Target" })).toBeVisible();
-    await expect(page.getByRole("textbox", { name: "Target summary" })).toBeVisible();
     await expect(page.getByRole("textbox", { name: "Step note" })).toBeVisible();
     await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
       "Distance swim"
@@ -144,6 +146,13 @@ test.describe("my library workout builder", () => {
     await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
       "Send-off time"
     );
+    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
+      "CSS send-off"
+    );
+    await expect(page.getByLabel("Step name")).toHaveCount(0);
+    await expect(page.getByLabel("Effort cue")).toHaveCount(0);
+    await expect(page.getByLabel("Target summary")).toHaveCount(0);
+    await expect(page.getByLabel("Target notes")).toHaveCount(0);
     await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
       "CSS send-off"
     );
@@ -205,11 +214,9 @@ test.describe("my library workout builder", () => {
     );
     await savedWorkoutPdfPopup.close();
 
-    await page.getByTestId("session-draft-step-name-0").fill("Warmup swim");
-
     await page.getByTestId("session-draft-step-remove-0").click();
     await expect(page.getByTestId("workout-editor-removal-confirm")).toContainText(
-      "Remove Warmup swim?"
+      "Remove 100m · Freestyle?"
     );
     await expect(page.getByTestId("workout-builder-save")).toBeDisabled();
     await page.getByTestId("workout-editor-removal-cancel-button").click();
@@ -217,7 +224,7 @@ test.describe("my library workout builder", () => {
     await page.getByTestId("session-draft-step-remove-0").click();
     await page.getByTestId("workout-editor-removal-confirm-button").click();
     await expect(page.getByTestId("workout-editor-removal-undo")).toContainText(
-      "Removed Warmup swim."
+      "Removed 100m · Freestyle."
     );
     await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
       "Unsaved changes stay local until you save this workout."
@@ -231,7 +238,6 @@ test.describe("my library workout builder", () => {
 
     await openMetadataPanelIfCollapsed(page);
     await expect(page.getByTestId("session-draft-title")).toHaveValue("Untitled pool session");
-    await expect(page.getByTestId("session-draft-step-name-0")).toHaveValue("Warmup swim");
     await page.getByTestId("session-draft-pool-length-input").fill("33.33");
     await page.getByTestId("session-draft-step-distance-0").selectOption("custom");
     await page.getByTestId("session-draft-step-distance-custom-0").fill("333");
@@ -240,7 +246,6 @@ test.describe("my library workout builder", () => {
     await page
       .getByTestId("session-draft-repeat-ending-rest-mode-1")
       .selectOption("skip_last_rest");
-    await page.getByTestId("session-draft-step-name-1").fill("Repeat swim focus");
     await page.getByTestId("session-draft-step-distance-1").selectOption("200");
     await page.getByTestId("session-draft-step-stroke-1").selectOption("backstroke");
     await page.getByTestId("session-draft-step-drill-type-1").selectOption("pull");
@@ -321,7 +326,7 @@ test.describe("my library workout builder", () => {
       page.getByText(
         "Optional. Use this for the whole-session purpose or one short coaching note that applies across the session."
       )
-    ).toBeVisible();
+    ).toHaveCount(0);
     await expect(page.getByTestId("workout-builder-save")).toBeEnabled();
 
     const pdfPopupPromise = page.waitForEvent("popup");
@@ -335,7 +340,8 @@ test.describe("my library workout builder", () => {
     await expect(pdfPopup.locator('[data-testid="workout-pdf-title"]')).toContainText(uniqueTitle);
     await expect(pdfPopup.locator("body")).toContainText("Workout PDF");
     await expect(pdfPopup.locator("body")).toContainText("Print / Save PDF");
-    await expect(pdfPopup.locator("body")).toContainText("Repeat swim focus");
+    await expect(pdfPopup.locator("body")).toContainText("200m");
+    await expect(pdfPopup.locator("body")).toContainText("Backstroke");
     await pdfPopup.close();
 
     const poolsidePopupPromise = page.waitForEvent("popup");
@@ -403,7 +409,6 @@ test.describe("my library workout builder", () => {
     await expect(page.getByTestId("session-draft-step-distance-custom-0")).toHaveValue("333");
     await expect(page.getByTestId("session-draft-repeat-count-1")).toHaveValue("6");
     await page.getByTestId("session-draft-step-toggle-1").click();
-    await expect(page.getByTestId("session-draft-step-name-1")).toHaveValue("Repeat swim focus");
     await expect(page.getByTestId("session-draft-step-distance-1")).toHaveValue("200");
     await expect(page.getByTestId("session-draft-step-stroke-1")).toHaveValue("backstroke");
     await expect(page.getByTestId("session-draft-step-drill-type-1")).toHaveValue("pull");

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -1180,12 +1180,12 @@ describe("WorkoutBuilderHub", () => {
 
     fireEvent.click(screen.getByTestId("session-draft-step-toggle-0"));
 
+    expect(screen.getByText("Session builder")).toBeVisible();
     expect(screen.getByLabelText("Step type")).toBeVisible();
     expect(screen.getByLabelText("Stroke")).toBeVisible();
     expect(screen.getByLabelText("Drill type")).toBeVisible();
     expect(screen.getByLabelText("Step timing")).toBeVisible();
     expect(screen.getByLabelText("Target")).toBeVisible();
-    expect(screen.getByLabelText("Target summary")).toBeVisible();
     expect(screen.getByLabelText("Step note")).toBeVisible();
     expect(screen.getByRole("option", { name: "Distance swim" })).toBeVisible();
     expect(screen.getByRole("option", { name: "Time-based swim" })).toBeVisible();
@@ -1193,21 +1193,20 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.getByRole("option", { name: "Rest time" })).toBeVisible();
     expect(screen.getByRole("option", { name: "Send-off time" })).toBeVisible();
     expect(screen.getByRole("option", { name: "CSS send-off" })).toBeVisible();
+    expect(screen.queryByLabelText("Step name")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Effort cue")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Target summary")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Target notes")).not.toBeInTheDocument();
     expect(
-      screen.getByText(
-        "Use Stroke for the swim pattern. Add Drill type only when the step needs extra drill, kick, or pull notation."
+      screen.queryByText(
+        "Use Stroke pattern for the swim pattern. Add Drill type only when the step needs extra drill, kick, or pull notation."
       )
-    ).toBeVisible();
+    ).not.toBeInTheDocument();
     expect(
-      screen.getByText(
+      screen.queryByText(
         "Optional. Leave Drill type on None unless the step needs extra drill, kick, or pull notation."
       )
-    ).toBeVisible();
-    expect(
-      screen.getByText(
-        "Optional short cue for the interval summary. Use Step note for the Garmin-style step note."
-      )
-    ).toBeVisible();
+    ).not.toBeInTheDocument();
     expect(
       screen.getByText("Closest match to Garmin Add Step Note for this pool step.")
     ).toBeVisible();


### PR DESCRIPTION
## Summary

- User-visible changes: Saved pool workout builder now places `Delete session` beside the details toggle, renames the step section to `Session builder`, removes redundant manual-pool step fields (`Step name`, top `Effort cue`, `Target notes`), and keeps `Session note` / `Step note` compact with auto-grow.
- Technical changes: Rebased the owner-note slice onto latest `main`, preserved canonical generated pool step summaries after removing manual `Step name`, updated targeted unit/e2e coverage, and kept hidden compatibility fields schema-safe.
- Policy impact: no - this is owner-facing builder polish only, with no auth, privacy, billing, analytics, or third-party processor change.
- Policy version note: N/A - no policy-impacting scope.
- Brief link(s): `docs/task-briefs/in-progress/2026-04-07-pool-builder-owner-note-3a29feae-step-detail-polish-10-10.md`
- Scorecard target outcomes: `Product goals and IA 4/5`, `UX flow clarity 5/5`, `Visual design quality 4/5`, `Business logic correctness and data integrity 5/5`, `Admin editor ergonomics 5/5`, `Data placement and sync boundaries 5/5`, `Reliability and failure handling 5/5`, `Admin workflow and editability 5/5`.

## Scope

- In scope: saved pool session builder polish on `/my-library/workouts/[workoutId]`, including note density, action placement, section naming, and manual-pool step field cleanup.
- Out of scope: new Garmin slice work, open-water contract changes, schema migration, or unrelated builder redesign.

## Risk

- Main risk: regression in saved pool builder step summaries or delete-session placement after rebasing onto newer `main` changes in the same editor/test files.
- Rollback plan: revert commits `65b92fa` and `81a50b3` from `main` to restore the previous pool builder behavior.

## Test Evidence

- Policy-impact checklist: N/A (owner-facing builder polish only; no auth, analytics, user-data-rights, or third-party processor paths changed).
- verify:pre-pr: PASS (ran locally before the first PR push on the pre-rebase branch head; current rebased head is covered by the full pre-merge pass below).
- verify:pre-merge: PASS (ran locally on rebased HEAD `81a50b3`).
- `npx vitest run tests/unit/workout-builder-hub.test.tsx`: PASS
- `npm run typecheck`: PASS
- `npx playwright test tests/e2e/my-library-workout-builder.spec.ts --project=desktop-chromium`: PASS
- GitHub checks currently PASS for `Analyze (javascript-typescript)`, `size-check`, `deploy-preview`, `e2e-smoke`, `site-lock-smoke`, and `Vercel`; `verify` is being rerun after PR body correction.

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task brief includes full 10/10 scorecard mapping
- [x] Targeted local validation completed on rebased HEAD
- [ ] Owner visual QA on the saved pool builder route
- [ ] GitHub `verify` green after PR body fix
