### PR TITLE
close out pool builder owner note 3A29FEAE brief

### DIFF
--- a/docs/task-briefs/done/2026-04-07-pool-builder-owner-note-3a29feae-step-detail-polish-10-10.md
+++ b/docs/task-briefs/done/2026-04-07-pool-builder-owner-note-3a29feae-step-detail-polish-10-10.md
@@ -3,10 +3,10 @@
 ## Metadata
 
 - `id`: `2026-04-07-pool-builder-owner-note-3a29feae-step-detail-polish-10-10`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-04-07`
-- `updated`: `2026-04-07`
+- `updated`: `2026-04-08`
 
 ## Goal
 
@@ -26,20 +26,20 @@ The pool session builder removes the remaining small authoring seams from owner 
 ## Dependencies And Boundaries
 
 - Parent builder live-review brief:
-  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md`
+  - `docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md`
 - Recently shipped pool builder lineage that stays authoritative:
-  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/docs/task-briefs/done/2026-04-06-pool-swim-builder-field-parity-10-10.md`
-  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/docs/task-briefs/done/2026-04-06-pool-swim-builder-repeat-rest-parity-10-10.md`
-  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/docs/task-briefs/done/2026-04-06-pool-swim-builder-garmin-parity-10-10.md`
+  - `docs/task-briefs/done/2026-04-06-pool-swim-builder-field-parity-10-10.md`
+  - `docs/task-briefs/done/2026-04-06-pool-swim-builder-repeat-rest-parity-10-10.md`
+  - `docs/task-briefs/done/2026-04-06-pool-swim-builder-garmin-parity-10-10.md`
 - Metadata-panel lineage that this slice builds on:
-  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/docs/task-briefs/done/2026-04-05-swim-session-builder-metadata-panel-clarity-10-10.md`
+  - `docs/task-briefs/done/2026-04-05-swim-session-builder-metadata-panel-clarity-10-10.md`
 - Parked follow-up that must remain parked in this chat:
-  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/docs/task-briefs/planned/2026-04-07-pool-swim-builder-garmin-follow-up-map-10-10.md`
+  - `docs/task-briefs/planned/2026-04-07-pool-swim-builder-garmin-follow-up-map-10-10.md`
 - Primary implementation files likely touched:
-  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/components/my-library/workouts/WorkoutEditor.tsx`
-  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/components/my-library/workouts/WorkoutBuilderHub.tsx`
-  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/tests/unit/workout-builder-hub.test.tsx`
-  - `/tmp/freeswimming-pool-builder-owner-note-3a29feae-2026-04-07/tests/e2e/my-library-workout-builder.spec.ts`
+  - `components/my-library/workouts/WorkoutEditor.tsx`
+  - `components/my-library/workouts/WorkoutBuilderHub.tsx`
+  - `tests/unit/workout-builder-hub.test.tsx`
+  - `tests/e2e/my-library-workout-builder.spec.ts`
 - Boundary decisions for this brief:
   - no new Garmin slice,
   - no open-water contract decisions,
@@ -224,3 +224,4 @@ Critical target categories for `10/10` claim in this brief:
 ## Checkpoint Log
 
 - `2026-04-07 | planning | created a dedicated child brief from owner note 3A29FEAE on the shipped pool builder route; scoped it to UI/detail polish only, explicitly kept the parked Garmin follow-up out of scope, and documented that hidden pool step fields must stay compatibility-safe without turning this into a schema migration | next: implement the pool-builder UI cleanup, update targeted tests, and run lint:briefs + targeted validation + verify:pre-pr`
+- `2026-04-08 | shipped | merged PR #388 to main as squash commit def4b42 after rebasing, targeted unit/e2e fixes, local verify:pre-merge PASS, and green required GitHub checks; moved this brief to done and normalized repo-relative references for long-term traceability | next: continue collecting owner-led builder-polish findings under the parent live-review thread`


### PR DESCRIPTION
## Summary

- User-visible changes: The shipped pool builder owner-note brief is now closed out in the repo lifecycle, moved from `in-progress` to `done`, and no longer points at temporary `/tmp` worktree paths.
- Technical changes: Moved `docs/task-briefs/in-progress/2026-04-07-pool-builder-owner-note-3a29feae-step-detail-polish-10-10.md` to `docs/task-briefs/done/`, updated metadata to `done`, normalized dependency/file references to repo-relative paths, and added a shipped checkpoint entry for PR #388 / merge commit `def4b42`.
- Policy impact: no - brief lifecycle housekeeping only, with no runtime, auth, privacy, billing, analytics, or processor-path changes.
- Policy version note: N/A - no policy-impacting scope.

## Scope

- In scope: brief lifecycle closeout for the already-merged pool builder owner-note slice, including status/path normalization and checkpoint traceability.
- Out of scope: any product/runtime code changes, new builder polish work, Garmin follow-up work, or open-water contract changes.

## Risk

- Main risk: the brief closeout could leave stale references or mismatched lifecycle metadata if the move/update is incomplete.
- Rollback plan: revert commit `1855618` from `main` to restore the brief to its prior `in-progress` location and contents.

## Test Evidence

- Policy-impact checklist: N/A (brief lifecycle housekeeping only; no auth, analytics, user-data-rights, or third-party processor paths changed).
- verify:pre-pr: PASS (ran locally on closeout HEAD `1855618`).
- verify:pre-merge: NOT RUN (reserved for merge gate after PR checks are green).
- `npm run lint:briefs:all`: PASS

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task brief includes full 10/10 scorecard mapping
- [x] `verify:pre-pr`
- [ ] `verify:pre-merge`
