### PR TITLE
docs: close out workout builder containment brief

### DIFF
--- a/docs/task-briefs/done/2026-04-09-workout-builder-containment-cleanup-10-10.md
+++ b/docs/task-briefs/done/2026-04-09-workout-builder-containment-cleanup-10-10.md
@@ -3,10 +3,10 @@
 ## Metadata
 
 - `id`: `2026-04-09-workout-builder-containment-cleanup-10-10`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-04-09`
-- `updated`: `2026-04-09`
+- `updated`: `2026-04-10`
 
 ## Goal
 
@@ -265,3 +265,4 @@ Strict 10/10 mode for this brief:
 - `2026-04-09 | planned | brief lint, verify:pre-pr, and verify:pre-merge all passed in the isolated worktree; branch is ready for docs-only PR handoff | next: commit, push, and open/update the PR`
 - `2026-04-09 | in-progress | implementation started from main in an isolated worktree; scope stays limited to WorkoutBuilderHub plus the targeted top-level WorkoutEditor containment surfaces from this brief | next: flatten the builder shell, pool-size, support/export, poolside note, and repeat chrome without touching workout semantics`
 - `2026-04-09 | in-progress | flattened the builder shell plus the targeted pool-size, support/export, poolside, and repeat-containment surfaces; targeted unit/e2e checks and full verify:pre-pr passed locally | next: commit, push, and open the implementation PR`
+- `2026-04-10 | done | implementation PR #402 merged to main as 90702ade5ae83b31251430c1b9e52997fb80962a after local verify:pre-pr, local verify:pre-merge, and green required CI; brief moved to done during closeout | next: mobile density follow-up, if approved, should be scoped as a separate child brief rather than reopening this slice`


### PR DESCRIPTION
## Summary

- What changed and why? Moves the merged workout-builder containment brief from `in-progress` to `done` after PR `#402` shipped, and records the merge checkpoint in the brief log.
- User-visible changes: none.
- Technical changes: updates brief status/date/checkpoint only.
- Policy impact: no (docs-only closeout; no runtime, schema, or workflow change)
- Policy version note: N/A (no policy surface changed)
- Brief link(s):
  - `docs/task-briefs/done/2026-04-09-workout-builder-containment-cleanup-10-10.md`
  - merged implementation PR: `#402`

## Scope

- In scope: brief lifecycle closeout only.
- Out of scope: any new implementation, visual changes, or follow-up mobile-density work.

## Risk

- Main risk: none beyond documentation drift if the closeout is not recorded.
- Rollback plan: revert `185ab82` if the brief move/checkpoint needs to be undone.

## Test Evidence

- Policy-impact checklist: N/A (docs-only closeout)
- `npm run lint:briefs:all` PASS
- `npm run verify:pre-pr` NOT RUN (docs-only closeout; full implementation gate already passed on merged PR `#402`)
- `npm run verify:pre-merge` NOT RUN (docs-only closeout; full implementation gate already passed on merged PR `#402`)
- Local full implementation validation was already completed on merged PR `#402`
- Required GitHub checks on this docs-only PR must still be green before merge

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [x] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks are green.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d docs/workout-builder-containment-cleanup-closeout-2026-04-10`
- [ ] Optional: `git fetch --prune`
