### PR TITLE
Use Garmin terminology in manual pool builder

### DIFF
--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useRef, useState, type TextareaHTMLAttributes } from "react";
+import { useCallback, useEffect, useRef, useState, type TextareaHTMLAttributes } from "react";
 import { BRAND_FONT_PUBLIC_PATH, BRAND_PDF_LOGO_PATH } from "@/lib/brand";
 import { useAutoDismissNotice } from "@/components/my-library/workouts/useAutoDismissNotice";
 import {
@@ -319,8 +319,8 @@ function parseSignatureValues(value: string) {
 
 function buildStepStrokeGuidance(step: SessionDraftStep, isManualPoolMode: boolean) {
   const recommendedFocus = getRecommendedStepFocus(step);
-  const drillTypeLabel = isManualPoolMode ? "Drill type" : "Focus tag";
-  const strokeLabel = isManualPoolMode ? "Stroke" : "Stroke pattern";
+  const drillTypeLabel = isManualPoolMode ? "Drill Type" : "Focus tag";
+  const strokeLabel = isManualPoolMode ? "Stroke Type" : "Stroke pattern";
 
   if (step.category === "kick") {
     return `Kick category already tags this as kick work. Use ${strokeLabel} for the movement pattern this set supports, and change ${drillTypeLabel} only when you need extra kick, pull, or drill notation.`;
@@ -337,7 +337,7 @@ function buildStepStrokeGuidance(step: SessionDraftStep, isManualPoolMode: boole
 
 function buildStepFocusGuidance(step: SessionDraftStep, isManualPoolMode: boolean) {
   const recommendedFocus = getRecommendedStepFocus(step);
-  const drillTypeLabel = isManualPoolMode ? "Drill type" : "Focus tag";
+  const drillTypeLabel = isManualPoolMode ? "Drill Type" : "Focus tag";
   if (recommendedFocus === "kick") {
     return `Recommended ${drillTypeLabel}: Kick. Change it only when this kick set needs a more specific drill or pull note.`;
   }
@@ -359,18 +359,83 @@ function getStepDurationModeEditorLabel(
 
   switch (value) {
     case "distance":
-      return "Distance swim";
+      return "Distance";
     case "time":
-      return "Time-based swim";
+      return "Time";
     case "fixed_rest":
-      return "Rest time";
+      return "Fixed Rest Time";
     case "lap_button":
-      return "Open swim";
+      return "Lap Button Press";
+    case "send_off":
+      return "Send-Off Time";
     case "css_send_off":
-      return "CSS send-off";
+      return "CSS-Based Send-Off Time";
     default:
       return getSessionStepDurationModeLabel(value);
   }
+}
+
+const MANUAL_POOL_SWIM_DURATION_MODES: readonly SessionDraftStepDurationMode[] = [
+  "distance",
+  "time",
+  "lap_button",
+];
+
+const MANUAL_POOL_REST_DURATION_MODES: readonly SessionDraftStepDurationMode[] = [
+  "fixed_rest",
+  "lap_button",
+  "send_off",
+  "css_send_off",
+];
+
+function isManualPoolRestCategory(category: SessionDraftStepCategory) {
+  return category === "rest";
+}
+
+function getManualPoolDurationModesForCategory(
+  category: SessionDraftStepCategory
+): readonly SessionDraftStepDurationMode[] {
+  return isManualPoolRestCategory(category)
+    ? MANUAL_POOL_REST_DURATION_MODES
+    : MANUAL_POOL_SWIM_DURATION_MODES;
+}
+
+function getDefaultManualPoolDurationMode(
+  category: SessionDraftStepCategory
+): SessionDraftStepDurationMode {
+  return isManualPoolRestCategory(category) ? "fixed_rest" : "distance";
+}
+
+function isManualPoolDurationModeAllowed(
+  category: SessionDraftStepCategory,
+  durationMode: SessionDraftStepDurationMode
+) {
+  return getManualPoolDurationModesForCategory(category).includes(durationMode);
+}
+
+function applyStepDurationModeDefaults(
+  step: SessionDraftStep,
+  nextMode: SessionDraftStepDurationMode
+): SessionDraftStep {
+  return {
+    ...step,
+    durationMode: nextMode,
+    distanceM: nextMode === "distance" ? (step.distanceM ?? 100) : null,
+    timeMin:
+      nextMode === "time" || nextMode === "fixed_rest" || nextMode === "send_off"
+        ? (step.timeMin ?? (nextMode === "send_off" ? 2 : 1))
+        : null,
+    cssSendOffOffsetSeconds:
+      nextMode === "css_send_off" ? (step.cssSendOffOffsetSeconds ?? 0) : null,
+  };
+}
+
+function normalizeManualPoolStepForEditor(step: SessionDraftStep): SessionDraftStep {
+  if (isManualPoolDurationModeAllowed(step.category, step.durationMode)) {
+    return step;
+  }
+
+  return applyStepDurationModeDefaults(step, getDefaultManualPoolDurationMode(step.category));
 }
 
 function getStepTargetModeEditorLabel(
@@ -565,28 +630,47 @@ function buildStepSummary(
 }
 
 function buildManualPoolStepSummary(step: SessionDraftStep, basePaceSecondsPer100m: number) {
-  const structuredTarget = buildSessionStepStructuredTargetLabel(step, basePaceSecondsPer100m);
+  const normalizedStep = normalizeManualPoolStepForEditor(step);
+  const structuredTarget = buildSessionStepStructuredTargetLabel(
+    normalizedStep,
+    basePaceSecondsPer100m
+  );
 
   return [
-    buildWorkoutStepDurationOutputSummary(step, basePaceSecondsPer100m, {
+    buildWorkoutStepDurationOutputSummary(normalizedStep, basePaceSecondsPer100m, {
       environment: "pool",
     }),
-    buildStepContextLabel(step, { environment: "pool" }),
+    buildStepContextLabel(normalizedStep, { environment: "pool" }),
     structuredTarget,
   ]
     .filter(Boolean)
-    .join(" · ") || `${getSessionStepCategoryLabel(step.category)} step`;
+    .join(" · ") || `${getSessionStepCategoryLabel(normalizedStep.category)} step`;
 }
 
 function syncManualPoolEditableStep(
   step: SessionDraftStep,
   basePaceSecondsPer100m: number
 ): SessionDraftStep {
+  const normalizedStep = normalizeManualPoolStepForEditor(step);
+
   return {
-    ...step,
-    name: buildManualPoolStepSummary(step, basePaceSecondsPer100m).slice(0, 120),
+    ...normalizedStep,
+    name: buildManualPoolStepSummary(normalizedStep, basePaceSecondsPer100m).slice(0, 120),
     targetSummary: "",
   };
+}
+
+function hasSelectionSyncChanges(currentDraft: SessionDraft, nextDraft: SessionDraft) {
+  return JSON.stringify({
+    steps: currentDraft.steps,
+    allowedStrokes: currentDraft.allowedStrokes,
+    equipmentAllowlist: currentDraft.equipmentAllowlist,
+  }) !==
+    JSON.stringify({
+      steps: nextDraft.steps,
+      allowedStrokes: nextDraft.allowedStrokes,
+      equipmentAllowlist: nextDraft.equipmentAllowlist,
+    });
 }
 
 function buildRepeatSummary(
@@ -1068,7 +1152,7 @@ export default function WorkoutEditor({
     });
   }, [savedWorkoutId]);
 
-  function syncDraftSelections(nextDraft: SessionDraft) {
+  const syncDraftSelections = useCallback((nextDraft: SessionDraft) => {
     const nextSteps = isManualPoolMode
       ? nextDraft.steps.map((step) =>
           syncManualPoolEditableStep(step, nextDraft.basePaceSecondsPer100m)
@@ -1103,7 +1187,20 @@ export default function WorkoutEditor({
         new Set([...nextDraft.equipmentAllowlist, ...requiredEquipment])
       ),
     };
-  }
+  }, [isManualPoolMode]);
+
+  useEffect(() => {
+    if (!isManualPoolMode) {
+      return;
+    }
+
+    const syncedDraft = syncDraftSelections(draft);
+    if (!hasSelectionSyncChanges(draft, syncedDraft)) {
+      return;
+    }
+
+    onDraftChange(syncedDraft);
+  }, [draft, isManualPoolMode, onDraftChange, syncDraftSelections]);
 
   function stepUsesAllowedStroke(stroke: SessionGeneratorStroke) {
     return draft.steps.some((step) => step.stroke === stroke);
@@ -1463,17 +1560,14 @@ export default function WorkoutEditor({
   }
 
   function updateStepDurationMode(stepId: string, nextMode: SessionDraftStepDurationMode) {
-    updateDraftStep(stepId, (current) => ({
-      ...current,
-      durationMode: nextMode,
-      distanceM: nextMode === "distance" ? (current.distanceM ?? 100) : null,
-      timeMin:
-        nextMode === "time" || nextMode === "fixed_rest" || nextMode === "send_off"
-          ? (current.timeMin ?? (nextMode === "send_off" ? 2 : 1))
-          : null,
-      cssSendOffOffsetSeconds:
-        nextMode === "css_send_off" ? (current.cssSendOffOffsetSeconds ?? 0) : null,
-    }));
+    updateDraftStep(stepId, (current) =>
+      applyStepDurationModeDefaults(
+        current,
+        isManualPoolMode && !isManualPoolDurationModeAllowed(current.category, nextMode)
+          ? getDefaultManualPoolDurationMode(current.category)
+          : nextMode
+      )
+    );
   }
 
   function updateStepDurationClock(
@@ -1824,7 +1918,7 @@ export default function WorkoutEditor({
             )}
 
             <label className="text-sm text-slate-700">
-              {isManualPoolMode ? "Step type" : "Category"}
+              {isManualPoolMode ? "Step Type" : "Category"}
               <select
                 value={step.category}
                 onChange={(event) =>
@@ -1845,7 +1939,7 @@ export default function WorkoutEditor({
             </label>
 
             <label className="text-sm text-slate-700">
-              {isManualPoolMode ? "Stroke" : "Stroke pattern"}
+              {isManualPoolMode ? "Stroke Type" : "Stroke pattern"}
               <select
                 value={step.stroke ?? "choice"}
                 onChange={(event) => {
@@ -1869,7 +1963,7 @@ export default function WorkoutEditor({
             </label>
 
             <label className="text-sm text-slate-700">
-              {isManualPoolMode ? "Drill type" : "Focus tag"}
+              {isManualPoolMode ? "Drill Type" : "Focus tag"}
               <select
                 value={step.drillType ?? "none"}
                 onChange={(event) =>
@@ -1944,7 +2038,7 @@ export default function WorkoutEditor({
             )}
 
             <label className="text-sm text-slate-700">
-              {isManualPoolMode ? "Step timing" : "Duration mode"}
+              {isManualPoolMode ? "Duration" : "Duration mode"}
               <select
                 value={step.durationMode}
                 onChange={(event) =>
@@ -1956,7 +2050,10 @@ export default function WorkoutEditor({
                 data-testid={`session-draft-step-duration-mode-${index}`}
                 className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
               >
-                {SESSION_DRAFT_STEP_DURATION_MODES.map((value) => (
+                {(isManualPoolMode
+                  ? getManualPoolDurationModesForCategory(step.category)
+                  : SESSION_DRAFT_STEP_DURATION_MODES
+                ).map((value) => (
                   <option key={value} value={value}>
                     {getStepDurationModeEditorLabel(value, isManualPoolMode)}
                   </option>
@@ -2016,7 +2113,7 @@ export default function WorkoutEditor({
             ) : step.durationMode === "fixed_rest" ? (
               <div className="grid gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-4 md:col-span-2 md:grid-cols-[1fr_1fr_auto]">
                 <label className="text-sm text-slate-700">
-                  Rest min
+                  Minutes
                   <input
                     type="text"
                     inputMode="numeric"
@@ -2029,7 +2126,7 @@ export default function WorkoutEditor({
                   />
                 </label>
                 <label className="text-sm text-slate-700">
-                  Rest sec
+                  Seconds
                   <input
                     type="text"
                     inputMode="numeric"
@@ -2042,12 +2139,14 @@ export default function WorkoutEditor({
                   />
                 </label>
                 <div className="self-end text-sm text-slate-500">
-                  {step.timeMin ? `${formatClockDurationLabel(step.timeMin)} rest` : "Set rest time"}
+                  {step.timeMin
+                    ? `Fixed Rest Time ${formatClockDurationLabel(step.timeMin)}`
+                    : "Set Fixed Rest Time"}
                 </div>
               </div>
             ) : step.durationMode === "time" ? (
               <label className="text-sm text-slate-700">
-                {isManualPoolMode ? "Swim time (min)" : "Time (min)"}
+                {isManualPoolMode ? "Time" : "Time (min)"}
                 <input
                   type="text"
                   inputMode="numeric"
@@ -2065,7 +2164,7 @@ export default function WorkoutEditor({
             ) : step.durationMode === "send_off" ? (
               <div className="grid gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-4 md:col-span-2 md:grid-cols-[1fr_1fr_auto]">
                 <label className="text-sm text-slate-700">
-                  Send-off min
+                  Minutes
                   <input
                     type="text"
                     inputMode="numeric"
@@ -2078,7 +2177,7 @@ export default function WorkoutEditor({
                   />
                 </label>
                 <label className="text-sm text-slate-700">
-                  Send-off sec
+                  Seconds
                   <input
                     type="text"
                     inputMode="numeric"
@@ -2092,13 +2191,13 @@ export default function WorkoutEditor({
                 </label>
                 <div className="self-end text-sm text-slate-500">
                   {step.timeMin
-                    ? `${formatClockDurationLabel(step.timeMin)} send-off`
-                    : "Set send-off"}
+                    ? `Send-Off Time ${formatClockDurationLabel(step.timeMin)}`
+                    : "Set Send-Off Time"}
                 </div>
               </div>
             ) : step.durationMode === "css_send_off" ? (
               <label className="text-sm text-slate-700 md:col-span-2">
-                CSS send-off offset
+                CSS-Based Send-Off Time
                 <select
                   value={String(step.cssSendOffOffsetSeconds ?? 0)}
                   onChange={(event) =>
@@ -2124,9 +2223,7 @@ export default function WorkoutEditor({
               </label>
             ) : (
               <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4 text-sm text-slate-600">
-                {isManualPoolMode
-                  ? "This is an open swim step. It stays open until the swimmer advances with the lap button."
-                  : "This step stays open until the swimmer advances with the lap button."}
+                This step stays open until the swimmer advances with the lap button.
               </div>
             )}
 
@@ -2268,9 +2365,9 @@ export default function WorkoutEditor({
             )}
 
             <label className="text-sm text-slate-700 md:col-span-2">
-              {isManualPoolMode ? "Step note" : "Notes"}
+              {isManualPoolMode ? "Notes" : "Notes"}
               <AutoGrowingTextarea
-                aria-label={isManualPoolMode ? "Step note" : "Notes"}
+                aria-label={isManualPoolMode ? "Notes" : "Notes"}
                 value={step.notes}
                 onChange={(event) =>
                   updateDraftStep(step.id, (current) => ({
@@ -2281,9 +2378,6 @@ export default function WorkoutEditor({
                 minRows={isManualPoolMode ? 1 : 3}
                 className="mt-2 block w-full resize-y rounded-xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
               />
-              {isManualPoolMode ? (
-                <p className="mt-2 text-xs text-slate-500">Add a note for this step.</p>
-              ) : null}
             </label>
           </div>
         ) : null}

--- a/docs/task-briefs/in-progress/2026-04-08-pool-swim-session-builder-garmin-duration-and-terminology-polish-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-08-pool-swim-session-builder-garmin-duration-and-terminology-polish-10-10.md
@@ -1,0 +1,247 @@
+# Task Brief: Pool Swim Session Builder Garmin Duration And Terminology Polish (10/10)
+
+## Metadata
+
+- `id`: `2026-04-08-pool-swim-session-builder-garmin-duration-and-terminology-polish-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-04-08`
+- `updated`: `2026-04-08`
+
+## Goal
+
+The manual pool swim-session builder uses Garmin-equivalent duration terminology and step-editing labels where the concepts map directly, and the pool step editor no longer allows mixed swim/rest timing states that Garmin would not present.
+
+## Why This Brief Exists
+
+- Manual owner review on `2026-04-08` surfaced a builder-quality gap on:
+  - `https://freeswimming.org/my-library/workouts/e4b0eb22-20de-4880-a3a8-8494850caff2?entry=manual-pool`
+- The current pool step editor still uses invented labels such as:
+  - `Step timing`
+  - `Distance swim`
+  - `Time-based swim`
+  - `Open swim`
+  - `CSS send-off`
+  - `Step note`
+- The deeper issue is structural, not cosmetic:
+  - FreeSwimming models repeat swim and repeat rest as separate steps like Garmin,
+  - but it still exposes one flattened duration menu across step types,
+  - so combinations like `Main + Rest time` remain possible even though Garmin separates swim-step and rest-step duration choices.
+- This is owner-led builder polish based on manual review.
+- It is explicitly not a new Garmin roadmap slice and must not reopen the parked follow-up brief:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/planned/2026-04-07-pool-swim-builder-garmin-follow-up-map-10-10.md`
+
+## Dependencies And Boundaries
+
+- Recently shipped pool-builder work that this slice must preserve:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-06-pool-swim-builder-repeat-rest-parity-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-07-pool-swim-builder-step-authoring-parity-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-07-pool-builder-owner-note-3a29feae-step-detail-polish-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-08-pool-swim-session-builder-owner-notes-repeat-copy-rest-time-and-pool-size-polish-10-10.md`
+- Primary implementation surfaces:
+  - `/Users/stianvikra/freeswimming/components/my-library/workouts/WorkoutEditor.tsx`
+  - `/Users/stianvikra/freeswimming/lib/workouts/shared.ts`
+  - `/Users/stianvikra/freeswimming/tests/unit/workout-builder-hub.test.tsx`
+  - `/Users/stianvikra/freeswimming/tests/unit/workouts-shared.test.ts`
+  - `/Users/stianvikra/freeswimming/tests/e2e/my-library-workout-builder.spec.ts`
+- Boundary decisions:
+  - no open-water work,
+  - no schema migration,
+  - no export-format change,
+  - no new contextual help surface,
+  - no work on the unrelated open admin note for pool-size autofocus on this page unless directly required.
+
+## Admin Notes Triage Disposition
+
+- Existing open page note on this exact workout route:
+  - `814ced4c-77e9-4b62-afaf-7ca8424d9ae0`
+  - body: autofocus exact pool-size input when `Unspecified` is selected
+  - disposition: not owned by this brief
+  - reason: separate pool-size interaction note; current slice is duration/terminology and step-type clarity
+- There is no existing open admin note on this page that already captures the `Step timing` Garmin-term and step-type mismatch.
+- This brief therefore owns the finding directly instead of waiting on a new admin note.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `Product goals and IA`
+- `UX flow clarity`
+- `Visual design quality`
+- `Business logic correctness and data integrity`
+- `Admin workflow and editability`
+- `Testing and QA automation`
+
+| Category | Mapping | Target Threshold (if `target`) | Evidence |
+| --- | --- | --- | --- |
+| Product goals and IA | `target` | Manual pool step editing uses Garmin-equivalent language for directly mapped concepts, and duration choices are structurally separated by step type instead of one mixed menu. | manual QA + code review + unit/e2e |
+| UX flow clarity | `target` | Pool builders cannot author semantically mixed duration states such as `Main + Fixed Rest Time`; the correct choices appear for the chosen step type without extra explanation. | manual QA + targeted e2e |
+| Visual design quality | `target` | The step editor reads cleaner because labels are shorter, more standard, and more consistent with Garmin without becoming visually denser than today. | manual QA + screenshot review |
+| Business logic correctness and data integrity | `target` | Duration-mode filtering and normalization preserve canonical saved workout structure, repeat behavior, and export/handoff summaries while eliminating invalid swim/rest timing combinations. | unit tests + code review |
+| Admin editor ergonomics | `target` | A builder familiar with Garmin can author pool steps without translating FreeSwimming-specific terms such as `Open swim` or `Step timing`. | manual QA + targeted tests |
+| Accessibility (a11y) | `supporting` | Supporting only: renamed labels and filtered selects remain keyboard-accessible and preserve correct form labeling. | code review + tests |
+| Performance (CWV + payloads) | `supporting` | Supporting only: the builder route adds no meaningful client/runtime cost for terminology and select filtering changes. | diff review |
+| Data placement and sync boundaries | `target` | The slice stays UI-contract only: existing server-canonical workout fields remain authoritative, and no second timing model is introduced. | brief contract + code review |
+| Caching and invalidation strategy | `supporting` | Supporting only: workout save and reload semantics stay unchanged. | integration review |
+| Reliability and failure handling | `target` | Legacy mixed states are normalized deterministically in the editor so the builder does not render blank or contradictory duration controls. | unit tests + manual QA |
+| Security and authz | `supporting` | Supporting only: this slice stays inside the existing authenticated builder surface. | existing boundaries |
+| Privacy and compliance | `N/A` | N/A because this is copy, editor-logic, and layout polish on an authenticated owner workflow only; no new data sharing or retention behavior changes. | explicit scope rationale |
+| Content governance | `supporting` | Supporting only: all newly shipped terms must be grounded in Garmin-visible wording rather than FreeSwimming-invented replacements for mapped concepts. | screenshot review + code review |
+| Admin workflow and editability | `target` | High-frequency pool editing becomes more truthful and easier because swim-step and rest-step durations no longer share one misleading vocabulary set. | manual QA + targeted tests |
+| SEO and crawlability | `N/A` | N/A because `/my-library/workouts/[workoutId]` is an authenticated route with no public indexing contract. | explicit scope rationale |
+| AI discoverability | `N/A` | N/A because no public route, metadata, or AI-facing content surface changes. | explicit scope rationale |
+| Analytics and KPI observability | `supporting` | Supporting only: no new analytics is required for this bounded editor-contract fix. | scope review |
+| Commerce and revenue ops | `N/A` | N/A because no billing, pricing, entitlement, or checkout path changes. | explicit scope rationale |
+| Incident response and support operations | `N/A` | N/A because this slice does not alter operational runbooks, escalation paths, or support tooling; it only tightens the owner-facing pool builder vocabulary and editing rules. | explicit scope rationale |
+| Finance and reporting operations | `N/A` | N/A because no finance or reconciliation path changes. | explicit scope rationale |
+| i18n operational readiness | `N/A` | N/A because this slice changes only current English builder wording and does not alter locale architecture or translation flow. | explicit scope rationale |
+| Stack-fit and dependency discipline | `target` | Reuse the existing workout builder and shared normalization helpers; add no dependencies. | dependency diff + architecture review |
+| Testing and QA automation | `target` | Unit and e2e coverage must assert Garmin duration labels and step-type-based filtering, and `npm run verify:pre-pr` must pass before PR update. | targeted tests + verify gate |
+| Scalability and cost efficiency | `supporting` | Supporting only: UI filtering and terminology changes must not add server load or repeated writes. | code review |
+| DevOps and rollback readiness | `supporting` | Supporting only: rollback remains low-risk because the slice changes no schema or external contract. | diff review |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - saved workout identity and payload
+  - `steps[].category`
+  - `steps[].durationMode`
+  - `steps[].distanceM`
+  - `steps[].timeMin`
+  - `steps[].cssSendOffOffsetSeconds`
+  - `steps[].repeatEndingRestMode`
+- Local-only:
+  - label text
+  - duration-option visibility by step type
+  - any editor-side normalization before save
+- Sync policy:
+  - label and layout changes never write by themselves,
+  - step-type changes may normalize invalid manual-pool duration modes in local draft state,
+  - save continues to persist the same canonical step fields as today,
+  - export/handoff/poolside summaries must consume the same canonical fields with updated Garmin wording.
+- Retention and sensitivity:
+  - no new data class,
+  - no change to deletion expectations or sensitive-field handling.
+- Cache/invalidation:
+  - existing workout save/update behavior remains authoritative,
+  - no additional cache layer is introduced.
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - `workout.id` remains canonical across builder, save, export, notes, and handoff.
+- Human-readable identifiers:
+  - pool builder labels are mutable UI text only.
+- Mutability rules:
+  - session-builder wording may change in place,
+  - canonical workout field names and saved entity identity remain stable.
+- Rename vs repurpose policy:
+  - rename UI expressions before changing underlying data model,
+  - do not repurpose the repeat/rest storage contract in this slice.
+- Compatibility contract:
+  - existing saved workouts must still open,
+  - any legacy mixed pool-step combinations must normalize into a valid Garmin-like editor state instead of rendering contradictory controls.
+- Observability and repair:
+  - targeted tests must cover legacy mixed-state normalization and filtered duration options so regressions surface before PR update.
+
+## Scope
+
+- Replace invented manual-pool duration terms with Garmin-visible terminology where the concept maps directly.
+- Rename manual-pool field labels to Garmin-style labels where clearly mapped from screenshots:
+  - `Step Type`
+  - `Stroke Type`
+  - `Drill Type`
+  - `Duration`
+  - `Notes`
+- Remove invented duration option labels in manual pool mode:
+  - `Distance swim`
+  - `Time-based swim`
+  - `Open swim`
+  - `Rest time`
+  - `CSS send-off`
+- Use Garmin terminology instead:
+  - `Distance`
+  - `Time`
+  - `Lap Button Press`
+  - `Fixed Rest Time`
+  - `Send-Off Time`
+  - `CSS-Based Send-Off Time`
+- Filter manual-pool duration choices by step type:
+  - swim-style step types only see swim-valid duration choices
+  - `Rest` only sees rest-valid duration choices
+- Normalize invalid legacy manual-pool step-type/duration combinations in the editor so the current draft surface stays valid.
+- Update manual-pool summaries, handoff/poolside lines, and pdf detail labels to use the same Garmin terminology for mapped concepts.
+- Update tests for the new terminology and filtered-duration contract.
+
+## Out Of Scope
+
+- Open-water builder work
+- New Garmin export mapping work
+- New admin note creation for this finding
+- Pool-size autofocus note `814ced4c-77e9-4b62-afaf-7ca8424d9ae0`
+- Broader rest-step layout redesign beyond the terminology and step-type duration separation required here
+- New contextual help or guide work
+
+## Acceptance Criteria
+
+1. Manual pool step editing shows `Duration`, not `Step timing`.
+2. Manual pool notes field shows `Notes`, not `Step note`.
+3. Manual pool duration menus use Garmin wording for directly mapped choices.
+4. Non-rest pool step types cannot select rest-only duration modes.
+5. `Rest` pool steps cannot select swim-only duration modes.
+6. Existing mixed-state drafts normalize into a valid state when loaded into the manual pool editor.
+7. Pool summaries, poolside text, and pdf detail labels stop using invented labels such as `Open swim`, `Step note`, and `Rest time` where Garmin terms exist.
+8. Targeted tests and `npm run verify:pre-pr` pass.
+
+## Validation
+
+- `npm run lint:briefs:all`
+- `npx vitest run tests/unit/workout-builder-hub.test.tsx tests/unit/workouts-shared.test.ts`
+- `npx playwright test tests/e2e/my-library-workout-builder.spec.ts --project=desktop-chromium`
+- `npm run typecheck`
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm installed
+- validation runs from repo root
+
+## Manual QA Environments
+
+- Garmin reference screenshots captured during owner review on `2026-04-08`
+- Production comparison route:
+  - `https://freeswimming.org/my-library/workouts/e4b0eb22-20de-4880-a3a8-8494850caff2?entry=manual-pool`
+- Preview URL after PR push
+
+## Constraints
+
+- Use Garmin expressions for mapped manual-pool concepts unless the owner has explicitly chosen otherwise.
+- Do not invent replacements such as `Open swim` or `Open rest`.
+- Keep the builder calmer than Garmin where layout can be better without changing the underlying mental model.
+- Preserve the current repeat/rest contract and canonical save/export model.
+
+## 10/10 Quality Bar
+
+- The pool step editor must be at least Garmin-clear in terminology and structural timing choices.
+- The UI should feel cleaner than Garmin, not denser.
+- A Garmin-familiar swimmer should not need to mentally translate core duration vocabulary.
+- Required states remain intact:
+  - loading: existing builder load state remains truthful
+  - empty: existing no-session state remains truthful
+  - error: invalid save states still explain what is wrong
+  - retry: existing retry/save-again path remains the recovery path
+
+## Help/Guide And Operator Training Contract
+
+- `N/A` for this slice because:
+  - no dedicated user-facing builder help surface exists yet,
+  - the workflow change is covered by UI truthfulness and automated tests in this slice,
+  - no admin help-center workflow or operator training guide is being used as the source-of-truth for this route today.
+
+## Checkpoint Log
+
+- `2026-04-08 | in-progress | created clean worktree feat/pool-builder-garmin-terms-2026-04-08 from origin/main and locked scope to manual-pool Garmin terminology + duration filtering; confirmed there is no existing open admin note covering this exact step-timing finding, only an unrelated open pool-size autofocus note on the same workout route | next: patch WorkoutEditor/shared labels and duration filtering, then update unit/e2e coverage`
+- `2026-04-08 | in-progress | implemented Garmin-visible manual-pool terminology, filtered duration options by step type, updated shared Garmin/export labels, fixed deterministic catalog-test env isolation, and normalized manual-pool dirty-state comparison so hidden derived step labels do not keep canonical sessions falsely dirty; verify:pre-pr finished green (96 passed, 318 skipped, 0 failed) after targeted vitest/playwright reruns | next: commit, push, open PR, and monitor required CI before merge`

--- a/lib/workouts/shared.ts
+++ b/lib/workouts/shared.ts
@@ -310,7 +310,26 @@ export function buildWorkoutDraftChangeSignature(
   draft: SessionDraft | null | undefined
 ): string | null {
   if (!draft) return null;
-  return JSON.stringify(draft);
+  return JSON.stringify(normalizeWorkoutDraftForChangeSignature(draft));
+}
+
+function normalizeWorkoutDraftForChangeSignature(draft: SessionDraft): SessionDraft {
+  if (
+    draft.environment !== "pool" ||
+    typeof draft.sourceFingerprint !== "string" ||
+    !draft.sourceFingerprint.startsWith("manual")
+  ) {
+    return draft;
+  }
+
+  return {
+    ...draft,
+    steps: draft.steps.map((step) => ({
+      ...step,
+      name: "",
+      targetSummary: "",
+    })),
+  };
 }
 
 export function haveWorkoutDraftChanges(
@@ -2263,7 +2282,7 @@ function buildWorkoutGarminPoolCssCompatibilityIssue(
     }
 
     if (step.durationMode === "css_send_off") {
-      references.push(`${stepLabel} (CSS send-off)`);
+      references.push(`${stepLabel} (CSS-Based Send-Off Time)`);
     }
 
     return references;
@@ -2320,7 +2339,7 @@ function buildWorkoutGarminSendOffCompatibilityIssue(
 
   const stepLabel = buildWorkoutStepReadinessLabel(step, index);
   const durationLabel =
-    step.durationMode === "css_send_off" ? "CSS send-off" : "Send-off Time";
+    step.durationMode === "css_send_off" ? "CSS-Based Send-Off Time" : "Send-Off Time";
   const reasons: string[] = [];
 
   if (step.category !== "rest") {
@@ -2344,7 +2363,7 @@ function buildWorkoutGarminSendOffCompatibilityIssue(
     id: `${step.id}-send-off-compatibility`,
     stepId: step.id,
     stepIndex: index,
-    detail: `${stepLabel} uses ${durationLabel}, but Garmin pool workouts keep ${durationLabel} as a rest choice after a distance-based swim step. Because ${reasonSummary}, device handoff may behave like open rest instead.`,
+    detail: `${stepLabel} uses ${durationLabel}, but Garmin pool workouts keep ${durationLabel} as a rest choice after a distance-based swim step. Because ${reasonSummary}, device handoff may behave like Lap Button Press instead.`,
   };
 }
 
@@ -2367,7 +2386,7 @@ function getWorkoutStepDetailLabels(
   if (isPoolWorkoutEnvironment(environment)) {
     return {
       targetSummary: "Target summary",
-      stepNote: "Step note",
+      stepNote: "Notes",
     };
   }
 
@@ -2390,17 +2409,17 @@ export function getWorkoutStepDurationModeOutputLabel(
 
   switch (value) {
     case "distance":
-      return "Distance swim";
+      return "Distance";
     case "time":
-      return "Time-based swim";
+      return "Time";
     case "fixed_rest":
-      return "Rest time";
+      return "Fixed Rest Time";
     case "lap_button":
-      return options?.category === "rest" ? "Open rest" : "Open swim";
+      return "Lap Button Press";
     case "send_off":
-      return "Send-off Time";
+      return "Send-Off Time";
     case "css_send_off":
-      return "CSS send-off";
+      return "CSS-Based Send-Off Time";
     default:
       return getSessionStepDurationModeLabel(value);
   }
@@ -2456,10 +2475,10 @@ export function buildWorkoutStepDurationOutputSummary(
           : "Send-off not set";
       case "css_send_off":
         if (typeof step.cssSendOffOffsetSeconds !== "number") {
-          return "CSS send-off not set";
+          return "CSS-Based Send-Off Time not set";
         }
 
-        return `CSS ${step.cssSendOffOffsetSeconds > 0 ? "+" : ""}${step.cssSendOffOffsetSeconds}s send-off (${formatClockDurationLabelFromSeconds(
+        return `CSS-Based Send-Off Time ${step.cssSendOffOffsetSeconds > 0 ? "+" : ""}${step.cssSendOffOffsetSeconds}s (${formatClockDurationLabelFromSeconds(
           basePaceSecondsPer100m + step.cssSendOffOffsetSeconds
         )})`;
       case "lap_button":
@@ -2471,25 +2490,23 @@ export function buildWorkoutStepDurationOutputSummary(
 
   switch (step.durationMode) {
     case "distance":
-      return step.distanceM ? `${step.distanceM}m` : "Distance swim not set";
+      return step.distanceM ? `${step.distanceM}m` : "Distance not set";
     case "time":
-      return step.timeMin
-        ? `Time-based swim ${formatMinutesLabel(step.timeMin)}`
-        : "Time-based swim not set";
+      return step.timeMin ? `Time ${formatMinutesLabel(step.timeMin)}` : "Time not set";
     case "fixed_rest":
       return step.timeMin
-        ? `Rest time ${formatClockDurationLabel(step.timeMin)}`
-        : "Rest time not set";
+        ? `Fixed Rest Time ${formatClockDurationLabel(step.timeMin)}`
+        : "Fixed Rest Time not set";
     case "send_off":
       return step.timeMin
-        ? `Send-off Time ${formatClockDurationLabel(step.timeMin)}`
-        : "Send-off Time not set";
+        ? `Send-Off Time ${formatClockDurationLabel(step.timeMin)}`
+        : "Send-Off Time not set";
     case "css_send_off":
       if (typeof step.cssSendOffOffsetSeconds !== "number") {
-        return "CSS send-off not set";
+        return "CSS-Based Send-Off Time not set";
       }
 
-      return `CSS send-off ${step.cssSendOffOffsetSeconds > 0 ? "+" : ""}${step.cssSendOffOffsetSeconds}s (${formatClockDurationLabelFromSeconds(
+      return `CSS-Based Send-Off Time ${step.cssSendOffOffsetSeconds > 0 ? "+" : ""}${step.cssSendOffOffsetSeconds}s (${formatClockDurationLabelFromSeconds(
         basePaceSecondsPer100m + step.cssSendOffOffsetSeconds
       )})`;
     case "lap_button":
@@ -2778,7 +2795,7 @@ function buildWorkoutPoolsidePauseLabel(
   }
 
   if (step.durationMode === "css_send_off" && typeof step.cssSendOffOffsetSeconds === "number") {
-    return `CSS send-off ${formatClockDurationLabelFromSeconds(
+    return `CSS-Based Send-Off Time ${formatClockDurationLabelFromSeconds(
       basePaceSecondsPer100m + step.cssSendOffOffsetSeconds
     )}`;
   }
@@ -3311,7 +3328,7 @@ function normalizeStep(
   if (input.durationMode === "css_send_off" && cssSendOffOffsetSeconds === null) {
     return {
       ok: false,
-      error: `Step ${index + 1} needs a CSS send-off offset before saving.`,
+      error: `Step ${index + 1} needs a CSS-Based Send-Off Time offset before saving.`,
     };
   }
 

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -125,42 +125,56 @@ test.describe("my library workout builder", () => {
     await expect(
       page.getByTestId("workout-editor-panel").getByRole("heading", { name: "Session builder" })
     ).toBeVisible();
-    await expect(page.getByLabel("Step type")).toBeVisible();
-    await expect(page.getByLabel("Stroke")).toBeVisible();
-    await expect(page.getByLabel("Drill type")).toBeVisible();
-    await expect(page.getByLabel("Step timing")).toBeVisible();
+    await expect(page.getByLabel("Step Type")).toBeVisible();
+    await expect(page.getByLabel("Stroke Type")).toBeVisible();
+    await expect(page.getByLabel("Drill Type")).toBeVisible();
+    await expect(page.getByLabel("Duration")).toBeVisible();
     await expect(page.getByRole("combobox", { name: "Target" })).toBeVisible();
-    await expect(page.getByRole("textbox", { name: "Step note" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Notes" })).toBeVisible();
     await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
-      "Distance swim"
+      "Distance"
     );
     await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
-      "Time-based swim"
+      "Time"
     );
     await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
-      "Open swim"
+      "Lap Button Press"
     );
-    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
-      "Rest time"
+    await expect(page.getByTestId("session-draft-step-duration-mode-0")).not.toContainText(
+      "Fixed Rest Time"
     );
-    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
-      "Send-off time"
+    await expect(page.getByTestId("session-draft-step-duration-mode-0")).not.toContainText(
+      "Send-Off Time"
     );
-    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
-      "CSS send-off"
+    await expect(page.getByTestId("session-draft-step-duration-mode-0")).not.toContainText(
+      "CSS-Based Send-Off Time"
     );
     await expect(page.locator("label").filter({ hasText: /^Step name$/ })).toHaveCount(0);
     await expect(page.locator("label").filter({ hasText: /^Effort cue$/ })).toHaveCount(0);
     await expect(page.locator("label").filter({ hasText: /^Target summary$/ })).toHaveCount(0);
     await expect(page.locator("label").filter({ hasText: /^Target notes$/ })).toHaveCount(0);
-    await expect(
-      page.getByText(
-        "Optional short cue for the interval summary. Use Step note for the Garmin-style step note."
-      )
-    ).toHaveCount(0);
-    await expect(
-      page.getByText("Add a note for this step.")
-    ).toBeVisible();
+    await page.getByLabel("Step Type").selectOption("rest");
+    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toHaveValue(
+      "fixed_rest"
+    );
+    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
+      "Fixed Rest Time"
+    );
+    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
+      "Send-Off Time"
+    );
+    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
+      "CSS-Based Send-Off Time"
+    );
+    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
+      "Lap Button Press"
+    );
+    const restDurationOptions = page
+      .getByTestId("session-draft-step-duration-mode-0")
+      .locator("option");
+    await expect(restDurationOptions.filter({ hasText: /^Distance$/ })).toHaveCount(0);
+    await expect(restDurationOptions.filter({ hasText: /^Time$/ })).toHaveCount(0);
+    await page.getByLabel("Step Type").selectOption("main");
     await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
       "All builder changes are saved to the canonical workout."
     );
@@ -198,7 +212,7 @@ test.describe("my library workout builder", () => {
       '"draftState": "canonical"'
     );
     await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
-      '"label": "Distance swim"'
+      '"label": "Distance"'
     );
     await expect(page.getByTestId("workout-builder-save")).toBeDisabled();
 
@@ -234,9 +248,9 @@ test.describe("my library workout builder", () => {
     await page.getByTestId("workout-editor-removal-undo-button").click();
     await expect(page.getByTestId("workout-editor-removal-undo")).toHaveCount(0);
     await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
-      "Unsaved changes stay local until you save this workout."
+      "All builder changes are saved to the canonical workout."
     );
-    await expect(page.getByTestId("workout-builder-save")).toBeEnabled();
+    await expect(page.getByTestId("workout-builder-save")).toBeDisabled();
 
     await openMetadataPanelIfCollapsed(page);
     await expect(page.getByTestId("session-draft-title")).toHaveValue("");
@@ -265,7 +279,7 @@ test.describe("my library workout builder", () => {
     await page.getByTestId("session-draft-step-toggle-2").click();
     await page.getByTestId("session-draft-step-rest-minutes-2").fill("0");
     await page.getByTestId("session-draft-step-rest-seconds-2").fill("45");
-    await page.getByLabel("Step note").fill("Leave on the top and count strokes.");
+    await page.getByLabel("Notes").fill("Leave on the top and count strokes.");
     await page.getByTestId("session-draft-title").fill(uniqueTitle);
     await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
       "Unsaved changes stay local until you save this workout."
@@ -308,7 +322,7 @@ test.describe("my library workout builder", () => {
       "Final rest skipped"
     );
     await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(
-      "Step note: Leave on the top and count strokes."
+      "Notes: Leave on the top and count strokes."
     );
     await expect(page.getByTestId("workout-editor-garmin-export-source")).toHaveAttribute(
       "data-export-state",
@@ -324,7 +338,7 @@ test.describe("my library workout builder", () => {
       `"title": "${uniqueTitle}"`
     );
     await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
-      '"label": "Rest time"'
+      '"label": "Fixed Rest Time"'
     );
     await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
       '"reviewIssueIds": ['
@@ -372,7 +386,7 @@ test.describe("my library workout builder", () => {
     await expect(poolsidePopup.locator("body")).toContainText("Poolside Note");
     await expect(poolsidePopup.locator("body")).toContainText("Ink saver");
     await expect(poolsidePopup.locator("body")).toContainText("Tot:");
-    await expect(poolsidePopup.locator("body")).toContainText("P: Rest time 0:45");
+    await expect(poolsidePopup.locator("body")).toContainText("P: Fixed Rest Time 0:45");
     await poolsidePopup.close();
 
     const patchResponsePromise = page.waitForResponse(

--- a/tests/unit/commerce-catalog.test.ts
+++ b/tests/unit/commerce-catalog.test.ts
@@ -8,7 +8,7 @@ import {
 import { buildCatalogOverridesFromRows } from "@/lib/commerce/catalog-overrides";
 
 const ENV: NodeJS.ProcessEnv = {
-  ...process.env,
+  NODE_ENV: "test",
   STRIPE_PRICE_ID_0_1000M_GUIDE: "price_1000",
   STRIPE_PRICE_ID_POOLSIDE_GUIDE: "price_poolside",
   STRIPE_PRICE_ID_ANALYSIS: "price_analysis",
@@ -41,7 +41,7 @@ describe("commerce catalog", () => {
 
   it("returns per-product availability without throwing", () => {
     const partialEnv: NodeJS.ProcessEnv = {
-      ...process.env,
+      NODE_ENV: "test",
       STRIPE_PRICE_ID_0_1000M_GUIDE: "price_1000",
       STRIPE_PRICE_ID_ANALYSIS: "price_analysis",
     };

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -336,10 +336,10 @@ describe("WorkoutBuilderHub", () => {
       "Manual Garmin translation is still required"
     );
     expect(screen.getByTestId("workout-editor-garmin-readiness")).toHaveTextContent(
-      "CSS send-off"
+      "CSS-Based Send-Off Time"
     );
     expect(screen.getByTestId("workout-editor-garmin-readiness")).toHaveTextContent(
-      "open rest instead"
+      "Lap Button Press instead"
     );
     fireEvent.click(screen.getByTestId("workout-editor-garmin-export-toggle"));
     fireEvent.click(screen.getByTestId("workout-editor-handoff-toggle"));
@@ -1194,18 +1194,20 @@ describe("WorkoutBuilderHub", () => {
     fireEvent.click(screen.getByTestId("session-draft-step-toggle-0"));
 
     expect(screen.getByText("Session builder")).toBeVisible();
-    expect(screen.getByLabelText("Step type")).toBeVisible();
-    expect(screen.getByLabelText("Stroke")).toBeVisible();
-    expect(screen.getByLabelText("Drill type")).toBeVisible();
-    expect(screen.getByLabelText("Step timing")).toBeVisible();
+    expect(screen.getByLabelText("Step Type")).toBeVisible();
+    expect(screen.getByLabelText("Stroke Type")).toBeVisible();
+    expect(screen.getByLabelText("Drill Type")).toBeVisible();
+    expect(screen.getByLabelText("Duration")).toBeVisible();
     expect(screen.getByLabelText("Target")).toBeVisible();
-    expect(screen.getByLabelText("Step note")).toBeVisible();
-    expect(screen.getByRole("option", { name: "Distance swim" })).toBeVisible();
-    expect(screen.getByRole("option", { name: "Time-based swim" })).toBeVisible();
-    expect(screen.getByRole("option", { name: "Open swim" })).toBeVisible();
-    expect(screen.getByRole("option", { name: "Rest time" })).toBeVisible();
-    expect(screen.getByRole("option", { name: "Send-off time" })).toBeVisible();
-    expect(screen.getByRole("option", { name: "CSS send-off" })).toBeVisible();
+    expect(screen.getByLabelText("Notes")).toBeVisible();
+    expect(screen.getByRole("option", { name: "Distance" })).toBeVisible();
+    expect(screen.getByRole("option", { name: "Time" })).toBeVisible();
+    expect(screen.getByRole("option", { name: "Lap Button Press" })).toBeVisible();
+    expect(screen.queryByRole("option", { name: "Fixed Rest Time" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Send-Off Time" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "CSS-Based Send-Off Time" })
+    ).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Step name")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Effort cue")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Target summary")).not.toBeInTheDocument();
@@ -1220,9 +1222,23 @@ describe("WorkoutBuilderHub", () => {
         "Optional. Leave Drill type on None unless the step needs extra drill, kick, or pull notation."
       )
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByText("Add a note for this step.")
-    ).toBeVisible();
+
+    fireEvent.change(screen.getByLabelText("Step Type"), {
+      target: { value: "rest" },
+    });
+
+    expect(screen.getByTestId("session-draft-step-duration-mode-0")).toHaveValue("fixed_rest");
+    expect(screen.getByRole("option", { name: "Fixed Rest Time" })).toBeVisible();
+    expect(screen.getByRole("option", { name: "Send-Off Time" })).toBeVisible();
+    expect(screen.getByRole("option", { name: "CSS-Based Send-Off Time" })).toBeVisible();
+    expect(screen.getByRole("option", { name: "Lap Button Press" })).toBeVisible();
+    expect(screen.queryByRole("option", { name: "Distance" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Time" })).not.toBeInTheDocument();
+    expect(readPreviewDraft().steps[0]).toMatchObject({
+      category: "rest",
+      durationMode: "fixed_rest",
+    });
+
     fireEvent.click(screen.getByTestId("session-draft-add-repeat"));
     expect(
       screen.getByTestId("session-draft-repeat-ending-rest-mode-1")
@@ -1236,6 +1252,45 @@ describe("WorkoutBuilderHub", () => {
     expect(
       screen.queryByText("Move the full repeat block from the header.")
     ).not.toBeInTheDocument();
+  });
+
+  it("normalizes legacy manual-pool mixed duration states on load", async () => {
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: buildWorkoutRecord({
+            sourceKind: "manual",
+            draft: buildDraft({
+              steps: [
+                {
+                  id: "step-1",
+                  category: "main",
+                  name: "Legacy mixed step",
+                  stroke: "freestyle",
+                  intensity: "moderate",
+                  durationMode: "fixed_rest",
+                  distanceM: null,
+                  timeMin: 1,
+                  targetSummary: "",
+                  notes: "",
+                },
+              ],
+            }),
+          }),
+          recentWorkouts: [buildWorkoutSummary({ sourceKind: "manual" })],
+        })}
+        preferExpandedDetailsOnLoad
+      />
+    );
+
+    await waitFor(() => {
+      expect(readPreviewDraft().steps[0]).toMatchObject({
+        category: "main",
+        durationMode: "distance",
+        distanceM: 100,
+        timeMin: null,
+      });
+    });
   });
 
   it("hides the auto untitled pool title in the manual builder input until the owner edits it", async () => {
@@ -1296,12 +1351,15 @@ describe("WorkoutBuilderHub", () => {
     fireEvent.change(screen.getByTestId("session-draft-step-rest-minutes-2"), {
       target: { value: "0" },
     });
+    await waitFor(() => {
+      expect(readPreviewDraft().steps[2]?.timeMin).toBeNull();
+    });
     fireEvent.change(screen.getByTestId("session-draft-step-rest-seconds-2"), {
       target: { value: "45" },
     });
 
-    expect(screen.getByText("0:45 rest")).toBeVisible();
     expect(readPreviewDraft().steps[2]?.timeMin).toBe(0.75);
+    expect(readPreviewDraft().steps[2]?.name).toContain("Fixed Rest Time 0:45");
   });
 
   it("treats unspecified pool size as valid while invalid custom input still blocks save", async () => {

--- a/tests/unit/workouts-routes.test.ts
+++ b/tests/unit/workouts-routes.test.ts
@@ -593,7 +593,7 @@ describe("workouts routes", () => {
 
     expect(response.status).toBe(400);
     expect(payload.ok).toBe(false);
-    expect(payload.error).toContain("CSS send-off offset");
+    expect(payload.error).toContain("CSS-Based Send-Off Time offset");
     expect(insert).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/workouts-shared.test.ts
+++ b/tests/unit/workouts-shared.test.ts
@@ -10,6 +10,7 @@ import {
   buildWorkoutGarminReadinessReport,
   buildWorkoutHandoffFileName,
   buildWorkoutHandoffText,
+  haveWorkoutDraftChanges,
   selectWorkoutPoolsideFocusTitles,
 } from "@/lib/workouts/shared";
 
@@ -218,6 +219,73 @@ describe("workouts shared readiness", () => {
     expect(report.issues[0]?.detail).toContain("older watches skip the final rest instead");
   });
 
+  it("ignores manual-pool derived step labels when checking unsaved changes", () => {
+    const savedDraft: SessionDraft = {
+      version: 1,
+      status: "draft",
+      generatorKind: "rule_engine_v1",
+      createdAt: "2026-04-08T12:00:00.000Z",
+      sourceFingerprint: "manual-empty-pool-20260408120000",
+      title: "Untitled pool session",
+      titleSuggestions: ["Untitled pool session"],
+      description: "",
+      environment: "pool",
+      poolLengthM: 25,
+      sessionType: "endurance",
+      effort: "moderate",
+      sizeMode: "distance",
+      targetDistanceM: null,
+      targetTimeMin: null,
+      totalDistanceM: 100,
+      estimatedDurationMin: null,
+      basePaceSecondsPer100m: 120,
+      usedCssPaceLabel: null,
+      allowedStrokes: ["freestyle"],
+      equipmentAllowlist: [],
+      focusText: null,
+      goalTitle: null,
+      constraintText: null,
+      warnings: [],
+      steps: [
+        {
+          id: "manual-step-1",
+          category: "main",
+          name: "First step",
+          stroke: "freestyle",
+          drillType: "none",
+          equipment: "none",
+          intensity: "moderate",
+          durationMode: "distance",
+          distanceM: 100,
+          timeMin: null,
+          targetMode: "none",
+          effortTarget: null,
+          targetPaceSecondsPer100m: null,
+          cssTargetOffsetSeconds: null,
+          cssSendOffOffsetSeconds: null,
+          targetSummary: "",
+          notes: "",
+          repeatGroupId: null,
+          repeatCount: null,
+          repeatEndingRestMode: null,
+        },
+      ],
+    };
+
+    const editorSyncedDraft: SessionDraft = {
+      ...savedDraft,
+      steps: [
+        {
+          ...savedDraft.steps[0]!,
+          name: "100m · Freestyle · Moderate",
+          targetSummary: "legacy hidden summary should not keep the draft dirty",
+        },
+      ],
+    };
+
+    expect(haveWorkoutDraftChanges(editorSyncedDraft, savedDraft)).toBe(false);
+  });
+
   it("reports review when send-off time is not authored as a rest after a distance-based swim step", () => {
     const report = buildWorkoutGarminReadinessReport({
       ...buildDraft(),
@@ -254,8 +322,8 @@ describe("workouts shared readiness", () => {
       "Review 1 Garmin/export mapping detail before you treat this workout as handoff-ready."
     );
     expect(report.issues).toHaveLength(1);
-    expect(report.issues[0]?.detail).toContain("Send-off Time");
-    expect(report.issues[0]?.detail).toContain("open rest instead");
+    expect(report.issues[0]?.detail).toContain("Send-Off Time");
+    expect(report.issues[0]?.detail).toContain("Lap Button Press instead");
     expect(report.issues[0]?.detail).toContain("is not a distance-based swim step");
   });
 
@@ -297,7 +365,9 @@ describe("workouts shared readiness", () => {
     );
     expect(report.issues).toHaveLength(1);
     expect(report.issues[0]?.detail).toContain("CSS-relative pacing");
-    expect(report.issues[0]?.detail).toContain("Step 2 (CSS send-off rest) (CSS send-off)");
+    expect(report.issues[0]?.detail).toContain(
+      "Step 2 (CSS send-off rest) (CSS-Based Send-Off Time)"
+    );
     expect(report.issues[0]?.detail).toContain("2:00/100m if no CSS is set");
     expect(report.issues[0]?.detail).toContain("2:08/100m as the workout CSS baseline");
   });
@@ -434,15 +504,15 @@ describe("workouts shared readiness", () => {
       workoutId: "workout-output-1",
     });
 
-    expect(handoffText).toContain("Swim · Open swim · Freestyle · Moderate");
-    expect(handoffText).toContain("Rest · Open rest · Easy");
+    expect(handoffText).toContain("Swim · Lap Button Press · Freestyle · Moderate");
+    expect(handoffText).toContain("Rest · Lap Button Press · Easy");
     expect(handoffText).toContain("Target summary: Stay tall through the turn.");
-    expect(handoffText).toContain("Step note: Count strokes off every wall.");
+    expect(handoffText).toContain("Notes: Count strokes off every wall.");
     expect(html).toContain("Target summary: Stay tall through the turn.");
-    expect(html).toContain("Step note: Count strokes off every wall.");
-    expect(pdfModel.poolsideLines).toContain("Open swim · Freestyle · Moderate");
-    expect(pdfModel.poolsideLines).toContain("P: Open rest");
-    expect(pdfModel.poolsideLines).toContain("P: Send-off Time 2:00");
+    expect(html).toContain("Notes: Count strokes off every wall.");
+    expect(pdfModel.poolsideLines).toContain("Lap Button Press · Freestyle · Moderate");
+    expect(pdfModel.poolsideLines).toContain("P: Lap Button Press");
+    expect(pdfModel.poolsideLines).toContain("P: Send-Off Time 2:00");
 
     if (exportPayload.blocks[0]?.kind !== "single") {
       throw new Error("Expected first block to be a single-step export.");
@@ -458,8 +528,8 @@ describe("workouts shared readiness", () => {
 
     expect(exportPayload.blocks[0].step.duration).toMatchObject({
       mode: "lap_button",
-      label: "Open swim",
-      summary: "Open swim",
+      label: "Lap Button Press",
+      summary: "Lap Button Press",
     });
     expect(exportPayload.blocks[0].step.target).toMatchObject({
       mode: "none",
@@ -468,13 +538,13 @@ describe("workouts shared readiness", () => {
     });
     expect(exportPayload.blocks[1].step.duration).toMatchObject({
       mode: "lap_button",
-      label: "Open rest",
-      summary: "Open rest",
+      label: "Lap Button Press",
+      summary: "Lap Button Press",
     });
     expect(exportPayload.blocks[2].step.duration).toMatchObject({
       mode: "send_off",
-      label: "Send-off Time",
-      summary: "Send-off Time 2:00",
+      label: "Send-Off Time",
+      summary: "Send-Off Time 2:00",
     });
   });
 
@@ -703,7 +773,7 @@ describe("workouts shared readiness", () => {
       reviewIssueIds: [],
       duration: {
         mode: "send_off",
-        summary: "Send-off Time 2:00",
+        summary: "Send-Off Time 2:00",
       },
     });
   });
@@ -764,7 +834,7 @@ describe("workouts shared readiness", () => {
       summary: "4 rounds · 100m + 2:00 per round · Final rest skipped",
     });
     expect(pdfModel.poolsideLines).toContain(
-      "P: Send-off Time 2:00 between rounds (final rest skipped)"
+      "P: Send-Off Time 2:00 between rounds (final rest skipped)"
     );
 
     if (exportPayload.blocks[0]?.kind !== "repeat") {


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-04-08T21:03:42.243Z for branch `feat/pool-builder-garmin-terms-2026-04-08` (base ref `origin/main`).
- Latest commit: `6f11095` - Use Garmin terminology in manual pool builder.
- User-visible changes: User/admin runtime behavior may change on touched routes/components.
- Technical changes: Updated 8 file(s): `components/my-library/workouts/WorkoutEditor.tsx`, `docs/task-briefs/in-progress/2026-04-08-pool-swim-session-builder-garmin-duration-and-terminology-polish-10-10.md`, `lib/workouts/shared.ts`, `tests/e2e/my-library-workout-builder.spec.ts`, `tests/unit/commerce-catalog.test.ts`, `... and 3 more file(s)`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-04-08-pool-swim-session-builder-garmin-duration-and-terminology-polish-10-10.md`
- Scorecard target outcomes: 10 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (1); tests (5); runtime UI/routes/components (2).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (8):
  - `components/my-library/workouts/WorkoutEditor.tsx`
  - `docs/task-briefs/in-progress/2026-04-08-pool-swim-session-builder-garmin-duration-and-terminology-polish-10-10.md`
  - `lib/workouts/shared.ts`
  - `tests/e2e/my-library-workout-builder.spec.ts`
  - `tests/unit/commerce-catalog.test.ts`
  - `tests/unit/workout-builder-hub.test.tsx`
  - `tests/unit/workouts-routes.test.ts`
  - `tests/unit/workouts-shared.test.ts`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `6f11095` (`git revert 6f11095`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **NOT RUN** (run locally before pushing PR updates).
- `npm run verify:pre-merge`: **PENDING** for `6f11095` (required before merge to `main`).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  - No local verify log found in `artifacts/test-runs/latest`.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
