### PR TITLE
feat: polish swim session builder support tools

### DIFF
--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -44,7 +44,6 @@ import {
   getSessionStrokeLabel,
   getSessionTypeLabel,
   isSessionDraftRepeatEndingRestStep,
-  isSessionDraftPoolLengthPreset,
   isSessionDraftStepDistancePreset,
   resolveSessionDraftRepeatEndingRestMode,
   type SessionDraft,
@@ -132,6 +131,10 @@ type PendingRemoval =
     };
 
 const MANUAL_POOL_SIZE_QUICK_CHOICES = [25, 50] as const;
+const YARD_POOL_SIZE_QUICK_CHOICES = [25, 50] as const;
+const METERS_PER_YARD = 0.9144;
+
+type PoolLengthUnit = "m" | "yd";
 
 type LastRemovedBlock = {
   kind: "step" | "repeat";
@@ -246,7 +249,19 @@ function parsePositiveInteger(value: string) {
   return parsed;
 }
 
-function parsePoolLengthInput(value: string) {
+function roundToTwoDecimals(value: number) {
+  return Math.round(value * 100) / 100;
+}
+
+function convertPoolLengthToMeters(value: number, unit: PoolLengthUnit) {
+  return roundToTwoDecimals(unit === "yd" ? value * METERS_PER_YARD : value);
+}
+
+function convertMetersToPoolLengthUnit(value: number, unit: PoolLengthUnit) {
+  return roundToTwoDecimals(unit === "yd" ? value / METERS_PER_YARD : value);
+}
+
+function parsePoolLengthInput(value: string, unit: PoolLengthUnit = "m") {
   const trimmed = value.trim().replace(",", ".");
   if (trimmed.length === 0) return null;
   if (!/^\d+(\.\d{0,2})?$/.test(trimmed)) return null;
@@ -254,17 +269,36 @@ function parsePoolLengthInput(value: string) {
   const parsed = Number.parseFloat(trimmed);
   if (!Number.isFinite(parsed)) return null;
 
-  const normalized = Math.round(parsed * 100) / 100;
-  if (normalized < SESSION_DRAFT_POOL_LENGTH_MIN || normalized > SESSION_DRAFT_POOL_LENGTH_MAX) {
+  const normalizedMeters = convertPoolLengthToMeters(parsed, unit);
+  if (
+    normalizedMeters < SESSION_DRAFT_POOL_LENGTH_MIN ||
+    normalizedMeters > SESSION_DRAFT_POOL_LENGTH_MAX
+  ) {
     return null;
   }
 
-  return normalized;
+  return normalizedMeters;
 }
 
-function formatEditablePoolLength(value: number | null | undefined) {
+function formatEditablePoolLength(value: number | null | undefined, unit: PoolLengthUnit = "m") {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return "";
-  return value.toFixed(2).replace(/\.?0+$/, "");
+  return convertMetersToPoolLengthUnit(value, unit).toFixed(2).replace(/\.?0+$/, "");
+}
+
+function formatPoolLengthUnitLabel(value: number, unit: PoolLengthUnit) {
+  return `${formatEditablePoolLength(value, unit)}${unit}`;
+}
+
+function isPoolLengthQuickChoiceSelected(
+  currentValueMeters: number | null | undefined,
+  quickChoiceValue: number,
+  unit: PoolLengthUnit
+) {
+  if (typeof currentValueMeters !== "number" || !Number.isFinite(currentValueMeters)) {
+    return false;
+  }
+
+  return Math.abs(currentValueMeters - convertPoolLengthToMeters(quickChoiceValue, unit)) < 0.01;
 }
 
 function formatEditableDistance(value: number | null | undefined) {
@@ -707,6 +741,7 @@ export default function WorkoutEditor({
   const isManualPoolMode = manualBuilderMode === "pool";
   const isManualOpenWaterMode = manualBuilderMode === "open_water";
   const [openStepId, setOpenStepId] = useState<string | null>(null);
+  const [poolLengthUnit, setPoolLengthUnit] = useState<PoolLengthUnit>("m");
   const [poolLengthInput, setPoolLengthInput] = useState(() =>
     formatEditablePoolLength(draft.poolLengthM)
   );
@@ -770,9 +805,18 @@ export default function WorkoutEditor({
           unsavedDraftPendingState:
             "This draft still needs to be accepted into the canonical workout layer.",
         };
+  const poolLengthQuickChoices =
+    poolLengthUnit === "yd"
+      ? YARD_POOL_SIZE_QUICK_CHOICES
+      : isManualPoolMode
+        ? MANUAL_POOL_SIZE_QUICK_CHOICES
+        : SESSION_DRAFT_POOL_LENGTH_PRESETS;
   const poolLengthUsesPreset =
-    typeof draft.poolLengthM === "number" && isSessionDraftPoolLengthPreset(draft.poolLengthM);
-  const parsedPoolLengthInput = parsePoolLengthInput(poolLengthInput);
+    typeof draft.poolLengthM === "number" &&
+    poolLengthQuickChoices.some((value) =>
+      isPoolLengthQuickChoiceSelected(draft.poolLengthM, value, poolLengthUnit)
+    );
+  const parsedPoolLengthInput = parsePoolLengthInput(poolLengthInput, poolLengthUnit);
   const poolSizeInputInvalid =
     draft.environment === "pool" &&
     !poolSizeExplicitlyUnspecified &&
@@ -816,7 +860,9 @@ export default function WorkoutEditor({
     ? [
         draftTotals.totalDistanceM ? `${draftTotals.totalDistanceM}m` : null,
         draftTotals.estimatedDurationMin ? `~${draftTotals.estimatedDurationMin} min` : null,
-        draft.poolLengthM === null ? "Pool size unspecified" : formatPoolLengthLabel(draft.poolLengthM),
+        draft.poolLengthM === null
+          ? "Pool size unspecified"
+          : formatPoolLengthUnitLabel(draft.poolLengthM, poolLengthUnit),
       ]
         .filter(Boolean)
         .join(" · ")
@@ -919,9 +965,9 @@ export default function WorkoutEditor({
   useAutoDismissNotice(handoffNotice, setHandoffNotice);
 
   useEffect(() => {
-    setPoolLengthInput(formatEditablePoolLength(draft.poolLengthM));
+    setPoolLengthInput(formatEditablePoolLength(draft.poolLengthM, poolLengthUnit));
     setPoolSizeExplicitlyUnspecified(draft.environment === "pool" && draft.poolLengthM === null);
-  }, [draft.environment, draft.poolLengthM]);
+  }, [draft.environment, draft.poolLengthM, poolLengthUnit]);
 
   useEffect(() => {
     if (openStepId && !draft.steps.some((step) => step.id === openStepId)) {
@@ -1496,10 +1542,21 @@ export default function WorkoutEditor({
       return;
     }
 
-    const parsed = parsePoolLengthInput(nextValue);
+    const parsed = parsePoolLengthInput(nextValue, poolLengthUnit);
     if (parsed !== null) {
       updateDraft("poolLengthM", parsed);
     }
+  }
+
+  function updatePoolLengthUnit(nextUnit: PoolLengthUnit) {
+    setPoolLengthUnit(nextUnit);
+  }
+
+  function choosePoolLengthQuickChoice(value: number) {
+    const nextPoolLength = convertPoolLengthToMeters(value, poolLengthUnit);
+    setPoolSizeExplicitlyUnspecified(false);
+    setPoolLengthInput(formatEditablePoolLength(nextPoolLength, poolLengthUnit));
+    updateDraft("poolLengthM", nextPoolLength);
   }
 
   function chooseUnspecifiedPoolSize() {
@@ -2348,31 +2405,65 @@ export default function WorkoutEditor({
           <p className="text-sm font-medium text-slate-900">
             {isManualPoolMode ? "Pool Size" : "Pool length"}
           </p>
+          <div
+            role="group"
+            aria-label={isManualPoolMode ? "Pool size unit" : "Pool length unit"}
+            className="mt-3 flex flex-wrap items-center gap-2"
+          >
+            {([
+              ["m", "Meters"],
+              ["yd", "Yards"],
+            ] as const).map(([unit, label]) => {
+              const isSelected = poolLengthUnit === unit;
+              return (
+                <button
+                  key={unit}
+                  type="button"
+                  aria-pressed={isSelected}
+                  data-testid={`workout-editor-pool-length-unit-${unit}`}
+                  onClick={() => updatePoolLengthUnit(unit)}
+                  className={`inline-flex h-9 items-center justify-center rounded-full border px-3 text-sm transition ${
+                    isSelected
+                      ? "border-blue-600 bg-blue-50 text-blue-700"
+                      : "border-slate-200 bg-white text-slate-700 hover:bg-slate-100"
+                  }`}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+          {poolLengthUnit === "yd" ? (
+            <p className="mt-2 text-xs text-slate-500">
+              Yard entry converts to the saved meter value automatically.
+            </p>
+          ) : null}
           {isManualPoolMode ? null : (
             <p className="mt-1 text-xs text-slate-500">
-              Choose 12.5m, 25m, or 50m, or type the exact length when you build for a less common
-              setup.
+              Choose the unit first, then pick a common pool size or type the exact length for a
+              less common setup.
             </p>
           )}
 
           <div className={`${isManualPoolMode ? "mt-0" : "mt-3"} flex flex-wrap gap-2`}>
-            {(isManualPoolMode
-              ? MANUAL_POOL_SIZE_QUICK_CHOICES
-              : SESSION_DRAFT_POOL_LENGTH_PRESETS
-            ).map((value) => {
-              const isSelected = draft.poolLengthM === value;
+            {poolLengthQuickChoices.map((value) => {
+              const isSelected = isPoolLengthQuickChoiceSelected(
+                draft.poolLengthM,
+                value,
+                poolLengthUnit
+              );
               return (
                 <button
                   key={value}
                   type="button"
-                  onClick={() => updateDraft("poolLengthM", value)}
+                  onClick={() => choosePoolLengthQuickChoice(value)}
                   className={`inline-flex h-10 items-center justify-center rounded-full border px-3 text-sm transition ${
                     isSelected
                       ? "border-blue-600 bg-blue-50 text-blue-700"
                       : "border-slate-200 bg-white text-slate-700 hover:bg-slate-100"
                   }`}
                 >
-                  {formatPoolLengthLabel(value)}
+                  {poolLengthUnit === "yd" ? `${value}yd` : formatPoolLengthLabel(value)}
                 </button>
               );
             })}
@@ -2393,7 +2484,9 @@ export default function WorkoutEditor({
           </div>
 
           <label className="mt-4 block text-sm text-slate-700">
-            {isManualPoolMode ? "Exact pool size (m)" : "Exact pool length (m)"}
+            {isManualPoolMode
+              ? `Exact pool size (${poolLengthUnit})`
+              : `Exact pool length (${poolLengthUnit})`}
             <input
               type="text"
               inputMode="decimal"
@@ -2407,20 +2500,28 @@ export default function WorkoutEditor({
           <p className="mt-2 text-xs text-slate-500">
             {poolSizeInputInvalid ? (
               <>
-                Enter a valid pool size between {formatPoolLengthLabel(SESSION_DRAFT_POOL_LENGTH_MIN)}{" "}
-                and {formatPoolLengthLabel(SESSION_DRAFT_POOL_LENGTH_MAX)}, or choose Unspecified.
+                {poolLengthUnit === "yd"
+                  ? `Enter a valid pool ${isManualPoolMode ? "size" : "length"} in yards, or choose Unspecified.`
+                  : `Enter a valid pool ${isManualPoolMode ? "size" : "length"} between ${formatPoolLengthLabel(
+                      SESSION_DRAFT_POOL_LENGTH_MIN
+                    )} and ${formatPoolLengthLabel(SESSION_DRAFT_POOL_LENGTH_MAX)}, or choose Unspecified.`}
               </>
             ) : (
               <>
-                Supported range: {formatPoolLengthLabel(SESSION_DRAFT_POOL_LENGTH_MIN)} to{" "}
-                {formatPoolLengthLabel(SESSION_DRAFT_POOL_LENGTH_MAX)}.{" "}
+                {poolLengthUnit === "yd"
+                  ? "Common yard presets: 25yd and 50yd. "
+                  : `Supported range: ${formatPoolLengthLabel(
+                      SESSION_DRAFT_POOL_LENGTH_MIN
+                    )} to ${formatPoolLengthLabel(SESSION_DRAFT_POOL_LENGTH_MAX)}. `}
                 {draft.poolLengthM === null
                   ? isManualPoolMode
                     ? "Unspecified selected."
                     : "Enter a valid pool length before saving."
                   : poolLengthUsesPreset
                     ? "Preset selected."
-                    : `Custom length saved as ${formatPoolLengthLabel(draft.poolLengthM)}.`}
+                    : `Custom ${
+                        poolLengthUnit === "yd" ? "size" : "length"
+                      } saved as ${formatPoolLengthUnitLabel(draft.poolLengthM, poolLengthUnit)}.`}
               </>
             )}
           </p>
@@ -2836,7 +2937,10 @@ export default function WorkoutEditor({
         <div className="rounded-2xl border border-blue-100 bg-white/80 p-4">
           <p className="text-sm font-semibold text-slate-900">Open focus cues</p>
           {trainingFocusOptions.length > 0 ? (
-            <div className="mt-3 grid gap-3">
+            <div
+              data-testid="workout-editor-poolside-focus-list"
+              className="mt-3 grid max-h-72 gap-3 overflow-y-auto pr-1"
+            >
               {trainingFocusOptions.map((focus) => (
                 <label
                   key={focus.id}
@@ -2848,11 +2952,8 @@ export default function WorkoutEditor({
                     onChange={() => togglePoolsideFocusSelection(focus.id)}
                     data-testid={`workout-editor-poolside-focus-${focus.id}`}
                   />
-                  <span>
+                  <span className="min-w-0 flex-1">
                     <span className="block font-medium text-slate-900">{focus.title}</span>
-                    <span className="mt-1 block text-xs text-slate-500">
-                      {focus.isPrimary ? "Primary focus" : "Optional focus"}
-                    </span>
                   </span>
                 </label>
               ))}
@@ -2926,13 +3027,17 @@ export default function WorkoutEditor({
           >
             Export and handoff support
           </p>
-          <p className="mt-2 text-sm font-medium text-slate-900">
-            {supportToolsAudienceDescription}
-          </p>
-          <p className="mt-1 text-sm text-slate-700">{supportToolsDraftStateDescription}</p>
-          <p className="mt-1 text-sm text-slate-600">{supportToolsPersistenceDescription}</p>
-          {supportToolsWarningSummary ? (
-            <p className="mt-1 text-sm text-slate-600">{supportToolsWarningSummary}</p>
+          {supportToolsOpen ? (
+            <>
+              <p className="mt-2 text-sm font-medium text-slate-900">
+                {supportToolsAudienceDescription}
+              </p>
+              <p className="mt-1 text-sm text-slate-700">{supportToolsDraftStateDescription}</p>
+              <p className="mt-1 text-sm text-slate-600">{supportToolsPersistenceDescription}</p>
+              {supportToolsWarningSummary ? (
+                <p className="mt-1 text-sm text-slate-600">{supportToolsWarningSummary}</p>
+              ) : null}
+            </>
           ) : null}
         </div>
         <div className="flex flex-wrap items-center gap-2">

--- a/docs/task-briefs/in-progress/2026-04-08-swim-session-builder-support-tools-pool-size-and-poolside-focus-polish-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-08-swim-session-builder-support-tools-pool-size-and-poolside-focus-polish-10-10.md
@@ -1,0 +1,206 @@
+# Task Brief: Swim Session Builder Support Tools, Pool Size, And Poolside Focus Polish (10/10)
+
+## Metadata
+
+- `id`: `2026-04-08-swim-session-builder-support-tools-pool-size-and-poolside-focus-polish-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-04-08`
+- `updated`: `2026-04-08`
+
+## Goal
+
+The saved swim-session builder feels calmer on first load, supports yard-pool authoring without changing the meter-canonical workout contract, and keeps the Poolside Note focus selector compact and readable.
+
+## Why This Brief Exists
+
+- Live owner review on `2026-04-08` surfaced two remaining open `Swim Session Builder` notes after the earlier create-vs-edit and step-detail slices shipped.
+- The remaining notes point to three still-open UX seams on `/my-library/workouts`:
+  - support/export boxes still feel too visible even when collapsed,
+  - pool-size authoring does not support yards like Garmin users expect,
+  - the Poolside Note focus selector grows too much and repeats redundant `Primary focus` / `Optional focus` helper text.
+- These are polish-level improvements on the saved session builder and should ship as one owner-led cleanup slice instead of reopening the broader Garmin roadmap.
+
+## Dependencies And Boundaries
+
+- Parent brief that remains authoritative for the broader saved-workout builder wave:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md`
+- Related already-shipped child briefs to preserve rather than reopen:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-05-swim-session-builder-create-vs-edit-clarity-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-07-pool-builder-owner-note-3a29feae-step-detail-polish-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-06-pool-swim-builder-field-parity-10-10.md`
+- Core implementation surfaces in scope:
+  - `/Users/stianvikra/freeswimming/components/my-library/workouts/WorkoutEditor.tsx`
+  - `/Users/stianvikra/freeswimming/tests/unit/workout-builder-hub.test.tsx`
+  - `/Users/stianvikra/freeswimming/tests/e2e/my-library-workout-builder.spec.ts`
+- Locked product boundary for this slice:
+  - `workouts.pool_length_m` and workout export/handoff stay meter-canonical,
+  - this slice may add a builder-side `meters / yards` authoring preference, but it must not reopen export-step distance parity, Garmin delivery scope, or open-water contract work,
+  - support/export tooling stays available, but the collapsed builder state should reveal less explanatory chrome by default.
+
+## Admin Notes Triage Disposition
+
+- `54f170f7-63dc-48f4-ae8e-3f784b04870a` `Swim Session Builder`
+  - disposition: owned by this brief.
+  - reason: the note asks for a truly collapsed support-tools surface and yard-pool authoring support on the saved swim-session builder.
+- `66e90451-f008-4fcd-8e9d-810f2b1ef740` `Swim Session Builder - Poolside Note`
+  - disposition: owned by this brief.
+  - reason: the note asks to remove redundant focus helper text and keep the focus picker visually contained instead of letting the box grow indefinitely.
+- `3a29feae-c00d-4088-b72f-c265f8253ca2` `Swim Session Builder`
+  - disposition: already shipped outside this brief.
+  - reason: the step-detail polish slice merged on `main` earlier and should only be marked done in admin notes, not reopened here.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Business logic correctness and data integrity`
+- `Data placement and sync boundaries`
+- `Admin workflow and editability`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                                           | Evidence                                    |
+| --------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------- |
+| Product goals and IA                          | `target`     | The saved swim-session route stays focused on editing the session first, with support tooling and Poolside Note choices reading as secondary polish rather than primary work. | manual QA + targeted tests                  |
+| UX flow clarity                               | `target`     | Support/export tools feel genuinely collapsed on first load, pool-size unit choice is obvious, and the Poolside Note focus list stays scannable without redundant copy. | manual QA + unit/e2e                        |
+| Visual design quality                         | `target`     | The builder becomes calmer by reducing persistent copy blocks and containing the focus selector without introducing cramped or visually inconsistent controls.             | screenshot review + manual QA               |
+| Business logic correctness and data integrity | `target`     | Yard entry converts deterministically into the existing meter-canonical workout save contract with no ambiguous or lossy builder-save behavior.                           | unit tests + code review                    |
+| Admin editor ergonomics                       | `target`     | The owner can set common yard-pool sizes, inspect support outputs on demand, and manage open Poolside Note focuses without the builder feeling noisy or oversized.       | timed manual QA + targeted tests            |
+| Accessibility (a11y)                          | `supporting` | Supporting only: new unit toggles, condensed support disclosure, and focus list scroll area must remain keyboard reachable with explicit labels and stable semantics.    | code review + targeted tests                |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: the builder route should not add material client/runtime cost for the new local unit preference or list containment polish.                              | build/typecheck + review                    |
+| Data placement and sync boundaries            | `target`     | The brief explicitly keeps `pool_length_m` meter-canonical while any unit preference is UI-local only and must not change export/handoff truth.                           | brief contract + code review                |
+| Caching and invalidation strategy             | `supporting` | Supporting only: the slice keeps existing workout refresh/save invalidation behavior unchanged and adds no new server cache boundary.                                    | integration review                          |
+| Reliability and failure handling              | `target`     | Invalid custom pool-size input still blocks save deterministically and the builder never silently rewrites support/export state when the user only changes the display unit. | unit tests + existing route behavior        |
+| Security and authz                            | `supporting` | Supporting only: the slice stays inside authenticated owner-scoped builder surfaces and does not widen any protected mutation surface.                                   | existing auth boundaries                    |
+| Privacy and compliance                        | `N/A`        | N/A because the slice changes authenticated owner-side builder presentation only and introduces no new personal-data collection, sharing, or retention behavior.         | explicit scope rationale                    |
+| Content governance                            | `supporting` | Supporting only: support/export copy and pool-size wording must remain truthful to the meter-canonical persistence model and existing Garmin-readiness language.          | copy review                                 |
+| Admin workflow and editability                | `target`     | High-frequency saved-session editing remains calm: support tools stay tucked away until requested, yard-pool entry is fast, and the focus picker stays manageable.      | manual QA + targeted tests                  |
+| SEO and crawlability                          | `N/A`        | N/A because this work changes authenticated My Library builder surfaces with no public crawl or metadata contract.                                                       | explicit scope rationale                    |
+| AI discoverability                            | `N/A`        | N/A because the slice changes no public route, metadata, or AI-facing document structure.                                                                               | explicit scope rationale                    |
+| Analytics and KPI observability               | `supporting` | Supporting only: the calmer support disclosure and yard toggle should remain inspectable in manual QA without requiring new analytics instrumentation in this slice.      | scope review                                |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, entitlement, checkout, or revenue flow changes in this slice.                                                                                   | explicit scope rationale                    |
+| Incident response and support operations      | `N/A`        | N/A because the slice keeps the same authenticated builder actions and export surfaces, with no new operational alert/runbook branch beyond existing builder support guidance. | explicit scope rationale                    |
+| Finance and reporting operations              | `N/A`        | N/A because the slice changes no finance, payout, reconciliation, or commerce reporting path.                                                                           | explicit scope rationale                    |
+| i18n operational readiness                    | `N/A`        | N/A because this slice only adjusts internal English builder labels/copy on authenticated surfaces and does not introduce new locale-coupled data shape.                 | explicit scope rationale                    |
+| Stack-fit and dependency discipline           | `target`     | Reuse the existing workout-builder stack and local component state; do not add dependencies or a new persistence layer for builder display-unit preference.              | dependency diff + architecture review       |
+| Testing and QA automation                     | `target`     | Coverage proves collapsed support-tools behavior, yard-pool conversion/save semantics, and the compact Poolside Note focus selector, with verification gates passing.    | unit/e2e coverage + `verify:pre-pr`         |
+| Scalability and cost efficiency               | `supporting` | Supporting only: the slice must not add repeated server writes or background fetches for local-only unit preference or focus-list containment.                           | code review                                 |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: the slice remains rollback-safe because it changes no schema and keeps meter-canonical workout storage intact.                                          | rollback note + diff review                 |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - `workout.id`,
+  - persisted `workouts.pool_length_m`,
+  - persisted canonical workout draft fields and steps,
+  - existing Garmin/export/handoff outputs derived from the canonical meter-based draft.
+- Local-only:
+  - support-tools disclosure open/closed UI state,
+  - Poolside Note focus-selection UI state,
+  - builder display-unit preference for editing pool size (`m` vs `yd`) if implemented locally.
+- Sync policy:
+  - changing the pool-size display unit must not write to the server by itself,
+  - saving a workout continues to persist only the normalized meter value already required by the canonical workout save contract,
+  - support/export tools and Poolside Note preview must reflect the current draft on screen without implying that changing the display unit or opening disclosures saves anything.
+- Retention and sensitivity:
+  - no new sensitive data is introduced,
+  - any unit preference remains a non-sensitive UI preference only.
+- Cache/invalidation:
+  - existing workout save/update refresh behavior remains authoritative,
+  - no new server cache boundary is introduced by this slice.
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - `workout.id` remains the only persisted swim-session identity.
+- Human-readable identifiers:
+  - support-panel labels, pool-size unit labels, and Poolside Note helper copy are mutable UI labels only.
+- Mutability rules:
+  - UI wording and disclosure presentation may change in place,
+  - persisted workout identity and route structure do not change.
+- Rename vs repurpose policy:
+  - this slice polishes current builder controls only,
+  - it does not repurpose support/export tools into a new workflow or create a yard-native workout entity.
+- Compatibility contract:
+  - saved workouts created before this slice continue to load under the same route and remain meter-canonical,
+  - support/export outputs remain compatible with existing downstream meter-based logic.
+- Observability and repair:
+  - invalid pool-size input remains visible in the builder before save,
+  - no silent rewrite of existing saved workout IDs or route params is allowed.
+
+## Scope
+
+- Make the calm builder support-tools disclosure feel truly collapsed on first load by removing persistent body copy from the closed state while keeping the same optional export/handoff actions behind the disclosure.
+- Add builder-side pool-size authoring support for yards on pool workouts while keeping canonical workout save/export data meter-based.
+- Remove redundant `Primary focus` / `Optional focus` helper text from the Poolside Note focus selector and keep the list visually contained with internal scrolling when it grows.
+- Update targeted unit/e2e coverage and the brief checkpoint log.
+
+## Out Of Scope
+
+- Any new Garmin delivery slice or partner API work.
+- Open-water contract work.
+- Reworking step distances, workout totals, or export payloads to become yard-native.
+- Schema changes or a new persisted workout-unit field.
+- Reopening already-shipped step-detail changes from note `3a29feae`.
+
+## Acceptance Criteria
+
+1. The saved swim-session builder support-tools surface shows as a compact disclosure header by default, with the detailed support cards revealed only after explicit expansion.
+2. Pool workouts can be authored in either meters or yards from the builder pool-size control, while save/export/handoff continue to use the existing meter-canonical workout contract.
+3. Invalid custom pool-size input still disables save with deterministic inline feedback.
+4. The Poolside Note focus selector no longer shows the per-item `Primary focus` / `Optional focus` helper text.
+5. The Poolside Note focus selector keeps a contained scrollable area instead of expanding indefinitely when many open focuses exist.
+6. Existing support/export actions (`PDF`, `Poolside Note`, `Garmin-ready JSON`, `Workout handoff`) still work after the disclosure polish.
+7. Targeted tests and `npm run verify:pre-pr` pass before PR update.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run typecheck`
+- targeted `vitest`:
+  - `tests/unit/workout-builder-hub.test.tsx`
+  - `tests/unit/workouts-shared.test.ts`
+- targeted `playwright`:
+  - `tests/e2e/my-library-workout-builder.spec.ts --project=desktop-chromium`
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm must be installed on the machine used for local validation.
+- Local validation runs from repo root.
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3000/my-library/workouts`
+  - `http://127.0.0.1:3000/my-library/workouts/<id>`
+- Preview:
+  - PR preview URL after branch push
+
+## Constraints
+
+- Keep the slice narrow and owner-led.
+- Do not reopen the parked Garmin follow-up map.
+- Keep the canonical workout contract truthful: meters remain the persisted/exported unit.
+- Do not add a new dependency or a schema migration for unit selection.
+
+## 10/10 Quality Bar
+
+- The builder should feel calmer before the owner opens any support tooling.
+- A Garmin-familiar swimmer should be able to set a yard pool without mental conversion math.
+- The Poolside Note selector should stay compact and legible even when many open focuses exist.
+- Save-state, export-state, and Garmin-readiness truthfulness must remain explicit and deterministic.
+- Keyboard and touch interactions must remain intact for the new disclosure and unit controls.
+
+## Help/Guide Impact
+
+- `N/A` for this slice because it changes only authenticated builder presentation details, keeps the existing support/export action names, and does not change the documented recovery flow or public Help/Guide content contract.
+
+## Checkpoint Log
+
+- `2026-04-08 | planning + implementation start | created owner-led child brief for the two remaining open Swim Session Builder notes (`54f170f7`, `66e90451`) after confirming the earlier note `3a29feae` was already shipped; scoped this slice to calmer support disclosure, yard-pool authoring over the existing meter-canonical contract, and compact Poolside Note focus selection | next: implement the builder polish, update targeted coverage, mark shipped note 3a29 done in admin notes, and run verification before PR handoff`
+- `2026-04-08 | implementation + validation complete on branch | implemented truly collapsed support-tools copy, yard-pool authoring with meter-canonical save conversion, and compact Poolside Note focus selection; marked shipped admin note `3a29feae` done in production while leaving the two newly implemented notes open until merge; passed `npm run lint:briefs:all`, targeted `vitest`, targeted `playwright`, `npm run typecheck`, and full `npm run verify:pre-pr` in clean worktree `/private/tmp/freeswimming-swim-session-builder-owner-notes-2026-04-08` from base commit `bef9edc` | next: commit, push, open PR, and summarize before merge`

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -169,6 +169,11 @@ test.describe("my library workout builder", () => {
       "false"
     );
     await expect(page.getByTestId("workout-editor-support-tools-status")).toHaveText("Ready");
+    await expect(
+      page.getByText(
+        "Optional export and handoff tools stay here so the workout itself can remain the primary editing surface."
+      )
+    ).toHaveCount(0);
     await openSupportToolsPanel(page);
     await page.getByTestId("workout-editor-garmin-export-toggle").click();
     await page.getByTestId("workout-editor-handoff-toggle").click();
@@ -235,7 +240,9 @@ test.describe("my library workout builder", () => {
 
     await openMetadataPanelIfCollapsed(page);
     await expect(page.getByTestId("session-draft-title")).toHaveValue("Untitled pool session");
-    await page.getByTestId("session-draft-pool-length-input").fill("33.33");
+    await page.getByTestId("workout-editor-pool-length-unit-yd").click();
+    await expect(page.getByLabel("Exact pool size (yd)")).toBeVisible();
+    await page.getByRole("button", { name: "25yd" }).click();
     await page.getByTestId("session-draft-step-distance-0").selectOption("custom");
     await page.getByTestId("session-draft-step-distance-custom-0").fill("333");
     await page.getByTestId("session-draft-add-repeat").click();
@@ -396,7 +403,7 @@ test.describe("my library workout builder", () => {
     );
     await expect(page.getByTestId("workout-builder-save")).toBeDisabled();
     await expect(page.getByTestId("session-draft-title")).toHaveValue(uniqueTitle);
-    await expect(page.getByTestId("session-draft-pool-length-input")).toHaveValue("33.33");
+    await expect(page.getByTestId("session-draft-pool-length-input")).toHaveValue("25");
     await page.getByTestId("session-draft-step-toggle-0").click();
     await expect(page.getByTestId("session-draft-step-distance-0")).toHaveValue("custom");
     await expect(page.getByTestId("session-draft-step-distance-custom-0")).toHaveValue("333");

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import WorkoutBuilderHub from "@/components/my-library/workouts/WorkoutBuilderHub";
 import { WORKOUT_NOTICE_AUTO_DISMISS_MS } from "@/components/my-library/workouts/useAutoDismissNotice";
@@ -167,6 +167,21 @@ describe("WorkoutBuilderHub", () => {
     );
     expect(screen.getByTestId("workout-editor-support-tools-status")).toHaveTextContent("Ready");
     expect(
+      screen.queryByText(
+        "Optional export and handoff tools stay here so the workout itself can remain the primary editing surface."
+      )
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Opening or downloading anything here does not send or publish anything. It only opens or downloads support output for this saved session."
+      )
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("workout-editor-garmin-readiness")).not.toBeInTheDocument();
+
+    openSupportToolsPanel();
+
+    expect(screen.getByTestId("workout-editor-garmin-readiness")).toBeVisible();
+    expect(
       screen.getByText(
         "Optional export and handoff tools stay here so the workout itself can remain the primary editing surface."
       )
@@ -176,11 +191,6 @@ describe("WorkoutBuilderHub", () => {
         "Opening or downloading anything here does not send or publish anything. It only opens or downloads support output for this saved session."
       )
     ).toBeVisible();
-    expect(screen.queryByTestId("workout-editor-garmin-readiness")).not.toBeInTheDocument();
-
-    openSupportToolsPanel();
-
-    expect(screen.getByTestId("workout-editor-garmin-readiness")).toBeVisible();
   });
 
   it("loads an accepted workout and saves canonical edits back to the same workout", async () => {
@@ -1263,6 +1273,99 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.getByTestId("workout-editor-garmin-readiness")).toHaveTextContent(
       "yard pools"
     );
+  });
+
+  it("converts yard pool sizes back into the canonical meter value on save", async () => {
+    vi.mocked(fetch).mockImplementation(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        draft: SessionDraft;
+      };
+
+      return {
+        ok: true,
+        json: async () => ({
+          ok: true,
+          workout: buildWorkoutRecord({
+            sourceKind: "manual",
+            draft: body.draft,
+          }),
+          summary: buildWorkoutSummary({
+            sourceKind: "manual",
+            title: body.draft.title,
+            totalDistanceM: body.draft.totalDistanceM,
+            estimatedDurationMin: body.draft.estimatedDurationMin,
+          }),
+        }),
+      } as Response;
+    });
+
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: buildWorkoutRecord({ sourceKind: "manual" }),
+          recentWorkouts: [buildWorkoutSummary({ sourceKind: "manual" })],
+        })}
+        preferExpandedDetailsOnLoad
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("workout-editor-pool-length-unit-yd"));
+    fireEvent.click(screen.getByRole("button", { name: "25yd" }));
+
+    expect(screen.getByLabelText("Exact pool size (yd)")).toHaveValue("25");
+    expect(
+      screen.getByText("Common yard presets: 25yd and 50yd. Preset selected.")
+    ).toBeVisible();
+    expect(screen.getByRole("button", { name: "Save changes" })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/my-library/workouts/workout-1",
+        expect.objectContaining({
+          method: "PATCH",
+        })
+      );
+    });
+
+    const fetchBody = JSON.parse(String(vi.mocked(fetch).mock.calls[0]?.[1]?.body ?? "{}")) as {
+      draft: SessionDraft;
+    };
+
+    expect(fetchBody.draft.poolLengthM).toBe(22.86);
+  });
+
+  it("keeps the poolside focus selector compact and removes redundant focus role labels", async () => {
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary()}
+        trainingFocusOptions={Array.from({ length: 10 }, (_, index) => ({
+          id: `focus-${index + 1}`,
+          title: `Focus ${index + 1}`,
+          isPrimary: index === 0,
+        }))}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    const focusList = screen.getByTestId("workout-editor-poolside-focus-list");
+    expect(focusList).toHaveClass("overflow-y-auto");
+    expect(within(focusList).queryByText("Primary focus")).not.toBeInTheDocument();
+    expect(within(focusList).queryByText("Optional focus")).not.toBeInTheDocument();
   });
 
   it("shows recovery guidance when the requested workout is missing", () => {


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-04-08T10:58:35.754Z for branch `feat/swim-session-builder-owner-notes-2026-04-08` (base ref `origin/main`).
- Latest commit: `6c9d8a2` - feat: polish swim session builder support tools.
- User-visible changes: User/admin runtime behavior may change on touched routes/components.
- Technical changes: Updated 4 file(s): `components/my-library/workouts/WorkoutEditor.tsx`, `docs/task-briefs/in-progress/2026-04-08-swim-session-builder-support-tools-pool-size-and-poolside-focus-polish-10-10.md`, `tests/e2e/my-library-workout-builder.spec.ts`, `tests/unit/workout-builder-hub.test.tsx`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-04-08-swim-session-builder-support-tools-pool-size-and-poolside-focus-polish-10-10.md`
- Scorecard target outcomes: 10 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (1); tests (2); runtime UI/routes/components (1).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (4):
  - `components/my-library/workouts/WorkoutEditor.tsx`
  - `docs/task-briefs/in-progress/2026-04-08-swim-session-builder-support-tools-pool-size-and-poolside-focus-polish-10-10.md`
  - `tests/e2e/my-library-workout-builder.spec.ts`
  - `tests/unit/workout-builder-hub.test.tsx`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `6c9d8a2` (`git revert 6c9d8a2`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **NOT RUN** (run locally before pushing PR updates).
- `npm run verify:pre-merge`: **PENDING** for `6c9d8a2` (required before merge to `main`).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  - No local verify log found in `artifacts/test-runs/latest`.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
