### PR TITLE
Polish swim session builder scan and poolside UX

### DIFF
--- a/app/my-library/workouts/[workoutId]/page.tsx
+++ b/app/my-library/workouts/[workoutId]/page.tsx
@@ -67,6 +67,13 @@ export default async function WorkoutBuilderPage({ params, searchParams }: Props
           isPrimary: focus.isPrimary,
         }))
       : [];
+  const builderHeading =
+    workoutLibrary.selectedWorkout?.draft.environment === "pool" || entryMode === "manual-pool"
+      ? "Pool session builder"
+      : workoutLibrary.selectedWorkout?.draft.environment === "open_water" ||
+          entryMode === "manual-open-water"
+        ? "Open-water session builder"
+        : "Swim session builder";
 
   return (
     <SiteChrome>
@@ -86,7 +93,7 @@ export default async function WorkoutBuilderPage({ params, searchParams }: Props
                 My Library
               </p>
               <h1 className="mt-2 text-2xl font-bold text-slate-900 sm:text-3xl">
-                Swim session builder
+                {builderHeading}
               </h1>
             </div>
             <div className="flex flex-wrap gap-2">

--- a/components/my-library/workouts/SavedWorkoutsPanel.tsx
+++ b/components/my-library/workouts/SavedWorkoutsPanel.tsx
@@ -2,7 +2,11 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { getSessionTypeLabel } from "@/lib/session-generator-v1/shared";
+import {
+  formatDistanceMetersLabel,
+  getSessionTypeLabel,
+  resolveSessionDraftPoolLengthUnit,
+} from "@/lib/session-generator-v1/shared";
 import type { WorkoutSummary } from "@/lib/workouts/shared";
 
 type Props = {
@@ -23,6 +27,9 @@ type Props = {
   onConfirmDeleteWorkout?: ((workout: WorkoutSummary) => void) | null;
   pendingDeleteWorkoutId?: string | null;
   deletingWorkoutId?: string | null;
+  enableBulkDelete?: boolean;
+  onConfirmDeleteWorkouts?: ((workouts: WorkoutSummary[]) => void) | null;
+  bulkDeleting?: boolean;
   printButtonTestIdBuilder?: (workoutId: string) => string;
   poolsidePdfButtonTestIdBuilder?: (workoutId: string) => string;
   currentWorkoutId?: string | null;
@@ -52,6 +59,9 @@ export default function SavedWorkoutsPanel({
   onConfirmDeleteWorkout = null,
   pendingDeleteWorkoutId = null,
   deletingWorkoutId = null,
+  enableBulkDelete = false,
+  onConfirmDeleteWorkouts = null,
+  bulkDeleting = false,
   printButtonTestIdBuilder = (workoutId) => `saved-workouts-print-${workoutId}`,
   poolsidePdfButtonTestIdBuilder = (workoutId) => `saved-workouts-poolside-${workoutId}`,
   currentWorkoutId = null,
@@ -65,12 +75,13 @@ export default function SavedWorkoutsPanel({
   const [expanded, setExpanded] = useState(() => !collapsedByDefault);
   const [previewWorkoutId, setPreviewWorkoutId] = useState<string | null>(null);
   const [showAllWorkouts, setShowAllWorkouts] = useState(() => initialVisibleCount == null);
+  const [bulkSelectionMode, setBulkSelectionMode] = useState(false);
+  const [pendingBulkDelete, setPendingBulkDelete] = useState(false);
+  const [selectedWorkoutIds, setSelectedWorkoutIds] = useState<string[]>([]);
   const visibleLimit = initialVisibleCount ?? undefined;
 
   const hasHiddenWorkouts =
-    visibleLimit != null && Number.isFinite(visibleLimit)
-      ? workouts.length > visibleLimit
-      : false;
+    visibleLimit != null && Number.isFinite(visibleLimit) ? workouts.length > visibleLimit : false;
   const visibleWorkouts =
     hasHiddenWorkouts && !showAllWorkouts ? workouts.slice(0, visibleLimit) : workouts;
   const hiddenWorkoutCount = hasHiddenWorkouts ? workouts.length - visibleWorkouts.length : 0;
@@ -79,6 +90,7 @@ export default function SavedWorkoutsPanel({
     if (pendingDeleteWorkoutId) {
       setExpanded(true);
       setShowAllWorkouts(true);
+      setPendingBulkDelete(false);
     }
   }, [pendingDeleteWorkoutId]);
 
@@ -95,6 +107,18 @@ export default function SavedWorkoutsPanel({
   }, [previewWorkoutId, workouts]);
 
   useEffect(() => {
+    setSelectedWorkoutIds((current) =>
+      current.filter((workoutId) => workouts.some((workout) => workout.id === workoutId))
+    );
+  }, [workouts]);
+
+  useEffect(() => {
+    if (selectedWorkoutIds.length === 0) {
+      setPendingBulkDelete(false);
+    }
+  }, [selectedWorkoutIds.length]);
+
+  useEffect(() => {
     if (initialVisibleCount == null) {
       setShowAllWorkouts(true);
     }
@@ -104,6 +128,9 @@ export default function SavedWorkoutsPanel({
     return null;
   }
 
+  const selectedWorkouts = workouts.filter((workout) => selectedWorkoutIds.includes(workout.id));
+  const showBulkToolbar = enableBulkDelete && typeof onConfirmDeleteWorkouts === "function";
+
   return (
     <div data-testid={testId} className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
       {showHeader ? (
@@ -112,7 +139,7 @@ export default function SavedWorkoutsPanel({
             <h3 className="text-sm font-semibold text-slate-900">{heading}</h3>
             {description ? <p className="mt-1 text-sm text-slate-600">{description}</p> : null}
             <p className="mt-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
-              {workouts.length} saved swim session{workouts.length === 1 ? "" : "s"}
+              {workouts.length} saved session{workouts.length === 1 ? "" : "s"}
             </p>
           </div>
           {showToggle ? (
@@ -131,6 +158,97 @@ export default function SavedWorkoutsPanel({
 
       {!showToggle || expanded ? (
         <div className={`${showHeader ? "mt-4" : ""} grid gap-3`}>
+          {showBulkToolbar ? (
+            <div className="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-white/80 bg-white px-3 py-3">
+              <div>
+                <p className="text-sm font-semibold text-slate-900">Library cleanup</p>
+                <p className="mt-1 text-sm text-slate-600">
+                  {bulkSelectionMode
+                    ? `${selectedWorkoutIds.length} selected`
+                    : "Use selection mode when you want to delete multiple saved sessions at once."}
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                {!bulkSelectionMode ? (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setBulkSelectionMode(true);
+                      setPendingBulkDelete(false);
+                    }}
+                    data-testid={`${testId}-bulk-select-toggle`}
+                    className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+                  >
+                    Select sessions
+                  </button>
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => setSelectedWorkoutIds(workouts.map((workout) => workout.id))}
+                      className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+                    >
+                      Select all
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setBulkSelectionMode(false);
+                        setPendingBulkDelete(false);
+                        setSelectedWorkoutIds([]);
+                      }}
+                      disabled={bulkDeleting}
+                      data-testid={`${testId}-bulk-cancel`}
+                      className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      Done
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setPendingBulkDelete(true)}
+                      disabled={selectedWorkoutIds.length === 0 || bulkDeleting}
+                      data-testid={`${testId}-bulk-delete`}
+                      className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-700 transition hover:bg-rose-50 active:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {bulkDeleting ? "Deleting..." : "Delete selected"}
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
+          ) : null}
+
+          {showBulkToolbar && bulkSelectionMode && pendingBulkDelete ? (
+            <div className="rounded-2xl border border-rose-200 bg-rose-50/80 p-3">
+              <p className="text-sm font-medium text-rose-900">
+                Delete {selectedWorkoutIds.length} saved session
+                {selectedWorkoutIds.length === 1 ? "" : "s"} from My Library?
+              </p>
+              <p className="mt-1 text-sm text-rose-900/90">
+                Selected sessions are deleted permanently from this library view.
+              </p>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => onConfirmDeleteWorkouts?.(selectedWorkouts)}
+                  disabled={selectedWorkoutIds.length === 0 || bulkDeleting}
+                  data-testid={`${testId}-bulk-confirm-delete`}
+                  className="inline-flex h-10 items-center justify-center rounded-xl bg-rose-600 px-4 text-sm font-semibold text-white transition hover:bg-rose-500 active:bg-rose-700 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {bulkDeleting ? "Deleting..." : "Delete selected sessions"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPendingBulkDelete(false)}
+                  disabled={bulkDeleting}
+                  className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-700 transition hover:bg-rose-50 active:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : null}
+
           {visibleWorkouts.map((workout) => {
             const deleting = deletingWorkoutId === workout.id;
             const pendingDelete = pendingDeleteWorkoutId === workout.id;
@@ -138,6 +256,22 @@ export default function SavedWorkoutsPanel({
             const workoutPoolsidePdfHref = workoutPoolsidePdfHrefBuilder?.(workout.id) ?? null;
             const isCurrentWorkout = currentWorkoutId === workout.id;
             const previewOpen = previewWorkoutId === workout.id;
+            const isSelected = selectedWorkoutIds.includes(workout.id);
+            const workoutDistanceLabel = workout.totalDistanceM
+              ? workout.environment === "pool"
+                ? formatDistanceMetersLabel(
+                    workout.totalDistanceM,
+                    resolveSessionDraftPoolLengthUnit(workout.poolLengthUnit)
+                  )
+                : `${workout.totalDistanceM}m`
+              : null;
+            const updatedLabel = new Intl.DateTimeFormat("en-GB", {
+              day: "2-digit",
+              month: "short",
+              year: "numeric",
+              hour: "2-digit",
+              minute: "2-digit",
+            }).format(new Date(workout.updatedAt));
 
             return (
               <div
@@ -146,7 +280,25 @@ export default function SavedWorkoutsPanel({
                 className="rounded-2xl border border-white/80 bg-white p-3"
               >
                 <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div>
+                  <div className="min-w-0 flex-1">
+                    {bulkSelectionMode ? (
+                      <label className="mb-3 flex items-center gap-2 text-sm font-medium text-slate-700">
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() =>
+                            setSelectedWorkoutIds((current) =>
+                              current.includes(workout.id)
+                                ? current.filter((workoutId) => workoutId !== workout.id)
+                                : [...current, workout.id]
+                            )
+                          }
+                          data-testid={`saved-workout-select-${workout.id}`}
+                          className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-200"
+                        />
+                        Select session
+                      </label>
+                    ) : null}
                     <div className="flex flex-wrap items-center gap-2">
                       <p className="text-sm font-semibold text-slate-900">{workout.title}</p>
                       {isCurrentWorkout ? (
@@ -159,11 +311,14 @@ export default function SavedWorkoutsPanel({
                       ) : null}
                     </div>
                     <p className="mt-1 text-sm text-slate-600">
-                      {workout.totalDistanceM ? `${workout.totalDistanceM}m` : null}
-                      {workout.totalDistanceM && workout.estimatedDurationMin ? " · " : null}
+                      {workoutDistanceLabel}
+                      {workoutDistanceLabel && workout.estimatedDurationMin ? " · " : null}
                       {workout.estimatedDurationMin ? `~${workout.estimatedDurationMin} min` : null}
-                      {workout.totalDistanceM || workout.estimatedDurationMin ? " · " : null}
+                      {workoutDistanceLabel || workout.estimatedDurationMin ? " · " : null}
                       {getSessionTypeLabel(workout.sessionType)}
+                    </p>
+                    <p className="mt-1 text-xs font-medium uppercase tracking-wide text-slate-500">
+                      Updated {updatedLabel}
                     </p>
                   </div>
                   <div className="flex flex-wrap items-center gap-2">
@@ -212,7 +367,9 @@ export default function SavedWorkoutsPanel({
                         Poolside Note
                       </Link>
                     ) : null}
-                    {!isCurrentWorkout && typeof onRequestDeleteWorkout === "function" ? (
+                    {!bulkSelectionMode &&
+                    !isCurrentWorkout &&
+                    typeof onRequestDeleteWorkout === "function" ? (
                       <button
                         type="button"
                         onClick={() => onRequestDeleteWorkout(workout)}

--- a/components/my-library/workouts/WorkoutBuilderHub.tsx
+++ b/components/my-library/workouts/WorkoutBuilderHub.tsx
@@ -30,7 +30,9 @@ type Props = {
 
 function upsertRecentWorkoutSummary(current: WorkoutSummary[], next: WorkoutSummary) {
   const existing = current.filter((summary) => summary.id !== next.id);
-  return [next, ...existing].slice(0, 6);
+  return [next, ...existing].sort(
+    (left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt)
+  );
 }
 
 export default function WorkoutBuilderHub({
@@ -54,6 +56,7 @@ export default function WorkoutBuilderHub({
   const [isSaving, setIsSaving] = useState(false);
   const [pendingDeleteWorkoutId, setPendingDeleteWorkoutId] = useState<string | null>(null);
   const [deletingWorkoutId, setDeletingWorkoutId] = useState<string | null>(null);
+  const [bulkDeleting, setBulkDeleting] = useState(false);
   const [pendingCurrentDelete, setPendingCurrentDelete] = useState(false);
   const [clientReady, setClientReady] = useState(false);
   const hasUnsavedChanges = haveWorkoutDraftChanges(draft, savedWorkout?.draft ?? null);
@@ -72,6 +75,7 @@ export default function WorkoutBuilderHub({
     setSuccess("");
     setPendingDeleteWorkoutId(null);
     setDeletingWorkoutId(null);
+    setBulkDeleting(false);
     setPendingCurrentDelete(false);
   }, [
     workoutLibrary.recentWorkouts,
@@ -168,6 +172,77 @@ export default function WorkoutBuilderHub({
     }
   }
 
+  async function confirmDeleteWorkouts(workouts: WorkoutSummary[]) {
+    if (workouts.length === 0) return;
+
+    setBulkDeleting(true);
+    setPendingDeleteWorkoutId(null);
+    setPendingCurrentDelete(false);
+    setError("");
+    setSuccess("");
+
+    try {
+      const results = await Promise.all(
+        workouts.map(async (workout) => {
+          try {
+            const response = await fetch(`/api/my-library/workouts/${workout.id}`, {
+              method: "DELETE",
+            });
+            const responseBody = (await response
+              .json()
+              .catch(() => null)) as WorkoutDeleteApiResponse | null;
+
+            return {
+              workout,
+              ok: Boolean(response.ok && responseBody?.ok),
+              error:
+                response.ok && responseBody?.ok
+                  ? null
+                  : responseBody && !responseBody.ok
+                    ? responseBody.error
+                    : "Could not delete workout right now.",
+            };
+          } catch {
+            return {
+              workout,
+              ok: false,
+              error: "Could not delete workout right now.",
+            };
+          }
+        })
+      );
+
+      const deletedIds = results.filter((result) => result.ok).map((result) => result.workout.id);
+      const failedDeletes = results.filter((result) => !result.ok);
+
+      if (deletedIds.length > 0) {
+        setRecentWorkouts((current) =>
+          current.filter((summary) => !deletedIds.includes(summary.id))
+        );
+      }
+
+      if (deletedIds.length > 0 && failedDeletes.length === 0) {
+        setSuccess(
+          deletedIds.length === 1
+            ? `Deleted ${results.find((result) => result.ok)?.workout.title ?? "1 session"}.`
+            : `Deleted ${deletedIds.length} saved sessions.`
+        );
+      } else if (deletedIds.length > 0) {
+        setError(
+          `Deleted ${deletedIds.length} saved session${
+            deletedIds.length === 1 ? "" : "s"
+          }, but ${failedDeletes.length} could not be deleted right now.`
+        );
+      } else {
+        setError(failedDeletes[0]?.error ?? "Could not delete the selected sessions right now.");
+      }
+
+      router.refresh();
+    } finally {
+      setBulkDeleting(false);
+    }
+  }
+
   return (
     <section
       data-testid="workout-builder-hub"
@@ -205,7 +280,7 @@ export default function WorkoutBuilderHub({
           </div>
           {recentWorkouts.length > 0 ? (
             <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-              {recentWorkouts.length} saved swim session{recentWorkouts.length === 1 ? "" : "s"}
+              {recentWorkouts.length} saved session{recentWorkouts.length === 1 ? "" : "s"}
             </p>
           ) : null}
         </div>
@@ -313,7 +388,8 @@ export default function WorkoutBuilderHub({
               showToggle={false}
               showInlinePreview
               showHeader={false}
-              initialVisibleCount={3}
+              initialVisibleCount={null}
+              enableBulkDelete
               editButtonTestIdBuilder={(workoutId) => `workout-builder-edit-workout-${workoutId}`}
               deleteButtonTestIdBuilder={(workoutId) =>
                 `workout-builder-delete-workout-${workoutId}`
@@ -329,8 +405,10 @@ export default function WorkoutBuilderHub({
               }}
               onCancelDeleteWorkout={() => setPendingDeleteWorkoutId(null)}
               onConfirmDeleteWorkout={confirmDeleteWorkout}
+              onConfirmDeleteWorkouts={confirmDeleteWorkouts}
               pendingDeleteWorkoutId={pendingDeleteWorkoutId}
               deletingWorkoutId={deletingWorkoutId}
+              bulkDeleting={bulkDeleting}
             />
           ) : (
             <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-3 sm:p-4">

--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -629,7 +629,7 @@ function buildRepeatStarterSteps(index: number): SessionDraftStep[] {
       intensity: "easy",
       durationMode: "fixed_rest",
       distanceM: null,
-      timeMin: 1,
+      timeMin: 0.5,
       targetMode: "none",
       targetSummary: "Short recovery before the next round.",
       notes: "",
@@ -645,7 +645,7 @@ function buildRepeatStarterSteps(index: number): SessionDraftStep[] {
       intensity: "easy",
       durationMode: "fixed_rest",
       distanceM: null,
-      timeMin: 1,
+      timeMin: 0.5,
       targetMode: "none",
       targetSummary: "",
       notes: "",
@@ -710,14 +710,28 @@ function formatEditableClockDuration(valueMinutes: number | null | undefined) {
 
 function sanitizeClockDurationInput(rawValue: string) {
   const cleaned = rawValue.replace(/[^\d:]/g, "");
-  const [rawMinutes = "", ...rest] = cleaned.split(":");
-  const minutes = rawMinutes.slice(0, 3);
+  const digits = cleaned.replace(/[^\d]/g, "").slice(0, 5);
 
-  if (rest.length === 0) {
-    return minutes;
+  if (cleaned.includes(":")) {
+    const [rawMinutes = "", rawSeconds = ""] = cleaned.split(":");
+    const minutes = rawMinutes.replace(/[^\d]/g, "").slice(0, 3);
+    const seconds = rawSeconds.replace(/[^\d]/g, "").slice(0, 2);
+
+    if (!minutes && !seconds) {
+      return "";
+    }
+
+    return `${minutes}${cleaned.endsWith(":") && seconds.length === 0 ? ":" : seconds.length > 0 ? `:${seconds}` : ""}`;
   }
 
-  return `${minutes}:${rest.join("").slice(0, 2)}`;
+  if (digits.length === 0) return "";
+  if (digits.length === 1) return digits;
+  if (digits.length === 2) return `${digits}:`;
+  if (digits.length <= 4) {
+    return `${digits.slice(0, 2)}:${digits.slice(2)}`;
+  }
+
+  return `${digits.slice(0, 3)}:${digits.slice(3)}`;
 }
 
 function parseClockDurationInputForChange(value: string) {
@@ -730,6 +744,10 @@ function parseClockDurationInputForChange(value: string) {
   if (/^\d{1,3}$/.test(trimmed)) {
     const minutes = Number.parseInt(trimmed, 10);
     return minutes > 0 ? minutes : null;
+  }
+
+  if (/^\d{1,3}:$/.test(trimmed)) {
+    return undefined;
   }
 
   const completeClockMatch = trimmed.match(/^(\d{1,3}):(\d{2})$/);
@@ -998,6 +1016,195 @@ function buildRepeatSummary(
   }
 
   return parts.join(" · ");
+}
+
+type ManualPoolViewSectionLine = {
+  text: string;
+  tone?: "default" | "rest" | "subtle";
+};
+
+type ManualPoolViewSection = {
+  key: string;
+  title: string;
+  lines: ManualPoolViewSectionLine[];
+  numbered: boolean;
+  variant: "default" | "rest" | "repeat";
+};
+
+function findTopLevelLinkedRestStep(
+  steps: SessionDraftStep[],
+  step: SessionDraftStep,
+  index: number
+) {
+  const nextStep = steps[index + 1] ?? null;
+
+  if (
+    step.category === "rest" ||
+    step.repeatGroupId ||
+    step.postSetRestForRepeatGroupId ||
+    !nextStep ||
+    nextStep.category !== "rest" ||
+    nextStep.repeatGroupId ||
+    nextStep.postSetRestForRepeatGroupId
+  ) {
+    return null;
+  }
+
+  return nextStep;
+}
+
+function buildManualPoolViewLine(
+  step: SessionDraftStep,
+  basePaceSecondsPer100m: number,
+  poolLengthUnit: SessionDraftPoolLengthUnit,
+  linkedRestStep?: SessionDraftStep | null
+) {
+  const normalizedStep = normalizeManualPoolStepForEditor(step);
+
+  if (normalizedStep.category === "rest") {
+    return buildManualPoolRestInlineSummary(normalizedStep, basePaceSecondsPer100m);
+  }
+
+  const stepSummary = buildManualPoolStepSummary(
+    normalizedStep,
+    basePaceSecondsPer100m,
+    poolLengthUnit
+  );
+
+  if (!linkedRestStep || linkedRestStep.category !== "rest") {
+    return stepSummary;
+  }
+
+  const restSummary = buildManualPoolRestInlineSummary(linkedRestStep, basePaceSecondsPer100m);
+  return `${stepSummary} · ${restSummary.replace(/^Rest /, "Rest: ")}`;
+}
+
+function buildManualPoolRepeatViewSection(
+  group: Extract<StepRenderGroup, { kind: "repeat" }>,
+  basePaceSecondsPer100m: number,
+  poolLengthUnit: SessionDraftPoolLengthUnit
+): ManualPoolViewSection {
+  const workStep = group.entries[0]?.step ?? null;
+  const betweenStep = group.entries[1]?.step ?? null;
+  const normalizedWorkStep = workStep ? normalizeManualPoolStepForEditor(workStep) : null;
+  const repeatCountLabel = group.repeatCount ? `${group.repeatCount} x ` : "";
+  const title = normalizedWorkStep
+    ? getSessionStepCategoryLabel(normalizedWorkStep.category)
+    : "Repeat";
+
+  if (!normalizedWorkStep) {
+    return {
+      key: group.repeatGroupId,
+      title,
+      lines: [{ text: "Set the work interval for this repeat block." }],
+      numbered: false,
+      variant: "repeat",
+    };
+  }
+
+  const lines: ManualPoolViewSectionLine[] = [
+    {
+      text: `${repeatCountLabel}${buildManualPoolStepSummary(
+        normalizedWorkStep,
+        basePaceSecondsPer100m,
+        poolLengthUnit
+      )}`,
+    },
+  ];
+
+  if (betweenStep) {
+    if (betweenStep.category === "rest") {
+      lines[0] = {
+        text: `${lines[0].text} · Rest: ${formatClockDurationLabel(betweenStep.timeMin)}`,
+      };
+    } else {
+      lines.push({
+        text: `Recovery: ${buildManualPoolStepSummary(
+          betweenStep,
+          basePaceSecondsPer100m,
+          poolLengthUnit
+        )}`,
+        tone: "subtle",
+      });
+    }
+  }
+
+  if (group.postSetRestEntry?.step && group.repeatEndingRestMode !== "use_last_rest") {
+    lines.push({
+      text: `Post-set rest: ${formatClockDurationLabel(group.postSetRestEntry.step.timeMin)}`,
+      tone: "rest",
+    });
+  }
+
+  return {
+    key: group.repeatGroupId,
+    title,
+    lines,
+    numbered: false,
+    variant: "repeat",
+  };
+}
+
+function buildManualPoolViewSections(
+  stepGroups: StepRenderGroup[],
+  draftSteps: SessionDraftStep[],
+  basePaceSecondsPer100m: number,
+  poolLengthUnit: SessionDraftPoolLengthUnit
+) {
+  const sections: ManualPoolViewSection[] = [];
+  const consumedRestStepIds = new Set<string>();
+
+  stepGroups.forEach((group) => {
+    if (group.kind === "repeat") {
+      sections.push(
+        buildManualPoolRepeatViewSection(group, basePaceSecondsPer100m, poolLengthUnit)
+      );
+      return;
+    }
+
+    const entry = group.entries[0];
+    const linkedRestStep = findTopLevelLinkedRestStep(draftSteps, entry.step, entry.index);
+    if (linkedRestStep) {
+      consumedRestStepIds.add(linkedRestStep.id);
+    }
+    if (consumedRestStepIds.has(entry.step.id)) {
+      return;
+    }
+
+    const normalizedStep = normalizeManualPoolStepForEditor(entry.step);
+    const title = getSessionStepCategoryLabel(normalizedStep.category);
+    const nextLine: ManualPoolViewSectionLine = {
+      text: buildManualPoolViewLine(
+        normalizedStep,
+        basePaceSecondsPer100m,
+        poolLengthUnit,
+        linkedRestStep
+      ),
+      tone: normalizedStep.category === "rest" ? "rest" : "default",
+    };
+    const lastSection = sections[sections.length - 1] ?? null;
+
+    if (
+      lastSection &&
+      lastSection.variant !== "repeat" &&
+      lastSection.title === title &&
+      normalizedStep.category !== "rest"
+    ) {
+      lastSection.lines.push(nextLine);
+      lastSection.numbered = true;
+      return;
+    }
+
+    sections.push({
+      key: entry.step.id,
+      title,
+      lines: [nextLine],
+      numbered: false,
+      variant: normalizedStep.category === "rest" ? "rest" : "default",
+    });
+  });
+
+  return sections;
 }
 
 function getPaceMinutes(secondsPer100m: number | null | undefined) {
@@ -1326,6 +1533,14 @@ export default function WorkoutEditor({
   const desktopSummaryBlockClass = "min-w-0 flex-1 sm:w-full";
   const desktopRepeatControlRowClass = "grid gap-3";
   const isViewMode = builderViewMode === "view";
+  const manualPoolViewSections = isManualPoolMode
+    ? buildManualPoolViewSections(
+        stepGroups,
+        draft.steps,
+        draft.basePaceSecondsPer100m,
+        poolLengthUnit
+      )
+    : [];
 
   useAutoDismissNotice(workoutPdfNotice, setWorkoutPdfNotice);
   useAutoDismissNotice(garminExportNotice, setGarminExportNotice);
@@ -2203,7 +2418,7 @@ export default function WorkoutEditor({
     const insideRepeatGroup = options?.insideRepeatGroup ?? false;
     const isLinkedPostSetRest = options?.isLinkedPostSetRest ?? false;
     const isOpen = !isViewMode && openStepId === step.id;
-    const toggleLabel = isOpen ? "Done" : "Edit step";
+    const toggleLabel = isOpen ? "Done" : "Edit";
     const panelId = `session-draft-step-panel-${step.id}`;
     const normalizedStep = isManualPoolMode ? normalizeManualPoolStepForEditor(step) : step;
     const nextDraftStep = draft.steps[index + 1] ?? null;
@@ -2252,6 +2467,7 @@ export default function WorkoutEditor({
       isDistanceQuickChoiceSelected(normalizedStep.distanceM, value, poolLengthUnit)
     );
     const isMinimalRestEditor = isManualPoolMode && normalizedStep.category === "rest";
+    const isRestStepCard = normalizedStep.category === "rest";
     const stepTitle = isManualPoolMode
       ? buildManualPoolDisplaySummary(
           normalizedStep,
@@ -2285,6 +2501,7 @@ export default function WorkoutEditor({
     const stepEffortTargetValue = isManualPoolMode
       ? (normalizedStep.effortTarget ?? normalizedStep.intensity)
       : (step.effortTarget ?? step.intensity);
+    const pendingDelete = pendingRemoval?.kind === "step" && pendingRemoval.stepId === step.id;
     const stepSummaryContent = (
       <>
         <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">{stepLabel}</p>
@@ -2320,10 +2537,14 @@ export default function WorkoutEditor({
         data-mobile-actions="progressive"
         className={`rounded-2xl border p-3 transition sm:p-4 ${
           isOpen
-            ? "border-blue-300 bg-white shadow-sm ring-1 ring-blue-100"
-            : insideRepeatGroup
-              ? "border-blue-200 bg-white"
-              : "border-slate-200 bg-slate-50/70"
+            ? isRestStepCard
+              ? "border-blue-300 bg-blue-50/70 shadow-sm ring-1 ring-blue-100"
+              : "border-blue-300 bg-white shadow-sm ring-1 ring-blue-100"
+            : isRestStepCard
+              ? "border-blue-100 bg-blue-50/55"
+              : insideRepeatGroup
+                ? "border-blue-200 bg-white"
+                : "border-slate-200 bg-slate-50/70"
         }`}
       >
         <div className={desktopHeaderStackClass}>
@@ -2481,7 +2702,7 @@ export default function WorkoutEditor({
                   data-testid={`session-draft-step-mobile-remove-${index}`}
                   className={`${mobileSecondaryActionClass} border-rose-200 bg-white text-rose-700 hover:bg-rose-50`}
                 >
-                  Remove
+                  Delete
                 </button>
               )}
             </div>
@@ -2514,6 +2735,39 @@ export default function WorkoutEditor({
                 Repeat after
               </button>
             ) : null}
+          </div>
+        ) : null}
+
+        {pendingDelete ? (
+          <div
+            data-testid="workout-editor-removal-confirm"
+            className="mt-3 rounded-2xl border border-rose-200 bg-rose-50/90 p-3"
+          >
+            <p className="text-sm font-medium text-rose-950">
+              Delete <span className="font-semibold">{pendingRemoval?.label ?? "this step"}</span>?
+            </p>
+            <p className="mt-1 text-sm text-rose-900">
+              This builder change stays local until you save, and you can still undo it right after
+              deletion.
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={confirmPendingRemoval}
+                data-testid="workout-editor-removal-confirm-button"
+                className="inline-flex h-10 items-center justify-center rounded-xl bg-rose-600 px-4 text-sm font-semibold text-white transition hover:bg-rose-500 active:bg-rose-700"
+              >
+                Delete now
+              </button>
+              <button
+                type="button"
+                onClick={cancelPendingRemoval}
+                data-testid="workout-editor-removal-cancel-button"
+                className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-900 transition hover:bg-rose-100 active:bg-rose-200"
+              >
+                Keep it
+              </button>
+            </div>
           </div>
         ) : null}
 
@@ -2947,7 +3201,7 @@ export default function WorkoutEditor({
 
             {!isMinimalRestEditor && stepTargetModeValue === "effort" ? (
               <label className="text-sm text-slate-700">
-                Target effort
+                {isManualPoolMode ? "Effort" : "Target effort"}
                 <select
                   value={stepEffortTargetValue}
                   onChange={(event) =>
@@ -3132,7 +3386,7 @@ export default function WorkoutEditor({
                     data-testid={`session-draft-step-remove-${index}`}
                     className="inline-flex h-9 items-center justify-center rounded-xl border border-rose-200 bg-white px-3 text-sm text-rose-700 transition hover:bg-rose-50"
                   >
-                    Remove
+                    Delete
                   </button>
                 )}
               </div>
@@ -3765,7 +4019,7 @@ export default function WorkoutEditor({
                     checked={selectedPoolsideFocusIds.includes(focus.id)}
                     onChange={() => togglePoolsideFocusSelection(focus.id)}
                     data-testid={`workout-editor-poolside-focus-${focus.id}`}
-                    className="mt-1"
+                    className="mt-1 h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-200"
                   />
                   <span className="min-w-0 flex-1">
                     <span className="block font-medium text-slate-900">{focus.title}</span>
@@ -3784,78 +4038,78 @@ export default function WorkoutEditor({
           )}
         </div>
 
-        <div className="min-w-0 space-y-5 lg:pl-5">
-          <fieldset className="space-y-3">
-            <legend className="text-sm font-semibold text-slate-900">Print style</legend>
-            <div className="grid gap-3">
-              <label className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-700">
-                <input
-                  type="radio"
-                  name="workout-poolside-print-style"
-                  checked={poolsidePrintStyle === "color"}
-                  onChange={() => setPoolsidePrintStyle("color")}
-                  data-testid="workout-editor-poolside-style-color"
-                  className="mt-1"
-                />
-                <span>
-                  <span className="block font-medium text-slate-900">Color mode</span>
-                  <span className="mt-1 block text-xs text-slate-500">Keeps the blue surfaces</span>
-                </span>
-              </label>
-              <label className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-700">
-                <input
-                  type="radio"
-                  name="workout-poolside-print-style"
-                  checked={poolsidePrintStyle === "ink_saver"}
-                  onChange={() => setPoolsidePrintStyle("ink_saver")}
-                  data-testid="workout-editor-poolside-style-ink-saver"
-                  className="mt-1"
-                />
-                <span>
-                  <span className="block font-medium text-slate-900">Ink saver</span>
-                  <span className="mt-1 block text-xs text-slate-500">Uses white surfaces.</span>
-                </span>
-              </label>
-            </div>
-          </fieldset>
+        <div className="min-w-0 space-y-4 lg:pl-5">
+          <div className="space-y-4 rounded-2xl border border-slate-200 bg-white p-4">
+            <p className="text-sm font-semibold text-slate-900">Print options</p>
 
-          <fieldset className="space-y-3">
-            <legend className="text-sm font-semibold text-slate-900">Print layout</legend>
-            <div className="grid gap-3">
-              <label className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-700">
-                <input
-                  type="radio"
-                  name="workout-poolside-print-layout"
-                  checked={poolsidePrintLayout === "portrait"}
-                  onChange={() => setPoolsidePrintLayout("portrait")}
-                  data-testid="workout-editor-poolside-layout-portrait"
-                  className="mt-1"
-                />
-                <span>
+            <fieldset className="space-y-3">
+              <legend className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Style
+              </legend>
+              <div className="grid gap-3">
+                <label className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-700">
+                  <input
+                    type="radio"
+                    name="workout-poolside-print-style"
+                    checked={poolsidePrintStyle === "color"}
+                    onChange={() => setPoolsidePrintStyle("color")}
+                    data-testid="workout-editor-poolside-style-color"
+                    className="h-4 w-4 border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-200"
+                  />
+                  <span>
+                    <span className="block font-medium text-slate-900">Color mode</span>
+                    <span className="mt-1 block text-xs text-slate-500">
+                      Keeps the blue surfaces
+                    </span>
+                  </span>
+                </label>
+                <label className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-700">
+                  <input
+                    type="radio"
+                    name="workout-poolside-print-style"
+                    checked={poolsidePrintStyle === "ink_saver"}
+                    onChange={() => setPoolsidePrintStyle("ink_saver")}
+                    data-testid="workout-editor-poolside-style-ink-saver"
+                    className="h-4 w-4 border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-200"
+                  />
+                  <span>
+                    <span className="block font-medium text-slate-900">Ink saver</span>
+                    <span className="mt-1 block text-xs text-slate-500">Uses white surfaces.</span>
+                  </span>
+                </label>
+              </div>
+            </fieldset>
+
+            <fieldset className="space-y-3">
+              <legend className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Layout
+              </legend>
+              <div className="grid gap-3">
+                <label className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-700">
+                  <input
+                    type="radio"
+                    name="workout-poolside-print-layout"
+                    checked={poolsidePrintLayout === "portrait"}
+                    onChange={() => setPoolsidePrintLayout("portrait")}
+                    data-testid="workout-editor-poolside-layout-portrait"
+                    className="h-4 w-4 border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-200"
+                  />
                   <span className="block font-medium text-slate-900">Portrait</span>
-                  <span className="mt-1 block text-xs text-slate-500">
-                    Compact lane-side note in one tall column.
-                  </span>
-                </span>
-              </label>
-              <label className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-700">
-                <input
-                  type="radio"
-                  name="workout-poolside-print-layout"
-                  checked={poolsidePrintLayout === "landscape"}
-                  onChange={() => setPoolsidePrintLayout("landscape")}
-                  data-testid="workout-editor-poolside-layout-landscape"
-                  className="mt-1"
-                />
-                <span>
+                </label>
+                <label className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-700">
+                  <input
+                    type="radio"
+                    name="workout-poolside-print-layout"
+                    checked={poolsidePrintLayout === "landscape"}
+                    onChange={() => setPoolsidePrintLayout("landscape")}
+                    data-testid="workout-editor-poolside-layout-landscape"
+                    className="h-4 w-4 border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-200"
+                  />
                   <span className="block font-medium text-slate-900">Landscape</span>
-                  <span className="mt-1 block text-xs text-slate-500">
-                    Wider split layout for longer programs and more focus notes.
-                  </span>
-                </span>
-              </label>
-            </div>
-          </fieldset>
+                </label>
+              </div>
+            </fieldset>
+          </div>
         </div>
       </div>
     </div>
@@ -4051,14 +4305,14 @@ export default function WorkoutEditor({
       <div className="rounded-2xl border border-slate-200 bg-white p-3 sm:p-4">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <h3 className="text-base font-semibold text-slate-900">
-            {isManualPoolMode ? "Session builder" : "Editable draft steps"}
+            {isManualPoolMode ? "Session steps" : "Editable draft steps"}
           </h3>
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center gap-3">
             {showCalmBuilderLayout ? (
               <div
                 role="group"
                 aria-label="Builder mode"
-                className="inline-flex rounded-xl border border-slate-200 bg-slate-50 p-1"
+                className="inline-flex rounded-xl border border-blue-100 bg-blue-50/60 p-1"
               >
                 {WORKOUT_VIEW_MODES.map((mode) => {
                   const isSelected = builderViewMode === mode;
@@ -4068,10 +4322,10 @@ export default function WorkoutEditor({
                       type="button"
                       onClick={() => setBuilderViewMode(mode)}
                       data-testid={`workout-editor-builder-mode-${mode}`}
-                      className={`inline-flex h-8 items-center justify-center rounded-lg px-3 text-sm font-medium transition ${
+                      className={`inline-flex h-8 items-center justify-center rounded-lg px-3 text-sm font-semibold transition ${
                         isSelected
-                          ? "bg-white text-slate-900 shadow-sm"
-                          : "text-slate-600 hover:text-slate-900"
+                          ? "border border-blue-200 bg-blue-600 text-white shadow-sm"
+                          : "text-blue-900/70 hover:text-blue-900"
                       }`}
                     >
                       {mode === "edit" ? "Edit" : "View"}
@@ -4081,7 +4335,7 @@ export default function WorkoutEditor({
               </div>
             ) : null}
             {!isViewMode ? (
-              <>
+              <div className="flex flex-wrap items-center gap-2 border-l border-slate-200 pl-3">
                 <button
                   type="button"
                   onClick={addStep}
@@ -4098,7 +4352,7 @@ export default function WorkoutEditor({
                 >
                   Add repeat
                 </button>
-              </>
+              </div>
             ) : null}
           </div>
         </div>
@@ -4118,46 +4372,13 @@ export default function WorkoutEditor({
             </div>
           ) : null}
 
-          {pendingRemoval ? (
-            <div
-              data-testid="workout-editor-removal-confirm"
-              className="rounded-2xl border border-amber-200 bg-amber-50/90 p-3 sm:p-4"
-            >
-              <p className="text-sm font-medium text-amber-950">
-                Confirm removal before this builder change is applied.
-              </p>
-              <p className="mt-1 text-sm text-amber-900">
-                Remove <span className="font-semibold">{pendingRemoval.label}</span>? You can still
-                undo it locally before saving.
-              </p>
-              <div className="mt-3 flex flex-wrap gap-2">
-                <button
-                  type="button"
-                  onClick={confirmPendingRemoval}
-                  data-testid="workout-editor-removal-confirm-button"
-                  className="inline-flex h-10 items-center justify-center rounded-xl bg-rose-600 px-4 text-sm font-semibold text-white transition hover:bg-rose-500 active:bg-rose-700"
-                >
-                  Remove now
-                </button>
-                <button
-                  type="button"
-                  onClick={cancelPendingRemoval}
-                  data-testid="workout-editor-removal-cancel-button"
-                  className="inline-flex h-10 items-center justify-center rounded-xl border border-amber-200 bg-white px-4 text-sm font-medium text-amber-900 transition hover:bg-amber-100 active:bg-amber-200"
-                >
-                  Keep it
-                </button>
-              </div>
-            </div>
-          ) : null}
-
           {lastRemovedBlock ? (
             <div
               data-testid="workout-editor-removal-undo"
               className="rounded-2xl border border-blue-200 bg-blue-50/90 p-3 sm:p-4"
             >
               <p className="text-sm font-medium text-blue-950">
-                Removed <span className="font-semibold">{lastRemovedBlock.label}</span>.
+                Deleted <span className="font-semibold">{lastRemovedBlock.label}</span>.
               </p>
               <p className="mt-1 text-sm text-blue-900">
                 Undo restores it to the same local spot before you save this workout.
@@ -4169,7 +4390,7 @@ export default function WorkoutEditor({
                   data-testid="workout-editor-removal-undo-button"
                   className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700"
                 >
-                  Undo removal
+                  Undo delete
                 </button>
                 <button
                   type="button"
@@ -4183,310 +4404,396 @@ export default function WorkoutEditor({
             </div>
           ) : null}
 
-          {stepGroups.map((group, groupIndex) =>
-            group.kind === "single" ? (
-              renderStepEditorCard(group.entries[0].step, group.entries[0].index, groupIndex)
-            ) : (
-              <section
-                key={group.repeatGroupId}
-                data-testid={`workout-editor-repeat-group-${groupIndex}`}
-                data-containment-style="calm"
-                className="rounded-2xl bg-gradient-to-b from-blue-50/70 to-white p-3 ring-1 ring-inset ring-blue-100 sm:p-4"
-              >
-                {(() => {
-                  const repeatSummary = buildRepeatSummary(
-                    group.entries,
-                    group.repeatCount,
-                    draft.basePaceSecondsPer100m,
-                    group.repeatEndingRestMode,
-                    poolLengthUnit
-                  );
-                  const hasEditableRepeatEndingRest = Boolean(
-                    draft.environment === "pool" &&
-                    (() => {
-                      const lastEntry = group.entries[group.entries.length - 1];
-                      return lastEntry && isSessionDraftRepeatEndingRestStep(lastEntry.step);
-                    })()
-                  );
-                  const repeatMobileActionKey = `repeat:${group.repeatGroupId}`;
-                  const repeatMobileActionsOpen = openMobileActionKey === repeatMobileActionKey;
-
-                  return (
-                    <div className="space-y-3">
-                      <div className={desktopHeaderStackClass}>
-                        <div
-                          data-testid={`session-draft-repeat-summary-${groupIndex}`}
-                          className={desktopSummaryBlockClass}
-                        >
-                          <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
-                            Repeat set
-                          </p>
-                          <p className="mt-1 text-sm font-medium text-slate-900">{repeatSummary}</p>
-                          {isManualPoolMode ? null : (
-                            <>
-                              <p className="mt-1 text-xs text-slate-600">
-                                Edit the repeated steps below instead of duplicating every round by
-                                hand.
-                              </p>
-                              <p className="mt-1 text-xs text-slate-500">
-                                Repeat counts currently support {SESSION_DRAFT_REPEAT_MIN}-
-                                {SESSION_DRAFT_REPEAT_MAX} rounds per block.
-                              </p>
-                            </>
-                          )}
-                        </div>
-                        {!isViewMode ? (
-                          <div className="flex shrink-0 sm:hidden">
-                            <button
-                              type="button"
-                              onClick={() =>
-                                setOpenMobileActionKey((current) =>
-                                  current === repeatMobileActionKey ? null : repeatMobileActionKey
-                                )
-                              }
-                              aria-expanded={repeatMobileActionsOpen}
-                              aria-controls={`session-draft-repeat-mobile-actions-panel-${group.repeatGroupId}`}
-                              data-testid={`session-draft-repeat-mobile-actions-toggle-${groupIndex}`}
-                              className={mobileActionToggleClass}
-                            >
-                              <Ellipsis className="size-5" />
-                              <span className="sr-only">
-                                {repeatMobileActionsOpen
-                                  ? "Hide repeat actions"
-                                  : "Show repeat actions"}
-                              </span>
-                            </button>
-                          </div>
+          {isViewMode && isManualPoolMode
+            ? manualPoolViewSections.map((section) => (
+                <section
+                  key={section.key}
+                  className={`rounded-2xl border p-4 ${
+                    section.variant === "repeat"
+                      ? "border-blue-200 bg-gradient-to-b from-blue-50/70 to-white"
+                      : section.variant === "rest"
+                        ? "border-blue-100 bg-blue-50/55"
+                        : "border-slate-200 bg-slate-50/70"
+                  }`}
+                >
+                  <p
+                    className={`text-xs font-semibold uppercase tracking-wide ${
+                      section.variant === "repeat" ? "text-blue-700" : "text-slate-500"
+                    }`}
+                  >
+                    {section.title}
+                  </p>
+                  <div className="mt-2 space-y-2">
+                    {section.lines.map((line, lineIndex) => (
+                      <div
+                        key={`${section.key}-line-${lineIndex}`}
+                        className={`text-base leading-6 ${
+                          line.tone === "rest"
+                            ? "font-semibold text-blue-900"
+                            : line.tone === "subtle"
+                              ? "text-slate-600"
+                              : "text-slate-900"
+                        }`}
+                      >
+                        {section.numbered ? (
+                          <span className="mr-2 font-semibold text-slate-500">
+                            {lineIndex + 1}.
+                          </span>
                         ) : null}
+                        <span>{line.text}</span>
                       </div>
+                    ))}
+                  </div>
+                </section>
+              ))
+            : stepGroups.map((group, groupIndex) =>
+                group.kind === "single" ? (
+                  renderStepEditorCard(group.entries[0].step, group.entries[0].index, groupIndex)
+                ) : (
+                  <section
+                    key={group.repeatGroupId}
+                    data-testid={`workout-editor-repeat-group-${groupIndex}`}
+                    data-containment-style="calm"
+                    className="rounded-2xl bg-gradient-to-b from-blue-50/70 to-white p-3 ring-1 ring-inset ring-blue-100 sm:p-4"
+                  >
+                    {(() => {
+                      const repeatSummary = buildRepeatSummary(
+                        group.entries,
+                        group.repeatCount,
+                        draft.basePaceSecondsPer100m,
+                        group.repeatEndingRestMode,
+                        poolLengthUnit
+                      );
+                      const hasEditableRepeatEndingRest = Boolean(
+                        draft.environment === "pool" &&
+                        (() => {
+                          const lastEntry = group.entries[group.entries.length - 1];
+                          return lastEntry && isSessionDraftRepeatEndingRestStep(lastEntry.step);
+                        })()
+                      );
+                      const repeatMobileActionKey = `repeat:${group.repeatGroupId}`;
+                      const repeatMobileActionsOpen = openMobileActionKey === repeatMobileActionKey;
 
-                      {!isViewMode ? (
-                        <div className={desktopRepeatControlRowClass}>
-                          <div className="grid gap-3 sm:flex sm:flex-wrap sm:items-end sm:gap-2">
-                            <label className="text-sm text-slate-700">
-                              Repeat count
-                              <input
-                                type="text"
-                                inputMode="numeric"
-                                value={group.repeatCount ?? ""}
-                                onChange={(event) =>
-                                  updateRepeatGroupCount(group.repeatGroupId, event.target.value)
-                                }
-                                min={SESSION_DRAFT_REPEAT_MIN}
-                                max={SESSION_DRAFT_REPEAT_MAX}
-                                data-testid={`session-draft-repeat-count-${groupIndex}`}
-                                className="mt-2 block h-11 w-full rounded-xl border border-blue-200 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200 sm:w-28"
-                              />
-                            </label>
-                            {hasEditableRepeatEndingRest ? (
-                              <label className="text-sm text-slate-700">
-                                Last rest interval
-                                <select
-                                  value={group.repeatEndingRestMode}
-                                  onChange={(event) =>
-                                    updateRepeatGroupEndingRestMode(
-                                      group.repeatGroupId,
-                                      event.target.value as SessionDraftRepeatEndingRestMode
+                      return (
+                        <div className="space-y-3">
+                          <div className={desktopHeaderStackClass}>
+                            <div
+                              data-testid={`session-draft-repeat-summary-${groupIndex}`}
+                              className={desktopSummaryBlockClass}
+                            >
+                              <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
+                                Repeat set
+                              </p>
+                              <p className="mt-1 text-sm font-medium text-slate-900">
+                                {repeatSummary}
+                              </p>
+                              {isManualPoolMode ? null : (
+                                <>
+                                  <p className="mt-1 text-xs text-slate-600">
+                                    Edit the repeated steps below instead of duplicating every round
+                                    by hand.
+                                  </p>
+                                  <p className="mt-1 text-xs text-slate-500">
+                                    Repeat counts currently support {SESSION_DRAFT_REPEAT_MIN}-
+                                    {SESSION_DRAFT_REPEAT_MAX} rounds per block.
+                                  </p>
+                                </>
+                              )}
+                            </div>
+                            {!isViewMode ? (
+                              <div className="flex shrink-0 sm:hidden">
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    setOpenMobileActionKey((current) =>
+                                      current === repeatMobileActionKey
+                                        ? null
+                                        : repeatMobileActionKey
                                     )
                                   }
-                                  data-testid={`session-draft-repeat-ending-rest-mode-${groupIndex}`}
-                                  className="mt-2 block h-11 w-full rounded-xl border border-blue-200 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200 sm:min-w-[15rem]"
+                                  aria-expanded={repeatMobileActionsOpen}
+                                  aria-controls={`session-draft-repeat-mobile-actions-panel-${group.repeatGroupId}`}
+                                  data-testid={`session-draft-repeat-mobile-actions-toggle-${groupIndex}`}
+                                  className={mobileActionToggleClass}
                                 >
-                                  {SESSION_DRAFT_REPEAT_ENDING_REST_MODES.map((mode) => (
-                                    <option key={mode} value={mode}>
-                                      {getSessionDraftRepeatEndingRestModeLabel(mode)}
-                                    </option>
-                                  ))}
-                                </select>
-                              </label>
+                                  <Ellipsis className="size-5" />
+                                  <span className="sr-only">
+                                    {repeatMobileActionsOpen
+                                      ? "Hide repeat actions"
+                                      : "Show repeat actions"}
+                                  </span>
+                                </button>
+                              </div>
                             ) : null}
+                          </div>
+
+                          {!isViewMode ? (
+                            <div className={desktopRepeatControlRowClass}>
+                              <div className="grid gap-3 sm:flex sm:flex-wrap sm:items-end sm:gap-2">
+                                <label className="text-sm text-slate-700">
+                                  Repeat count
+                                  <input
+                                    type="text"
+                                    inputMode="numeric"
+                                    value={group.repeatCount ?? ""}
+                                    onChange={(event) =>
+                                      updateRepeatGroupCount(
+                                        group.repeatGroupId,
+                                        event.target.value
+                                      )
+                                    }
+                                    min={SESSION_DRAFT_REPEAT_MIN}
+                                    max={SESSION_DRAFT_REPEAT_MAX}
+                                    data-testid={`session-draft-repeat-count-${groupIndex}`}
+                                    className="mt-2 block h-11 w-full rounded-xl border border-blue-200 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200 sm:w-28"
+                                  />
+                                </label>
+                                {hasEditableRepeatEndingRest ? (
+                                  <label className="text-sm text-slate-700">
+                                    Last rest interval
+                                    <select
+                                      value={group.repeatEndingRestMode}
+                                      onChange={(event) =>
+                                        updateRepeatGroupEndingRestMode(
+                                          group.repeatGroupId,
+                                          event.target.value as SessionDraftRepeatEndingRestMode
+                                        )
+                                      }
+                                      data-testid={`session-draft-repeat-ending-rest-mode-${groupIndex}`}
+                                      className="mt-2 block h-11 w-full rounded-xl border border-blue-200 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200 sm:min-w-[15rem]"
+                                    >
+                                      {SESSION_DRAFT_REPEAT_ENDING_REST_MODES.map((mode) => (
+                                        <option key={mode} value={mode}>
+                                          {getSessionDraftRepeatEndingRestModeLabel(mode)}
+                                        </option>
+                                      ))}
+                                    </select>
+                                  </label>
+                                ) : null}
+                              </div>
+                            </div>
+                          ) : null}
+
+                          {!isViewMode ? (
+                            <div className="sm:hidden">
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  insertStepAfterGroup(groupIndex);
+                                  setOpenMobileActionKey(null);
+                                }}
+                                data-testid={`session-draft-repeat-mobile-primary-add-step-after-${groupIndex}`}
+                                className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-50"
+                              >
+                                Add step after
+                              </button>
+                            </div>
+                          ) : null}
+
+                          {!isViewMode && repeatMobileActionsOpen ? (
+                            <div
+                              id={`session-draft-repeat-mobile-actions-panel-${group.repeatGroupId}`}
+                              data-testid={`session-draft-repeat-mobile-actions-panel-${groupIndex}`}
+                              className={`${mobileActionPanelClass} sm:hidden`}
+                            >
+                              <div className="grid grid-cols-2 gap-2">
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    moveDraftGroup(groupIndex, -1);
+                                    setOpenMobileActionKey(null);
+                                  }}
+                                  disabled={groupIndex === 0}
+                                  data-testid={`session-draft-repeat-mobile-move-up-${groupIndex}`}
+                                  className={`${mobileSecondaryActionClass} border-slate-200 bg-white text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60`}
+                                >
+                                  Move up
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    moveDraftGroup(groupIndex, 1);
+                                    setOpenMobileActionKey(null);
+                                  }}
+                                  disabled={groupIndex === stepGroups.length - 1}
+                                  data-testid={`session-draft-repeat-mobile-move-down-${groupIndex}`}
+                                  className={`${mobileSecondaryActionClass} border-slate-200 bg-white text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60`}
+                                >
+                                  Move down
+                                </button>
+                              </div>
+                              <div className="mt-2 grid gap-2">
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    insertRepeatAfterGroup(groupIndex);
+                                    setOpenMobileActionKey(null);
+                                  }}
+                                  data-testid={`session-draft-repeat-mobile-add-repeat-after-${groupIndex}`}
+                                  className={`${mobileSecondaryActionClass} border-blue-200 bg-white text-blue-800 hover:bg-blue-50`}
+                                >
+                                  Add repeat after
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    duplicateRepeatGroup(group.repeatGroupId);
+                                    setOpenMobileActionKey(null);
+                                  }}
+                                  data-testid={`session-draft-repeat-mobile-duplicate-${groupIndex}`}
+                                  className={`${mobileSecondaryActionClass} border-slate-200 bg-white text-slate-700 hover:bg-slate-100`}
+                                >
+                                  Duplicate repeat
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    requestRepeatGroupRemoval(group.repeatGroupId);
+                                    setOpenMobileActionKey(null);
+                                  }}
+                                  data-testid={`session-draft-repeat-mobile-remove-${groupIndex}`}
+                                  className={`${mobileSecondaryActionClass} border-rose-200 bg-white text-rose-700 hover:bg-rose-50`}
+                                >
+                                  Delete repeat
+                                </button>
+                              </div>
+                            </div>
+                          ) : null}
+                        </div>
+                      );
+                    })()}
+
+                    <div className="mt-4 space-y-3">
+                      {group.entries.map((entry, repeatIndex) =>
+                        renderStepEditorCard(entry.step, entry.index, groupIndex, {
+                          insideRepeatGroup: true,
+                          repeatStepNumber: repeatIndex + 1,
+                          labelOverride:
+                            repeatIndex === 0
+                              ? "Work interval"
+                              : repeatIndex === 1
+                                ? "Between-interval recovery"
+                                : undefined,
+                        })
+                      )}
+                      {group.postSetRestEntry
+                        ? renderStepEditorCard(
+                            group.postSetRestEntry.step,
+                            group.postSetRestEntry.index,
+                            groupIndex,
+                            {
+                              labelOverride: "Post-set rest",
+                              descriptionOverride:
+                                group.repeatEndingRestMode === "use_last_rest" &&
+                                Boolean(
+                                  group.entries[group.entries.length - 1] &&
+                                  isSessionDraftRepeatEndingRestStep(
+                                    group.entries[group.entries.length - 1].step
+                                  )
+                                )
+                                  ? "Separate canonical rest after the set. It is preserved here, but active execution and export suppress it because the last internal rest interval is used after the final rep."
+                                  : "Separate canonical rest after the set, outside the repeat block itself.",
+                              isLinkedPostSetRest: true,
+                            }
+                          )
+                        : null}
+                      {pendingRemoval?.kind === "repeat" &&
+                      pendingRemoval.repeatGroupId === group.repeatGroupId ? (
+                        <div
+                          data-testid="workout-editor-removal-confirm"
+                          className="rounded-2xl border border-rose-200 bg-rose-50/90 p-3"
+                        >
+                          <p className="text-sm font-medium text-rose-950">
+                            Delete{" "}
+                            <span className="font-semibold">
+                              {pendingRemoval?.label ?? "this repeat block"}
+                            </span>
+                            ?
+                          </p>
+                          <p className="mt-1 text-sm text-rose-900">
+                            This builder change stays local until you save, and you can still undo
+                            it right after deletion.
+                          </p>
+                          <div className="mt-3 flex flex-wrap gap-2">
+                            <button
+                              type="button"
+                              onClick={confirmPendingRemoval}
+                              data-testid="workout-editor-removal-confirm-button"
+                              className="inline-flex h-10 items-center justify-center rounded-xl bg-rose-600 px-4 text-sm font-semibold text-white transition hover:bg-rose-500 active:bg-rose-700"
+                            >
+                              Delete now
+                            </button>
+                            <button
+                              type="button"
+                              onClick={cancelPendingRemoval}
+                              data-testid="workout-editor-removal-cancel-button"
+                              className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-900 transition hover:bg-rose-100 active:bg-rose-200"
+                            >
+                              Keep it
+                            </button>
                           </div>
                         </div>
                       ) : null}
-
                       {!isViewMode ? (
-                        <div className="sm:hidden">
+                        <div
+                          data-testid={`session-draft-repeat-desktop-actions-${groupIndex}`}
+                          data-desktop-layout="bottom"
+                          className="hidden flex-wrap items-end gap-2 border-t border-blue-100 pt-3 sm:flex"
+                        >
                           <button
                             type="button"
-                            onClick={() => {
-                              insertStepAfterGroup(groupIndex);
-                              setOpenMobileActionKey(null);
-                            }}
-                            data-testid={`session-draft-repeat-mobile-primary-add-step-after-${groupIndex}`}
-                            className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-50"
+                            onClick={() => moveDraftGroup(groupIndex, -1)}
+                            disabled={groupIndex === 0}
+                            className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                          >
+                            Move up
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => moveDraftGroup(groupIndex, 1)}
+                            disabled={groupIndex === stepGroups.length - 1}
+                            className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                          >
+                            Move down
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => insertStepAfterGroup(groupIndex)}
+                            data-testid={`session-draft-repeat-add-step-after-${groupIndex}`}
+                            className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm text-blue-800 transition hover:bg-blue-100"
                           >
                             Add step after
                           </button>
-                        </div>
-                      ) : null}
-
-                      {!isViewMode && repeatMobileActionsOpen ? (
-                        <div
-                          id={`session-draft-repeat-mobile-actions-panel-${group.repeatGroupId}`}
-                          data-testid={`session-draft-repeat-mobile-actions-panel-${groupIndex}`}
-                          className={`${mobileActionPanelClass} sm:hidden`}
-                        >
-                          <div className="grid grid-cols-2 gap-2">
-                            <button
-                              type="button"
-                              onClick={() => {
-                                moveDraftGroup(groupIndex, -1);
-                                setOpenMobileActionKey(null);
-                              }}
-                              disabled={groupIndex === 0}
-                              data-testid={`session-draft-repeat-mobile-move-up-${groupIndex}`}
-                              className={`${mobileSecondaryActionClass} border-slate-200 bg-white text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60`}
-                            >
-                              Move up
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => {
-                                moveDraftGroup(groupIndex, 1);
-                                setOpenMobileActionKey(null);
-                              }}
-                              disabled={groupIndex === stepGroups.length - 1}
-                              data-testid={`session-draft-repeat-mobile-move-down-${groupIndex}`}
-                              className={`${mobileSecondaryActionClass} border-slate-200 bg-white text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60`}
-                            >
-                              Move down
-                            </button>
-                          </div>
-                          <div className="mt-2 grid gap-2">
-                            <button
-                              type="button"
-                              onClick={() => {
-                                insertRepeatAfterGroup(groupIndex);
-                                setOpenMobileActionKey(null);
-                              }}
-                              data-testid={`session-draft-repeat-mobile-add-repeat-after-${groupIndex}`}
-                              className={`${mobileSecondaryActionClass} border-blue-200 bg-white text-blue-800 hover:bg-blue-50`}
-                            >
-                              Add repeat after
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => {
-                                duplicateRepeatGroup(group.repeatGroupId);
-                                setOpenMobileActionKey(null);
-                              }}
-                              data-testid={`session-draft-repeat-mobile-duplicate-${groupIndex}`}
-                              className={`${mobileSecondaryActionClass} border-slate-200 bg-white text-slate-700 hover:bg-slate-100`}
-                            >
-                              Duplicate repeat
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => {
-                                requestRepeatGroupRemoval(group.repeatGroupId);
-                                setOpenMobileActionKey(null);
-                              }}
-                              data-testid={`session-draft-repeat-mobile-remove-${groupIndex}`}
-                              className={`${mobileSecondaryActionClass} border-rose-200 bg-white text-rose-700 hover:bg-rose-50`}
-                            >
-                              Remove repeat
-                            </button>
-                          </div>
+                          <button
+                            type="button"
+                            onClick={() => insertRepeatAfterGroup(groupIndex)}
+                            data-testid={`session-draft-repeat-add-repeat-after-${groupIndex}`}
+                            className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm text-blue-800 transition hover:bg-blue-100"
+                          >
+                            Add repeat after
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => duplicateRepeatGroup(group.repeatGroupId)}
+                            data-testid={`session-draft-repeat-duplicate-${groupIndex}`}
+                            className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm text-blue-800 transition hover:bg-blue-100"
+                          >
+                            Duplicate repeat
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => requestRepeatGroupRemoval(group.repeatGroupId)}
+                            data-testid={`session-draft-repeat-remove-${groupIndex}`}
+                            className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-3 text-sm text-rose-700 transition hover:bg-rose-50"
+                          >
+                            Delete repeat
+                          </button>
                         </div>
                       ) : null}
                     </div>
-                  );
-                })()}
-
-                <div className="mt-4 space-y-3">
-                  {group.entries.map((entry, repeatIndex) =>
-                    renderStepEditorCard(entry.step, entry.index, groupIndex, {
-                      insideRepeatGroup: true,
-                      repeatStepNumber: repeatIndex + 1,
-                      labelOverride:
-                        repeatIndex === 0
-                          ? "Work interval"
-                          : repeatIndex === 1
-                            ? "Between-interval recovery"
-                            : undefined,
-                    })
-                  )}
-                  {group.postSetRestEntry
-                    ? renderStepEditorCard(
-                        group.postSetRestEntry.step,
-                        group.postSetRestEntry.index,
-                        groupIndex,
-                        {
-                          labelOverride: "Post-set rest",
-                          descriptionOverride:
-                            group.repeatEndingRestMode === "use_last_rest" &&
-                            Boolean(
-                              group.entries[group.entries.length - 1] &&
-                              isSessionDraftRepeatEndingRestStep(
-                                group.entries[group.entries.length - 1].step
-                              )
-                            )
-                              ? "Separate canonical rest after the set. It is preserved here, but active execution and export suppress it because the last internal rest interval is used after the final rep."
-                              : "Separate canonical rest after the set, outside the repeat block itself.",
-                          isLinkedPostSetRest: true,
-                        }
-                      )
-                    : null}
-                  {!isViewMode ? (
-                    <div
-                      data-testid={`session-draft-repeat-desktop-actions-${groupIndex}`}
-                      data-desktop-layout="bottom"
-                      className="hidden flex-wrap items-end gap-2 border-t border-blue-100 pt-3 sm:flex"
-                    >
-                      <button
-                        type="button"
-                        onClick={() => moveDraftGroup(groupIndex, -1)}
-                        disabled={groupIndex === 0}
-                        className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-                      >
-                        Move up
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => moveDraftGroup(groupIndex, 1)}
-                        disabled={groupIndex === stepGroups.length - 1}
-                        className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-                      >
-                        Move down
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => insertStepAfterGroup(groupIndex)}
-                        data-testid={`session-draft-repeat-add-step-after-${groupIndex}`}
-                        className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm text-blue-800 transition hover:bg-blue-100"
-                      >
-                        Add step after
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => insertRepeatAfterGroup(groupIndex)}
-                        data-testid={`session-draft-repeat-add-repeat-after-${groupIndex}`}
-                        className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm text-blue-800 transition hover:bg-blue-100"
-                      >
-                        Add repeat after
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => duplicateRepeatGroup(group.repeatGroupId)}
-                        data-testid={`session-draft-repeat-duplicate-${groupIndex}`}
-                        className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm text-blue-800 transition hover:bg-blue-100"
-                      >
-                        Duplicate repeat
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => requestRepeatGroupRemoval(group.repeatGroupId)}
-                        data-testid={`session-draft-repeat-remove-${groupIndex}`}
-                        className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-3 text-sm text-rose-700 transition hover:bg-rose-50"
-                      >
-                        Remove repeat
-                      </button>
-                    </div>
-                  ) : null}
-                </div>
-              </section>
-            )
-          )}
+                  </section>
+                )
+              )}
         </div>
       </div>
 

--- a/docs/task-briefs/in-progress/2026-04-12-swim-session-builder-scan-delete-and-poolside-brand-polish-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-12-swim-session-builder-scan-delete-and-poolside-brand-polish-10-10.md
@@ -1,0 +1,384 @@
+# Task Brief: Swim Session Builder Scan, Delete, And Poolside Brand Polish (10/10)
+
+## Metadata
+
+- `id`: `2026-04-12-swim-session-builder-scan-delete-and-poolside-brand-polish-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-04-12`
+- `updated`: `2026-04-12`
+
+## Goal
+
+FreeSwimming's pool workout surfaces should behave like a polished production builder: truthful saved-session deletion, compact high-scan read mode, clearer edit/view controls, safer inline destructive actions, faster time entry, and premium poolside-note outputs that are strong enough to function as branded lane-side artifacts.
+
+## Why This Brief Exists
+
+- The recent pool-builder parity wave fixed the structural Garmin semantics, but several high-value UX seams remain visible in the live builder.
+- The remaining issues are no longer isolated wording tweaks; they now span:
+  - saved-session list truthfulness,
+  - destructive-flow trust,
+  - builder read-mode scanability,
+  - edit/view control clarity,
+  - rest-step differentiation,
+  - time-input ergonomics,
+  - and poolside-note brand/design quality.
+- The owner explicitly wants these surfaces treated as `10/10` quality work across:
+  - UX flow clarity,
+  - visual design quality,
+  - data integrity,
+  - admin/workflow ergonomics,
+  - testing and QA,
+  - and indirect brand/marketing quality for the printable poolside surfaces.
+
+## Dependencies And Boundaries
+
+- Parent builder direction:
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-07-pool-swim-builder-step-authoring-parity-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-10-swim-session-builder-metadata-panel-clarity-10-10.md`
+  - `/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-09-platform-containment-and-border-hierarchy-audit-10-10.md`
+- Primary implementation surfaces:
+  - `/Users/stianvikra/freeswimming/components/my-library/workouts/WorkoutBuilderHub.tsx`
+  - `/Users/stianvikra/freeswimming/components/my-library/workouts/SavedWorkoutsPanel.tsx`
+  - `/Users/stianvikra/freeswimming/components/my-library/workouts/WorkoutEditor.tsx`
+  - `/Users/stianvikra/freeswimming/lib/workouts/server.ts`
+  - `/Users/stianvikra/freeswimming/lib/workouts/shared.ts`
+  - `/Users/stianvikra/freeswimming/app/my-library/workouts/[workoutId]/page.tsx`
+  - `/Users/stianvikra/freeswimming/tests/unit/workout-builder-hub.test.tsx`
+  - `/Users/stianvikra/freeswimming/tests/unit/workouts-shared.test.ts`
+  - `/Users/stianvikra/freeswimming/tests/e2e/my-library-workout-builder.spec.ts`
+- Live admin-note context already reconciled before this slice:
+  - shipped/stale notes were closed,
+  - remaining builder-facing note still relevant here: `a175f6bc-6814-4010-9f4a-e6620fb9f5dc` (`My Swim Sessions`, bulk delete need).
+
+## Product Direction Locked By This Brief
+
+1. `View` mode in the pool builder is a read mode, not a disabled edit form.
+2. Read mode should optimize for scanability and session comprehension first, not one-card-per-step symmetry.
+3. Builder destructive actions should say `Delete`, not `Remove`, when they delete a step, repeat block, or saved session.
+4. Delete confirmation inside the builder must appear locally near the affected item, not in a detached global banner above the list.
+5. `My Swim Sessions` must be truthful:
+   - deleting one session must not appear to instantly resurrect the same session because of list truncation,
+   - and identical untitled rows must be easier to distinguish.
+6. Manual pool time entry should use one `MM:SS` field pattern consistently across swim/rest/send-off cases.
+7. Poolside note builder options should stay simpler and lower-noise.
+8. Printed/previewed poolside notes are brand surfaces:
+   - both portrait and landscape must look intentional, premium, and highly scannable,
+   - internal implementation labels such as draft source or print-mode chips must not leak into the artifact.
+9. Existing Garmin-compatible canonical repeat/rest semantics stay intact.
+10. Existing canonical save/update/delete APIs stay authoritative unless this brief explicitly extends them.
+
+## Locked Decisions
+
+### 1. Session-Builder Read Mode
+
+- Rename inner section heading from `Session builder` to `Session steps`.
+- Keep page-level route heading dynamic:
+  - `Pool session builder` for manual `pool`,
+  - `Open-water session builder` for manual `open_water`,
+  - fallback `Swim session builder` only where environment-specific naming is not available.
+- In `View` mode:
+  - remove per-card `Edit step` buttons,
+  - remove expanded edit controls,
+  - render a compact grouped read surface with higher scan value.
+- For non-repeat top-level steps:
+  - group consecutive steps by visible section label (`Warmup`, `Main`, `Cooldown`, `Rest`, etc.),
+  - if there is one step in a section, show one clean line,
+  - if there are multiple steps in the same section, render numbered lines:
+    - `Main`
+    - `1. 100m · Freestyle · Moderate · Rest: 1:00`
+    - `2. 100m · Freestyle · Hard · Rest: 0:10`
+- For repeat blocks:
+  - keep repeat semantics visible as a single compact summary:
+    - `Main`
+    - `4 x 100m · Freestyle · Moderate · Rest: 0:30`
+    - `Post-set rest: 1:00`
+- Do not collapse distinct non-repeat steps into fake `2 x` summaries.
+
+### 2. Edit/View Control Clarity
+
+- Keep `Edit` and `View` as a segmented control.
+- Active state must be substantially clearer than the current grey/white treatment.
+- Selected mode should use FreeSwimming blue emphasis, but still read as a mode toggle, not as a primary CTA.
+- Separate mode controls from action buttons (`Add step`, `Add repeat`) so the two groups do not visually compete.
+
+### 3. Rest-Step Treatment
+
+- Separate canonical rest steps should read visually as rest steps, not as regular swim cards with swim-style weight.
+- In edit mode, rest cards should have a lighter, clearly distinct rest presentation.
+- In view mode, rest content should read as compact rest rows/lines.
+- If a swim step already shows linked inline rest for scanability, do not duplicate the same rest information as if it were another full swim summary.
+
+### 4. Builder Action Placement And Delete Confirmation
+
+- Use `Delete`, not `Remove`, for destructive builder actions.
+- Delete confirmation must render inline near the affected step or repeat block.
+- Confirmation copy should name the affected target clearly and stay inside the user’s viewport context.
+- Keep local undo after delete.
+- Maintain predictable keyboard/focus behavior.
+
+### 5. Saved Session Truthfulness And Bulk Cleanup
+
+- `My Swim Sessions` must stop using a misleading visible count that only reflects a limited subset.
+- The saved-session list must no longer backfill a visually identical untitled row immediately after deletion in a way that looks like deletion failed.
+- The list should expose distinguishing metadata for otherwise identical rows.
+- Add practical multi-select/bulk-delete support on `My Swim Sessions` so the owner can clear many test sessions efficiently.
+
+### 6. Time Input
+
+- Use a single field for manual pool time entry across:
+  - swim time,
+  - rest time,
+  - send-off time.
+- Entry model:
+  - `MM:SS`
+  - colon appears automatically while typing digits where practical,
+  - normalization should make `10` seconds easy to enter without split minute/second fields.
+- The same behavior should apply to rest-step timing and swim-time timing in manual pool mode.
+
+### 7. Poolside Note Builder Panel
+
+- Keep `Swimmer: <name>` sourced from athlete profile.
+- Keep `Print Preview` button label.
+- Replace the right-side headings with a lower-noise structure:
+  - top heading: `Print options`
+  - subgroups: `Style` and `Layout`
+- Remove helper descriptions under portrait/landscape options:
+  - `Compact lane-side note in one tall column.`
+  - `Wider split layout for longer programs and more focus notes.`
+- Keep `Color mode`, `Ink saver`, `Portrait`, and `Landscape` as builder options only.
+
+### 8. Poolside Note Output
+
+- Portrait and landscape outputs must both be treated as `10/10` brand surfaces.
+- Remove output text/chips that expose internal implementation state:
+  - `Pool session execution`
+  - `Source: Local draft`
+  - `Source: Canonical workout`
+  - `Color mode`
+  - `Ink saver`
+  - `Portrait`
+  - `Landscape`
+- Replace `Tot:` with `Total`.
+- Header should be more compact, premium, and balanced:
+  - logo/brand lockup cleaned up,
+  - `Poolside Note` as primary title,
+  - session title,
+  - swimmer name,
+  - session meta row such as `200m · ~4 min · Moderate`.
+- Landscape should use width intentionally:
+  - metadata/focus in left column,
+  - workout program in the wider right column,
+  - less dead stacking in the header.
+- Portrait should also get the same premium header cleanup and improved vertical rhythm.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Visual design quality`
+- `Business logic correctness and data integrity`
+- `Reliability and failure handling`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                                           | Evidence                                     |
+| --------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
+| Product goals and IA                          | `target`     | Private workout routes clearly separate page purpose (`builder`) from section purpose (`session steps`) and expose a read mode that matches swimmer/operator scan needs. | route review + unit/e2e assertions           |
+| UX flow clarity                               | `target`     | Edit/view mode, delete flows, bulk cleanup, and time entry are all understandable without hidden/offscreen steps or misleading resurrection behavior.                    | unit/e2e + manual QA                         |
+| Visual design quality                         | `target`     | Builder read mode and poolside portrait/landscape outputs look intentionally composed, balanced, and brand-fit with no obvious unfinished seams.                         | manual QA + screenshot review + e2e coverage |
+| Business logic correctness and data integrity | `target`     | Saved-session delete, list counts, repeat/rest summaries, and time normalization remain deterministic with no silent corruption or mismatched canonical semantics.       | unit coverage + code review + regression QA  |
+| Admin editor ergonomics                       | `target`     | High-frequency builder tasks require fewer confusing steps: easier scanning, local delete confirm, faster time entry, bulk cleanup, and clearer edit/view state.         | manual QA + targeted tests                   |
+| Accessibility (a11y)                          | `target`     | Mode toggles, inline confirms, radio groups, and grouped read-mode summaries keep keyboard/focus/label semantics intact on changed surfaces.                             | test review + manual keyboard QA             |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: changes stay within existing private routes and should not materially regress builder responsiveness or print-preview startup.                          | build/verify + diff review                   |
+| Data placement and sync boundaries            | `target`     | Canonical workout rows remain server truth; view mode, pending delete UI, bulk selection, and poolside option state stay local-only and predictable.                     | brief contract + code review                 |
+| Caching and invalidation strategy             | `target`     | Saved-session reads and deletes define explicit refresh/update behavior so list state stays truthful after mutations.                                                    | code review + deletion flow tests            |
+| Reliability and failure handling              | `target`     | Delete/save/print flows fail predictably, confirmations stay visible, and list state cannot falsely imply a failed delete because of stale truncation.                   | unit/e2e + manual QA                         |
+| Security and authz                            | `supporting` | Supporting only: reuse existing authenticated workout APIs and owner scoping; no new privilege boundary is introduced.                                                   | route review + existing API constraints      |
+| Privacy and compliance                        | `supporting` | Supporting only: swimmer name is sourced from athlete profile and only rendered in the authenticated builder/print surface already intended for that user.               | scope review                                 |
+| Content governance                            | `supporting` | Supporting only: section labels and poolside print labels become more intentional, with no duplicate competing copy for the same concept.                                | code review                                  |
+| Admin workflow and editability                | `target`     | Manual pool editing, saved-session cleanup, and read-mode review are all faster and less error-prone for repeated admin/owner workflows.                                 | manual QA + targeted tests                   |
+| SEO and crawlability                          | `N/A`        | N/A because changed routes are private authenticated My Library surfaces and print previews are not public crawl targets.                                                | explicit scope rationale                     |
+| AI discoverability                            | `N/A`        | N/A because this slice changes no public crawlable entity surface, metadata contract, or structured public documentation.                                                | explicit scope rationale                     |
+| Analytics and KPI observability               | `supporting` | Supporting only: this slice does not add new event taxonomy, but success/error notices and truthful deletion behavior improve operator trust.                            | scope review                                 |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, entitlement, checkout, or billing workflow changes.                                                                                              | explicit scope rationale                     |
+| Incident response and support operations      | `N/A`        | N/A because this slice changes private builder UX and print composition only; it does not alter on-call/runbook mechanics for production incidents.                      | explicit scope rationale                     |
+| Finance and reporting operations              | `N/A`        | N/A because no revenue, refund, payout, or finance reconciliation path changes.                                                                                          | explicit scope rationale                     |
+| i18n operational readiness                    | `N/A`        | N/A because this slice refines centralized English private-surface copy only and introduces no new locale blocker beyond current baseline.                               | explicit scope rationale                     |
+| Stack-fit and dependency discipline           | `target`     | Reuse existing Next.js, React, Tailwind, and workout-shared utilities with no new dependency unless strictly necessary.                                                  | dependency diff + code review                |
+| Testing and QA automation                     | `target`     | Targeted unit/e2e coverage protects delete truthfulness, inline confirmation, view-mode summaries, poolside output, and time entry; `verify:pre-pr` must pass.           | updated tests + `verify:pre-pr`              |
+| Scalability and cost efficiency               | `supporting` | Supporting only: list handling should remain reasonable without introducing obviously wasteful repeated fetch/delete patterns for normal library sizes.                  | code review                                  |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: no schema migration is required unless this slice explicitly extends mutation APIs; rollback remains normal code rollback.                              | diff review + validation                     |
+
+## Data Placement And Sync Contract
+
+- Server-canonical data:
+  - saved workout rows in `workouts`
+  - workout draft payloads
+  - workout stable IDs
+  - saved-session updated timestamps and canonical summaries
+  - delete mutations against workout rows
+- Local-only data:
+  - builder `edit` vs `view` mode
+  - expanded/collapsed card state
+  - pending inline delete-confirm target
+  - last-removed undo buffer
+  - multi-select UI state for bulk delete
+  - selected poolside focus ids
+  - selected print style/layout
+  - in-progress time-input formatting state
+- Sync policy:
+  - canonical library data is loaded server-side into `WorkoutLibrarySnapshot`
+  - local optimistic updates may adjust the visible list immediately after delete,
+  - then route refresh/revalidation must converge the client back onto canonical server truth,
+  - delete failures must leave the item visible and surface an error,
+  - no client-side shadow copy may continue to claim a delete succeeded if the canonical row still exists.
+- Retention and sensitivity:
+  - swimmer name comes from athlete profile and is shown only on the private builder/print surface.
+  - deleted workouts follow existing canonical deletion rules; no new retention layer is introduced here.
+- Cache/invalidation:
+  - delete and save flows must invalidate/refresh the saved-session list immediately after success,
+  - builder read mode and poolside options remain local UI state and do not require server invalidation.
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - `workout.id` remains the only canonical stable identity for saved sessions.
+- Human-readable identifiers:
+  - `title` is editable and not stable identity.
+  - section labels such as `Main`, `Warmup`, `Rest`, and `Session steps` are UI labels only.
+- Mutability rules:
+  - workout titles are renameable in place.
+  - changing builder labels or print labels must not repurpose canonical workout rows.
+- Rename vs repurpose policy:
+  - UI label cleanup is an in-place presentation change.
+  - deleting a saved workout destroys the canonical row; it is not a rename or archive in this slice.
+- Compatibility contract:
+  - older saved workouts must continue to load into the same canonical schema.
+  - view-mode grouping must derive from existing canonical steps rather than requiring a migration.
+- Observability and repair:
+  - if a selected workout row is missing/invalid, existing missing/invalid workout handling remains authoritative.
+
+## Scope
+
+- Make `My Swim Sessions` truthful after delete and more useful for cleanup.
+- Add bulk-delete support on saved sessions.
+- Improve saved-session differentiators for otherwise identical rows.
+- Rename inner builder section to `Session steps`.
+- Make page-level builder heading environment-specific where available.
+- Rework builder `View` mode into a compact grouped read mode.
+- Strengthen edit/view active-state clarity and visual grouping.
+- Move destructive builder confirmation inline/local to the affected item.
+- Rename destructive builder actions from `Remove` to `Delete`.
+- Improve rest-step visual separation and edit ergonomics.
+- Standardize manual pool time entry to one `MM:SS` field pattern with auto-formatting.
+- Simplify poolside note builder option copy and layout.
+- Redesign poolside portrait and landscape output headers/composition for stronger scanability and brand quality.
+- Remove implementation-state labels from poolside output.
+- Update tests and validation for all changed behavior.
+
+## Out Of Scope
+
+- Open-water session-builder redesign beyond route heading truthfulness
+- Garmin export schema changes unless strictly required by this UI slice
+- Payment, subscription, or public-site flows
+- Generic sitewide border/containment audit beyond the directly touched builder/list/poolside surfaces
+- Rewriting canonical repeat semantics already locked in prior parity work
+
+## Acceptance Criteria
+
+1. The page-level manual builder heading is environment-specific where the environment is known.
+2. The inner builder section heading reads `Session steps`.
+3. `View` mode renders compact grouped summaries instead of full edit-style step cards.
+4. `View` mode contains no per-step `Edit step` buttons.
+5. Active `Edit` / `View` state is clearly visible and visually distinct from CTA buttons.
+6. Builder destructive actions use `Delete` wording.
+7. Step/repeat delete confirmations render inline near the affected target, not as a detached top-of-list confirmation.
+8. Undo after builder delete still works.
+9. Manual pool time entry uses a single `MM:SS` pattern across relevant timing fields and makes second-level entry practical.
+10. `My Swim Sessions` count reflects real loaded library truth rather than an arbitrary six-item subset.
+11. Deleting one saved session does not create the impression that the same row immediately reappeared.
+12. Saved-session rows expose enough metadata to distinguish otherwise identical untitled sessions.
+13. Bulk delete is available from `My Swim Sessions`.
+14. Poolside note builder uses a lower-noise `Print options` presentation and removes the portrait/landscape helper copy.
+15. Poolside portrait and landscape outputs no longer display internal source/print mode/layout labels.
+16. Poolside portrait and landscape headers feel intentionally designed, compact, and premium.
+17. Poolside output uses `Total`, not `Tot:`.
+18. Relevant unit/e2e coverage is updated and local validation passes.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run lint`
+- `npm run typecheck`
+- targeted `vitest`
+  - `tests/unit/workout-builder-hub.test.tsx`
+  - `tests/unit/workouts-shared.test.ts`
+- targeted Playwright
+  - `tests/e2e/my-library-workout-builder.spec.ts --project=desktop-chromium`
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm must be available on the machine that runs validation.
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3100/my-library/workouts`
+  - desktop Chromium
+  - Safari/WebKit for print preview checks
+- Vercel preview:
+  - PR preview URL from checks
+- Recommended matrix for this slice:
+  - iPhone Safari
+  - desktop Chrome
+  - desktop Safari/WebKit
+
+## Constraints
+
+- Preserve Garmin-compatible canonical repeat/rest behavior.
+- Prefer stack-native changes; do not add dependencies unless there is no simpler route.
+- Keep destructive flows explicit and reversible where possible.
+- Poolside output must favor scanability and brand quality over exposing internal system state.
+
+## Help/Guide And Operator Training Contract
+
+- `N/A` for this slice because it changes private builder/list/poolside surfaces only and does not currently alter a public Help/Guide contract.
+- If implementation touches any documented operator workflow wording, update that surface in the same PR.
+
+## 10/10 Quality Bar
+
+- UX clarity:
+  - users immediately understand whether they are editing or reviewing,
+  - delete flows are local, visible, and confidence-inspiring,
+  - library cleanup feels truthful and efficient.
+- Required states:
+  - loading: existing route loading remains safe
+  - empty: empty session/read mode still gives a clear next step
+  - error: delete/save failures keep truthful UI state and clear messaging
+  - retry: failed save/delete can be retried without stale phantom state
+  - offline/partial failure: no silent disappearance or silent data corruption
+- Accessibility:
+  - segmented control exposes active state clearly,
+  - inline confirms remain keyboard reachable,
+  - grouped read summaries remain semantic and readable,
+  - radio/checkbox alignment remains visually and semantically clean.
+- Performance:
+  - no obvious interaction lag added to builder editing, read mode, or print preview launch.
+- Visual consistency:
+  - builder/list surfaces stay within FreeSwimming’s visual system,
+  - poolside note should feel like a refined premium extension of the brand, not a debug printout.
+- Business logic:
+  - delete/list state remains deterministic,
+  - view summaries reflect canonical structure truthfully,
+  - time inputs normalize consistently and save the intended value,
+  - poolside output must reflect the current draft/canonical workout content without leaking internal diagnostic labels.
+
+## Checkpoint Log
+
+- `2026-04-12 | in progress | brief created after consolidating all owner-reported builder findings into one execution slice: session-step read mode, mode-toggle clarity, truthful saved-session deletion and bulk cleanup, local inline builder delete confirm, MM:SS time entry, rest differentiation, and premium poolside-note builder/output polish | next: implement list truthfulness + bulk delete + builder interaction changes, then patch poolside output and run validation`
+- `2026-04-12 | in progress | implementation completed across builder list, builder read/edit UX, delete flows, time entry, and poolside portrait/landscape output; targeted unit/e2e runs passed and full \`npm run verify:pre-pr\` passed (97 passed, 323 skipped) | next: stage, commit, push, update PR, run \`npm run verify:pre-merge\`, and confirm merge readiness`

--- a/lib/workouts/server.ts
+++ b/lib/workouts/server.ts
@@ -169,7 +169,9 @@ function buildStoredWorkoutDraftInput(row: WorkoutRow): SessionDraft {
       : "pool",
     poolLengthUnit: resolveSessionDraftPoolLengthUnit(row.pool_length_unit),
     poolLengthM: normalizePoolLength(row.pool_length_m),
-    sessionType: SESSION_GENERATOR_SESSION_TYPES.includes(row.session_type as SessionDraft["sessionType"])
+    sessionType: SESSION_GENERATOR_SESSION_TYPES.includes(
+      row.session_type as SessionDraft["sessionType"]
+    )
       ? (row.session_type as SessionDraft["sessionType"])
       : "endurance",
     effort: SESSION_GENERATOR_EFFORT_PRESETS.includes(row.effort as SessionDraft["effort"])
@@ -275,8 +277,7 @@ export async function loadWorkoutLibrarySnapshot(
       .from("workouts")
       .select(WORKOUT_SELECT)
       .eq("user_id", userId)
-      .order("updated_at", { ascending: false })
-      .limit(6),
+      .order("updated_at", { ascending: false }),
     selectedWorkoutId
       ? supabase
           .from("workouts")
@@ -337,7 +338,9 @@ export async function loadWorkoutLibrarySnapshot(
         ? "This saved workout could not be opened because its stored data is invalid."
         : null,
       selectedWorkout,
-      selectedWorkoutMissing: Boolean(selectedWorkoutId && (!selectedResult.data || invalidSelectedWorkout)),
+      selectedWorkoutMissing: Boolean(
+        selectedWorkoutId && (!selectedResult.data || invalidSelectedWorkout)
+      ),
       recentWorkouts,
     };
   } catch (error) {

--- a/lib/workouts/shared.ts
+++ b/lib/workouts/shared.ts
@@ -809,7 +809,7 @@ export function buildWorkoutPdfModel(
   const issuesByStepId = new Map<string, string[]>();
   const totalDistanceLabel =
     normalizedDraft.totalDistanceM && normalizedDraft.totalDistanceM > 0
-      ? `Tot: ${formatWorkoutDistanceLabel(normalizedDraft.totalDistanceM, {
+      ? `Total: ${formatWorkoutDistanceLabel(normalizedDraft.totalDistanceM, {
           environment: draft.environment,
           poolLengthUnit,
         })}`
@@ -1516,10 +1516,9 @@ function buildStandardWorkoutPdfHtmlDocument(
 function buildPoolsideWorkoutPdfHtmlDocument(model: WorkoutPdfModel, fontUrl: string | null) {
   const isInkSaver = model.poolsidePrintStyle === "ink_saver";
   const isLandscape = model.poolsidePrintLayout === "landscape";
-  const printModeLabel = isInkSaver ? "Ink saver" : "Color mode";
-  const printLayoutLabel = isLandscape ? "Landscape" : "Portrait";
   const fontFaceCss = buildPdfBrandFontFaceCss(fontUrl);
   const logoHtml = buildPdfBrandLockupHtml(model.logoUrl);
+  const totalDistanceValue = model.totalDistanceLabel?.replace(/^Total:\s*/, "") ?? null;
   const focusPointsHtml =
     model.focusPoints.length > 0
       ? `
@@ -1531,8 +1530,13 @@ function buildPoolsideWorkoutPdfHtmlDocument(model: WorkoutPdfModel, fontUrl: st
         </section>
       `
       : "";
-  const totalDistanceHtml = model.totalDistanceLabel
-    ? `<p class="poolside-total">${escapeHtml(model.totalDistanceLabel)}</p>`
+  const totalDistanceHtml = totalDistanceValue
+    ? `
+        <section class="metric-card">
+          <p class="metric-label">Total</p>
+          <p class="metric-value">${escapeHtml(totalDistanceValue)}</p>
+        </section>
+      `
     : "";
   const swimmerNameHtml = model.swimmerName
     ? `<p class="swimmer-pill">Swimmer: ${escapeHtml(model.swimmerName)}</p>`
@@ -1647,7 +1651,7 @@ function buildPoolsideWorkoutPdfHtmlDocument(model: WorkoutPdfModel, fontUrl: st
       }
 
       .page {
-        width: min(100%, ${isLandscape ? "240mm" : "104mm"});
+        width: min(100%, ${isLandscape ? "244mm" : "112mm"});
         margin: 0 auto;
         border: 1px solid rgba(16, 33, 60, 0.08);
         border-radius: 24px;
@@ -1657,11 +1661,13 @@ function buildPoolsideWorkoutPdfHtmlDocument(model: WorkoutPdfModel, fontUrl: st
       }
 
       .hero {
-        padding: 18px 18px 16px;
+        padding: 16px 18px 14px;
         background: ${
           isInkSaver ? "#ffffff" : "linear-gradient(165deg, #eff5ff 0%, #f9fbff 68%, #ffffff 100%)"
         };
         border-bottom: 1px solid rgba(16, 33, 60, 0.08);
+        display: grid;
+        gap: 12px;
       }
 
       .brand-mark {
@@ -1688,33 +1694,26 @@ function buildPoolsideWorkoutPdfHtmlDocument(model: WorkoutPdfModel, fontUrl: st
         display: inline-flex;
       }
 
-      .source-pill {
-        display: inline-flex;
-        margin-top: 10px;
-        border-radius: 999px;
-        border: 1px solid ${isInkSaver ? "rgba(15, 23, 42, 0.18)" : "rgba(29, 78, 216, 0.12)"};
-        background: ${isInkSaver ? "#ffffff" : "rgba(255, 255, 255, 0.92)"};
-        padding: 6px 10px;
-        font-size: 10px;
-        font-weight: 700;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        color: var(--accent-strong);
-      }
-
       h1 {
-        margin: 4px 0 0;
-        font-size: 22px;
+        margin: 0;
+        font-size: 24px;
         font-weight: 800;
         letter-spacing: -0.02em;
         line-height: 1.15;
       }
 
-      .hero-top {
+      .hero-brand-row {
         display: flex;
         align-items: flex-start;
         justify-content: space-between;
         gap: 16px;
+      }
+
+      .hero-brand-lockup {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        min-width: 0;
       }
 
       .hero-copy {
@@ -1722,24 +1721,16 @@ function buildPoolsideWorkoutPdfHtmlDocument(model: WorkoutPdfModel, fontUrl: st
         min-width: 0;
       }
 
-      .brand-tagline {
-        margin: 4px 0 0;
-        color: var(--muted);
-        font-size: 11px;
+      .hero-session-title {
+        margin: 0;
+        font-size: 16px;
         font-weight: 700;
-        letter-spacing: 0.04em;
-      }
-
-      .lede {
-        margin: 10px 0 0;
-        font-size: 13px;
-        line-height: 1.45;
-        color: var(--muted);
+        line-height: 1.35;
+        color: var(--ink);
       }
 
       .swimmer-pill {
         display: inline-flex;
-        margin: 10px 0 0;
         border-radius: 999px;
         border: 1px solid var(--line);
         background: rgba(255, 255, 255, 0.92);
@@ -1749,11 +1740,10 @@ function buildPoolsideWorkoutPdfHtmlDocument(model: WorkoutPdfModel, fontUrl: st
         color: var(--ink);
       }
 
-      .session-pill-row {
+      .hero-meta-row {
         display: flex;
         flex-wrap: wrap;
         gap: 6px;
-        margin-top: 12px;
       }
 
       .session-pill {
@@ -1765,10 +1755,6 @@ function buildPoolsideWorkoutPdfHtmlDocument(model: WorkoutPdfModel, fontUrl: st
         font-weight: 700;
         letter-spacing: 0.05em;
         text-transform: uppercase;
-      }
-
-      .session-pill-neutral {
-        color: var(--muted);
       }
 
       .body {
@@ -1789,6 +1775,30 @@ function buildPoolsideWorkoutPdfHtmlDocument(model: WorkoutPdfModel, fontUrl: st
         display: grid;
         gap: 10px;
         align-content: start;
+      }
+
+      .metric-card {
+        border: 1px solid var(--line);
+        border-radius: 16px;
+        background: rgba(255, 255, 255, 0.9);
+        padding: 10px 12px;
+      }
+
+      .metric-label {
+        margin: 0;
+        font-size: 10px;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--accent-strong);
+      }
+
+      .metric-value {
+        margin: 6px 0 0;
+        font-size: 17px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+        color: var(--ink);
       }
 
       .callout,
@@ -1892,13 +1902,6 @@ function buildPoolsideWorkoutPdfHtmlDocument(model: WorkoutPdfModel, fontUrl: st
         color: var(--accent-strong);
       }
 
-      .poolside-total {
-        margin: 6px 0 0;
-        font-size: 13px;
-        font-weight: 700;
-        color: var(--ink);
-      }
-
       @media print {
         html,
         body {
@@ -1918,9 +1921,9 @@ function buildPoolsideWorkoutPdfHtmlDocument(model: WorkoutPdfModel, fontUrl: st
         }
 
         .page {
-          width: ${isLandscape ? "100%" : "96mm"};
-          max-width: ${isLandscape ? "100%" : "96mm"};
-          min-width: ${isLandscape ? "100%" : "96mm"};
+          width: ${isLandscape ? "100%" : "104mm"};
+          max-width: ${isLandscape ? "100%" : "104mm"};
+          min-width: ${isLandscape ? "100%" : "104mm"};
           border-radius: 20px;
           box-shadow: none;
         }
@@ -1956,25 +1959,23 @@ function buildPoolsideWorkoutPdfHtmlDocument(model: WorkoutPdfModel, fontUrl: st
         data-poolside-print-layout="${escapeHtml(model.poolsidePrintLayout)}"
       >
         <header class="hero">
-          <div class="hero-top">
-            ${logoHtml}
-            <div class="hero-copy">
-              <p class="section-kicker">freeswimming.org</p>
-              <p class="brand-tagline">Pool session execution</p>
-              <h1 data-testid="workout-pdf-title">Poolside Note</h1>
-              ${swimmerNameHtml}
+          <div class="hero-brand-row">
+            <div class="hero-brand-lockup">
+              ${logoHtml}
+              <div class="hero-copy">
+                <p class="section-kicker">freeswimming.org</p>
+                <h1 data-testid="workout-pdf-title">Poolside Note</h1>
+              </div>
             </div>
+            ${swimmerNameHtml}
           </div>
-          <p class="lede">${escapeHtml(model.title)}</p>
-          <div class="session-pill-row">
+          <p class="hero-session-title">${escapeHtml(model.title)}</p>
+          <div class="hero-meta-row">
             <span class="session-pill">${escapeHtml(model.sessionSummary)}</span>
-            <span class="session-pill session-pill-neutral">${escapeHtml(printModeLabel)}</span>
-            <span class="session-pill session-pill-neutral">${escapeHtml(printLayoutLabel)}</span>
           </div>
         </header>
         <div class="body ${isLandscape ? "body-landscape" : "body-portrait"}">
           <aside class="poolside-meta">
-            <p class="source-pill" data-testid="workout-pdf-source">Source: ${escapeHtml(model.sourceLabel)}</p>
             ${totalDistanceHtml}
             ${focusPointsHtml}
           </aside>
@@ -2883,7 +2884,7 @@ export function buildWorkoutSummaryPreviewText(draft: SessionDraft | null | unde
 
   const totalDistanceLabel =
     draft?.totalDistanceM && draft.totalDistanceM > 0
-      ? `Tot: ${formatWorkoutDistanceLabel(draft.totalDistanceM, {
+      ? `Total: ${formatWorkoutDistanceLabel(draft.totalDistanceM, {
           environment: draft.environment,
           poolLengthUnit: draft.poolLengthUnit ?? null,
         })}`

--- a/tests/e2e/my-library-generator-intake.spec.ts
+++ b/tests/e2e/my-library-generator-intake.spec.ts
@@ -344,7 +344,7 @@ test.describe("my library generator intake", () => {
 
     await waitForWorkoutBuilderClientReady(page);
     await expect(
-      page.getByRole("heading", { name: "Swim session builder", level: 1 })
+      page.getByRole("heading", { name: "Pool session builder", level: 1 })
     ).toBeVisible();
     await ensureWorkoutMetadataOpen(page);
     await expect(page.getByTestId("session-draft-title")).toHaveValue(uniqueTitle);

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -202,6 +202,9 @@ test.describe("my library workout builder", () => {
     await waitForWorkoutBuilderRoute(page);
     await waitForWorkoutBuilderClientReady(page);
     await waitForWorkoutBuilderSaveReady(page);
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Pool session builder" })
+    ).toBeVisible();
     await expect(page.getByTestId("workout-builder-hub")).toHaveAttribute(
       "data-containment-style",
       "flat"
@@ -264,7 +267,7 @@ test.describe("my library workout builder", () => {
       stepSummaryBox!.y + stepSummaryBox!.height - 2
     );
     await expect(
-      page.getByTestId("workout-editor-panel").getByRole("heading", { name: "Session builder" })
+      page.getByTestId("workout-editor-panel").getByRole("heading", { name: "Session steps" })
     ).toBeVisible();
     await expect(page.getByLabel("Step Type")).toBeVisible();
     await expect(page.getByLabel("Stroke Type")).toBeVisible();
@@ -375,7 +378,7 @@ test.describe("my library workout builder", () => {
 
     await page.getByTestId("session-draft-step-remove-0").click();
     await expect(page.getByTestId("workout-editor-removal-confirm")).toContainText(
-      "Remove 100m · Freestyle · Moderate?"
+      "Delete 100m · Freestyle · Moderate?"
     );
     await expect(page.getByTestId("workout-builder-save")).toBeDisabled();
     await page.getByTestId("workout-editor-removal-cancel-button").click();
@@ -383,7 +386,7 @@ test.describe("my library workout builder", () => {
     await page.getByTestId("session-draft-step-remove-0").click();
     await page.getByTestId("workout-editor-removal-confirm-button").click();
     await expect(page.getByTestId("workout-editor-removal-undo")).toContainText(
-      "Removed 100m · Freestyle · Moderate."
+      "Deleted 100m · Freestyle · Moderate."
     );
     await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
       "Unsaved changes stay local until you save this workout."
@@ -530,6 +533,13 @@ test.describe("my library workout builder", () => {
     await expect(page.getByTestId("workout-editor-poolside-pdf-open")).toBeVisible();
     await page.getByTestId("workout-editor-poolside-style-ink-saver").click();
     await page.getByTestId("workout-editor-poolside-layout-landscape").click();
+    await expect(page.getByText("Print options")).toBeVisible();
+    await expect(
+      page.getByTestId("workout-editor-poolside-panel").getByText("Style", { exact: true })
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("workout-editor-poolside-panel").getByText("Layout", { exact: true })
+    ).toBeVisible();
     await expect(
       page.getByText(
         "Optional. Use this for the whole-session purpose or one short coaching note that applies across the session."
@@ -568,9 +578,13 @@ test.describe("my library workout builder", () => {
       "landscape"
     );
     await expect(poolsidePopup.locator("body")).toContainText("Poolside Note");
-    await expect(poolsidePopup.locator("body")).toContainText("Ink saver");
-    await expect(poolsidePopup.locator("body")).toContainText("Landscape");
-    await expect(poolsidePopup.locator("body")).toContainText("Tot:");
+    await expect(poolsidePopup.locator("body")).not.toContainText("Color mode");
+    await expect(poolsidePopup.locator("body")).not.toContainText("Ink saver");
+    await expect(poolsidePopup.locator("body")).not.toContainText("Portrait");
+    await expect(poolsidePopup.locator("body")).not.toContainText("Landscape");
+    await expect(poolsidePopup.locator("body")).not.toContainText("Source: Local draft");
+    await expect(poolsidePopup.locator("body")).not.toContainText("Pool session execution");
+    await expect(poolsidePopup.locator("body")).toContainText("Total");
     await expect(poolsidePopup.locator("body")).toContainText("P: Fixed Rest Time 0:45");
     await poolsidePopup.close();
 
@@ -648,7 +662,7 @@ test.describe("my library workout builder", () => {
     await expect(page.getByRole("heading", { level: 1, name: "My Swim Sessions" })).toBeVisible();
     await expect(page.getByTestId(`saved-workout-card-${workoutId}`)).toBeVisible();
     await page.getByTestId(`saved-workouts-view-${workoutId}`).click();
-    await expect(page.getByTestId(`saved-workouts-preview-${workoutId}`)).toContainText("Tot:");
+    await expect(page.getByTestId(`saved-workouts-preview-${workoutId}`)).toContainText("Total:");
     await expect(page.getByTestId(`saved-workouts-preview-${workoutId}`)).toContainText("P:");
     await page.getByTestId(`workout-builder-edit-workout-${workoutId}`).click();
     await page.waitForURL(new RegExp(`/my-library/workouts/${workoutId}$`), {

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -85,7 +85,7 @@ function buildWorkoutSummary(overrides?: Partial<WorkoutSummary>): WorkoutSummar
     acceptedAt: "2026-03-20T12:18:00.000Z",
     sourceKind: "ai_session_v1",
     status: "accepted",
-    previewText: "400m · Freestyle · Easy\n\nTot: 2200m",
+    previewText: "400m · Freestyle · Easy\n\nTotal: 2200m",
     ...overrides,
   };
 }
@@ -600,7 +600,7 @@ describe("WorkoutBuilderHub", () => {
     fireEvent.click(screen.getByTestId("session-draft-step-remove-0"));
 
     expect(screen.getByTestId("workout-editor-removal-confirm")).toHaveTextContent(
-      "Remove Easy warmup swim?"
+      "Delete Easy warmup swim?"
     );
     expect(screen.getByTestId("workout-builder-save")).toBeDisabled();
 
@@ -615,7 +615,7 @@ describe("WorkoutBuilderHub", () => {
 
     expect(screen.queryByTestId("session-draft-step-toggle-0")).not.toBeInTheDocument();
     expect(screen.getByTestId("workout-editor-removal-undo")).toHaveTextContent(
-      "Removed Easy warmup swim."
+      "Deleted Easy warmup swim."
     );
     expect(screen.getByTestId("workout-builder-save")).toBeEnabled();
     expect(screen.getByTestId("workout-editor-save-state")).toHaveTextContent(
@@ -762,7 +762,7 @@ describe("WorkoutBuilderHub", () => {
 
     expect(screen.queryByTestId("session-draft-repeat-count-1")).not.toBeInTheDocument();
     expect(screen.getByTestId("workout-editor-removal-undo")).toHaveTextContent(
-      "Removed Repeat block (3 steps, 4 rounds)."
+      "Deleted Repeat block (3 steps, 4 rounds)."
     );
 
     fireEvent.click(screen.getByTestId("workout-editor-removal-undo-button"));
@@ -858,7 +858,7 @@ describe("WorkoutBuilderHub", () => {
     });
 
     expect(screen.queryByTestId("session-draft-step-name-0")).not.toBeInTheDocument();
-    expect(screen.getByTestId("session-draft-step-toggle-0")).toHaveTextContent("Edit step");
+    expect(screen.getByTestId("session-draft-step-toggle-0")).toHaveTextContent("Edit");
 
     fireEvent.click(screen.getByTestId("session-draft-step-toggle-0"));
 
@@ -868,7 +868,7 @@ describe("WorkoutBuilderHub", () => {
     fireEvent.click(screen.getByTestId("session-draft-step-toggle-0"));
 
     expect(screen.queryByTestId("session-draft-step-name-0")).not.toBeInTheDocument();
-    expect(screen.getByTestId("session-draft-step-toggle-0")).toHaveTextContent("Edit step");
+    expect(screen.getByTestId("session-draft-step-toggle-0")).toHaveTextContent("Edit");
   });
 
   it("builds a truthful handoff preview and supports copy/download actions", async () => {
@@ -1116,18 +1116,30 @@ describe("WorkoutBuilderHub", () => {
       expect(printWindow.document.write).toHaveBeenCalledWith(
         expect.stringContaining("Poolside Note")
       );
-      expect(printWindow.document.write).toHaveBeenCalledWith(expect.stringContaining("Tot:"));
       expect(printWindow.document.write).toHaveBeenCalledWith(
         expect.stringContaining("lockup-domain-ink.png")
       );
     });
 
+    const poolsideHtml = String(printWindow.document.write.mock.calls.at(-1)?.[0] ?? "");
+
+    expect(poolsideHtml).toContain("Total");
+    expect(poolsideHtml).not.toContain("Pool session execution");
+    expect(poolsideHtml).not.toContain("Source: Local draft");
+    expect(poolsideHtml).not.toContain(">Color mode<");
+    expect(poolsideHtml).not.toContain(">Ink saver<");
+    expect(poolsideHtml).not.toContain(">Portrait<");
+    expect(poolsideHtml).not.toContain(">Landscape<");
+
     expect(screen.getByText("Keeps the blue surfaces")).toBeVisible();
     expect(screen.getByText("Uses white surfaces.")).toBeVisible();
-    expect(screen.getByText("Compact lane-side note in one tall column.")).toBeVisible();
+    expect(screen.getByText("Print options")).toBeVisible();
     expect(
-      screen.getByText("Wider split layout for longer programs and more focus notes.")
-    ).toBeVisible();
+      screen.queryByText("Compact lane-side note in one tall column.")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Wider split layout for longer programs and more focus notes.")
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByText("Keeps the blue surfaces when your browser prints backgrounds.")
     ).not.toBeInTheDocument();
@@ -1284,7 +1296,7 @@ describe("WorkoutBuilderHub", () => {
               sourceKind: "manual",
               environment: "open_water",
               poolLengthM: null,
-              previewText: "Open water aerobic session\n\nTot: ~45 min",
+              previewText: "Open water aerobic session\n\nTotal: ~45 min",
             }),
           ],
         })}
@@ -1324,7 +1336,17 @@ describe("WorkoutBuilderHub", () => {
   });
 
   it("switches the saved builder into a clean view mode without edit controls", async () => {
-    render(<WorkoutBuilderHub workoutLibrary={buildWorkoutLibrary()} />);
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: buildWorkoutRecord({
+            sourceKind: "manual",
+            draft: buildDraft({ sourceFingerprint: "manual-view-mode" }),
+          }),
+          recentWorkouts: [buildWorkoutSummary({ sourceKind: "manual" })],
+        })}
+      />
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
@@ -1342,7 +1364,10 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.queryByTestId("session-draft-add-repeat")).not.toBeInTheDocument();
     expect(screen.queryByTestId("workout-editor-metadata-toggle")).not.toBeInTheDocument();
     expect(screen.queryByTestId("session-draft-step-toggle-0")).not.toBeInTheDocument();
-    expect(screen.getByTestId("session-draft-step-summary-0")).toBeVisible();
+    expect(screen.getByText("Session steps")).toBeVisible();
+    expect(screen.getByText("Warmup")).toBeVisible();
+    expect(screen.getByText("400m · Freestyle · Easy")).toBeVisible();
+    expect(screen.queryByText("Edit step")).not.toBeInTheDocument();
   });
 
   it("shows clearer kick and drill taxonomy guidance inside the step form", async () => {
@@ -1429,7 +1454,7 @@ describe("WorkoutBuilderHub", () => {
 
     fireEvent.click(screen.getByTestId("session-draft-step-toggle-0"));
 
-    expect(screen.getByText("Session builder")).toBeVisible();
+    expect(screen.getByText("Session steps")).toBeVisible();
     expect(screen.getByLabelText("Step Type")).toBeVisible();
     expect(screen.getByLabelText("Stroke Type")).toBeVisible();
     expect(screen.getByLabelText("Drill Type")).toBeVisible();
@@ -1659,7 +1684,7 @@ describe("WorkoutBuilderHub", () => {
     fireEvent.click(screen.getByTestId("session-draft-step-toggle-2"));
 
     const restTimeInput = screen.getByTestId("session-draft-step-rest-time-2");
-    expect(restTimeInput).toHaveValue("1:00");
+    expect(restTimeInput).toHaveValue("0:30");
 
     fireEvent.focus(restTimeInput);
     fireEvent.change(restTimeInput, {
@@ -1897,7 +1922,7 @@ describe("WorkoutBuilderHub", () => {
               title: "Old QA cleanup workout",
               totalDistanceM: 1600,
               estimatedDurationMin: 37,
-              previewText: "8 x 25m Kick · Easy\nP: 20 sec\n\nTot: 1600m",
+              previewText: "8 x 25m Kick · Easy\nP: 20 sec\n\nTotal: 1600m",
             }),
           ],
         })}
@@ -2121,7 +2146,14 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.queryByTestId("workout-builder-view-sessions-link")).not.toBeInTheDocument();
   });
 
-  it("shows only the first three saved sessions in browse mode until the owner loads the rest", async () => {
+  it("shows all saved sessions immediately in browse mode and supports bulk delete cleanup", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+      }),
+    } as Response);
+
     render(
       <WorkoutBuilderHub
         workoutLibrary={buildWorkoutLibrary({
@@ -2162,16 +2194,27 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.getByTestId("saved-workout-card-workout-1")).toBeVisible();
     expect(screen.getByTestId("saved-workout-card-workout-2")).toBeVisible();
     expect(screen.getByTestId("saved-workout-card-workout-3")).toBeVisible();
-    expect(screen.queryByTestId("saved-workout-card-workout-4")).not.toBeInTheDocument();
-    expect(screen.getByTestId("workout-builder-saved-sessions-load-more")).toHaveTextContent(
-      "Load 1 more session"
-    );
-
-    fireEvent.click(screen.getByTestId("workout-builder-saved-sessions-load-more"));
-
     expect(screen.getByTestId("saved-workout-card-workout-4")).toBeVisible();
     expect(
       screen.queryByTestId("workout-builder-saved-sessions-load-more")
     ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("workout-builder-saved-sessions-bulk-select-toggle"));
+    fireEvent.click(screen.getByTestId("saved-workout-select-workout-2"));
+    fireEvent.click(screen.getByTestId("saved-workout-select-workout-4"));
+    fireEvent.click(screen.getByTestId("workout-builder-saved-sessions-bulk-delete"));
+
+    expect(screen.getByText("Delete 2 saved sessions from My Library?")).toBeVisible();
+
+    fireEvent.click(screen.getByTestId("workout-builder-saved-sessions-bulk-confirm-delete"));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith("/api/my-library/workouts/workout-2", {
+        method: "DELETE",
+      });
+      expect(fetch).toHaveBeenCalledWith("/api/my-library/workouts/workout-4", {
+        method: "DELETE",
+      });
+    });
   });
 });

--- a/tests/unit/workouts-server.test.ts
+++ b/tests/unit/workouts-server.test.ts
@@ -559,11 +559,10 @@ describe("workouts server", () => {
   });
 
   it("marks selected workouts as missing when the id is not found", async () => {
-    const recentLimit = vi.fn().mockResolvedValue({
+    const recentOrder = vi.fn().mockResolvedValue({
       data: [buildWorkoutRow()],
       error: null,
     });
-    const recentOrder = vi.fn(() => ({ limit: recentLimit }));
     const recentEq = vi.fn(() => ({ order: recentOrder }));
 
     const selectedMaybeSingle = vi.fn().mockResolvedValue({
@@ -597,7 +596,7 @@ describe("workouts server", () => {
   });
 
   it("skips invalid legacy recent workouts instead of crashing the library snapshot", async () => {
-    const recentLimit = vi.fn().mockResolvedValue({
+    const recentOrder = vi.fn().mockResolvedValue({
       data: [
         buildWorkoutRow(),
         buildWorkoutRow({
@@ -608,7 +607,6 @@ describe("workouts server", () => {
       ],
       error: null,
     });
-    const recentOrder = vi.fn(() => ({ limit: recentLimit }));
     const recentEq = vi.fn(() => ({ order: recentOrder }));
 
     const supabase = {

--- a/tests/unit/workouts-shared.test.ts
+++ b/tests/unit/workouts-shared.test.ts
@@ -1011,9 +1011,15 @@ describe("workouts shared readiness", () => {
     expect(html).toContain("High elbow catch");
     expect(html).toContain("Calm exhale");
     expect(html).toContain("400m");
-    expect(html).toContain("Tot: 400m");
+    expect(html).toContain("Total");
+    expect(html).toContain('metric-value">400m<');
     expect(html).toContain("lockup-domain-ink.png");
-    expect(html).toContain("Pool session execution");
+    expect(html).not.toContain("Pool session execution");
+    expect(html).not.toContain("Source: Local draft");
+    expect(html).not.toContain(">Color mode<");
+    expect(html).not.toContain(">Ink saver<");
+    expect(html).not.toContain(">Portrait<");
+    expect(html).not.toContain(">Landscape<");
     expect(html).not.toContain("Compact lane-side note");
   });
 


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-04-12T09:41:46.207Z for branch `feat/swim-session-builder-view-delete-poolside-polish-2026-04-12` (base ref `origin/main`).
- Latest commit: `428fe07` - Polish swim session builder scan and poolside UX.
- User-visible changes: User/admin runtime behavior may change on touched routes/components.
- Technical changes: Updated 12 file(s): `app/my-library/workouts/[workoutId]/page.tsx`, `components/my-library/workouts/SavedWorkoutsPanel.tsx`, `components/my-library/workouts/WorkoutBuilderHub.tsx`, `components/my-library/workouts/WorkoutEditor.tsx`, `docs/task-briefs/in-progress/2026-04-12-swim-session-builder-scan-delete-and-poolside-brand-polish-10-10.md`, `... and 7 more file(s)`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-04-12-swim-session-builder-scan-delete-and-poolside-brand-polish-10-10.md`
- Scorecard target outcomes: 12 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (1); tests (5); runtime UI/routes/components (6).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (12):
  - `app/my-library/workouts/[workoutId]/page.tsx`
  - `components/my-library/workouts/SavedWorkoutsPanel.tsx`
  - `components/my-library/workouts/WorkoutBuilderHub.tsx`
  - `components/my-library/workouts/WorkoutEditor.tsx`
  - `docs/task-briefs/in-progress/2026-04-12-swim-session-builder-scan-delete-and-poolside-brand-polish-10-10.md`
  - `lib/workouts/server.ts`
  - `lib/workouts/shared.ts`
  - `tests/e2e/my-library-generator-intake.spec.ts`
  - `... and 4 more file(s)`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `428fe07` (`git revert 428fe07`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **PASS** (artifacts/test-runs/20260412-111701, lane: full-public)
- `npm run verify:pre-merge`: **PENDING** for `428fe07` (latest PASS was `48958ea` at 2026-04-12T07:14:54Z; rerun on current HEAD).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  -   -  416 [desktop-firefox] › tests/e2e/private-access-gate.spec.ts:14:7 › private access gate › redirects public users to preview access and unlocks
  -   -  417 [desktop-firefox] › tests/e2e/private-access-gate.spec.ts:52:7 › private access gate › blocks protected api paths for unauthenticated public request context
  -   -  418 [desktop-firefox] › tests/e2e/private-access-gate.spec.ts:59:7 › private access gate › keeps indexing metadata locked while site is private
  -   ✓  419 [desktop-firefox] › tests/e2e/sitemap.spec.ts:30:5 › sitemap contains canonical public routes (29ms)
  -   ✓  420 [desktop-firefox] › tests/e2e/soft-launch-banner.spec.ts:38:5 › public pages do not render legacy under-construction banner (2.1s)
  -   97 passed (16.1m)
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
