### PR TITLE
docs: close out pool repeat/rest and pool size brief

### DIFF
--- a/docs/task-briefs/done/2026-04-09-pool-swim-builder-repeat-rest-and-pool-size-clarity-10-10.md
+++ b/docs/task-briefs/done/2026-04-09-pool-swim-builder-repeat-rest-and-pool-size-clarity-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-04-09-pool-swim-builder-repeat-rest-and-pool-size-clarity-10-10`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-04-09`
 - `updated`: `2026-04-09`
@@ -266,3 +266,4 @@ Critical target categories for `10/10` claim:
 - `2026-04-09 | in-progress | committed implementation as bae5464 (Clarify pool repeat rest and unit semantics) and pushed branch feat/pool-repeat-rest-pool-size-clarity-2026-04-09 to origin | next: create/update PR, watch CI, and run npm run verify:pre-merge before merge recommendation`
 - `2026-04-09 | in-progress | confirmed the Supabase account exposed to this repo currently has only one project (`freeswimming-org-prod` / `sazgjhgxvmxcyowovond`), linked the worktree to that project, and ran \`supabase db push --dry-run\`, which reported exactly one pending migration: \`20260409121500_workouts_pool_units_and_decimal_distances.sql\`; there is no discoverable preview/non-prod database target to validate against first | next: get explicit owner approval before any live prod \`supabase db push\`, then rerun preview/schema follow-up on the applied schema`
 - `2026-04-09 | in-progress | applied \`20260409121500_workouts_pool_units_and_decimal_distances.sql\` to the linked project, reran schema-dependent workout flows, and found one real yard-roundtrip precision bug: whole-yard custom step distances and totals could reopen as \`333.01yd\`/\`1533.01yd\` because canonical meter normalization was still limited to 2 decimals; patched internal distance precision to 4 decimals, added a follow-up migration for top-level stored distances, and revalidated with targeted vitest plus desktop Chromium workout/generator/program Playwright coverage | next: run full verify on the follow-up precision patch, push it, apply the new distance-precision migration, and then recheck PR merge readiness`
+- `2026-04-09 | done | merged PR #398 as \`93c0abd\`, applied both workout schema migrations to the linked production project (\`20260409121500\` and \`20260409160500\`), revalidated with local \`verify:pre-pr\`, local \`verify:pre-merge\`, targeted schema-sensitive Playwright after live rollout, and confirmed all GitHub checks green before closeout | next: none`


### PR DESCRIPTION
## Summary

- What changed and why? The implementation is already merged and live via PR #398; this follow-up PR only closes the task-brief lifecycle cleanly by moving the shipped brief to `done` and recording the final rollout checkpoint.
- User-visible changes: No user-visible product changes.
- Technical changes: Move the pool repeat/rest and pool-size clarity brief from `docs/task-briefs/in-progress/` to `docs/task-briefs/done/`, change brief status to `done`, and append the final checkpoint entry.
- Policy impact: no (docs-only lifecycle closeout; no runtime, schema, auth, privacy, or support policy behavior changes).
- Policy version note: N/A (no policy document or policy-governed behavior changed).
- Brief link(s): `docs/task-briefs/done/2026-04-09-pool-swim-builder-repeat-rest-and-pool-size-clarity-10-10.md`

## Scope

- In scope: brief lifecycle move to `done`, metadata status update, and final merge/rollout checkpoint note.
- Out of scope: runtime code, database schema, tests, deployments, and any user-facing behavior.

## Risk

- Main risk: very low; the only real risk is brief lifecycle drift if the shipped slice is left marked `in-progress`.
- Rollback plan: revert this docs-only commit or close the PR unmerged; production behavior is unaffected either way.

## Test Evidence

- Policy-impact checklist: N/A (policy impact is `no`; this PR only updates task-brief lifecycle state).
- `npm run lint:briefs`: PASS via `npm run lint:briefs:all`.
- [x] `npm run lint:briefs` equivalent run via `npm run lint:briefs:all`
- `npm run verify:pre-pr`: NOT RUN on this docs-only closeout PR (the shipped implementation passed locally before PR #398 updates).
- `npm run verify:pre-merge`: NOT RUN on this docs-only closeout PR (the shipped implementation passed locally on `e6d8a41` before merge of PR #398).

## Checklist

- [x] Acceptance criteria are met for this docs-only closeout.
- [x] Docs updated for behavior/contract changes.
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A).
- [x] Every `target` scorecard row has measurable threshold + evidence source.
- [x] If claiming `10/10`: critical target categories are listed and each is scored `5/5`.
- [x] PR is <= 500 changed lines.
- [x] No secrets or sensitive data added.