### PR TITLE
Fix workout builder step action desktop regression

### DIFF
--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -1237,6 +1237,10 @@ export default function WorkoutEditor({
   const mobileActionPanelClass = "mt-3 rounded-2xl border border-slate-200 bg-slate-50/90 p-2.5";
   const mobileSecondaryActionClass =
     "inline-flex min-h-10 w-full items-center justify-start rounded-xl border px-3 py-2 text-sm font-medium transition";
+  const desktopHeaderStackClass = "flex items-start justify-between gap-3 sm:flex-col sm:justify-start";
+  const desktopSummaryBlockClass = "min-w-0 flex-1 sm:w-full";
+  const desktopActionRowClass = "hidden w-full flex-wrap items-center gap-2 sm:flex";
+  const desktopRepeatControlRowClass = "grid gap-3";
 
   useAutoDismissNotice(workoutPdfNotice, setWorkoutPdfNotice);
   useAutoDismissNotice(garminExportNotice, setGarminExportNotice);
@@ -2140,8 +2144,8 @@ export default function WorkoutEditor({
               : "border-slate-200 bg-slate-50/70"
         }`}
       >
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0 flex-1">
+        <div className={desktopHeaderStackClass}>
+          <div className={desktopSummaryBlockClass}>
             <button
               type="button"
               onClick={() => {
@@ -2160,9 +2164,18 @@ export default function WorkoutEditor({
                 </span>
               </div>
             </button>
-            <div className="hidden sm:block">{stepSummaryContent}</div>
+            <div
+              data-testid={`session-draft-step-summary-${index}`}
+              className="hidden sm:block"
+            >
+              {stepSummaryContent}
+            </div>
           </div>
-          <div className="hidden flex-wrap items-center gap-2 sm:flex">
+          <div
+            data-testid={`session-draft-step-desktop-actions-${index}`}
+            data-desktop-layout="stacked"
+            className={desktopActionRowClass}
+          >
             {insideRepeatGroup || isLinkedPostSetRest ? null : (
               <>
                 <button
@@ -3959,8 +3972,11 @@ export default function WorkoutEditor({
 
                   return (
                     <div className="space-y-3">
-                      <div className="flex items-start justify-between gap-3">
-                        <div className="min-w-0 flex-1">
+                      <div className={desktopHeaderStackClass}>
+                        <div
+                          data-testid={`session-draft-repeat-summary-${groupIndex}`}
+                          className={desktopSummaryBlockClass}
+                        >
                           <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
                             Repeat set
                           </p>
@@ -4015,7 +4031,7 @@ export default function WorkoutEditor({
                         </div>
                       </div>
 
-                      <div className="grid gap-3 sm:flex sm:flex-wrap sm:items-end sm:justify-between">
+                      <div className={desktopRepeatControlRowClass}>
                         <div className="grid gap-3 sm:flex sm:flex-wrap sm:items-end sm:gap-2">
                           <label className="text-sm text-slate-700">
                             Repeat count
@@ -4056,7 +4072,11 @@ export default function WorkoutEditor({
                           ) : null}
                         </div>
 
-                        <div className="hidden flex-wrap items-end gap-2 sm:flex">
+                        <div
+                          data-testid={`session-draft-repeat-desktop-actions-${groupIndex}`}
+                          data-desktop-layout="stacked"
+                          className="hidden w-full flex-wrap items-end gap-2 sm:flex"
+                        >
                           <button
                             type="button"
                             onClick={() => moveDraftGroup(groupIndex, -1)}

--- a/docs/task-briefs/in-progress/2026-04-10-workout-builder-step-action-desktop-regression-fix-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-10-workout-builder-step-action-desktop-regression-fix-10-10.md
@@ -1,0 +1,127 @@
+# Task Brief: Workout Builder Step Action Desktop Regression Fix (10/10)
+
+## Metadata
+
+- `id`: `2026-04-10-workout-builder-step-action-desktop-regression-fix-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-04-10`
+- `updated`: `2026-04-10`
+
+## Goal
+
+Fix the desktop and larger-screen workout-builder action-row regression introduced by the recent mobile-density slice, while preserving the new mobile progressive-disclosure behavior and all existing workout semantics.
+
+## Why This Brief Exists
+
+- The mobile density slice that shipped on `2026-04-10` improved phone layouts, but a follow-up visual check found a new desktop/tablet regression in the session-builder step header.
+- On larger screens, the step summary text can now be squeezed under or behind the action row instead of keeping a stable readable block.
+- The same responsive risk exists in repeat headers, where summary content and action controls still compete for the same horizontal space.
+- This is a small responsive layout regression, not a workflow or data-model issue.
+
+## Dependencies And Boundaries
+
+- Parent slice already shipped on `main`:
+  - `docs/task-briefs/done/2026-04-10-workout-builder-mobile-density-and-width-reclaim-10-10.md`
+- Broader builder umbrella still in progress:
+  - `docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md`
+- Primary implementation surface:
+  - `components/my-library/workouts/WorkoutEditor.tsx`
+- Primary regression protections:
+  - `tests/unit/workout-builder-hub.test.tsx`
+  - `tests/e2e/my-library-workout-builder.spec.ts`
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Visual design quality`
+- `Business logic correctness and data integrity`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                                     | Evidence                                 | Expected Closeout Score |
+| --------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | Step and repeat headers on larger screens keep a stable readable summary area and a stable action area without overlapping or hiding key content.               | desktop/tablet review + code review      | `5/5`                   |
+| UX flow clarity                               | `target`     | Builder steps remain easy to scan on desktop/tablet, with action controls available without crushing the step summary.                                           | manual QA + targeted tests               | `5/5`                   |
+| Visual design quality                         | `target`     | The larger-screen action rows feel intentional and aligned, not crowded or broken by the mobile density work.                                                    | screenshot review + manual QA            | `5/5`                   |
+| Business logic correctness and data integrity | `target`     | The fix changes layout only and preserves all step, repeat, save, export, and destructive-action semantics.                                                      | code review + targeted tests             | `5/5`                   |
+| Admin editor ergonomics                       | `N/A`        | N/A because this slice changes an owner-facing workout-builder surface, not an admin editorial workflow.                                                         | explicit scope rationale                 | `N/A`                   |
+| Accessibility (a11y)                          | `supporting` | Supporting only: buttons, labels, focus order, and disclosure affordances remain keyboard- and screen-reader-safe after the responsive fix.                     | targeted review + tests                  | `4/5`                   |
+| Performance (CWV + payloads)                  | `N/A`        | N/A because this slice only adjusts responsive layout classes and does not add new runtime work or payload.                                                      | explicit scope rationale                 | `N/A`                   |
+| Data placement and sync boundaries            | `N/A`        | N/A because this slice does not change state ownership, persistence, or sync boundaries.                                                                          | explicit scope rationale                 | `N/A`                   |
+| Caching and invalidation strategy             | `N/A`        | N/A because no fetch, cache, or invalidation behavior changes.                                                                                                    | explicit scope rationale                 | `N/A`                   |
+| Reliability and failure handling              | `supporting` | Supporting only: destructive and secondary actions remain visible and reachable after the responsive layout change.                                               | targeted review + tests                  | `4/5`                   |
+| Security and authz                            | `N/A`        | N/A because no auth, permission, or protected-route behavior changes.                                                                                             | explicit scope rationale                 | `N/A`                   |
+| Privacy and compliance                        | `N/A`        | N/A because no data collection, disclosure, or retention behavior changes.                                                                                        | explicit scope rationale                 | `N/A`                   |
+| Content governance                            | `N/A`        | N/A because no workflow copy contract changes are introduced in this regression fix.                                                                              | explicit scope rationale                 | `N/A`                   |
+| Admin workflow and editability                | `N/A`        | N/A because no admin/operator workflow changes in scope.                                                                                                          | explicit scope rationale                 | `N/A`                   |
+| SEO and crawlability                          | `N/A`        | N/A because this is an authenticated My Library route with no public crawl contract.                                                                              | explicit scope rationale                 | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because no public AI-facing metadata or public content changes.                                                                                               | explicit scope rationale                 | `N/A`                   |
+| Analytics and KPI observability               | `N/A`        | N/A because no event model or instrumentation changes are required for this layout-only fix.                                                                      | explicit scope rationale                 | `N/A`                   |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, billing, checkout, or entitlement behavior changes.                                                                                       | explicit scope rationale                 | `N/A`                   |
+| Incident response and support operations      | `N/A`        | N/A because this is a narrow responsive regression fix with no workflow/runbook change.                                                                           | explicit scope rationale                 | `N/A`                   |
+| Finance and reporting operations              | `N/A`        | N/A because no finance or reporting path changes.                                                                                                                 | explicit scope rationale                 | `N/A`                   |
+| i18n operational readiness                    | `N/A`        | N/A because no localization architecture or translation workflow changes are introduced.                                                                           | explicit scope rationale                 | `N/A`                   |
+| Stack-fit and dependency discipline           | `target`     | The fix uses existing Tailwind/layout primitives in `WorkoutEditor` and adds no new dependency or parallel layout system.                                        | dependency diff + code review            | `5/5`                   |
+| Testing and QA automation                     | `target`     | Tests protect larger-screen action-row readability and preserve mobile progressive disclosure before PR update.                                                   | targeted unit/e2e + `verify:pre-pr`      | `5/5`                   |
+| Scalability and cost efficiency               | `N/A`        | N/A because this slice only changes local layout classes and does not affect infra or storage cost.                                                               | explicit scope rationale                 | `N/A`                   |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: the change remains a small UI-only diff that is easy to revert if the responsive behavior is not satisfactory.                                  | diff review + rollback note              | `4/5`                   |
+
+## Data Placement And Sync Contract
+
+- `N/A`
+- Rationale: this slice only changes responsive layout and does not move or redefine any state boundary.
+
+## Identity And Rename Contract
+
+- `N/A`
+- Rationale: this slice does not add or change persisted identifiers, slugs, route params, or canonical names.
+
+## Scope
+
+- Fix larger-screen step-card header layout so the summary block keeps a stable readable area next to action controls.
+- Fix larger-screen repeat-header layout so summary copy and controls do not fight for the same horizontal space.
+- Preserve the phone-width progressive-disclosure action model shipped in the mobile density slice.
+- Preserve all existing action availability and button labels in this slice.
+- Add or update targeted regression tests for the desktop/tablet layout contract.
+
+## Out Of Scope
+
+- Any workout logic, save, export, or repeat/rest semantic change.
+- Mobile density redesign beyond preserving the already-shipped behavior.
+- Metadata-panel, pool-size, or poolside-note work.
+- New copy changes, action reordering policy changes, or new builder controls.
+
+## Acceptance Criteria
+
+1. Step-card headers on desktop and larger screens keep the summary text readable without being overlapped or visually crushed by action controls.
+2. Repeat headers on desktop and larger screens keep the summary content readable alongside action controls.
+3. Mobile step and repeat actions remain progressive and do not regress to the full always-visible action wall.
+4. All existing step and repeat actions remain reachable after the layout fix.
+5. No workout semantics, save behavior, or export behavior change in this slice.
+6. Targeted tests and `npm run verify:pre-pr` pass before PR update.
+
+## Validation
+
+- `npm run lint:briefs`
+- targeted `vitest`:
+  - `tests/unit/workout-builder-hub.test.tsx`
+- targeted `playwright`:
+  - `tests/e2e/my-library-workout-builder.spec.ts --project=desktop-chromium`
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Constraints
+
+- Keep this slice layout-only.
+- Do not reopen or weaken the shipped mobile action-disclosure behavior.
+- Prefer stable flex/grid wrapping and minimum-width guards over adding new wrappers or new copy.
+- Keep the diff small enough to ship safely as a regression follow-up.
+
+## Checkpoint Log
+
+- `2026-04-10 | in-progress | owner-reported screenshot review found a new larger-screen step-header regression after the shipped mobile density slice: step summary text can be squeezed behind the action row on desktop/tablet | next: fix the step/repeat action header layout in WorkoutEditor, add targeted desktop regression coverage, and run the normal local gates`
+- `2026-04-10 | in-progress | layout fix and targeted regression coverage landed in WorkoutEditor, unit coverage passed, targeted desktop Playwright passed/skipped safely in local env, and full local verify:pre-pr completed green | next: clean test artifacts, commit, push, open PR, and run verify:pre-merge before merge recommendation`

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -232,6 +232,20 @@ test.describe("my library workout builder", () => {
     await expect(page.locator("fieldset").filter({ hasText: "Equipment" })).toHaveCount(0);
     await expect(page.getByRole("combobox", { name: "Session type" })).toHaveCount(0);
     await expect(page.getByRole("combobox", { name: "Effort" })).toHaveCount(0);
+    await expect(page.getByTestId("session-draft-step-summary-0")).toBeVisible();
+    await expect(page.getByTestId("session-draft-step-desktop-actions-0")).toHaveAttribute(
+      "data-desktop-layout",
+      "stacked"
+    );
+    const stepSummaryBox = await page.getByTestId("session-draft-step-summary-0").boundingBox();
+    const stepActionsBox = await page
+      .getByTestId("session-draft-step-desktop-actions-0")
+      .boundingBox();
+    expect(stepSummaryBox).not.toBeNull();
+    expect(stepActionsBox).not.toBeNull();
+    expect(stepActionsBox!.y).toBeGreaterThanOrEqual(
+      stepSummaryBox!.y + stepSummaryBox!.height - 2
+    );
     await expect(page.getByTestId("session-draft-step-toggle-0")).toBeVisible();
     await page.getByTestId("session-draft-step-toggle-0").click();
     await expect(
@@ -376,6 +390,19 @@ test.describe("my library workout builder", () => {
     await page.getByTestId("session-draft-step-distance-0").selectOption("custom");
     await page.getByTestId("session-draft-step-distance-custom-0").fill("333");
     await page.getByTestId("session-draft-add-repeat").click();
+    await expect(page.getByTestId("session-draft-repeat-desktop-actions-1")).toHaveAttribute(
+      "data-desktop-layout",
+      "stacked"
+    );
+    const repeatSummaryBox = await page.getByTestId("session-draft-repeat-summary-1").boundingBox();
+    const repeatActionsBox = await page
+      .getByTestId("session-draft-repeat-desktop-actions-1")
+      .boundingBox();
+    expect(repeatSummaryBox).not.toBeNull();
+    expect(repeatActionsBox).not.toBeNull();
+    expect(repeatActionsBox!.y).toBeGreaterThanOrEqual(
+      repeatSummaryBox!.y + repeatSummaryBox!.height - 2
+    );
     await page.getByTestId("session-draft-repeat-count-1").fill("6");
     await expect(page.getByTestId("session-draft-repeat-ending-rest-mode-1")).toHaveValue(
       "skip_last_rest"

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -272,6 +272,31 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.getByTestId("session-draft-repeat-mobile-remove-1")).toBeVisible();
   });
 
+  it("keeps larger-screen step and repeat action rows stacked below readable summaries", async () => {
+    render(<WorkoutBuilderHub workoutLibrary={buildWorkoutLibrary()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    expect(screen.getByTestId("session-draft-step-summary-0")).toBeVisible();
+    expect(screen.getByTestId("session-draft-step-desktop-actions-0")).toHaveAttribute(
+      "data-desktop-layout",
+      "stacked"
+    );
+
+    fireEvent.click(screen.getByTestId("session-draft-add-repeat"));
+
+    expect(screen.getByTestId("session-draft-repeat-summary-1")).toBeVisible();
+    expect(screen.getByTestId("session-draft-repeat-desktop-actions-1")).toHaveAttribute(
+      "data-desktop-layout",
+      "stacked"
+    );
+  });
+
   it("loads an accepted workout and saves canonical edits back to the same workout", async () => {
     vi.mocked(fetch).mockImplementation(async (_input, init) => {
       const body = JSON.parse(String(init?.body ?? "{}")) as {


### PR DESCRIPTION
## Summary

- What changed and why? Fix the larger-screen workout-builder step/repeat header regression introduced by the recent mobile density slice, so summary text stays readable on desktop and tablet while the new mobile disclosure behavior stays intact.
- User-visible changes: Step and repeat cards on larger screens now keep a stable readable summary block with the action row stacked below instead of squeezing or overlapping the summary.
- Technical changes: Update `WorkoutEditor` responsive header layout classes, add desktop regression test hooks, and extend unit + desktop Playwright coverage for the stacked layout contract.
- Policy impact: no (layout-only regression fix; no workflow, schema, or policy contract change)
- Policy version note: N/A (no policy document or runtime policy changed)
- Brief link(s): `docs/task-briefs/in-progress/2026-04-10-workout-builder-step-action-desktop-regression-fix-10-10.md`

## Scope

- In scope:
  - Desktop/tablet workout-builder step header layout regression
  - Desktop/tablet repeat header layout regression
  - Targeted unit and desktop Playwright regression coverage
- Out of scope:
  - Workout semantics, save/export behavior, and repeat/rest logic
  - New copy, new controls, or mobile action-model redesign
  - Metadata-panel, pool-size, or poolside-note follow-up work

## Risk

- Main risk: Responsive class changes could unintentionally disturb the newly shipped mobile progressive-disclosure layout or desktop action reachability.
- Rollback plan: Revert commit `67079f6` to restore the previous layout slice if preview/CI uncovers a responsive regression.

## Test Evidence

- Policy-impact checklist: N/A (`docs/checklists/policy-impact-release-review.md`; no policy-impact change in this slice)
- `npm run lint:briefs`: PASS
- `npm run lint`: PASS
- `npm run typecheck`: PASS
- `npm run test:unit`: PASS
- `npm run build`: PASS
- `npm run test:e2e`: PASS (targeted desktop Playwright and full suite inside `verify:pre-pr`)
- `npm run verify:pre-pr`: PASS
- `npm run verify:pre-merge`: PENDING
- [x] `npm run lint:briefs`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] `npm run test:e2e` (targeted desktop Playwright plus full suite inside `verify:pre-pr`)
- [x] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (running locally on current HEAD SHA)
- [ ] Local manual QA done on dev URL (not yet recorded)
- [ ] Vercel preview manual QA done (not yet recorded)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [x] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/408`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d feat/workout-builder-step-action-desktop-regression-2026-04-10`
- [ ] Optional: `git fetch --prune`
