### PR TITLE
Clean up swim builder repeat summary and poolside copy

### DIFF
--- a/app/api/my-library/workouts/[workoutId]/export/pdf/route.ts
+++ b/app/api/my-library/workouts/[workoutId]/export/pdf/route.ts
@@ -5,7 +5,7 @@ import { loadTrainingContextSnapshot } from "@/lib/training-context/server";
 import {
   buildWorkoutPdfHtmlDocument,
   normalizeWorkoutPoolsidePrintStyle,
-  selectWorkoutPoolsideFocusTitles,
+  selectWorkoutPoolsideFocusPoints,
   type WorkoutPoolsideFocusOption,
 } from "@/lib/workouts/shared";
 import { buildWorkoutEditorRecord, WORKOUT_SELECT } from "@/lib/workouts/server";
@@ -93,13 +93,16 @@ export async function GET(request: Request, context: RouteContext) {
       ? trainingContextSnapshot.openFocuses.map((focus) => ({
           id: focus.id,
           title: focus.title,
+          description: focus.details,
           isPrimary: focus.isPrimary,
         }))
       : [];
   const focusPoints =
     requestedFocusIds.length > 0
-      ? selectWorkoutPoolsideFocusTitles(focusOptions, requestedFocusIds)
-      : focusOptions.map((focus) => focus.title);
+      ? selectWorkoutPoolsideFocusPoints(focusOptions, requestedFocusIds)
+      : focusOptions.map((focus) =>
+          focus.description ? `${focus.title}: ${focus.description}` : focus.title
+        );
 
   return applySupabaseCookies(
     noStoreHtml(

--- a/app/my-library/workouts/[workoutId]/page.tsx
+++ b/app/my-library/workouts/[workoutId]/page.tsx
@@ -63,6 +63,7 @@ export default async function WorkoutBuilderPage({ params, searchParams }: Props
       ? trainingContextSnapshot.openFocuses.map((focus) => ({
           id: focus.id,
           title: focus.title,
+          description: focus.details,
           isPrimary: focus.isPrimary,
         }))
       : [];
@@ -103,7 +104,9 @@ export default async function WorkoutBuilderPage({ params, searchParams }: Props
             <WorkoutBuilderHub
               workoutLibrary={workoutLibrary}
               trainingFocusOptions={trainingFocusOptions}
-              manualPoolCssMetricSecondsPer100m={athleteProfileSnapshot.cssMetric?.valueSeconds ?? null}
+              manualPoolCssMetricSecondsPer100m={
+                athleteProfileSnapshot.cssMetric?.valueSeconds ?? null
+              }
               manualPoolCssPaceLabel={athleteProfileSnapshot.cssMetric?.paceLabel ?? null}
               hideShellIntro
               preferExpandedDetailsOnLoad={preferExpandedDetailsOnLoad}

--- a/app/my-library/workouts/page.tsx
+++ b/app/my-library/workouts/page.tsx
@@ -30,6 +30,7 @@ export default async function WorkoutSessionsPage() {
       ? trainingContextSnapshot.openFocuses.map((focus) => ({
           id: focus.id,
           title: focus.title,
+          description: focus.details,
           isPrimary: focus.isPrimary,
         }))
       : [];
@@ -70,7 +71,9 @@ export default async function WorkoutSessionsPage() {
             <WorkoutBuilderHub
               workoutLibrary={workoutLibrary}
               trainingFocusOptions={trainingFocusOptions}
-              manualPoolCssMetricSecondsPer100m={athleteProfileSnapshot.cssMetric?.valueSeconds ?? null}
+              manualPoolCssMetricSecondsPer100m={
+                athleteProfileSnapshot.cssMetric?.valueSeconds ?? null
+              }
               manualPoolCssPaceLabel={athleteProfileSnapshot.cssMetric?.paceLabel ?? null}
               browseOnly
             />

--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -67,7 +67,7 @@ import {
   buildWorkoutGarminReadinessReport,
   buildWorkoutHandoffFileName,
   buildWorkoutHandoffText,
-  selectWorkoutPoolsideFocusTitles,
+  selectWorkoutPoolsideFocusPoints,
   type WorkoutEditorRecord,
   type WorkoutHandoffDraftState,
   type WorkoutPoolsideFocusOption,
@@ -859,46 +859,7 @@ function buildRepeatSummary(
     );
   }
 
-  const lastEntry = entries[entries.length - 1];
-
-  if (
-    repeatEndingRestMode === "skip_last_rest" &&
-    repeatCount > 1 &&
-    lastEntry &&
-    isSessionDraftRepeatEndingRestStep(lastEntry.step)
-  ) {
-    parts.push("Final rest skipped");
-  }
-
   return parts.join(" · ");
-}
-
-function buildRepeatEndingRestDescription(
-  entries: StepRenderEntry[],
-  repeatCount: number | null,
-  basePaceSecondsPer100m: number,
-  repeatEndingRestMode: SessionDraftRepeatEndingRestMode,
-  poolLengthUnit: SessionDraftPoolLengthUnit
-) {
-  const lastEntry = entries[entries.length - 1];
-  if (!lastEntry || !isSessionDraftRepeatEndingRestStep(lastEntry.step)) {
-    return null;
-  }
-
-  const restLabel = buildWorkoutStepDurationOutputSummary(lastEntry.step, basePaceSecondsPer100m, {
-    environment: "pool",
-    poolLengthUnit,
-  });
-
-  if (repeatCount !== null && repeatCount <= 1) {
-    return repeatEndingRestMode === "skip_last_rest"
-      ? `${restLabel} is skipped after the round.`
-      : `${restLabel} runs after the round.`;
-  }
-
-  return repeatEndingRestMode === "skip_last_rest"
-    ? `${restLabel} still runs between rounds. It is skipped only after the final round.`
-    : `${restLabel} runs between rounds and again after the final round.`;
 }
 
 function getPaceMinutes(secondsPer100m: number | null | undefined) {
@@ -1116,11 +1077,11 @@ export default function WorkoutEditor({
         ? BRAND_PDF_LOGO_PATH
         : new URL(BRAND_PDF_LOGO_PATH, window.location.origin).toString(),
   });
-  const selectedPoolsideFocusTitles = selectWorkoutPoolsideFocusTitles(
+  const selectedPoolsideFocusPoints = selectWorkoutPoolsideFocusPoints(
     trainingFocusOptions,
     selectedPoolsideFocusIds
   );
-  const selectedPoolsideFocusSignature = selectedPoolsideFocusTitles.join("|");
+  const selectedPoolsideFocusSignature = selectedPoolsideFocusPoints.join("|");
   const metadataSummary = isManualPoolMode
     ? [
         draftTotals.totalDistanceM
@@ -1226,7 +1187,8 @@ export default function WorkoutEditor({
   const mobileActionPanelClass = "mt-3 rounded-2xl border border-slate-200 bg-slate-50/90 p-2.5";
   const mobileSecondaryActionClass =
     "inline-flex min-h-10 w-full items-center justify-start rounded-xl border px-3 py-2 text-sm font-medium transition";
-  const desktopHeaderStackClass = "flex items-start justify-between gap-3 sm:flex-col sm:justify-start";
+  const desktopHeaderStackClass =
+    "flex items-start justify-between gap-3 sm:flex-col sm:justify-start";
   const desktopSummaryBlockClass = "min-w-0 flex-1 sm:w-full";
   const desktopActionRowClass = "hidden w-full flex-wrap items-center gap-2 sm:flex";
   const desktopRepeatControlRowClass = "grid gap-3";
@@ -2032,7 +1994,7 @@ export default function WorkoutEditor({
           ? buildWorkoutPdfHtmlDocument(draft, {
               draftState: handoffDraftState,
               variant: "poolside",
-              focusPoints: selectedPoolsideFocusTitles,
+              focusPoints: selectedPoolsideFocusPoints,
               poolsidePrintStyle,
               logoUrl: new URL(BRAND_PDF_LOGO_PATH, window.location.origin).toString(),
               fontUrl: new URL(BRAND_FONT_PUBLIC_PATH, window.location.origin).toString(),
@@ -2104,7 +2066,12 @@ export default function WorkoutEditor({
         </p>
         {!isManualPoolMode ? (
           <p className="mt-2 text-xs text-slate-600">
-            {buildStepSummary(step, draft.basePaceSecondsPer100m, draft.environment, poolLengthUnit)}
+            {buildStepSummary(
+              step,
+              draft.basePaceSecondsPer100m,
+              draft.environment,
+              poolLengthUnit
+            )}
           </p>
         ) : null}
         {options?.descriptionOverride ? (
@@ -2149,10 +2116,7 @@ export default function WorkoutEditor({
                 </span>
               </div>
             </button>
-            <div
-              data-testid={`session-draft-step-summary-${index}`}
-              className="hidden sm:block"
-            >
+            <div data-testid={`session-draft-step-summary-${index}`} className="hidden sm:block">
               {stepSummaryContent}
             </div>
           </div>
@@ -2724,9 +2688,7 @@ export default function WorkoutEditor({
                   })}
                 </select>
               </label>
-            ) : (
-              null
-            )}
+            ) : null}
 
             {isMinimalRestEditor ? null : (
               <label className="text-sm text-slate-700">
@@ -2891,7 +2853,7 @@ export default function WorkoutEditor({
 
   const metadataFields = (
     <div className="grid gap-4 md:grid-cols-2">
-      <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-3 sm:p-4 text-sm text-slate-700">
+      <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-3 text-sm text-slate-700 sm:p-4">
         Title
         <input
           type="text"
@@ -2908,7 +2870,7 @@ export default function WorkoutEditor({
       </label>
 
       {!simplifyManualMetadata ? (
-        <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-3 sm:p-4 text-sm text-slate-700">
+        <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-3 text-sm text-slate-700 sm:p-4">
           Session type
           <select
             value={draft.sessionType}
@@ -2926,7 +2888,7 @@ export default function WorkoutEditor({
         </label>
       ) : null}
 
-      <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-3 sm:p-4 text-sm text-slate-700 md:col-span-2">
+      <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-3 text-sm text-slate-700 sm:p-4 md:col-span-2">
         {simplifyManualMetadata ? "Session note" : "Description"}
         {!simplifyManualMetadata ? (
           <p className="mt-2 text-xs text-slate-500">
@@ -2976,7 +2938,7 @@ export default function WorkoutEditor({
         <div
           data-testid="workout-editor-pool-size-panel"
           data-containment-style="integrated"
-          className="rounded-2xl border border-slate-200 bg-slate-50/60 p-3 sm:p-4 text-sm text-slate-700 md:col-span-2"
+          className="rounded-2xl border border-slate-200 bg-slate-50/60 p-3 text-sm text-slate-700 sm:p-4 md:col-span-2"
         >
           <p className="text-sm font-medium text-slate-900">
             {isManualPoolMode ? "Pool Size" : "Pool length"}
@@ -3077,7 +3039,7 @@ export default function WorkoutEditor({
       ) : null}
 
       {!simplifyManualMetadata ? (
-        <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-3 sm:p-4 text-sm text-slate-700">
+        <label className="rounded-2xl border border-slate-200 bg-slate-50/60 p-3 text-sm text-slate-700 sm:p-4">
           Effort
           <select
             value={draft.effort}
@@ -3516,6 +3478,9 @@ export default function WorkoutEditor({
                   />
                   <span className="min-w-0 flex-1">
                     <span className="block font-medium text-slate-900">{focus.title}</span>
+                    {focus.description ? (
+                      <span className="mt-1 block text-xs text-slate-500">{focus.description}</span>
+                    ) : null}
                   </span>
                 </label>
               ))}
@@ -3542,9 +3507,7 @@ export default function WorkoutEditor({
                 />
                 <span>
                   <span className="block font-medium text-slate-900">Color mode</span>
-                  <span className="mt-1 block text-xs text-slate-500">
-                    Keeps the blue surfaces when your browser prints backgrounds.
-                  </span>
+                  <span className="mt-1 block text-xs text-slate-500">Keeps the blue surfaces</span>
                 </span>
               </span>
             </label>
@@ -3559,9 +3522,7 @@ export default function WorkoutEditor({
                 />
                 <span>
                   <span className="block font-medium text-slate-900">Ink saver</span>
-                  <span className="mt-1 block text-xs text-slate-500">
-                    Uses white surfaces and strong outlines for cheaper printing.
-                  </span>
+                  <span className="mt-1 block text-xs text-slate-500">Uses white surfaces.</span>
                 </span>
               </span>
             </label>
@@ -3714,9 +3675,7 @@ export default function WorkoutEditor({
               <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
                 Session details
               </p>
-              <h3 className="mt-2 text-base font-semibold text-slate-900">
-                Session setup
-              </h3>
+              <h3 className="mt-2 text-base font-semibold text-slate-900">Session setup</h3>
               {!metadataOpen ? (
                 <p
                   data-testid="workout-editor-metadata-summary"
@@ -3879,37 +3838,12 @@ export default function WorkoutEditor({
                     group.repeatEndingRestMode,
                     poolLengthUnit
                   );
-                  const repeatEndingRestDescription = buildRepeatEndingRestDescription(
-                    group.entries,
-                    group.repeatCount,
-                    draft.basePaceSecondsPer100m,
-                    group.repeatEndingRestMode,
-                    poolLengthUnit
-                  );
-                  const postSetRestLabel = group.postSetRestEntry
-                    ? buildWorkoutStepDurationOutputSummary(
-                        group.postSetRestEntry.step,
-                        draft.basePaceSecondsPer100m,
-                        {
-                          environment: "pool",
-                          poolLengthUnit,
-                        }
-                      )
-                    : null;
-                  const postSetRestSuppressed =
-                    group.repeatEndingRestMode === "use_last_rest" &&
-                    Boolean(
-                      group.entries[group.entries.length - 1] &&
-                      isSessionDraftRepeatEndingRestStep(
-                        group.entries[group.entries.length - 1].step
-                      )
-                    );
                   const hasEditableRepeatEndingRest = Boolean(
                     draft.environment === "pool" &&
-                      (() => {
-                        const lastEntry = group.entries[group.entries.length - 1];
-                        return lastEntry && isSessionDraftRepeatEndingRestStep(lastEntry.step);
-                      })()
+                    (() => {
+                      const lastEntry = group.entries[group.entries.length - 1];
+                      return lastEntry && isSessionDraftRepeatEndingRestStep(lastEntry.step);
+                    })()
                   );
                   const repeatMobileActionKey = `repeat:${group.repeatGroupId}`;
                   const repeatMobileActionsOpen = openMobileActionKey === repeatMobileActionKey;
@@ -3924,9 +3858,7 @@ export default function WorkoutEditor({
                           <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
                             Repeat set
                           </p>
-                          <p className="mt-1 text-sm font-medium text-slate-900">
-                            {repeatSummary}
-                          </p>
+                          <p className="mt-1 text-sm font-medium text-slate-900">{repeatSummary}</p>
                           {isManualPoolMode ? null : (
                             <>
                               <p className="mt-1 text-xs text-slate-600">
@@ -3939,18 +3871,6 @@ export default function WorkoutEditor({
                               </p>
                             </>
                           )}
-                          {repeatEndingRestDescription ? (
-                            <p className="mt-2 text-xs text-slate-600">
-                              {repeatEndingRestDescription}
-                            </p>
-                          ) : null}
-                          {postSetRestLabel ? (
-                            <p className="mt-1 text-xs text-slate-600">
-                              {postSetRestSuppressed
-                                ? `${postSetRestLabel} is preserved as post-set rest, but suppressed while the last internal rest interval runs after the final round.`
-                                : `${postSetRestLabel} stays outside the repeat block as the post-set rest after the set.`}
-                            </p>
-                          ) : null}
                         </div>
                         <div className="flex shrink-0 sm:hidden">
                           <button
@@ -4155,7 +4075,6 @@ export default function WorkoutEditor({
                           </div>
                         </div>
                       ) : null}
-
                     </div>
                   );
                 })()}

--- a/docs/task-briefs/in-progress/2026-04-11-swim-session-builder-repeat-summary-and-poolside-note-copy-cleanup-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-11-swim-session-builder-repeat-summary-and-poolside-note-copy-cleanup-10-10.md
@@ -1,0 +1,212 @@
+# Task Brief: Swim Session Builder Repeat Summary And Poolside Note Copy Cleanup (10/10)
+
+## Metadata
+
+- `id`: `2026-04-11-swim-session-builder-repeat-summary-and-poolside-note-copy-cleanup-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-04-11`
+- `updated`: `2026-04-11`
+
+## Goal
+
+Remove the remaining low-value repeat-summary helper copy and make Poolside Note focus cues meaningful by carrying focus descriptions through the builder and poolside output.
+
+## Why This Brief Exists
+
+- A fresh live admin-note check on `freeswimming.org` on `2026-04-11` shows that the earlier helper-copy cleanup slice already shipped part of note `68e1e612`, but some note items are still live:
+  - repeat headers still auto-render explanatory rest text that now feels noisy after the Garmin-parity repeat work,
+  - repeat headers still append `Final rest skipped` even though the rest-mode control already expresses that state,
+  - Poolside Note focus cues only carry titles, not the underlying focus descriptions/details,
+  - print-style helper copy is still longer than needed.
+- The same live check also confirms that other open notes on this route are either stale against newer shipped work or belong to separate slices:
+  - `814ced4c-77e9-4b62-afaf-7ca8424d9ae0` references the old `Unspecified` pool-size flow and is stale,
+  - `7a506574-6245-468c-8aea-17e1444c672a` references delete-helper text that is no longer present and is stale,
+  - `e86b5ede-65d7-477e-a641-decc7755116c` mixes stale pool-size copy asks with a separate single-step auto-rest workflow decision,
+  - `a175f6bc-6814-4010-9f4a-e6620fb9f5dc` bulk delete remains out of scope.
+
+## Dependencies And Boundaries
+
+- Parent saved swim-session builder brief:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-03-27-workout-builder-live-review-ux-and-actions-10-10.md`
+- Related shipped builder cleanup that must remain intact:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-10-swim-session-builder-helper-copy-and-delete-copy-cleanup-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-09-pool-swim-builder-repeat-rest-and-pool-size-clarity-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-08-swim-session-builder-support-tools-pool-size-and-poolside-focus-polish-10-10.md`
+- Related poolside print brief that stays broader than this slice:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-04-01-workout-builder-poolside-note-print-and-surface-clarity-10-10.md`
+- Core implementation files in scope:
+  - `/Users/stianvikra/freeswimming/components/my-library/workouts/WorkoutEditor.tsx`
+  - `/Users/stianvikra/freeswimming/lib/workouts/shared.ts`
+  - `/Users/stianvikra/freeswimming/app/my-library/workouts/page.tsx`
+  - `/Users/stianvikra/freeswimming/app/my-library/workouts/[workoutId]/page.tsx`
+  - `/Users/stianvikra/freeswimming/app/api/my-library/workouts/[workoutId]/export/pdf/route.ts`
+  - `/Users/stianvikra/freeswimming/tests/unit/workout-builder-hub.test.tsx`
+  - `/Users/stianvikra/freeswimming/tests/unit/workouts-shared.test.ts`
+  - `/Users/stianvikra/freeswimming/tests/e2e/my-library-workout-builder.spec.ts`
+
+## Admin Notes Triage Disposition
+
+Production admin notes were re-checked against live `freeswimming.org` on `2026-04-11`.
+
+- `68e1e612-c9e8-4ac3-b3bb-ca284b6ed3db` `Swim session builder`
+  - disposition: partially owned by this brief.
+  - reason:
+    - already shipped before this brief: `Effort <Level>` wording and lap-button helper removal,
+    - owned now: remove the remaining repeat-header helper text, remove `Final rest skipped` from the builder repeat summary, add focus descriptions to Poolside Note, and shorten the print-style helper copy.
+
+- `e86b5ede-65d7-477e-a641-decc7755116c` `SWIM SESSION BUILDER`
+  - disposition: not owned by this brief.
+  - reason: its stale pool-size copy asks conflict with newer shipped pool-size work, and its single-step auto-rest request is a separate workflow decision.
+
+- `814ced4c-77e9-4b62-afaf-7ca8424d9ae0` `Swim session builder`
+  - disposition: not owned by this brief.
+  - reason: it references the removed `Unspecified` pool-size state and is stale.
+
+- `7a506574-6245-468c-8aea-17e1444c672a` `Swim session builder`
+  - disposition: not owned by this brief.
+  - reason: the exact delete-helper sentence is already gone from the current builder.
+
+- `a175f6bc-6814-4010-9f4a-e6620fb9f5dc` `My Swim Sessions`
+  - disposition: not owned by this brief.
+  - reason: bulk delete is a separate workflow slice.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Visual design quality`
+- `Business logic correctness and data integrity`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                                     | Evidence                            | Expected Closeout Score |
+| --------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | Repeat headers and Poolside Note controls expose only the copy that still helps the user act correctly.                                                            | copy review + manual QA             | `5/5`                   |
+| UX flow clarity                               | `target`     | The repeat header reads faster without redundant rest teaching copy, and Poolside Note focus cues remain understandable because titles can carry their details.    | manual QA + targeted unit/e2e       | `5/5`                   |
+| Visual design quality                         | `target`     | The builder and Poolside Note selector feel calmer and cleaner after the low-value helper text is removed or shortened.                                            | screenshot review + manual QA       | `5/5`                   |
+| Business logic correctness and data integrity | `target`     | Builder repeat/rest behavior, canonical save semantics, and export structure remain unchanged apart from richer focus text in the poolside output.                 | code review + targeted tests        | `5/5`                   |
+| Admin editor ergonomics                       | `N/A`        | N/A because this slice changes the authenticated swim-session builder rather than an admin editing tool.                                                           | explicit scope rationale            | `N/A`                   |
+| Accessibility (a11y)                          | `supporting` | Supporting only: trimmed copy must not remove labels or state context needed for keyboard and assistive-tech use.                                                  | code review + targeted tests        | `4/5`                   |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: no material route/runtime cost increase on `/my-library/workouts` from carrying focus details through existing local render paths.                | typecheck + targeted review         | `4/5`                   |
+| Data placement and sync boundaries            | `target`     | Existing server-canonical workout data stays untouched; focus descriptions are reused from existing training-context data and never saved into the workout draft.  | brief contract + code review        | `5/5`                   |
+| Caching and invalidation strategy             | `N/A`        | N/A because this slice changes no fetch cadence, cache policy, or invalidation trigger.                                                                            | explicit scope rationale            | `N/A`                   |
+| Reliability and failure handling              | `target`     | Repeat summaries and poolside output stay deterministic when focus details are present or absent, with graceful fallback to title-only rendering.                  | targeted unit tests                 | `5/5`                   |
+| Security and authz                            | `N/A`        | N/A because no auth, role, or protected mutation behavior changes.                                                                                                 | explicit scope rationale            | `N/A`                   |
+| Privacy and compliance                        | `N/A`        | N/A because the slice reuses existing owner-scoped training focus details and does not widen data exposure beyond the existing authenticated poolside flow.        | explicit scope rationale            | `N/A`                   |
+| Content governance                            | `target`     | Copy remains truthful to the shipped repeat/rest model, and Poolside Note focus text comes from the existing training-context source of truth instead of new copy. | code review + output review         | `5/5`                   |
+| Admin workflow and editability                | `N/A`        | N/A because no admin workflow or publishing flow is changed in this slice.                                                                                         | explicit scope rationale            | `N/A`                   |
+| SEO and crawlability                          | `N/A`        | N/A because this is an authenticated My Library route with no public crawl contract.                                                                               | explicit scope rationale            | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because this slice changes no public route, public metadata, or public AI-facing content.                                                                      | explicit scope rationale            | `N/A`                   |
+| Analytics and KPI observability               | `N/A`        | N/A because the slice changes no analytics event contract or KPI instrumentation.                                                                                  | explicit scope rationale            | `N/A`                   |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, entitlement, billing, or subscription flow changes.                                                                                        | explicit scope rationale            | `N/A`                   |
+| Incident response and support operations      | `N/A`        | N/A because no runbook branch, alert path, or support diagnostic workflow changes; this is a presentation-only cleanup on existing authenticated flows.            | explicit scope rationale            | `N/A`                   |
+| Finance and reporting operations              | `N/A`        | N/A because no finance, payout, reconciliation, or reporting path changes.                                                                                         | explicit scope rationale            | `N/A`                   |
+| i18n operational readiness                    | `N/A`        | N/A because this slice only adjusts internal English builder/output wording and does not change localization architecture or data shape.                           | explicit scope rationale            | `N/A`                   |
+| Stack-fit and dependency discipline           | `target`     | The slice reuses existing builder, training-context, and poolside-output helpers with no new dependency or duplicated rendering system.                            | dependency diff + code review       | `5/5`                   |
+| Testing and QA automation                     | `target`     | Coverage proves the repeat-summary cleanup, print-style copy tightening, and focus-description carry-through in builder and poolside output.                       | targeted unit/e2e + `verify:pre-pr` | `5/5`                   |
+| Scalability and cost efficiency               | `N/A`        | N/A because the slice adds no background jobs, storage growth, or extra network round trips.                                                                       | explicit scope rationale            | `N/A`                   |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: the slice stays rollback-safe because it changes no schema and only adjusts presentation/output composition.                                      | diff review + rollback note         | `4/5`                   |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - workout drafts and their repeat/rest semantics,
+  - existing training-context open-focus rows and their `title` / `details`,
+  - canonical workout export routes.
+- Local-only:
+  - selected Poolside Note focus IDs,
+  - repeat disclosure/open state and other builder presentation state.
+- Sync policy:
+  - this slice must not persist any new field on the workout draft,
+  - focus descriptions are read from the existing training-context snapshot and only affect display/output composition,
+  - selecting focus items for Poolside Note remains local until the user opens the poolside output.
+- Retention and sensitivity:
+  - no new sensitive data is introduced,
+  - focus descriptions already belong to the authenticated owner and remain owner-scoped.
+- Cache/invalidation:
+  - existing builder and export routes remain authoritative,
+  - no extra cache invalidation or revalidation behavior is introduced.
+
+## Identity And Rename Contract
+
+- `N/A`
+- Rationale: this slice does not add or mutate persisted IDs, slugs, or renameable route identifiers.
+
+## Scope
+
+- Remove the remaining repeat-header helper text that explains between-round recovery and external post-set rest.
+- Remove `Final rest skipped` from the builder repeat summary line only.
+- Carry focus descriptions/details into the Poolside Note selector and poolside output when available, with deterministic title-only fallback when not available.
+- Shorten Poolside Note print-style helper copy.
+- Update targeted tests for the new builder/poolside copy contract.
+
+## Out Of Scope
+
+- Pool-size semantics, presets, labels, or validation rules.
+- Any reintroduction of `Unspecified`.
+- Single-step auto-rest creation.
+- Bulk delete on `My Swim Sessions`.
+- Repeat/rest business logic, canonical repeat/export semantics, or Garmin mapping changes.
+- Broader Poolside Note print layout redesign.
+
+## Acceptance Criteria
+
+1. Builder repeat headers no longer show the `Final rest skipped` suffix.
+2. Builder repeat headers no longer show the auto-generated between-round/post-set explanatory paragraphs called out by note `68e1e612`.
+3. Poolside Note focus choices show each focus description when one exists, and still work cleanly when only a title exists.
+4. Poolside Note output carries the selected focus descriptions/details when available instead of title-only bullets.
+5. Print-style helper copy is shortened to the note-approved wording.
+6. Canonical save/export semantics, repeat/rest behavior, and pool-size behavior remain unchanged.
+7. Targeted tests and `npm run verify:pre-pr` pass before PR update.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run typecheck`
+- targeted `vitest`:
+  - `tests/unit/workout-builder-hub.test.tsx`
+  - `tests/unit/workouts-shared.test.ts`
+- targeted `playwright`:
+  - `tests/e2e/my-library-workout-builder.spec.ts --project=desktop-chromium`
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm must be installed on the machine used for local validation.
+- Local validation runs from repo root.
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3000/my-library/workouts`
+  - `http://127.0.0.1:3000/my-library/workouts/<id>`
+- Preview:
+  - PR preview URL after branch push
+
+## Constraints
+
+- Keep the slice narrow and note-driven.
+- Do not reopen the shipped pool-size parity work.
+- Do not touch canonical repeat/export semantics beyond the builder-only summary text requested by the note.
+- Prefer existing training-context fields over inventing new copy sources for Poolside Note details.
+
+## 10/10 Quality Bar
+
+- The builder repeat header should feel lighter immediately after this slice.
+- Poolside Note focus cues should be interpretable without forcing the user to remember what a short title means.
+- Missing focus details must degrade gracefully to title-only rendering.
+- Keyboard, screen-reader, and touch behavior must remain intact.
+- No existing builder action, export action, or save path may change meaning.
+
+## Help/Guide Impact
+
+- `N/A` for this slice because it changes only authenticated builder/poolside presentation details and does not change the documented workflow contract.
+
+## Checkpoint Log
+
+- `2026-04-11 | planning + implementation start | re-checked live admin notes on freeswimming.org and confirmed that note 68e1e612 is only partially shipped: effort wording and lap-button cleanup are already done, while repeat-header helper text, `Final rest skipped` in the builder summary, poolside focus descriptions, and short print-style copy still remain | next: implement the remaining note-owned copy/output cleanup, update targeted tests, and run verification before PR handoff`
+- `2026-04-11 | implementation + validation complete on branch | removed the remaining repeat-header helper copy from the builder summary, kept handoff/export repeat semantics intact, threaded training-focus descriptions into Poolside Note selection/output, shortened print-style helper copy, and validated with `npm run lint:briefs:all`, `npm run typecheck`, targeted `vitest`, targeted `playwright`, and full `npm run verify:pre-pr`; perf-budget trend recommendation remains `hold`because the weekly tighten gate is not met yet | next: commit, push, open PR, monitor CI, and run`npm run verify:pre-merge` before merge recommendation`

--- a/lib/workouts/shared.ts
+++ b/lib/workouts/shared.ts
@@ -131,7 +131,9 @@ const WORKOUT_GARMIN_POOL_MAX_STEP_COUNT = 100;
 const WORKOUT_GARMIN_DRAFT_ISSUE_STEP_ID = "__draft__";
 
 function getWorkoutPoolLengthUnit(draft: Pick<SessionDraft, "environment" | "poolLengthUnit">) {
-  return draft.environment === "pool" ? resolveSessionDraftPoolLengthUnit(draft.poolLengthUnit) : "m";
+  return draft.environment === "pool"
+    ? resolveSessionDraftPoolLengthUnit(draft.poolLengthUnit)
+    : "m";
 }
 
 function formatWorkoutDistanceLabel(
@@ -159,6 +161,7 @@ export type WorkoutPoolsidePrintStyle = (typeof WORKOUT_POOLSIDE_PRINT_STYLES)[n
 export type WorkoutPoolsideFocusOption = {
   id: string;
   title: string;
+  description?: string | null;
   isPrimary?: boolean;
 };
 
@@ -2109,7 +2112,10 @@ export function normalizeSessionDraftForWorkoutPersistence(
     existing.lastIndex = index;
   }
 
-  const linkedPostSetRestValidation = validateLinkedRepeatPostSetRestSteps(canonicalSteps, repeatGroups);
+  const linkedPostSetRestValidation = validateLinkedRepeatPostSetRestSteps(
+    canonicalSteps,
+    repeatGroups
+  );
   if (!linkedPostSetRestValidation.ok) {
     return linkedPostSetRestValidation;
   }
@@ -2325,13 +2331,17 @@ function buildWorkoutGarminPoolRepeatEndingRestCompatibilityIssue(
   }
 
   const useLastRestGroups = buildWorkoutHandoffGroups(draft.steps)
-    .filter((group): group is Extract<WorkoutHandoffGroup, { kind: "repeat" }> => group.kind === "repeat")
+    .filter(
+      (group): group is Extract<WorkoutHandoffGroup, { kind: "repeat" }> => group.kind === "repeat"
+    )
     .filter(
       (group) =>
         group.repeatCount !== null &&
         group.repeatCount > 1 &&
         group.repeatEndingRestMode === "use_last_rest" &&
-        Boolean(group.entries.at(-1) && isSessionDraftRepeatEndingRestStep(group.entries.at(-1)!.step))
+        Boolean(
+          group.entries.at(-1) && isSessionDraftRepeatEndingRestStep(group.entries.at(-1)!.step)
+        )
     )
     .map((group) => {
       const firstEntry = group.entries[0];
@@ -2420,9 +2430,13 @@ function buildWorkoutGarminSendOffCompatibilityIssue(
     return null;
   }
 
-  const previousStep = index > 0 ? steps[index - 1] ?? null : null;
+  const previousStep = index > 0 ? (steps[index - 1] ?? null) : null;
 
-  if (step.category === "rest" && previousStep && isWorkoutGarminDistanceBasedSwimStep(previousStep)) {
+  if (
+    step.category === "rest" &&
+    previousStep &&
+    isWorkoutGarminDistanceBasedSwimStep(previousStep)
+  ) {
     return null;
   }
 
@@ -2780,6 +2794,32 @@ export function selectWorkoutPoolsideFocusTitles(
   return focusOptions.filter((option) => validIds.has(option.id)).map((option) => option.title);
 }
 
+function buildWorkoutPoolsideFocusPoint(option: WorkoutPoolsideFocusOption) {
+  const description = normalizeNullableText(option.description, 240);
+  if (!description || description === option.title) {
+    return option.title;
+  }
+
+  return `${option.title}: ${description}`;
+}
+
+export function selectWorkoutPoolsideFocusPoints(
+  focusOptions: WorkoutPoolsideFocusOption[],
+  selectedFocusIds: string[] | null | undefined
+): string[] {
+  const validIds = new Set(
+    (selectedFocusIds ?? []).map((value) => normalizeRequiredText(value, 120)).filter(Boolean)
+  );
+
+  if (validIds.size === 0) {
+    return [];
+  }
+
+  return focusOptions
+    .filter((option) => validIds.has(option.id))
+    .map(buildWorkoutPoolsideFocusPoint);
+}
+
 export function buildWorkoutSummaryPreviewText(draft: SessionDraft | null | undefined) {
   const lines = buildWorkoutPoolsideLines(draft);
 
@@ -3023,11 +3063,9 @@ function buildWorkoutPoolsideTargetLabel(
   basePaceSecondsPer100m: number,
   poolLengthUnit: SessionDraftPoolLengthUnit
 ) {
-  return buildSessionStepStructuredTargetLabel(
-    step,
-    basePaceSecondsPer100m,
-    poolLengthUnit
-  ) ?? null;
+  return (
+    buildSessionStepStructuredTargetLabel(step, basePaceSecondsPer100m, poolLengthUnit) ?? null
+  );
 }
 
 function formatPoolsidePauseDuration(valueMinutes: number) {
@@ -3191,10 +3229,7 @@ function buildWorkoutHandoffRepeatSummary(
     return "repeat count not set";
   }
 
-  const roundMetrics = buildWorkoutRepeatRoundMetrics(
-    entries,
-    basePaceSecondsPer100m
-  );
+  const roundMetrics = buildWorkoutRepeatRoundMetrics(entries, basePaceSecondsPer100m);
 
   const parts = [`${repeatCount} rounds`];
 
@@ -3313,7 +3348,7 @@ function buildWorkoutGarminReadyExportStep(
       distanceValue:
         step.distanceM && environment === "pool"
           ? convertMetersToPoolUnitValue(step.distanceM, poolLengthUnit)
-          : step.distanceM ?? null,
+          : (step.distanceM ?? null),
       distanceUnit: step.distanceM && environment === "pool" ? poolLengthUnit : null,
       timeMin: step.timeMin ?? null,
       cssSendOffOffsetSeconds: step.cssSendOffOffsetSeconds ?? null,
@@ -3455,7 +3490,10 @@ function ensureManualPoolRepeatPostSetRestSteps(steps: SessionDraftStep[]) {
   return nextSteps;
 }
 
-function buildLinkedPostSetRestStep(repeatGroupId: string, lastRepeatStep: SessionDraftStep): SessionDraftStep {
+function buildLinkedPostSetRestStep(
+  repeatGroupId: string,
+  lastRepeatStep: SessionDraftStep
+): SessionDraftStep {
   const copyLastRestTiming = lastRepeatStep.category === "rest";
   const durationMode =
     copyLastRestTiming &&
@@ -3478,7 +3516,9 @@ function buildLinkedPostSetRestStep(repeatGroupId: string, lastRepeatStep: Sessi
     distanceM: null,
     timeMin:
       durationMode === "fixed_rest" || durationMode === "send_off"
-        ? (copyLastRestTiming ? lastRepeatStep.timeMin ?? 1 : 1)
+        ? copyLastRestTiming
+          ? (lastRepeatStep.timeMin ?? 1)
+          : 1
         : durationMode === "lap_button" || durationMode === "css_send_off"
           ? null
           : 1,
@@ -3488,7 +3528,7 @@ function buildLinkedPostSetRestStep(repeatGroupId: string, lastRepeatStep: Sessi
     cssTargetOffsetSeconds: null,
     cssSendOffOffsetSeconds:
       durationMode === "css_send_off" && copyLastRestTiming
-        ? lastRepeatStep.cssSendOffOffsetSeconds ?? 0
+        ? (lastRepeatStep.cssSendOffOffsetSeconds ?? 0)
         : null,
     targetSummary: "",
     notes: copyLastRestTiming ? lastRepeatStep.notes : "",

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -10,7 +10,10 @@ function runOnceOnDesktopChromium(projectName: string) {
 }
 
 function runOnceOnMobileChromium(projectName: string) {
-  test.skip(!projectName.startsWith("mobile-"), "Workout builder mobile density e2e is mobile-only.");
+  test.skip(
+    !projectName.startsWith("mobile-"),
+    "Workout builder mobile density e2e is mobile-only."
+  );
   test.skip(projectName !== "mobile-chromium", "Runs once on mobile Chromium.");
   test.skip(isSiteLockEnabled, "Skipped while private access gate is enabled.");
 }
@@ -413,11 +416,20 @@ test.describe("my library workout builder", () => {
     await expect(page.getByTestId("session-draft-repeat-ending-rest-mode-1")).toHaveValue(
       "skip_last_rest"
     );
+    const repeatSummary = page.getByTestId("session-draft-repeat-summary-1");
     await expect(
-      page.getByText(
+      repeatSummary.getByText(
         "Fixed Rest Time 1:00 still runs between rounds. It is skipped only after the final round."
       )
-    ).toBeVisible();
+    ).toHaveCount(0);
+    await expect(
+      repeatSummary.getByText(
+        "Fixed Rest Time 1:00 stays outside the repeat block as the post-set rest after the set."
+      )
+    ).toHaveCount(0);
+    await expect(repeatSummary.getByText("Final rest skipped")).toHaveCount(0);
+    await expect(page.getByText("Keeps the blue surfaces")).toBeVisible();
+    await expect(page.getByText("Uses white surfaces.")).toBeVisible();
     await expect(page.getByText("Edit this into the exact repeat you want to hold.")).toHaveCount(
       0
     );

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -122,8 +122,18 @@ function readPreviewDraft() {
 
 function buildTrainingFocusOptions() {
   return [
-    { id: "focus-1", title: "High elbow catch", isPrimary: true },
-    { id: "focus-2", title: "Calm exhale", isPrimary: false },
+    {
+      id: "focus-1",
+      title: "High elbow catch",
+      description: "Keep the forearm vertical before pressing back.",
+      isPrimary: true,
+    },
+    {
+      id: "focus-2",
+      title: "Calm exhale",
+      description: "Start the exhale before the head turns to breathe.",
+      isPrimary: false,
+    },
   ];
 }
 
@@ -244,7 +254,9 @@ describe("WorkoutBuilderHub", () => {
       "aria-expanded",
       "false"
     );
-    expect(screen.queryByTestId("session-draft-step-mobile-primary-add-after-0")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("session-draft-step-mobile-primary-add-after-0")
+    ).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("session-draft-step-mobile-summary-0"));
 
@@ -253,7 +265,9 @@ describe("WorkoutBuilderHub", () => {
       "true"
     );
     expect(screen.getByTestId("session-draft-step-mobile-primary-add-after-0")).toBeVisible();
-    expect(screen.getByTestId("session-draft-step-mobile-primary-add-repeat-after-0")).toBeVisible();
+    expect(
+      screen.getByTestId("session-draft-step-mobile-primary-add-repeat-after-0")
+    ).toBeVisible();
 
     fireEvent.click(screen.getByTestId("session-draft-step-mobile-actions-toggle-0"));
 
@@ -263,7 +277,9 @@ describe("WorkoutBuilderHub", () => {
 
     fireEvent.click(screen.getByTestId("session-draft-add-repeat"));
 
-    expect(screen.getByTestId("session-draft-repeat-mobile-primary-add-step-after-1")).toBeVisible();
+    expect(
+      screen.getByTestId("session-draft-repeat-mobile-primary-add-step-after-1")
+    ).toBeVisible();
 
     fireEvent.click(screen.getByTestId("session-draft-repeat-mobile-actions-toggle-1"));
 
@@ -704,12 +720,12 @@ describe("WorkoutBuilderHub", () => {
       "skip_last_rest"
     );
     expect(screen.getByText(/4 rounds/)).toBeVisible();
-    expect(screen.getByText(/Final rest skipped/)).toBeVisible();
     expect(
-      screen.getByText(
+      screen.queryByText(
         "Fixed Rest Time 1:00 still runs between rounds. It is skipped only after the final round."
       )
-    ).toBeVisible();
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Final rest skipped/)).not.toBeInTheDocument();
 
     const previewDraft = readPreviewDraft();
     const repeatSteps = previewDraft.steps.filter((step) => step.repeatGroupId);
@@ -1084,6 +1100,12 @@ describe("WorkoutBuilderHub", () => {
         expect.stringContaining("Calm exhale")
       );
       expect(printWindow.document.write).toHaveBeenCalledWith(
+        expect.stringContaining("High elbow catch: Keep the forearm vertical before pressing back.")
+      );
+      expect(printWindow.document.write).toHaveBeenCalledWith(
+        expect.stringContaining("Calm exhale: Start the exhale before the head turns to breathe.")
+      );
+      expect(printWindow.document.write).toHaveBeenCalledWith(
         expect.stringContaining("Poolside Note")
       );
       expect(printWindow.document.write).toHaveBeenCalledWith(expect.stringContaining("Tot:"));
@@ -1091,6 +1113,15 @@ describe("WorkoutBuilderHub", () => {
         expect.stringContaining("lockup-domain-ink.png")
       );
     });
+
+    expect(screen.getByText("Keeps the blue surfaces")).toBeVisible();
+    expect(screen.getByText("Uses white surfaces.")).toBeVisible();
+    expect(
+      screen.queryByText("Keeps the blue surfaces when your browser prints backgrounds.")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Uses white surfaces and strong outlines for cheaper printing.")
+    ).not.toBeInTheDocument();
   });
 
   it("collapses the metadata panel by default for saved builder sessions and reopens on demand", async () => {
@@ -1458,10 +1489,11 @@ describe("WorkoutBuilderHub", () => {
       )
     ).not.toBeInTheDocument();
     expect(
-      screen.getByText(
+      screen.queryByText(
         "Fixed Rest Time 1:00 still runs between rounds. It is skipped only after the final round."
       )
-    ).toBeVisible();
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Final rest skipped")).not.toBeInTheDocument();
   });
 
   it("uses a single MM:SS field for manual-pool time duration editing", async () => {
@@ -1746,6 +1778,7 @@ describe("WorkoutBuilderHub", () => {
         trainingFocusOptions={Array.from({ length: 10 }, (_, index) => ({
           id: `focus-${index + 1}`,
           title: `Focus ${index + 1}`,
+          description: index === 0 ? "Hold the line before pressing back." : null,
           isPrimary: index === 0,
         }))}
       />
@@ -1762,6 +1795,7 @@ describe("WorkoutBuilderHub", () => {
     expect(focusList).toHaveClass("overflow-y-auto");
     expect(within(focusList).queryByText("Primary focus")).not.toBeInTheDocument();
     expect(within(focusList).queryByText("Optional focus")).not.toBeInTheDocument();
+    expect(within(focusList).getByText("Hold the line before pressing back.")).toBeVisible();
   });
 
   it("shows recovery guidance when the requested workout is missing", () => {

--- a/tests/unit/workouts-routes.test.ts
+++ b/tests/unit/workouts-routes.test.ts
@@ -312,11 +312,13 @@ describe("workouts routes", () => {
         {
           id: "focus-1",
           title: "High elbow catch",
+          details: "Keep the forearm vertical before pressing back.",
           isPrimary: true,
         },
         {
           id: "focus-2",
           title: "Calm exhale",
+          details: "Start the exhale before the head turns to breathe.",
           isPrimary: false,
         },
       ],
@@ -354,7 +356,7 @@ describe("workouts routes", () => {
     expect(body).toContain("Poolside Note");
     expect(body).toContain('data-pdf-variant="poolside"');
     expect(body).toContain('data-poolside-print-style="ink_saver"');
-    expect(body).toContain("Calm exhale");
+    expect(body).toContain("Calm exhale: Start the exhale before the head turns to breathe.");
     expect(body).not.toContain("High elbow catch");
     expect(body).toContain("Breathing timing");
     expect(body).toContain("lockup-domain-ink.png");

--- a/tests/unit/workouts-shared.test.ts
+++ b/tests/unit/workouts-shared.test.ts
@@ -12,6 +12,7 @@ import {
   buildWorkoutHandoffText,
   haveWorkoutDraftChanges,
   normalizeSessionDraftForWorkoutPersistence,
+  selectWorkoutPoolsideFocusPoints,
   selectWorkoutPoolsideFocusTitles,
 } from "@/lib/workouts/shared";
 
@@ -1033,5 +1034,20 @@ describe("workouts shared readiness", () => {
         ["focus-2", "missing-focus", "focus-1"]
       )
     ).toEqual(["High elbow catch", "Calm exhale"]);
+
+    expect(
+      selectWorkoutPoolsideFocusPoints(
+        [
+          {
+            id: "focus-1",
+            title: "High elbow catch",
+            description: "Keep the forearm vertical before pressing back.",
+            isPrimary: true,
+          },
+          { id: "focus-2", title: "Calm exhale", description: null, isPrimary: false },
+        ],
+        ["focus-2", "missing-focus", "focus-1"]
+      )
+    ).toEqual(["High elbow catch: Keep the forearm vertical before pressing back.", "Calm exhale"]);
   });
 });


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-04-11T13:54:49.402Z for branch `feat/swim-session-builder-repeat-summary-and-poolside-copy-2026-04-11` (base ref `origin/main`).
- Latest commit: `d26d429` - Clean up swim builder repeat summary and poolside copy.
- User-visible changes: User/admin runtime behavior may change on touched routes/components.
- Technical changes: Updated 10 file(s): `app/api/my-library/workouts/[workoutId]/export/pdf/route.ts`, `app/my-library/workouts/[workoutId]/page.tsx`, `app/my-library/workouts/page.tsx`, `components/my-library/workouts/WorkoutEditor.tsx`, `docs/task-briefs/in-progress/2026-04-11-swim-session-builder-repeat-summary-and-poolside-note-copy-cleanup-10-10.md`, `... and 5 more file(s)`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-04-11-swim-session-builder-repeat-summary-and-poolside-note-copy-cleanup-10-10.md`
- Scorecard target outcomes: 9 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (1); tests (4); API handlers (1); runtime UI/routes/components (4).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (10):
  - `app/api/my-library/workouts/[workoutId]/export/pdf/route.ts`
  - `app/my-library/workouts/[workoutId]/page.tsx`
  - `app/my-library/workouts/page.tsx`
  - `components/my-library/workouts/WorkoutEditor.tsx`
  - `docs/task-briefs/in-progress/2026-04-11-swim-session-builder-repeat-summary-and-poolside-note-copy-cleanup-10-10.md`
  - `lib/workouts/shared.ts`
  - `tests/e2e/my-library-workout-builder.spec.ts`
  - `tests/unit/workout-builder-hub.test.tsx`
  - `... and 2 more file(s)`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `d26d429` (`git revert d26d429`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **NOT RUN** (run locally before pushing PR updates).
- `npm run verify:pre-merge`: **PENDING** for `d26d429` (required before merge to `main`).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  - No local verify log found in `artifacts/test-runs/latest`.
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
