### PR TITLE
Clarify pool repeat rest and seed CSS defaults

### DIFF
--- a/app/my-library/page.tsx
+++ b/app/my-library/page.tsx
@@ -256,6 +256,10 @@ export default async function MyLibraryPage() {
                     <CreateManualWorkoutButton
                       label="Build pool session"
                       testId="my-library-create-pool-workout"
+                      manualPoolCssMetricSecondsPer100m={
+                        athleteProfileSnapshot.cssMetric?.valueSeconds ?? null
+                      }
+                      manualPoolCssPaceLabel={athleteProfileSnapshot.cssMetric?.paceLabel ?? null}
                       className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
                     />
                   ) : null}

--- a/app/my-library/workouts/[workoutId]/page.tsx
+++ b/app/my-library/workouts/[workoutId]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import SiteChrome from "@/components/SiteChrome";
 import WorkoutBuilderHub from "@/components/my-library/workouts/WorkoutBuilderHub";
+import { loadAthleteProfileSnapshot } from "@/lib/athlete-profile/server";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { loadTrainingContextSnapshot } from "@/lib/training-context/server";
 import type { WorkoutPoolsideFocusOption } from "@/lib/workouts/shared";
@@ -52,9 +53,10 @@ export default async function WorkoutBuilderPage({ params, searchParams }: Props
     redirect(`/auth/sign-in?next=${encodeURIComponent(`/my-library/workouts/${workoutId}`)}`);
   }
 
-  const [workoutLibrary, trainingContextSnapshot] = await Promise.all([
+  const [workoutLibrary, trainingContextSnapshot, athleteProfileSnapshot] = await Promise.all([
     loadWorkoutLibrarySnapshot(supabase, user.id, workoutId),
     loadTrainingContextSnapshot(supabase, user.id),
+    loadAthleteProfileSnapshot(supabase, user.id),
   ]);
   const trainingFocusOptions: WorkoutPoolsideFocusOption[] =
     trainingContextSnapshot.schemaReady && !trainingContextSnapshot.loadError
@@ -90,6 +92,8 @@ export default async function WorkoutBuilderPage({ params, searchParams }: Props
             <WorkoutBuilderHub
               workoutLibrary={workoutLibrary}
               trainingFocusOptions={trainingFocusOptions}
+              manualPoolCssMetricSecondsPer100m={athleteProfileSnapshot.cssMetric?.valueSeconds ?? null}
+              manualPoolCssPaceLabel={athleteProfileSnapshot.cssMetric?.paceLabel ?? null}
               hideShellIntro
               preferExpandedDetailsOnLoad={preferExpandedDetailsOnLoad}
             />

--- a/app/my-library/workouts/page.tsx
+++ b/app/my-library/workouts/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import SiteChrome from "@/components/SiteChrome";
 import WorkoutBuilderHub from "@/components/my-library/workouts/WorkoutBuilderHub";
+import { loadAthleteProfileSnapshot } from "@/lib/athlete-profile/server";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { loadTrainingContextSnapshot } from "@/lib/training-context/server";
 import type { WorkoutPoolsideFocusOption } from "@/lib/workouts/shared";
@@ -19,9 +20,10 @@ export default async function WorkoutSessionsPage() {
     redirect("/auth/sign-in?next=%2Fmy-library%2Fworkouts");
   }
 
-  const [workoutLibrary, trainingContextSnapshot] = await Promise.all([
+  const [workoutLibrary, trainingContextSnapshot, athleteProfileSnapshot] = await Promise.all([
     loadWorkoutLibrarySnapshot(supabase, user.id, null),
     loadTrainingContextSnapshot(supabase, user.id),
+    loadAthleteProfileSnapshot(supabase, user.id),
   ]);
   const trainingFocusOptions: WorkoutPoolsideFocusOption[] =
     trainingContextSnapshot.schemaReady && !trainingContextSnapshot.loadError
@@ -57,6 +59,8 @@ export default async function WorkoutSessionsPage() {
             <WorkoutBuilderHub
               workoutLibrary={workoutLibrary}
               trainingFocusOptions={trainingFocusOptions}
+              manualPoolCssMetricSecondsPer100m={athleteProfileSnapshot.cssMetric?.valueSeconds ?? null}
+              manualPoolCssPaceLabel={athleteProfileSnapshot.cssMetric?.paceLabel ?? null}
               browseOnly
             />
           </div>

--- a/components/my-library/workouts/CreateManualWorkoutButton.tsx
+++ b/components/my-library/workouts/CreateManualWorkoutButton.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import {
   buildManualOpenWaterWorkoutEmptyDraft,
   buildManualPoolWorkoutEmptyDraft,
+  type ManualWorkoutDraftDefaults,
   type ManualWorkoutBuilderMode,
 } from "@/lib/workouts/manual";
 import type { WorkoutSaveApiResponse } from "@/lib/workouts/shared";
@@ -16,6 +17,8 @@ type Props = {
   testId?: string;
   builderMode?: ManualWorkoutBuilderMode;
   createdWorkoutHrefBuilder?: (workoutId: string) => string;
+  manualPoolCssMetricSecondsPer100m?: number | null;
+  manualPoolCssPaceLabel?: string | null;
 };
 
 export default function CreateManualWorkoutButton({
@@ -25,6 +28,8 @@ export default function CreateManualWorkoutButton({
   testId = "create-manual-workout",
   builderMode = "pool",
   createdWorkoutHrefBuilder,
+  manualPoolCssMetricSecondsPer100m = null,
+  manualPoolCssPaceLabel = null,
 }: Props) {
   const router = useRouter();
   const [isCreating, setIsCreating] = useState(false);
@@ -34,10 +39,16 @@ export default function CreateManualWorkoutButton({
   const resolvedPendingLabel =
     pendingLabel ??
     (builderMode === "pool" ? "Building pool session..." : "Building open water session...");
-  const buildDraft =
-    builderMode === "pool"
-      ? buildManualPoolWorkoutEmptyDraft
-      : buildManualOpenWaterWorkoutEmptyDraft;
+  const manualPoolDefaults: ManualWorkoutDraftDefaults | undefined =
+    builderMode === "pool" &&
+    typeof manualPoolCssMetricSecondsPer100m === "number" &&
+    Number.isFinite(manualPoolCssMetricSecondsPer100m) &&
+    manualPoolCssMetricSecondsPer100m > 0
+      ? {
+          basePaceSecondsPer100m: manualPoolCssMetricSecondsPer100m,
+          usedCssPaceLabel: manualPoolCssPaceLabel,
+        }
+      : undefined;
   const buildWorkoutHref =
     createdWorkoutHrefBuilder ??
     ((workoutId: string) =>
@@ -57,7 +68,10 @@ export default function CreateManualWorkoutButton({
         },
         body: JSON.stringify({
           sourceKind: "manual",
-          draft: buildDraft(),
+          draft:
+            builderMode === "pool"
+              ? buildManualPoolWorkoutEmptyDraft(new Date(), manualPoolDefaults)
+              : buildManualOpenWaterWorkoutEmptyDraft(),
         }),
       });
       const responseBody = (await response

--- a/components/my-library/workouts/WorkoutBuilderHub.tsx
+++ b/components/my-library/workouts/WorkoutBuilderHub.tsx
@@ -20,6 +20,8 @@ import { haveWorkoutDraftChanges } from "@/lib/workouts/shared";
 type Props = {
   workoutLibrary: WorkoutLibrarySnapshot;
   trainingFocusOptions?: WorkoutPoolsideFocusOption[];
+  manualPoolCssMetricSecondsPer100m?: number | null;
+  manualPoolCssPaceLabel?: string | null;
   browseOnly?: boolean;
   hideShellIntro?: boolean;
   preferExpandedDetailsOnLoad?: boolean;
@@ -33,6 +35,8 @@ function upsertRecentWorkoutSummary(current: WorkoutSummary[], next: WorkoutSumm
 export default function WorkoutBuilderHub({
   workoutLibrary,
   trainingFocusOptions = [],
+  manualPoolCssMetricSecondsPer100m = null,
+  manualPoolCssPaceLabel = null,
   browseOnly = false,
   hideShellIntro = false,
   preferExpandedDetailsOnLoad = false,
@@ -175,6 +179,8 @@ export default function WorkoutBuilderHub({
               <CreateManualWorkoutButton
                 label="Build pool session"
                 testId="workout-builder-browse-create-pool"
+                manualPoolCssMetricSecondsPer100m={manualPoolCssMetricSecondsPer100m}
+                manualPoolCssPaceLabel={manualPoolCssPaceLabel}
                 className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
               />
             ) : null}
@@ -356,6 +362,8 @@ export default function WorkoutBuilderHub({
                   <CreateManualWorkoutButton
                     label="Build pool session"
                     testId="workout-builder-empty-create-pool"
+                    manualPoolCssMetricSecondsPer100m={manualPoolCssMetricSecondsPer100m}
+                    manualPoolCssPaceLabel={manualPoolCssPaceLabel}
                     className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
                   />
                 ) : null}

--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -563,6 +563,83 @@ function formatClockDurationLabel(valueMinutes: number | null | undefined) {
   return formatClockDurationLabelFromSeconds(getClockTotalSeconds(valueMinutes));
 }
 
+function formatEditableClockDuration(valueMinutes: number | null | undefined) {
+  if (!valueMinutes || valueMinutes <= 0) return "";
+  return formatClockDurationLabel(valueMinutes);
+}
+
+function sanitizeClockDurationInput(rawValue: string) {
+  const cleaned = rawValue.replace(/[^\d:]/g, "");
+  const [rawMinutes = "", ...rest] = cleaned.split(":");
+  const minutes = rawMinutes.slice(0, 3);
+
+  if (rest.length === 0) {
+    return minutes;
+  }
+
+  return `${minutes}:${rest.join("").slice(0, 2)}`;
+}
+
+function parseClockDurationInputForChange(value: string) {
+  const trimmed = value.trim();
+
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  if (/^\d{1,3}$/.test(trimmed)) {
+    const minutes = Number.parseInt(trimmed, 10);
+    return minutes > 0 ? minutes : null;
+  }
+
+  const completeClockMatch = trimmed.match(/^(\d{1,3}):(\d{2})$/);
+  if (!completeClockMatch) {
+    return undefined;
+  }
+
+  const minutes = Number.parseInt(completeClockMatch[1], 10);
+  const seconds = Math.min(59, Number.parseInt(completeClockMatch[2], 10));
+  const totalSeconds = minutes * 60 + seconds;
+
+  return totalSeconds > 0 ? totalSeconds / 60 : null;
+}
+
+function normalizeClockDurationInput(value: string) {
+  const trimmed = value.trim();
+
+  if (trimmed.length === 0) {
+    return {
+      display: "",
+      timeMin: null as number | null,
+    };
+  }
+
+  if (/^\d{1,3}$/.test(trimmed)) {
+    const minutes = Number.parseInt(trimmed, 10);
+    return {
+      display: `${minutes}:00`,
+      timeMin: minutes > 0 ? minutes : null,
+    };
+  }
+
+  const partialClockMatch = trimmed.match(/^(\d{1,3}):(\d{0,2})$/);
+  if (!partialClockMatch) {
+    return {
+      display: "",
+      timeMin: null as number | null,
+    };
+  }
+
+  const minutes = Number.parseInt(partialClockMatch[1], 10);
+  const seconds = Math.min(59, Number.parseInt(partialClockMatch[2] || "0", 10));
+  const totalSeconds = minutes * 60 + seconds;
+
+  return {
+    display: `${minutes}:${String(seconds).padStart(2, "0")}`,
+    timeMin: totalSeconds > 0 ? totalSeconds / 60 : null,
+  };
+}
+
 function buildStepRemovalLabel(
   step: SessionDraftStep,
   fallbackIndex: number,
@@ -731,6 +808,32 @@ function buildRepeatSummary(
   return parts.join(" · ");
 }
 
+function buildRepeatEndingRestDescription(
+  entries: StepRenderEntry[],
+  repeatCount: number | null,
+  basePaceSecondsPer100m: number,
+  repeatEndingRestMode: SessionDraftRepeatEndingRestMode
+) {
+  const lastEntry = entries[entries.length - 1];
+  if (!lastEntry || !isSessionDraftRepeatEndingRestStep(lastEntry.step)) {
+    return null;
+  }
+
+  const restLabel = buildWorkoutStepDurationOutputSummary(lastEntry.step, basePaceSecondsPer100m, {
+    environment: "pool",
+  });
+
+  if (repeatCount !== null && repeatCount <= 1) {
+    return repeatEndingRestMode === "skip_last_rest"
+      ? `${restLabel} is skipped after the round.`
+      : `${restLabel} runs after the round.`;
+  }
+
+  return repeatEndingRestMode === "skip_last_rest"
+    ? `${restLabel} still runs between rounds. It is skipped only after the final round.`
+    : `${restLabel} runs between rounds and again after the final round.`;
+}
+
 function getPaceMinutes(secondsPer100m: number | null | undefined) {
   if (!secondsPer100m || secondsPer100m <= 0) return "";
   return String(Math.floor(secondsPer100m / 60));
@@ -828,10 +931,18 @@ export default function WorkoutEditor({
   const isManualPoolMode = manualBuilderMode === "pool";
   const isManualOpenWaterMode = manualBuilderMode === "open_water";
   const autoPoolBuilderTitle = getPoolBuilderAutoTitle(draft.environment);
+  const timeDurationInputFocusRef = useRef<Record<string, boolean>>({});
   const [openStepId, setOpenStepId] = useState<string | null>(null);
   const [poolLengthUnit, setPoolLengthUnit] = useState<PoolLengthUnit>("m");
   const [poolLengthInput, setPoolLengthInput] = useState(() =>
     formatEditablePoolLength(draft.poolLengthM)
+  );
+  const [timeDurationInputs, setTimeDurationInputs] = useState<Record<string, string>>(() =>
+    Object.fromEntries(
+      draft.steps
+        .filter((step) => step.durationMode === "time")
+        .map((step) => [step.id, formatEditableClockDuration(step.timeMin)])
+    )
   );
   const [manualPoolTitleEdited, setManualPoolTitleEdited] = useState(false);
   const [poolSizeExplicitlyUnspecified, setPoolSizeExplicitlyUnspecified] = useState(
@@ -1059,6 +1170,31 @@ export default function WorkoutEditor({
       setOpenStepId(null);
     }
   }, [draft.steps, openStepId]);
+
+  useEffect(() => {
+    setTimeDurationInputs((current) => {
+      const next: Record<string, string> = {};
+
+      for (const step of draft.steps) {
+        if (step.durationMode !== "time") continue;
+
+        next[step.id] = timeDurationInputFocusRef.current[step.id]
+          ? (current[step.id] ?? formatEditableClockDuration(step.timeMin))
+          : formatEditableClockDuration(step.timeMin);
+      }
+
+      const currentKeys = Object.keys(current);
+      const nextKeys = Object.keys(next);
+      if (
+        currentKeys.length === nextKeys.length &&
+        currentKeys.every((key) => current[key] === next[key])
+      ) {
+        return current;
+      }
+
+      return next;
+    });
+  }, [draft.steps]);
 
   useEffect(() => {
     setSupportToolsOpen(!showCalmBuilderLayout);
@@ -1600,6 +1736,35 @@ export default function WorkoutEditor({
     });
   }
 
+  function handleTimeDurationInputChange(stepId: string, rawValue: string) {
+    const sanitized = sanitizeClockDurationInput(rawValue);
+    setTimeDurationInputs((current) =>
+      current[stepId] === sanitized ? current : { ...current, [stepId]: sanitized }
+    );
+
+    const parsed = parseClockDurationInputForChange(sanitized);
+    if (parsed === undefined) {
+      return;
+    }
+
+    updateDraftStep(stepId, (current) => ({
+      ...current,
+      timeMin: parsed,
+    }));
+  }
+
+  function commitTimeDurationInput(stepId: string) {
+    timeDurationInputFocusRef.current[stepId] = false;
+    const normalized = normalizeClockDurationInput(timeDurationInputs[stepId] ?? "");
+    setTimeDurationInputs((current) =>
+      current[stepId] === normalized.display ? current : { ...current, [stepId]: normalized.display }
+    );
+    updateDraftStep(stepId, (current) => ({
+      ...current,
+      timeMin: normalized.timeMin,
+    }));
+  }
+
   function updateStepDistanceSelection(stepId: string, value: string) {
     updateDraftStep(stepId, (current) => ({
       ...current,
@@ -1789,6 +1954,11 @@ export default function WorkoutEditor({
     const isOpen = openStepId === step.id;
     const toggleLabel = isOpen ? "Done" : "Edit step";
     const panelId = `session-draft-step-panel-${step.id}`;
+    const stepLabel = insideRepeatGroup
+      ? step.category === "rest"
+        ? `Repeat rest step ${options?.repeatStepNumber ?? 1}`
+        : `Repeat step ${options?.repeatStepNumber ?? 1}`
+      : `Step ${index + 1}`;
     const stepTitle = isManualPoolMode
       ? buildManualPoolStepSummary(step, draft.basePaceSecondsPer100m)
       : step.name || getSessionStepCategoryLabel(step.category);
@@ -1807,9 +1977,7 @@ export default function WorkoutEditor({
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-              {insideRepeatGroup
-                ? `Repeat step ${options?.repeatStepNumber ?? 1}`
-                : `Step ${index + 1}`}
+              {stepLabel}
             </p>
             <p className="mt-1 text-sm font-medium text-slate-900">{stepTitle}</p>
             <p className="mt-1 text-xs font-medium text-slate-600">
@@ -2150,16 +2318,30 @@ export default function WorkoutEditor({
                 <input
                   type="text"
                   inputMode="numeric"
-                  value={step.timeMin ?? ""}
+                  placeholder={isManualPoolMode ? "MM:SS" : undefined}
+                  value={isManualPoolMode ? (timeDurationInputs[step.id] ?? "") : (step.timeMin ?? "")}
+                  onFocus={() => {
+                    if (!isManualPoolMode) return;
+                    timeDurationInputFocusRef.current[step.id] = true;
+                  }}
+                  onBlur={() => {
+                    if (!isManualPoolMode) return;
+                    commitTimeDurationInput(step.id);
+                  }}
                   onChange={(event) =>
-                    updateDraftStep(step.id, (current) => ({
-                      ...current,
-                      timeMin: parsePositiveNumber(event.target.value),
-                    }))
+                    isManualPoolMode
+                      ? handleTimeDurationInputChange(step.id, event.target.value)
+                      : updateDraftStep(step.id, (current) => ({
+                          ...current,
+                          timeMin: parsePositiveNumber(event.target.value),
+                        }))
                   }
                   data-testid={`session-draft-step-time-${index}`}
                   className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
                 />
+                {isManualPoolMode ? (
+                  <p className="mt-2 text-xs text-slate-500">Use `MM:SS`.</p>
+                ) : null}
               </label>
             ) : step.durationMode === "send_off" ? (
               <div className="grid gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-4 md:col-span-2 md:grid-cols-[1fr_1fr_auto]">
@@ -3407,30 +3589,41 @@ export default function WorkoutEditor({
                 key={group.repeatGroupId}
                 className="rounded-2xl border border-blue-200 bg-blue-50/80 p-4"
               >
+                {(() => {
+                  const repeatSummary = buildRepeatSummary(
+                    group.entries,
+                    group.repeatCount,
+                    draft.basePaceSecondsPer100m,
+                    group.repeatEndingRestMode
+                  );
+                  const repeatEndingRestDescription = buildRepeatEndingRestDescription(
+                    group.entries,
+                    group.repeatCount,
+                    draft.basePaceSecondsPer100m,
+                    group.repeatEndingRestMode
+                  );
+
+                  return (
                 <div className="flex flex-wrap items-start justify-between gap-3">
-                <div>
-                  <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
-                    Repeat block
-                  </p>
-                  {isManualPoolMode ? null : (
-                    <>
-                      <p className="mt-1 text-sm font-medium text-slate-900">
-                        {buildRepeatSummary(
-                          group.entries,
-                          group.repeatCount,
-                          draft.basePaceSecondsPer100m,
-                          group.repeatEndingRestMode
-                        )}
-                      </p>
-                      <p className="mt-1 text-xs text-slate-600">
-                        Edit the repeated steps below instead of duplicating every round by hand.
-                      </p>
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
+                      Repeat block
+                    </p>
+                    <p className="mt-1 text-sm font-medium text-slate-900">{repeatSummary}</p>
+                    {isManualPoolMode ? null : (
+                      <>
+                        <p className="mt-1 text-xs text-slate-600">
+                          Edit the repeated steps below instead of duplicating every round by hand.
+                        </p>
                         <p className="mt-1 text-xs text-slate-500">
                           Repeat counts currently support {SESSION_DRAFT_REPEAT_MIN}-
                           {SESSION_DRAFT_REPEAT_MAX} rounds per block.
                         </p>
                       </>
                     )}
+                    {repeatEndingRestDescription ? (
+                      <p className="mt-2 text-xs text-slate-600">{repeatEndingRestDescription}</p>
+                    ) : null}
                   </div>
                   <div className="flex flex-wrap items-end gap-2">
                     <label className="text-sm text-slate-700">
@@ -3526,6 +3719,8 @@ export default function WorkoutEditor({
                     </button>
                   </div>
                 </div>
+                  );
+                })()}
 
                 <div className="mt-4 space-y-3">
                   {group.entries.map((entry, repeatIndex) =>

--- a/docs/task-briefs/in-progress/2026-04-09-pool-builder-repeat-rest-time-and-css-profile-alignment-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-09-pool-builder-repeat-rest-time-and-css-profile-alignment-10-10.md
@@ -1,0 +1,203 @@
+# Task Brief: Pool Builder Repeat Rest, Time, And CSS Profile Alignment (10/10)
+
+## Metadata
+
+- `id`: `2026-04-09-pool-builder-repeat-rest-time-and-css-profile-alignment-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-04-09`
+- `updated`: `2026-04-09`
+
+## Goal
+
+The manual pool builder makes repeat-rest behavior explicit, uses `MM:SS` for time-based pool durations, and seeds new manual pool sessions from the swimmer's saved CSS pace instead of a hardcoded default.
+
+## Why This Brief Exists
+
+- Manual review on `2026-04-09` flagged three builder-quality issues on:
+  - `https://freeswimming.org/my-library/workouts/e4b0eb22-20de-4880-a3a8-8494850caff2?entry=manual-pool`
+- Findings confirmed in current `main`:
+  - repeat blocks still store an internal rest step, but the UI does not make it obvious enough that `Skip last rest interval` only affects the final internal rest after the last round,
+  - manual-pool `Time` still uses a single numeric minutes field instead of one `MM:SS` field,
+  - new manual pool sessions still start with hardcoded `basePaceSecondsPer100m = 120` instead of the swimmer's saved athlete-profile CSS pace when available.
+- This is owner-led pool-builder polish and must remain scoped to manual pool authoring.
+
+## Dependencies And Boundaries
+
+- Preserve recently shipped pool-builder work:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-06-pool-swim-builder-repeat-rest-parity-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-08-pool-swim-session-builder-garmin-duration-and-terminology-polish-10-10.md`
+- Primary surfaces:
+  - `/Users/stianvikra/freeswimming/components/my-library/workouts/WorkoutEditor.tsx`
+  - `/Users/stianvikra/freeswimming/components/my-library/workouts/CreateManualWorkoutButton.tsx`
+  - `/Users/stianvikra/freeswimming/components/my-library/workouts/WorkoutBuilderHub.tsx`
+  - `/Users/stianvikra/freeswimming/app/my-library/page.tsx`
+  - `/Users/stianvikra/freeswimming/app/my-library/workouts/page.tsx`
+  - `/Users/stianvikra/freeswimming/app/my-library/workouts/[workoutId]/page.tsx`
+  - `/Users/stianvikra/freeswimming/lib/workouts/manual.ts`
+  - `/Users/stianvikra/freeswimming/tests/unit/workout-builder-hub.test.tsx`
+  - `/Users/stianvikra/freeswimming/tests/e2e/my-library-workout-builder.spec.ts`
+- Boundaries:
+  - no open-water contract changes,
+  - no DB schema changes,
+  - no generator intake changes,
+  - no new help center surface,
+  - no merge in this slice until owner morning review.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim:
+
+- `Product goals and IA`
+- `UX flow clarity`
+- `Visual design quality`
+- `Business logic correctness and data integrity`
+- `Admin workflow and editability`
+- `Testing and QA automation`
+
+| Category | Mapping | Target Threshold (if `target`) | Evidence |
+| --- | --- | --- | --- |
+| Product goals and IA | `target` | Repeat-block controls must describe internal rest vs final skipped rest truthfully, `Time` must match swimmer mental model as `MM:SS`, and new manual pool sessions must inherit saved CSS pace when available. | manual QA + code review + unit/e2e |
+| UX flow clarity | `target` | A swimmer editing a repeat block can tell whether rest happens between rounds and after the last round without inferring from hidden logic. | manual QA + targeted e2e |
+| Visual design quality | `target` | The repeat block remains calm and uncluttered while making internal-rest semantics clearer than before. | manual QA + screenshot review |
+| Business logic correctness and data integrity | `target` | `skip_last_rest` must continue skipping only the final internal rest, `Time` `MM:SS` input must round-trip deterministically through `timeMin`, and CSS defaults must seed only new manual pool drafts without mutating saved workouts unexpectedly. | unit tests + code review |
+| Admin editor ergonomics | `target` | Pool builders can author time-based steps and repeat blocks without translating hidden timing conventions or manual CSS defaults. | manual QA + targeted tests |
+| Accessibility (a11y) | `supporting` | Supporting only: updated labels and `MM:SS` inputs remain keyboard- and screen-reader-usable. | code review + e2e |
+| Performance (CWV + payloads) | `supporting` | Supporting only: no material route or client cost regression. | diff review |
+| Data placement and sync boundaries | `target` | Athlete-profile CSS is used only as a creation-time default for new manual pool drafts; persisted workout draft pace remains workout-canonical afterward. | brief contract + code review |
+| Caching and invalidation strategy | `supporting` | Supporting only: existing no-store builder/load behavior remains unchanged. | integration review |
+| Reliability and failure handling | `target` | Builder continues to render valid repeat summaries and duration fields for existing drafts, including drafts created before this slice. | unit tests + manual QA |
+| Security and authz | `supporting` | Supporting only: scope stays inside authenticated builder/profile routes. | existing boundaries |
+| Privacy and compliance | `N/A` | N/A because this slice only reuses the authenticated owner's existing CSS metric as a local builder default and does not expand sharing or retention. | explicit scope rationale |
+| Content governance | `supporting` | Supporting only: repeat/rest microcopy must be grounded in actual builder behavior. | code review |
+| Admin workflow and editability | `target` | Manual pool editing must no longer imply that internal rest disappeared when `skip_last_rest` is selected. | manual QA + tests |
+| SEO and crawlability | `N/A` | N/A because this is an authenticated route with no public indexing contract. | explicit scope rationale |
+| AI discoverability | `N/A` | N/A because no public metadata or crawlable route changes. | explicit scope rationale |
+| Analytics and KPI observability | `supporting` | Supporting only: no new analytics required for this bounded editor-fidelity slice. | scope review |
+| Commerce and revenue ops | `N/A` | N/A because no billing or entitlement flow changes. | explicit scope rationale |
+| Incident response and support operations | `N/A` | N/A because no support tooling or runbook contract changes are introduced in this builder-only slice. | explicit scope rationale |
+| Finance and reporting operations | `N/A` | N/A because no finance or reconciliation path changes. | explicit scope rationale |
+| i18n operational readiness | `N/A` | N/A because this slice only improves current English builder wording and input behavior. | explicit scope rationale |
+| Stack-fit and dependency discipline | `target` | Reuse existing workout-builder and athlete-profile loaders; add no dependencies. | dependency diff + architecture review |
+| Testing and QA automation | `target` | Unit and e2e coverage must prove repeat-rest clarity, `MM:SS` time entry, CSS prefill behavior, and `npm run verify:pre-pr` must pass before PR update. | tests + verify gate |
+| Scalability and cost efficiency | `supporting` | Supporting only: CSS defaulting should add at most one already-owned server snapshot read on relevant routes. | code review |
+| DevOps and rollback readiness | `supporting` | Supporting only: no schema migration; rollback remains a code-only revert. | diff review |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - saved workout draft payload,
+  - `basePaceSecondsPer100m` and `usedCssPaceLabel` once a workout exists,
+  - repeat-step order and `repeatEndingRestMode`,
+  - `timeMin` for step durations.
+- Local-only:
+  - `MM:SS` editing string representation,
+  - repeat-rest explanatory UI copy,
+  - athlete-profile CSS value used to seed the POST body for new manual pool sessions.
+- Sync policy:
+  - new manual pool draft creation may prefill CSS pace from the current athlete profile snapshot,
+  - once the workout exists, the workout draft remains canonical until explicitly edited/saved,
+  - no background profile-to-workout resync is introduced in this slice.
+- Retention and sensitivity:
+  - no new data class,
+  - existing owner-only CSS metric remains owner-only.
+- Cache/invalidation:
+  - existing dynamic route loads remain authoritative,
+  - no extra cache layer is added.
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - `workout.id` remains canonical.
+- Human-readable identifiers:
+  - labels and helper copy are mutable UI only.
+- Mutability rules:
+  - repeat-rest copy can change in place,
+  - `timeMin` and pace fields retain current canonical schema.
+- Rename vs repurpose policy:
+  - improve UI wording before changing underlying repeat/rest structure,
+  - do not repurpose saved workout identity or route params.
+- Compatibility contract:
+  - existing saved workouts must still open,
+  - existing manual pool drafts with `timeMin` values continue to render and save correctly after `MM:SS` editor changes.
+- Observability and repair:
+  - targeted tests must cover prefilled CSS creation and repeat-rest summaries so regressions surface before merge.
+
+## Scope
+
+- Make repeat-block UI truthfully explain internal rest behavior when a repeat ends with a rest step.
+- Keep `skip_last_rest` semantics unchanged in the data model unless deterministic defects are found.
+- Change manual-pool `Time` editing from numeric minutes to a single `MM:SS` input.
+- Seed new manual pool workouts from athlete-profile CSS pace when available.
+- Preserve existing saved workout pace values after creation.
+- Update unit/e2e coverage for:
+  - repeat-rest clarity,
+  - `Time` `MM:SS`,
+  - CSS-based creation defaults.
+
+## Out Of Scope
+
+- Open-water builder work
+- Garmin export schema changes
+- AI generator behavior
+- New help center or guide surface
+- Live resync of existing saved workout pace from athlete profile after creation
+
+## Acceptance Criteria
+
+1. Selecting `Skip last rest interval` still leaves internal repeat rest between rounds intact.
+2. Repeat-block UI makes it clear that only the final internal rest is skipped.
+3. Manual-pool `Time` edits use one `MM:SS` field and persist correctly to canonical `timeMin`.
+4. New manual pool sessions use athlete-profile CSS pace as `basePaceSecondsPer100m` and `usedCssPaceLabel` when a saved CSS metric exists.
+5. Existing saved workouts keep their stored pace values unless the owner edits and saves them.
+6. Targeted tests and `npm run verify:pre-pr` pass.
+
+## Validation
+
+- `npm run lint:briefs:all`
+- `npx vitest run tests/unit/workout-builder-hub.test.tsx tests/unit/workouts-shared.test.ts tests/unit/my-library-new-content-signal-route.test.ts`
+- `npx playwright test tests/e2e/my-library-workout-builder.spec.ts --project=desktop-chromium`
+- `npm run typecheck`
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm installed
+- validation runs from repo root
+
+## Manual QA Environments
+
+- Production comparison route:
+  - `https://freeswimming.org/my-library/workouts/e4b0eb22-20de-4880-a3a8-8494850caff2?entry=manual-pool`
+- Preview URL after PR push
+
+## Constraints
+
+- Use Garmin expressions already established in the manual pool builder.
+- Do not claim the repeat/rest model changed if the fix is only UI clarity.
+- Keep the builder calm; prefer short, precise clarifications over verbose helper copy.
+- Do not merge in this slice without next-day owner go-ahead.
+
+## 10/10 Quality Bar
+
+- Repeat-block behavior must be at least Garmin-clear and easier to read than before.
+- `Time` entry must feel precise and swimmer-native, not like a generic numeric field.
+- CSS-based send-off and CSS-based target pace controls must reflect the swimmer's real saved CSS pace in newly created manual pool sessions.
+- Required states remain truthful:
+  - loading: existing builder load state remains accurate
+  - empty: existing no-session state remains accurate
+  - error: invalid time/CSS/save states remain clear
+  - retry: existing save-again path remains recovery
+
+## Help/Guide And Operator Training Contract
+
+- `N/A` for this slice because no dedicated user-facing builder help surface exists yet, and the fix is scoped to direct UI truthfulness plus automated test coverage.
+
+## Checkpoint Log
+
+- `2026-04-09 | in-progress | created clean worktree feat/pool-builder-repeat-time-css-2026-04-09 from origin/main, confirmed repeat blocks still contain an internal rest step and that skip_last_rest only skips the final internal rest, confirmed manual-pool Time still uses plain numeric minutes, and confirmed new manual pool drafts still seed CSS/base pace from hardcoded 120 instead of athlete profile | next: patch builder UI, creation defaults, and tests`
+- `2026-04-09 | in-progress | patched manual-pool builder so repeat blocks state clearly that skip_last_rest only skips the final internal rest, manual-pool Time edits use one MM:SS field that round-trips through canonical timeMin, and new manual pool sessions inherit athlete-profile CSS pace defaults at creation time | next: run full validation and prepare PR without merge`
+- `2026-04-09 | in-progress | validation green: npm run lint:briefs:all, targeted vitest, targeted playwright, npm run typecheck, npm run verify:pre-pr, and npm run verify:pre-merge including private-gate regression | next: commit, push, and open PR for morning merge review`

--- a/lib/workouts/manual.ts
+++ b/lib/workouts/manual.ts
@@ -5,6 +5,10 @@ import {
 } from "@/lib/session-generator-v1/shared";
 
 export type ManualWorkoutBuilderMode = "pool" | "open_water";
+export type ManualWorkoutDraftDefaults = {
+  basePaceSecondsPer100m?: number | null;
+  usedCssPaceLabel?: string | null;
+};
 
 function buildStepId(seed: string, index: number) {
   return `manual-step-${seed}-${index + 1}`;
@@ -155,13 +159,37 @@ export function buildManualWorkoutStarterDraft(now = new Date()): SessionDraft {
   };
 }
 
+function resolveManualWorkoutBasePaceDefaults(
+  mode: ManualWorkoutBuilderMode,
+  defaults?: ManualWorkoutDraftDefaults
+) {
+  if (
+    mode === "pool" &&
+    typeof defaults?.basePaceSecondsPer100m === "number" &&
+    Number.isFinite(defaults.basePaceSecondsPer100m) &&
+    defaults.basePaceSecondsPer100m > 0
+  ) {
+    return {
+      basePaceSecondsPer100m: defaults.basePaceSecondsPer100m,
+      usedCssPaceLabel: defaults.usedCssPaceLabel?.trim() || null,
+    };
+  }
+
+  return {
+    basePaceSecondsPer100m: 120,
+    usedCssPaceLabel: null,
+  };
+}
+
 function buildManualWorkoutEmptyDraftForMode(
   mode: ManualWorkoutBuilderMode,
-  now = new Date()
+  now = new Date(),
+  defaults?: ManualWorkoutDraftDefaults
 ): SessionDraft {
   const createdAt = now.toISOString();
   const seed = createdAt.replace(/[^0-9]/g, "").slice(0, 14);
   const title = mode === "pool" ? "Untitled pool session" : "Untitled open water session";
+  const paceDefaults = resolveManualWorkoutBasePaceDefaults(mode, defaults);
   const baseDraft: SessionDraft = {
     version: 1,
     status: "draft",
@@ -180,8 +208,8 @@ function buildManualWorkoutEmptyDraftForMode(
     targetTimeMin: null,
     totalDistanceM: null,
     estimatedDurationMin: null,
-    basePaceSecondsPer100m: 120,
-    usedCssPaceLabel: null,
+    basePaceSecondsPer100m: paceDefaults.basePaceSecondsPer100m,
+    usedCssPaceLabel: paceDefaults.usedCssPaceLabel,
     allowedStrokes: ["freestyle"],
     equipmentAllowlist: [],
     focusText: null,
@@ -199,14 +227,23 @@ function buildManualWorkoutEmptyDraftForMode(
   };
 }
 
-export function buildManualPoolWorkoutEmptyDraft(now = new Date()): SessionDraft {
-  return buildManualWorkoutEmptyDraftForMode("pool", now);
+export function buildManualPoolWorkoutEmptyDraft(
+  now = new Date(),
+  defaults?: ManualWorkoutDraftDefaults
+): SessionDraft {
+  return buildManualWorkoutEmptyDraftForMode("pool", now, defaults);
 }
 
-export function buildManualOpenWaterWorkoutEmptyDraft(now = new Date()): SessionDraft {
-  return buildManualWorkoutEmptyDraftForMode("open_water", now);
+export function buildManualOpenWaterWorkoutEmptyDraft(
+  now = new Date(),
+  defaults?: ManualWorkoutDraftDefaults
+): SessionDraft {
+  return buildManualWorkoutEmptyDraftForMode("open_water", now, defaults);
 }
 
-export function buildManualWorkoutEmptyDraft(now = new Date()): SessionDraft {
-  return buildManualPoolWorkoutEmptyDraft(now);
+export function buildManualWorkoutEmptyDraft(
+  now = new Date(),
+  defaults?: ManualWorkoutDraftDefaults
+): SessionDraft {
+  return buildManualPoolWorkoutEmptyDraft(now, defaults);
 }

--- a/lib/workouts/shared.ts
+++ b/lib/workouts/shared.ts
@@ -2492,7 +2492,7 @@ export function buildWorkoutStepDurationOutputSummary(
     case "distance":
       return step.distanceM ? `${step.distanceM}m` : "Distance not set";
     case "time":
-      return step.timeMin ? `Time ${formatMinutesLabel(step.timeMin)}` : "Time not set";
+      return step.timeMin ? `Time ${formatClockDurationLabel(step.timeMin)}` : "Time not set";
     case "fixed_rest":
       return step.timeMin
         ? `Fixed Rest Time ${formatClockDurationLabel(step.timeMin)}`

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -175,6 +175,12 @@ test.describe("my library workout builder", () => {
     await expect(restDurationOptions.filter({ hasText: /^Distance$/ })).toHaveCount(0);
     await expect(restDurationOptions.filter({ hasText: /^Time$/ })).toHaveCount(0);
     await page.getByLabel("Step Type").selectOption("main");
+    await page.getByTestId("session-draft-step-duration-mode-0").selectOption("time");
+    await page.getByTestId("session-draft-step-time-0").fill("1:30");
+    await page.getByTestId("session-draft-step-time-0").blur();
+    await expect(page.getByTestId("session-draft-step-time-0")).toHaveValue("1:30");
+    await expect(page.getByText("Use `MM:SS`.")).toBeVisible();
+    await page.getByTestId("session-draft-step-duration-mode-0").selectOption("distance");
     await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
       "All builder changes are saved to the canonical workout."
     );
@@ -264,6 +270,11 @@ test.describe("my library workout builder", () => {
     await expect(page.getByTestId("session-draft-repeat-ending-rest-mode-1")).toHaveValue(
       "skip_last_rest"
     );
+    await expect(
+      page.getByText(
+        "Fixed Rest Time 1:00 still runs between rounds. It is skipped only after the final round."
+      )
+    ).toBeVisible();
     await expect(page.getByText("Edit this into the exact repeat you want to hold.")).toHaveCount(0);
     await expect(
       page.getByText("Adjust or remove this recovery once the set is dialed in.")

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -566,7 +566,7 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.getByTestId("workout-builder-save")).toBeEnabled();
   });
 
-  it("hides the repeat-header summary in the manual pool builder while defaulting to skip last rest", async () => {
+  it("shows repeat summary and final-rest clarification in the manual pool builder while defaulting to skip last rest", async () => {
     render(
       <WorkoutBuilderHub
         workoutLibrary={buildWorkoutLibrary({
@@ -588,7 +588,13 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.getByTestId("session-draft-repeat-ending-rest-mode-1")).toHaveValue(
       "skip_last_rest"
     );
-    expect(screen.queryByText(/Final rest skipped/)).not.toBeInTheDocument();
+    expect(screen.getByText(/4 rounds/)).toBeVisible();
+    expect(screen.getByText(/Final rest skipped/)).toBeVisible();
+    expect(
+      screen.getByText(
+        "Fixed Rest Time 1:00 still runs between rounds. It is skipped only after the final round."
+      )
+    ).toBeVisible();
 
     const previewDraft = readPreviewDraft();
     const repeatSteps = previewDraft.steps.filter((step) => step.repeatGroupId);
@@ -1252,6 +1258,47 @@ describe("WorkoutBuilderHub", () => {
     expect(
       screen.queryByText("Move the full repeat block from the header.")
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Fixed Rest Time 1:00 still runs between rounds. It is skipped only after the final round."
+      )
+    ).toBeVisible();
+  });
+
+  it("uses a single MM:SS field for manual-pool time duration editing", async () => {
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: buildWorkoutRecord({ sourceKind: "manual" }),
+          recentWorkouts: [buildWorkoutSummary({ sourceKind: "manual" })],
+        })}
+        preferExpandedDetailsOnLoad
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("session-draft-step-toggle-0"));
+    fireEvent.change(screen.getByTestId("session-draft-step-duration-mode-0"), {
+      target: { value: "time" },
+    });
+
+    const timeInput = screen.getByTestId("session-draft-step-time-0");
+    fireEvent.focus(timeInput);
+    fireEvent.change(timeInput, { target: { value: "1:30" } });
+    fireEvent.blur(timeInput);
+
+    expect(screen.getByTestId("session-draft-step-time-0")).toHaveValue("1:30");
+    expect(screen.getByText("Use `MM:SS`.")).toBeVisible();
+    expect(readPreviewDraft().steps[0]).toMatchObject({
+      durationMode: "time",
+      timeMin: 1.5,
+    });
   });
 
   it("normalizes legacy manual-pool mixed duration states on load", async () => {
@@ -1693,6 +1740,61 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.getByRole("link", { name: "AI-generated session" })).toHaveAttribute(
       "href",
       "/my-library/generator"
+    );
+  });
+
+  it("seeds new manual pool sessions from the provided CSS pace", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        workout: buildWorkoutRecord({
+          id: "workout-created",
+          sourceKind: "manual",
+          draft: buildDraft({
+            sourceFingerprint: "manual-empty-pool-seeded",
+            basePaceSecondsPer100m: 118,
+            usedCssPaceLabel: "1:58",
+          }),
+        }),
+        summary: buildWorkoutSummary({
+          id: "workout-created",
+          sourceKind: "manual",
+        }),
+      }),
+    } as Response);
+
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: null,
+        })}
+        manualPoolCssMetricSecondsPer100m={118}
+        manualPoolCssPaceLabel="1:58"
+        browseOnly
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Build pool session" }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    const request = vi.mocked(fetch).mock.calls[0]?.[1] as RequestInit | undefined;
+    const body = JSON.parse(String(request?.body ?? "{}")) as { draft?: SessionDraft };
+
+    expect(body.draft?.basePaceSecondsPer100m).toBe(118);
+    expect(body.draft?.usedCssPaceLabel).toBe("1:58");
+    expect(navigationState.push).toHaveBeenCalledWith(
+      "/my-library/workouts/workout-created?entry=manual-pool"
     );
   });
 


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-04-09T05:18:49.985Z for branch `feat/pool-builder-repeat-time-css-2026-04-09` (base ref `origin/main`).
- Latest commit: `7fa3309` - Clarify pool repeat rest and seed CSS defaults.
- User-visible changes: User/admin runtime behavior may change on touched routes/components.
- Technical changes: Updated 11 file(s): `app/my-library/page.tsx`, `app/my-library/workouts/[workoutId]/page.tsx`, `app/my-library/workouts/page.tsx`, `components/my-library/workouts/CreateManualWorkoutButton.tsx`, `components/my-library/workouts/WorkoutBuilderHub.tsx`, `... and 6 more file(s)`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-04-09-pool-builder-repeat-rest-time-and-css-profile-alignment-10-10.md`
- Scorecard target outcomes: 10 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (1); tests (2); runtime UI/routes/components (8).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (11):
  - `app/my-library/page.tsx`
  - `app/my-library/workouts/[workoutId]/page.tsx`
  - `app/my-library/workouts/page.tsx`
  - `components/my-library/workouts/CreateManualWorkoutButton.tsx`
  - `components/my-library/workouts/WorkoutBuilderHub.tsx`
  - `components/my-library/workouts/WorkoutEditor.tsx`
  - `docs/task-briefs/in-progress/2026-04-09-pool-builder-repeat-rest-time-and-css-profile-alignment-10-10.md`
  - `lib/workouts/manual.ts`
  - `... and 3 more file(s)`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `7fa3309` (`git revert 7fa3309`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **NOT RUN** (run locally before pushing PR updates).
- `npm run verify:pre-merge`: **PENDING** for `7fa3309` (required before merge to `main`).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  - No local verify log found in `artifacts/test-runs/latest`.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
