### PR TITLE
Refine swim builder repeat containers and session actions

### DIFF
--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -176,6 +176,7 @@ type LastRemovedBlock = {
   steps: SessionDraftStep[];
   insertIndex: number;
   restoreOpenStepId: string | null;
+  restoreOpenRepeatGroupId: string | null;
 };
 
 type AutoGrowingTextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
@@ -1027,14 +1028,34 @@ function buildRepeatSummary(
 type ManualPoolViewSectionLine = {
   text: string;
   tone?: "default" | "rest" | "subtle";
+  target?:
+    | {
+        kind: "step";
+        stepId: string;
+      }
+    | {
+        kind: "repeat";
+        repeatGroupId: string;
+      };
 };
 
 type ManualPoolViewSection = {
   key: string;
   title: string;
+  badge?: string | null;
   lines: ManualPoolViewSectionLine[];
   numbered: boolean;
   variant: "default" | "rest" | "repeat";
+  target?: {
+    kind: "repeat";
+    repeatGroupId: string;
+  } | null;
+};
+
+type ManualPoolTopLevelSectionDescriptor = {
+  label: string;
+  title: string;
+  isRepeat: boolean;
 };
 
 function findTopLevelLinkedRestStep(
@@ -1088,23 +1109,29 @@ function buildManualPoolViewLine(
 function buildManualPoolRepeatViewSection(
   group: Extract<StepRenderGroup, { kind: "repeat" }>,
   basePaceSecondsPer100m: number,
-  poolLengthUnit: SessionDraftPoolLengthUnit
+  poolLengthUnit: SessionDraftPoolLengthUnit,
+  titleOverride?: string | null
 ): ManualPoolViewSection {
   const workStep = group.entries[0]?.step ?? null;
   const betweenStep = group.entries[1]?.step ?? null;
   const normalizedWorkStep = workStep ? normalizeManualPoolStepForEditor(workStep) : null;
   const repeatCountLabel = group.repeatCount ? `${group.repeatCount} x ` : "";
-  const title = normalizedWorkStep
-    ? getSessionStepCategoryLabel(normalizedWorkStep.category)
-    : "Repeat";
+  const title =
+    titleOverride ??
+    (normalizedWorkStep ? getSessionStepCategoryLabel(normalizedWorkStep.category) : "Repeat");
 
   if (!normalizedWorkStep) {
     return {
       key: group.repeatGroupId,
       title,
+      badge: "Repeat block",
       lines: [{ text: "Set the work interval for this repeat block." }],
       numbered: false,
       variant: "repeat",
+      target: {
+        kind: "repeat",
+        repeatGroupId: group.repeatGroupId,
+      },
     };
   }
 
@@ -1145,10 +1172,38 @@ function buildManualPoolRepeatViewSection(
   return {
     key: group.repeatGroupId,
     title,
+    badge: "Repeat block",
     lines,
     numbered: false,
     variant: "repeat",
+    target: {
+      kind: "repeat",
+      repeatGroupId: group.repeatGroupId,
+    },
   };
+}
+
+function buildManualPoolTopLevelSectionDescriptors(
+  stepGroups: StepRenderGroup[]
+): ManualPoolTopLevelSectionDescriptor[] {
+  const categories = stepGroups.map(
+    (group) => normalizeManualPoolStepForEditor(group.entries[0].step).category
+  );
+
+  return stepGroups.map((group, index) => {
+    const category = categories[index];
+    const title = getSessionStepCategoryLabel(category);
+    const sameTypeTotal = categories.filter((value) => value === category).length;
+    const sameTypePosition = categories
+      .slice(0, index + 1)
+      .filter((value) => value === category).length;
+
+    return {
+      label: sameTypeTotal > 1 ? `${title} ${sameTypePosition} of ${sameTypeTotal}` : title,
+      title,
+      isRepeat: group.kind === "repeat",
+    };
+  });
 }
 
 function buildManualPoolViewSections(
@@ -1159,11 +1214,17 @@ function buildManualPoolViewSections(
 ) {
   const sections: ManualPoolViewSection[] = [];
   const consumedRestStepIds = new Set<string>();
+  const topLevelDescriptors = buildManualPoolTopLevelSectionDescriptors(stepGroups);
 
-  stepGroups.forEach((group) => {
+  stepGroups.forEach((group, groupIndex) => {
     if (group.kind === "repeat") {
       sections.push(
-        buildManualPoolRepeatViewSection(group, basePaceSecondsPer100m, poolLengthUnit)
+        buildManualPoolRepeatViewSection(
+          group,
+          basePaceSecondsPer100m,
+          poolLengthUnit,
+          topLevelDescriptors[groupIndex]?.label ?? null
+        )
       );
       return;
     }
@@ -1187,6 +1248,10 @@ function buildManualPoolViewSections(
         linkedRestStep
       ),
       tone: normalizedStep.category === "rest" ? "rest" : "default",
+      target: {
+        kind: "step",
+        stepId: entry.step.id,
+      },
     };
     const lastSection = sections[sections.length - 1] ?? null;
 
@@ -1204,9 +1269,11 @@ function buildManualPoolViewSections(
     sections.push({
       key: entry.step.id,
       title,
+      badge: null,
       lines: [nextLine],
       numbered: false,
       variant: normalizedStep.category === "rest" ? "rest" : "default",
+      target: null,
     });
   });
 
@@ -1319,6 +1386,7 @@ export default function WorkoutEditor({
   const autoPoolBuilderTitle = getPoolBuilderAutoTitle(draft.environment);
   const timeDurationInputFocusRef = useRef<Record<string, boolean>>({});
   const [openStepId, setOpenStepId] = useState<string | null>(null);
+  const [openRepeatGroupId, setOpenRepeatGroupId] = useState<string | null>(null);
   const [openMobileActionKey, setOpenMobileActionKey] = useState<string | null>(null);
   const poolLengthUnit = resolveSessionDraftPoolLengthUnit(draft.poolLengthUnit);
   const [poolLengthInput, setPoolLengthInput] = useState(() =>
@@ -1455,6 +1523,12 @@ export default function WorkoutEditor({
         totalDistanceM: draftTotals.totalDistanceM ?? draft.totalDistanceM,
         estimatedDurationMin: draftTotals.estimatedDurationMin ?? draft.estimatedDurationMin,
       });
+  const saveStateMessage = savedWorkout
+    ? hasUnsavedChanges
+      ? editorCopy.savedWorkoutPendingState
+      : editorCopy.savedWorkoutSavedState
+    : editorCopy.unsavedDraftPendingState;
+  const saveStateToneClass = hasUnsavedChanges ? "text-amber-700" : "text-emerald-700";
   const workoutPdfHeadingLabel = "View PDF";
   const workoutPdfStateLabel =
     handoffDraftState === "canonical"
@@ -1534,6 +1608,9 @@ export default function WorkoutEditor({
   const desktopSummaryBlockClass = "min-w-0 flex-1";
   const desktopRepeatControlRowClass = "grid gap-3";
   const isViewMode = builderViewMode === "view";
+  const manualPoolTopLevelSectionDescriptors = isManualPoolMode
+    ? buildManualPoolTopLevelSectionDescriptors(stepGroups)
+    : [];
   const manualPoolViewSections = isManualPoolMode
     ? buildManualPoolViewSections(
         stepGroups,
@@ -1556,6 +1633,17 @@ export default function WorkoutEditor({
       setOpenStepId(null);
     }
   }, [draft.steps, openStepId]);
+
+  useEffect(() => {
+    if (
+      openRepeatGroupId &&
+      !stepGroups.some(
+        (group) => group.kind === "repeat" && group.repeatGroupId === openRepeatGroupId
+      )
+    ) {
+      setOpenRepeatGroupId(null);
+    }
+  }, [openRepeatGroupId, stepGroups]);
 
   useEffect(() => {
     if (!openMobileActionKey) return;
@@ -1608,6 +1696,7 @@ export default function WorkoutEditor({
     if (!isViewMode) return;
 
     setOpenStepId(null);
+    setOpenRepeatGroupId(null);
     setOpenMobileActionKey(null);
     setMetadataOpen(false);
   }, [isViewMode]);
@@ -1800,6 +1889,49 @@ export default function WorkoutEditor({
     );
   }
 
+  function openTargetedStepEditor(stepId: string) {
+    const targetStep = draft.steps.find((step) => step.id === stepId);
+    if (!targetStep) return;
+
+    setBuilderViewMode("edit");
+    setMetadataOpen(false);
+    setPendingRemoval(null);
+    setLastRemovedBlock(null);
+    setOpenMobileActionKey(null);
+    setOpenRepeatGroupId(targetStep.repeatGroupId ?? null);
+    setOpenStepId(stepId);
+  }
+
+  function openTargetedRepeatEditor(repeatGroupId: string) {
+    const hasRepeatGroup = draft.steps.some((step) => step.repeatGroupId === repeatGroupId);
+    if (!hasRepeatGroup) return;
+
+    setBuilderViewMode("edit");
+    setMetadataOpen(false);
+    setPendingRemoval(null);
+    setLastRemovedBlock(null);
+    setOpenMobileActionKey(null);
+    setOpenRepeatGroupId(repeatGroupId);
+    setOpenStepId(null);
+  }
+
+  function toggleRepeatEditor(repeatGroupId: string) {
+    setOpenMobileActionKey(null);
+    setOpenRepeatGroupId((current) => {
+      const nextOpen = current === repeatGroupId ? null : repeatGroupId;
+
+      if (nextOpen === null) {
+        setOpenStepId((currentOpenStepId) => {
+          if (!currentOpenStepId) return null;
+          const openStep = draft.steps.find((step) => step.id === currentOpenStepId);
+          return openStep?.repeatGroupId === repeatGroupId ? null : currentOpenStepId;
+        });
+      }
+
+      return nextOpen;
+    });
+  }
+
   function insertStepAt(
     insertIndex: number,
     overrides: Partial<SessionDraftStep> = {},
@@ -1823,6 +1955,7 @@ export default function WorkoutEditor({
     nextSteps.splice(safeInsertIndex, 0, ...insertedSteps);
     setPendingRemoval(null);
     setLastRemovedBlock(null);
+    setOpenRepeatGroupId(nextStep.repeatGroupId ?? null);
     setOpenStepId(nextStep.id);
     onDraftChange(
       syncDraftSelections({
@@ -1840,6 +1973,7 @@ export default function WorkoutEditor({
     nextDraftSteps.splice(safeInsertIndex, 0, ...nextSteps);
     setPendingRemoval(null);
     setLastRemovedBlock(null);
+    setOpenRepeatGroupId(nextSteps[0]?.repeatGroupId ?? null);
     setOpenStepId(nextSteps[0]?.id ?? null);
     onDraftChange(
       syncDraftSelections({
@@ -1916,6 +2050,7 @@ export default function WorkoutEditor({
 
     setPendingRemoval(null);
     setLastRemovedBlock(null);
+    setOpenRepeatGroupId(sourceStep.repeatGroupId ?? null);
     setOpenStepId(duplicatedStep.id);
     onDraftChange(
       syncDraftSelections({
@@ -1958,6 +2093,7 @@ export default function WorkoutEditor({
 
     setPendingRemoval(null);
     setLastRemovedBlock(null);
+    setOpenRepeatGroupId(nextRepeatGroupId);
     setOpenStepId(duplicatedSteps[0]?.id ?? null);
     onDraftChange(
       syncDraftSelections({
@@ -2029,6 +2165,10 @@ export default function WorkoutEditor({
         steps: [removedStep],
         insertIndex: removeIndex,
         restoreOpenStepId: removedOpenStep ? removedStep.id : openStepId,
+        restoreOpenRepeatGroupId:
+          removedOpenStep && removedStep.repeatGroupId
+            ? removedStep.repeatGroupId
+            : openRepeatGroupId,
       });
       if (removedOpenStep) {
         setOpenStepId(null);
@@ -2069,9 +2209,17 @@ export default function WorkoutEditor({
       steps: removedSteps,
       insertIndex,
       restoreOpenStepId: removedOpenStep ? (removedSteps[0]?.id ?? null) : openStepId,
+      restoreOpenRepeatGroupId:
+        removedSteps[0]?.repeatGroupId === pendingRemoval.repeatGroupId ||
+        openRepeatGroupId === pendingRemoval.repeatGroupId
+          ? pendingRemoval.repeatGroupId
+          : openRepeatGroupId,
     });
     if (removedOpenStep) {
       setOpenStepId(null);
+    }
+    if (openRepeatGroupId === pendingRemoval.repeatGroupId) {
+      setOpenRepeatGroupId(null);
     }
     onDraftChange(
       syncDraftSelections({
@@ -2094,6 +2242,7 @@ export default function WorkoutEditor({
         steps: nextSteps,
       })
     );
+    setOpenRepeatGroupId(lastRemovedBlock.restoreOpenRepeatGroupId);
     setOpenStepId(lastRemovedBlock.restoreOpenStepId);
     setLastRemovedBlock(null);
   }
@@ -2434,25 +2583,10 @@ export default function WorkoutEditor({
           !nextDraftStep.postSetRestForRepeatGroupId))
         ? nextDraftStep
         : null;
-    const topLevelSingleEntries = isManualPoolMode
-      ? stepGroups.filter(
-          (group): group is Extract<StepRenderGroup, { kind: "single" }> => group.kind === "single"
-        )
-      : [];
-    const sameTypeTotal = isManualPoolMode
-      ? topLevelSingleEntries.filter(
-          (group) =>
-            normalizeManualPoolStepForEditor(group.entries[0].step).category ===
-            normalizedStep.category
-        ).length
-      : 0;
-    const sameTypePosition = isManualPoolMode
-      ? topLevelSingleEntries.filter(
-          (group) =>
-            normalizeManualPoolStepForEditor(group.entries[0].step).category ===
-              normalizedStep.category && group.entries[0].index <= index
-        ).length
-      : 0;
+    const topLevelDescriptor =
+      isManualPoolMode && !insideRepeatGroup
+        ? (manualPoolTopLevelSectionDescriptors[groupIndex] ?? null)
+        : null;
     const stepLabel =
       options?.labelOverride ??
       (insideRepeatGroup
@@ -2460,9 +2594,7 @@ export default function WorkoutEditor({
           ? `Repeat rest step ${options?.repeatStepNumber ?? 1}`
           : `Repeat step ${options?.repeatStepNumber ?? 1}`
         : isManualPoolMode
-          ? sameTypeTotal > 1
-            ? `${getSessionStepCategoryLabel(normalizedStep.category)} ${sameTypePosition} of ${sameTypeTotal}`
-            : getSessionStepCategoryLabel(normalizedStep.category)
+          ? (topLevelDescriptor?.label ?? getSessionStepCategoryLabel(normalizedStep.category))
           : `Step ${index + 1}`);
     const selectedDistancePreset = SESSION_DRAFT_STEP_DISTANCE_PRESETS.find((value) =>
       isDistanceQuickChoiceSelected(normalizedStep.distanceM, value, poolLengthUnit)
@@ -2560,6 +2692,9 @@ export default function WorkoutEditor({
                 onClick={() => {
                   setOpenMobileActionKey(null);
                   setOpenStepId((current) => (current === step.id ? null : step.id));
+                  if (insideRepeatGroup && normalizedStep.repeatGroupId) {
+                    setOpenRepeatGroupId(normalizedStep.repeatGroupId);
+                  }
                 }}
                 aria-expanded={isOpen}
                 aria-controls={panelId}
@@ -2582,7 +2717,12 @@ export default function WorkoutEditor({
             <div className="hidden shrink-0 sm:flex">
               <button
                 type="button"
-                onClick={() => setOpenStepId((current) => (current === step.id ? null : step.id))}
+                onClick={() => {
+                  setOpenStepId((current) => (current === step.id ? null : step.id));
+                  if (insideRepeatGroup && normalizedStep.repeatGroupId) {
+                    setOpenRepeatGroupId(normalizedStep.repeatGroupId);
+                  }
+                }}
                 aria-expanded={isOpen}
                 aria-controls={panelId}
                 data-testid={`session-draft-step-toggle-${index}`}
@@ -4285,6 +4425,21 @@ export default function WorkoutEditor({
               <p className="mt-2 text-base font-semibold text-slate-900">
                 {draft.title || autoPoolBuilderTitle || "Untitled swim session"}
               </p>
+              <p
+                data-testid="workout-editor-save-state"
+                className={`mt-2 text-sm font-medium ${saveStateToneClass}`}
+              >
+                {saveStateMessage}
+              </p>
+              {showInlinePdfAction ? (
+                <p
+                  data-testid="workout-editor-pdf-source"
+                  data-pdf-state={handoffDraftState}
+                  className="mt-1 text-xs font-semibold uppercase tracking-wide text-slate-500"
+                >
+                  {workoutPdfStateLabel}
+                </p>
+              ) : null}
               {!metadataOpen || isViewMode ? (
                 <p
                   data-testid="workout-editor-metadata-summary"
@@ -4294,31 +4449,98 @@ export default function WorkoutEditor({
                 </p>
               ) : null}
             </div>
-            <div className="flex flex-wrap items-center gap-2">
-              {!isViewMode ? (
+            <div className="flex min-w-0 flex-col gap-2 sm:items-end">
+              <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+                {!isViewMode ? (
+                  <button
+                    type="button"
+                    onClick={() => setMetadataOpen((current) => !current)}
+                    aria-expanded={metadataOpen}
+                    data-testid="workout-editor-metadata-toggle"
+                    className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+                  >
+                    {metadataOpen ? "Hide details" : "Show details"}
+                  </button>
+                ) : null}
+                {showInlinePdfAction ? (
+                  <button
+                    type="button"
+                    onClick={() => openWorkoutPdfPrintView("standard")}
+                    data-testid="workout-editor-pdf-open"
+                    className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+                  >
+                    {workoutPdfButtonLabel}
+                  </button>
+                ) : null}
+                {savedWorkout && onResetToSaved ? (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setPendingRemoval(null);
+                      setLastRemovedBlock(null);
+                      onResetToSaved();
+                    }}
+                    disabled={isSaving || !hasUnsavedChanges || pendingRemoval !== null}
+                    data-testid="workout-editor-reset"
+                    className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    Reset to last saved
+                  </button>
+                ) : null}
                 <button
                   type="button"
-                  onClick={() => setMetadataOpen((current) => !current)}
-                  aria-expanded={metadataOpen}
-                  data-testid="workout-editor-metadata-toggle"
-                  className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+                  onClick={() => {
+                    setPendingRemoval(null);
+                    setLastRemovedBlock(null);
+                    onSave();
+                  }}
+                  disabled={
+                    isSaving ||
+                    !canonicalSaveReady ||
+                    poolSizeInputInvalid ||
+                    pendingRemoval !== null ||
+                    (savedWorkout ? !hasUnsavedChanges : false)
+                  }
+                  data-testid={saveButtonTestId}
+                  className="inline-flex h-10 items-center justify-center rounded-xl bg-emerald-600 px-4 text-sm font-semibold text-white transition hover:bg-emerald-500 active:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
                 >
-                  {metadataOpen ? "Hide details" : "Show details"}
+                  {isSaving
+                    ? "Saving..."
+                    : savedWorkout
+                      ? "Save changes"
+                      : "Accept and save workout"}
                 </button>
-              ) : null}
+              </div>
               {savedWorkout && onRequestDeleteCurrent ? (
-                <button
-                  type="button"
-                  onClick={onRequestDeleteCurrent}
-                  disabled={isDeletingCurrent}
-                  data-testid="workout-builder-delete-current-workout"
-                  className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-700 transition hover:bg-rose-50 active:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-60"
-                >
-                  {isDeletingCurrent ? "Deleting..." : "Delete session"}
-                </button>
+                <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+                  <button
+                    type="button"
+                    onClick={onRequestDeleteCurrent}
+                    disabled={isDeletingCurrent}
+                    data-testid="workout-builder-delete-current-workout"
+                    className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-700 transition hover:bg-rose-50 active:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {isDeletingCurrent ? "Deleting..." : "Delete session"}
+                  </button>
+                </div>
               ) : null}
             </div>
           </div>
+
+          {showInlinePdfAction && workoutPdfNotice ? (
+            <p
+              data-testid="workout-editor-pdf-notice"
+              className="mt-3 text-sm font-medium text-emerald-700"
+            >
+              {workoutPdfNotice}
+            </p>
+          ) : null}
+
+          {showInlinePdfAction && workoutPdfError ? (
+            <p data-testid="workout-editor-pdf-error" className="mt-3 text-sm text-rose-700">
+              {workoutPdfError}
+            </p>
+          ) : null}
 
           {!isViewMode && metadataOpen ? <div className="mt-4">{metadataFields}</div> : null}
         </section>
@@ -4429,47 +4651,121 @@ export default function WorkoutEditor({
           ) : null}
 
           {isViewMode && isManualPoolMode
-            ? manualPoolViewSections.map((section) => (
-                <section
-                  key={section.key}
-                  className={`rounded-2xl border p-4 ${
-                    section.variant === "repeat"
-                      ? "border-blue-200 bg-gradient-to-b from-blue-50/70 to-white"
-                      : section.variant === "rest"
-                        ? "border-blue-100 bg-blue-50/55"
-                        : "border-slate-200 bg-slate-50/70"
-                  }`}
-                >
-                  <p
-                    className={`text-xs font-semibold uppercase tracking-wide ${
-                      section.variant === "repeat" ? "text-blue-700" : "text-slate-500"
-                    }`}
+            ? manualPoolViewSections.map((section) => {
+                const sectionCardClass = `rounded-2xl border p-4 text-left transition ${
+                  section.variant === "repeat"
+                    ? "border-blue-200 bg-gradient-to-b from-blue-50/70 to-white hover:border-blue-300 hover:bg-blue-50/80"
+                    : section.variant === "rest"
+                      ? "border-blue-100 bg-blue-50/55"
+                      : "border-slate-200 bg-slate-50/70"
+                }`;
+                const sectionHeadingClass = `text-xs font-semibold uppercase tracking-wide ${
+                  section.variant === "repeat" ? "text-blue-700" : "text-slate-500"
+                }`;
+
+                if (section.target?.kind === "repeat") {
+                  return (
+                    <button
+                      key={section.key}
+                      type="button"
+                      data-testid={`workout-editor-view-repeat-${section.key}`}
+                      onClick={() => openTargetedRepeatEditor(section.target!.repeatGroupId)}
+                      className={`${sectionCardClass} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-300`}
+                    >
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                          <p className={sectionHeadingClass}>{section.title}</p>
+                          {section.badge ? (
+                            <p className="mt-2">
+                              <span className="inline-flex rounded-full border border-blue-200 bg-white px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-blue-700">
+                                {section.badge}
+                              </span>
+                            </p>
+                          ) : null}
+                        </div>
+                        <span className="inline-flex rounded-full border border-blue-200 bg-white px-3 py-1 text-xs font-semibold text-blue-800">
+                          Edit repeat
+                        </span>
+                      </div>
+                      <div className="mt-3 space-y-2">
+                        {section.lines.map((line, lineIndex) => (
+                          <div
+                            key={`${section.key}-line-${lineIndex}`}
+                            className={`text-base leading-6 ${
+                              line.tone === "rest"
+                                ? "font-semibold text-blue-900"
+                                : line.tone === "subtle"
+                                  ? "text-slate-600"
+                                  : "text-slate-900"
+                            }`}
+                          >
+                            <span>{line.text}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </button>
+                  );
+                }
+
+                return (
+                  <section
+                    key={section.key}
+                    data-testid={`workout-editor-view-section-${section.key}`}
+                    className={sectionCardClass}
                   >
-                    {section.title}
-                  </p>
-                  <div className="mt-2 space-y-2">
-                    {section.lines.map((line, lineIndex) => (
-                      <div
-                        key={`${section.key}-line-${lineIndex}`}
-                        className={`text-base leading-6 ${
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <p className={sectionHeadingClass}>{section.title}</p>
+                        {section.badge ? (
+                          <p className="mt-2">
+                            <span className="inline-flex rounded-full border border-blue-200 bg-white px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-blue-700">
+                              {section.badge}
+                            </span>
+                          </p>
+                        ) : null}
+                      </div>
+                    </div>
+                    <div className="mt-2 space-y-2">
+                      {section.lines.map((line, lineIndex) => {
+                        const lineTarget = line.target;
+                        const lineClass = `text-base leading-6 ${
                           line.tone === "rest"
                             ? "font-semibold text-blue-900"
                             : line.tone === "subtle"
                               ? "text-slate-600"
                               : "text-slate-900"
-                        }`}
-                      >
-                        {section.numbered ? (
-                          <span className="mr-2 font-semibold text-slate-500">
-                            {lineIndex + 1}.
-                          </span>
-                        ) : null}
-                        <span>{line.text}</span>
-                      </div>
-                    ))}
-                  </div>
-                </section>
-              ))
+                        }`;
+
+                        return lineTarget?.kind === "step" ? (
+                          <button
+                            key={`${section.key}-line-${lineIndex}`}
+                            type="button"
+                            data-testid={`workout-editor-view-line-${section.key}-${lineIndex}`}
+                            onClick={() => openTargetedStepEditor(lineTarget.stepId)}
+                            className={`${lineClass} flex w-full items-start rounded-xl px-2 py-1.5 text-left transition hover:bg-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-300`}
+                          >
+                            {section.numbered ? (
+                              <span className="mr-2 font-semibold text-slate-500">
+                                {lineIndex + 1}.
+                              </span>
+                            ) : null}
+                            <span>{line.text}</span>
+                          </button>
+                        ) : (
+                          <div key={`${section.key}-line-${lineIndex}`} className={lineClass}>
+                            {section.numbered ? (
+                              <span className="mr-2 font-semibold text-slate-500">
+                                {lineIndex + 1}.
+                              </span>
+                            ) : null}
+                            <span>{line.text}</span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </section>
+                );
+              })
             : stepGroups.map((group, groupIndex) =>
                 group.kind === "single" ? (
                   renderStepEditorCard(group.entries[0].step, group.entries[0].index, groupIndex)
@@ -4488,6 +4784,14 @@ export default function WorkoutEditor({
                         group.repeatEndingRestMode,
                         poolLengthUnit
                       );
+                      const repeatDescriptor = isManualPoolMode
+                        ? (manualPoolTopLevelSectionDescriptors[groupIndex] ?? null)
+                        : null;
+                      const repeatLabel = isManualPoolMode
+                        ? (repeatDescriptor?.label ?? "Repeat")
+                        : "Repeat set";
+                      const isRepeatOpen = !isViewMode && openRepeatGroupId === group.repeatGroupId;
+                      const repeatToggleLabel = isRepeatOpen ? "Done" : "Edit";
                       const hasEditableRepeatEndingRest = Boolean(
                         draft.environment === "pool" &&
                         (() => {
@@ -4497,61 +4801,98 @@ export default function WorkoutEditor({
                       );
                       const repeatMobileActionKey = `repeat:${group.repeatGroupId}`;
                       const repeatMobileActionsOpen = openMobileActionKey === repeatMobileActionKey;
+                      const repeatSummaryContent = (
+                        <>
+                          <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
+                            {repeatLabel}
+                          </p>
+                          {isManualPoolMode ? (
+                            <p className="mt-2">
+                              <span className="inline-flex rounded-full border border-blue-200 bg-white px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-blue-700">
+                                Repeat block
+                              </span>
+                            </p>
+                          ) : null}
+                          <p className="mt-2 text-sm font-medium text-slate-900">{repeatSummary}</p>
+                        </>
+                      );
 
                       return (
                         <div className="space-y-3">
                           <div className={desktopHeaderStackClass}>
-                            <div
-                              data-testid={`session-draft-repeat-summary-${groupIndex}`}
-                              className={desktopSummaryBlockClass}
-                            >
-                              <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
-                                Repeat set
-                              </p>
-                              <p className="mt-1 text-sm font-medium text-slate-900">
-                                {repeatSummary}
-                              </p>
-                              {isManualPoolMode ? null : (
-                                <>
-                                  <p className="mt-1 text-xs text-slate-600">
-                                    Edit the repeated steps below instead of duplicating every round
-                                    by hand.
-                                  </p>
-                                  <p className="mt-1 text-xs text-slate-500">
-                                    Repeat counts currently support {SESSION_DRAFT_REPEAT_MIN}-
-                                    {SESSION_DRAFT_REPEAT_MAX} rounds per block.
-                                  </p>
-                                </>
-                              )}
+                            <div className={desktopSummaryBlockClass}>
+                              <button
+                                type="button"
+                                onClick={() => toggleRepeatEditor(group.repeatGroupId)}
+                                aria-expanded={isRepeatOpen}
+                                data-testid={`session-draft-repeat-mobile-summary-${groupIndex}`}
+                                className={`${mobileSummaryToggleClass} sm:hidden`}
+                              >
+                                <div className="flex items-start justify-between gap-3">
+                                  <div className="min-w-0 flex-1">{repeatSummaryContent}</div>
+                                  <span className="mt-1 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500">
+                                    {isRepeatOpen ? (
+                                      <ChevronUp className="size-4" />
+                                    ) : (
+                                      <ChevronDown className="size-4" />
+                                    )}
+                                  </span>
+                                </div>
+                              </button>
+                              <div
+                                data-testid={`session-draft-repeat-summary-${groupIndex}`}
+                                className="hidden sm:block"
+                              >
+                                {repeatSummaryContent}
+                              </div>
                             </div>
                             {!isViewMode ? (
-                              <div className="flex shrink-0 sm:hidden">
+                              <div className="hidden shrink-0 sm:flex">
                                 <button
                                   type="button"
-                                  onClick={() =>
-                                    setOpenMobileActionKey((current) =>
-                                      current === repeatMobileActionKey
-                                        ? null
-                                        : repeatMobileActionKey
-                                    )
-                                  }
-                                  aria-expanded={repeatMobileActionsOpen}
-                                  aria-controls={`session-draft-repeat-mobile-actions-panel-${group.repeatGroupId}`}
-                                  data-testid={`session-draft-repeat-mobile-actions-toggle-${groupIndex}`}
-                                  className={mobileActionToggleClass}
+                                  onClick={() => toggleRepeatEditor(group.repeatGroupId)}
+                                  aria-expanded={isRepeatOpen}
+                                  data-testid={`session-draft-repeat-toggle-${groupIndex}`}
+                                  className={`inline-flex h-9 items-center justify-center rounded-xl border px-3 text-sm transition ${
+                                    isRepeatOpen
+                                      ? "border-blue-200 bg-blue-50 text-blue-800 hover:bg-blue-100"
+                                      : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
+                                  }`}
                                 >
-                                  <Ellipsis className="size-5" />
-                                  <span className="sr-only">
-                                    {repeatMobileActionsOpen
-                                      ? "Hide repeat actions"
-                                      : "Show repeat actions"}
-                                  </span>
+                                  {repeatToggleLabel}
                                 </button>
+                              </div>
+                            ) : null}
+                            {!isViewMode ? (
+                              <div className="flex shrink-0 sm:hidden">
+                                {isRepeatOpen ? (
+                                  <button
+                                    type="button"
+                                    onClick={() =>
+                                      setOpenMobileActionKey((current) =>
+                                        current === repeatMobileActionKey
+                                          ? null
+                                          : repeatMobileActionKey
+                                      )
+                                    }
+                                    aria-expanded={repeatMobileActionsOpen}
+                                    aria-controls={`session-draft-repeat-mobile-actions-panel-${group.repeatGroupId}`}
+                                    data-testid={`session-draft-repeat-mobile-actions-toggle-${groupIndex}`}
+                                    className={mobileActionToggleClass}
+                                  >
+                                    <Ellipsis className="size-5" />
+                                    <span className="sr-only">
+                                      {repeatMobileActionsOpen
+                                        ? "Hide repeat actions"
+                                        : "Show repeat actions"}
+                                    </span>
+                                  </button>
+                                ) : null}
                               </div>
                             ) : null}
                           </div>
 
-                          {!isViewMode ? (
+                          {!isViewMode && isRepeatOpen ? (
                             <div className={desktopRepeatControlRowClass}>
                               <div className="grid gap-3 sm:flex sm:flex-wrap sm:items-end sm:gap-2">
                                 <label className="text-sm text-slate-700">
@@ -4598,7 +4939,7 @@ export default function WorkoutEditor({
                             </div>
                           ) : null}
 
-                          {!isViewMode ? (
+                          {!isViewMode && isRepeatOpen ? (
                             <div className="sm:hidden">
                               <button
                                 type="button"
@@ -4614,7 +4955,7 @@ export default function WorkoutEditor({
                             </div>
                           ) : null}
 
-                          {!isViewMode && repeatMobileActionsOpen ? (
+                          {!isViewMode && isRepeatOpen && repeatMobileActionsOpen ? (
                             <div
                               id={`session-draft-repeat-mobile-actions-panel-${group.repeatGroupId}`}
                               data-testid={`session-draft-repeat-mobile-actions-panel-${groupIndex}`}
@@ -4687,78 +5028,78 @@ export default function WorkoutEditor({
                       );
                     })()}
 
-                    <div className="mt-4 space-y-3">
-                      {group.entries.map((entry, repeatIndex) =>
-                        renderStepEditorCard(entry.step, entry.index, groupIndex, {
-                          insideRepeatGroup: true,
-                          repeatStepNumber: repeatIndex + 1,
-                          labelOverride:
-                            repeatIndex === 0
-                              ? "Work interval"
-                              : repeatIndex === 1
-                                ? "Between-interval recovery"
-                                : undefined,
-                        })
-                      )}
-                      {group.postSetRestEntry
-                        ? renderStepEditorCard(
-                            group.postSetRestEntry.step,
-                            group.postSetRestEntry.index,
-                            groupIndex,
-                            {
-                              labelOverride: "Post-set rest",
-                              descriptionOverride:
-                                group.repeatEndingRestMode === "use_last_rest" &&
-                                Boolean(
-                                  group.entries[group.entries.length - 1] &&
-                                  isSessionDraftRepeatEndingRestStep(
-                                    group.entries[group.entries.length - 1].step
+                    {!isViewMode && openRepeatGroupId === group.repeatGroupId ? (
+                      <div className="mt-4 space-y-3">
+                        {group.entries.map((entry, repeatIndex) =>
+                          renderStepEditorCard(entry.step, entry.index, groupIndex, {
+                            insideRepeatGroup: true,
+                            repeatStepNumber: repeatIndex + 1,
+                            labelOverride:
+                              repeatIndex === 0
+                                ? "Work interval"
+                                : repeatIndex === 1
+                                  ? "Between-interval recovery"
+                                  : undefined,
+                          })
+                        )}
+                        {group.postSetRestEntry
+                          ? renderStepEditorCard(
+                              group.postSetRestEntry.step,
+                              group.postSetRestEntry.index,
+                              groupIndex,
+                              {
+                                labelOverride: "Post-set rest",
+                                descriptionOverride:
+                                  group.repeatEndingRestMode === "use_last_rest" &&
+                                  Boolean(
+                                    group.entries[group.entries.length - 1] &&
+                                    isSessionDraftRepeatEndingRestStep(
+                                      group.entries[group.entries.length - 1].step
+                                    )
                                   )
-                                )
-                                  ? "Separate canonical rest after the set. It is preserved here, but active execution and export suppress it because the last internal rest interval is used after the final rep."
-                                  : "Separate canonical rest after the set, outside the repeat block itself.",
-                              isLinkedPostSetRest: true,
-                            }
-                          )
-                        : null}
-                      {pendingRemoval?.kind === "repeat" &&
-                      pendingRemoval.repeatGroupId === group.repeatGroupId ? (
-                        <div
-                          data-testid="workout-editor-removal-confirm"
-                          className="rounded-2xl border border-rose-200 bg-rose-50/90 p-3"
-                        >
-                          <p className="text-sm font-medium text-rose-950">
-                            Delete{" "}
-                            <span className="font-semibold">
-                              {pendingRemoval?.label ?? "this repeat block"}
-                            </span>
-                            ?
-                          </p>
-                          <p className="mt-1 text-sm text-rose-900">
-                            This builder change stays local until you save, and you can still undo
-                            it right after deletion.
-                          </p>
-                          <div className="mt-3 flex flex-wrap gap-2">
-                            <button
-                              type="button"
-                              onClick={confirmPendingRemoval}
-                              data-testid="workout-editor-removal-confirm-button"
-                              className="inline-flex h-10 items-center justify-center rounded-xl bg-rose-600 px-4 text-sm font-semibold text-white transition hover:bg-rose-500 active:bg-rose-700"
-                            >
-                              Delete now
-                            </button>
-                            <button
-                              type="button"
-                              onClick={cancelPendingRemoval}
-                              data-testid="workout-editor-removal-cancel-button"
-                              className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-900 transition hover:bg-rose-100 active:bg-rose-200"
-                            >
-                              Keep it
-                            </button>
+                                    ? "Separate canonical rest after the set. It is preserved here, but active execution and export suppress it because the last internal rest interval is used after the final rep."
+                                    : "Separate canonical rest after the set, outside the repeat block itself.",
+                                isLinkedPostSetRest: true,
+                              }
+                            )
+                          : null}
+                        {pendingRemoval?.kind === "repeat" &&
+                        pendingRemoval.repeatGroupId === group.repeatGroupId ? (
+                          <div
+                            data-testid="workout-editor-removal-confirm"
+                            className="rounded-2xl border border-rose-200 bg-rose-50/90 p-3"
+                          >
+                            <p className="text-sm font-medium text-rose-950">
+                              Delete{" "}
+                              <span className="font-semibold">
+                                {pendingRemoval?.label ?? "this repeat block"}
+                              </span>
+                              ?
+                            </p>
+                            <p className="mt-1 text-sm text-rose-900">
+                              This builder change stays local until you save, and you can still undo
+                              it right after deletion.
+                            </p>
+                            <div className="mt-3 flex flex-wrap gap-2">
+                              <button
+                                type="button"
+                                onClick={confirmPendingRemoval}
+                                data-testid="workout-editor-removal-confirm-button"
+                                className="inline-flex h-10 items-center justify-center rounded-xl bg-rose-600 px-4 text-sm font-semibold text-white transition hover:bg-rose-500 active:bg-rose-700"
+                              >
+                                Delete now
+                              </button>
+                              <button
+                                type="button"
+                                onClick={cancelPendingRemoval}
+                                data-testid="workout-editor-removal-cancel-button"
+                                className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-900 transition hover:bg-rose-100 active:bg-rose-200"
+                              >
+                                Keep it
+                              </button>
+                            </div>
                           </div>
-                        </div>
-                      ) : null}
-                      {!isViewMode ? (
+                        ) : null}
                         <div
                           data-testid={`session-draft-repeat-desktop-actions-${groupIndex}`}
                           data-desktop-layout="bottom"
@@ -4813,8 +5154,8 @@ export default function WorkoutEditor({
                             Delete repeat
                           </button>
                         </div>
-                      ) : null}
-                    </div>
+                      </div>
+                    ) : null}
                   </section>
                 )
               )}
@@ -4823,107 +5164,109 @@ export default function WorkoutEditor({
 
       {poolsideNotePanel}
 
-      <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-3 sm:p-4">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-          <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="rounded-full bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600">
-                {savedWorkout ? "Saved workout" : "Draft"}
-              </span>
-              <p
-                data-testid="workout-editor-save-state"
-                className={`text-sm font-medium ${
-                  hasUnsavedChanges ? "text-amber-700" : "text-emerald-700"
-                }`}
-              >
-                {savedWorkout
-                  ? hasUnsavedChanges
-                    ? editorCopy.savedWorkoutPendingState
-                    : editorCopy.savedWorkoutSavedState
-                  : editorCopy.unsavedDraftPendingState}
-              </p>
+      {!showCalmBuilderLayout ? (
+        <>
+          <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-3 sm:p-4">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="rounded-full bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600">
+                    {savedWorkout ? "Saved workout" : "Draft"}
+                  </span>
+                  <p
+                    data-testid="workout-editor-save-state"
+                    className={`text-sm font-medium ${saveStateToneClass}`}
+                  >
+                    {saveStateMessage}
+                  </p>
+                </div>
+                {showInlinePdfAction ? (
+                  <p
+                    data-testid="workout-editor-pdf-source"
+                    data-pdf-state={handoffDraftState}
+                    className="mt-2 text-xs font-semibold uppercase tracking-wide text-slate-500"
+                  >
+                    {workoutPdfStateLabel}
+                  </p>
+                ) : null}
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                {showInlinePdfAction ? (
+                  <button
+                    type="button"
+                    onClick={() => openWorkoutPdfPrintView("standard")}
+                    data-testid="workout-editor-pdf-open"
+                    className="inline-flex h-11 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+                  >
+                    {workoutPdfButtonLabel}
+                  </button>
+                ) : null}
+                {!showPdfPanel && !showCalmBuilderLayout ? (
+                  <button
+                    type="button"
+                    onClick={() => openWorkoutPdfPrintView("poolside")}
+                    data-testid="workout-editor-poolside-pdf-open"
+                    className="inline-flex h-11 items-center justify-center rounded-xl border border-blue-200 bg-white px-4 text-sm font-medium text-blue-800 transition hover:bg-blue-50 active:bg-blue-100"
+                  >
+                    {workoutPoolsidePdfButtonLabel}
+                  </button>
+                ) : null}
+                {savedWorkout && onResetToSaved ? (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setPendingRemoval(null);
+                      setLastRemovedBlock(null);
+                      onResetToSaved();
+                    }}
+                    disabled={isSaving || !hasUnsavedChanges || pendingRemoval !== null}
+                    data-testid="workout-editor-reset"
+                    className="inline-flex h-11 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    Reset to last saved
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  onClick={() => {
+                    setPendingRemoval(null);
+                    setLastRemovedBlock(null);
+                    onSave();
+                  }}
+                  disabled={
+                    isSaving ||
+                    !canonicalSaveReady ||
+                    poolSizeInputInvalid ||
+                    pendingRemoval !== null ||
+                    (savedWorkout ? !hasUnsavedChanges : false)
+                  }
+                  data-testid={saveButtonTestId}
+                  className="inline-flex h-11 items-center justify-center rounded-xl bg-emerald-600 px-4 text-sm font-semibold text-white transition hover:bg-emerald-500 active:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isSaving
+                    ? "Saving..."
+                    : savedWorkout
+                      ? "Save changes"
+                      : "Accept and save workout"}
+                </button>
+              </div>
             </div>
-            {showInlinePdfAction ? (
-              <p
-                data-testid="workout-editor-pdf-source"
-                data-pdf-state={handoffDraftState}
-                className="mt-2 text-xs font-semibold uppercase tracking-wide text-slate-500"
-              >
-                {workoutPdfStateLabel}
-              </p>
-            ) : null}
           </div>
-          <div className="flex flex-wrap items-center gap-2">
-            {showInlinePdfAction ? (
-              <button
-                type="button"
-                onClick={() => openWorkoutPdfPrintView("standard")}
-                data-testid="workout-editor-pdf-open"
-                className="inline-flex h-11 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
-              >
-                {workoutPdfButtonLabel}
-              </button>
-            ) : null}
-            {!showPdfPanel && !showCalmBuilderLayout ? (
-              <button
-                type="button"
-                onClick={() => openWorkoutPdfPrintView("poolside")}
-                data-testid="workout-editor-poolside-pdf-open"
-                className="inline-flex h-11 items-center justify-center rounded-xl border border-blue-200 bg-white px-4 text-sm font-medium text-blue-800 transition hover:bg-blue-50 active:bg-blue-100"
-              >
-                {workoutPoolsidePdfButtonLabel}
-              </button>
-            ) : null}
-            {savedWorkout && onResetToSaved ? (
-              <button
-                type="button"
-                onClick={() => {
-                  setPendingRemoval(null);
-                  setLastRemovedBlock(null);
-                  onResetToSaved();
-                }}
-                disabled={isSaving || !hasUnsavedChanges || pendingRemoval !== null}
-                data-testid="workout-editor-reset"
-                className="inline-flex h-11 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                Reset to last saved
-              </button>
-            ) : null}
-            <button
-              type="button"
-              onClick={() => {
-                setPendingRemoval(null);
-                setLastRemovedBlock(null);
-                onSave();
-              }}
-              disabled={
-                isSaving ||
-                !canonicalSaveReady ||
-                poolSizeInputInvalid ||
-                pendingRemoval !== null ||
-                (savedWorkout ? !hasUnsavedChanges : false)
-              }
-              data-testid={saveButtonTestId}
-              className="inline-flex h-11 items-center justify-center rounded-xl bg-emerald-600 px-4 text-sm font-semibold text-white transition hover:bg-emerald-500 active:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {isSaving ? "Saving..." : savedWorkout ? "Save changes" : "Accept and save workout"}
-            </button>
-          </div>
-        </div>
-      </div>
 
-      {showInlinePdfAction && workoutPdfNotice ? (
-        <p
-          data-testid="workout-editor-pdf-notice"
-          className="mt-3 text-sm font-medium text-emerald-700"
-        >
-          {workoutPdfNotice}
-        </p>
+          {showInlinePdfAction && workoutPdfNotice ? (
+            <p
+              data-testid="workout-editor-pdf-notice"
+              className="mt-3 text-sm font-medium text-emerald-700"
+            >
+              {workoutPdfNotice}
+            </p>
+          ) : null}
+        </>
       ) : null}
 
       {showCalmBuilderLayout ? supportToolsPanel : null}
 
-      {showInlinePdfAction && workoutPdfError ? (
+      {!showCalmBuilderLayout && showInlinePdfAction && workoutPdfError ? (
         <p data-testid="workout-editor-pdf-error" className="mt-3 text-sm text-rose-700">
           {workoutPdfError}
         </p>

--- a/docs/task-briefs/in-progress/2026-04-13-swim-session-builder-repeat-container-targeted-edit-and-session-actions-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-13-swim-session-builder-repeat-container-targeted-edit-and-session-actions-10-10.md
@@ -1,0 +1,191 @@
+# Task Brief: Swim Session Builder Repeat Container, Targeted Edit, And Session Actions (10/10)
+
+## Metadata
+
+- `id`: `2026-04-13-swim-session-builder-repeat-container-targeted-edit-and-session-actions-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-04-13`
+- `updated`: `2026-04-13`
+
+## Goal
+
+Make repeat blocks scan and edit as first-class session sections, let view-mode cards jump directly into targeted edit, and move save/session actions into the session header so the manual pool builder feels denser and more intentional.
+
+## Dependencies And Boundaries
+
+- Parent lineage:
+  - [2026-02-28-workout-builder-and-poolside-execution-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md)
+- Recently merged residual cleanup slice:
+  - [2026-04-13-swim-session-builder-residual-density-starter-scaffold-and-library-cleanup-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-04-13-swim-session-builder-residual-density-starter-scaffold-and-library-cleanup-10-10.md)
+- Relevant delivered swim-builder slices:
+  - [2026-04-11-swim-session-builder-garmin-authoring-and-poolside-note-redesign-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-11-swim-session-builder-garmin-authoring-and-poolside-note-redesign-10-10.md)
+  - [2026-04-12-swim-session-builder-scan-delete-and-poolside-brand-polish-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-12-swim-session-builder-scan-delete-and-poolside-brand-polish-10-10.md)
+- Locked scope decisions for this slice:
+  - implement repeat-container summary and collapse/edit behavior now,
+  - implement targeted edit entry from `View` cards now,
+  - move save/PDF/reset actions into `Session details` now,
+  - do not add drag-and-drop in this slice,
+  - do not do private-preview/global-logo/poolside-brand full-pass work in this slice.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Visual design quality`
+- `Business logic correctness and data integrity`
+- `Admin workflow and editability`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold / Scope Rationale                                                                                                                                                    | Evidence                       | Expected Closeout Score |
+| --------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | ----------------------- |
+| Product goals and IA                          | `supporting` | Supporting only: builder surfaces should read as session sections rather than disconnected cards/actions.                                                                             | code review + QA               | `4`                     |
+| UX flow clarity                               | `target`     | Repeat containers, single steps, and session-level actions should each have one obvious scan path and one obvious edit/save path on desktop and mobile.                               | manual QA + e2e                | `5`                     |
+| Visual design quality                         | `target`     | The builder should reclaim vertical space, reduce detached control boxes, and make repeat containers look structurally deliberate instead of like one expanded form block.            | preview QA + screenshot review | `5`                     |
+| Business logic correctness and data integrity | `target`     | Repeat groups must remain Garmin-compatible canonical structures; only presentation and local editing state may change.                                                               | code review + unit/e2e         | `5`                     |
+| Admin editor ergonomics                       | `supporting` | Supporting only: the private authoring surface should reduce pointer travel and repeated mode switching.                                                                              | manual QA                      | `4`                     |
+| Accessibility (a11y)                          | `supporting` | Click-to-edit view cards must stay keyboard reachable, and repeat/session action controls must preserve labels, focus order, and clear state.                                         | code review + e2e              | `4`                     |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: no material route slowdown or client-state churn should be introduced by the interaction changes.                                                                    | build + verify                 | `4`                     |
+| Data placement and sync boundaries            | `target`     | View/edit mode, open-card state, and repeat expand/collapse state remain local authoring state; saved workout content remains server-canonical and unchanged in meaning.              | brief contract + code review   | `5`                     |
+| Caching and invalidation strategy             | `N/A`        | N/A because this slice changes no cache mode or invalidation policy; it only changes local editor presentation and interactions.                                                      | explicit scope rationale       | `N/A`                   |
+| Reliability and failure handling              | `supporting` | Supporting only: save/reset/delete must still behave predictably after moving actions into the session header.                                                                        | manual QA + e2e                | `4`                     |
+| Security and authz                            | `N/A`        | N/A because no auth boundary, entitlement rule, or protected API write policy changes in this slice.                                                                                  | explicit scope rationale       | `N/A`                   |
+| Privacy and compliance                        | `N/A`        | N/A because no personal-data scope, storage, or disclosure behavior changes here.                                                                                                     | explicit scope rationale       | `N/A`                   |
+| Content governance                            | `N/A`        | N/A because this slice changes UI structure and interaction design, not content governance flows or source-of-truth text policy.                                                      | explicit scope rationale       | `N/A`                   |
+| Admin workflow and editability                | `target`     | Authors should be able to scan the workout in `View`, jump into the exact section they want, collapse repeat blocks, and save from the session header without extra vertical hunting. | manual QA + targeted e2e       | `5`                     |
+| SEO and crawlability                          | `N/A`        | N/A because no public route metadata, sitemap, or crawl behavior changes.                                                                                                             | explicit scope rationale       | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because no public AI-discoverable route or metadata surface changes.                                                                                                              | explicit scope rationale       | `N/A`                   |
+| Analytics and KPI observability               | `N/A`        | N/A because this slice does not change analytics events or KPI reporting.                                                                                                             | explicit scope rationale       | `N/A`                   |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, entitlement, or billing behavior changes.                                                                                                                     | explicit scope rationale       | `N/A`                   |
+| Incident response and support operations      | `N/A`        | N/A because this slice changes no support/incident workflow, only private builder presentation.                                                                                       | explicit scope rationale       | `N/A`                   |
+| Finance and reporting operations              | `N/A`        | N/A because no finance reconciliation, invoicing, or reporting workflow changes.                                                                                                      | explicit scope rationale       | `N/A`                   |
+| i18n operational readiness                    | `N/A`        | N/A because this slice changes English-only private builder copy and interaction placement, not localization architecture.                                                            | explicit scope rationale       | `N/A`                   |
+| Stack-fit and dependency discipline           | `supporting` | Supporting only: implement using the existing `WorkoutEditor` state model and current design system primitives without adding dependencies.                                           | diff review                    | `4`                     |
+| Testing and QA automation                     | `target`     | Coverage must protect targeted edit entry, repeat-container collapse behavior, and relocated session actions; `verify:pre-pr` must pass.                                              | updated tests + verify         | `5`                     |
+| Scalability and cost efficiency               | `N/A`        | N/A because no backend compute/storage or third-party service footprint changes.                                                                                                      | explicit scope rationale       | `N/A`                   |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: the UI/control refactor should remain easy to rollback as one scoped diff if regressions are found.                                                                  | git diff + PR scope            | `4`                     |
+
+## Data Placement And Sync Contract
+
+- Server-canonical data:
+  - saved workout title, metadata, step list, repeat semantics, rests, and export-facing canonical structure remain source-of-truth on the server.
+- Local-only data:
+  - `View` vs `Edit` mode,
+  - currently opened step card,
+  - currently opened repeat container,
+  - unsaved form edits before save,
+  - temporary save-status and removal-confirmation UI.
+- Sync policy:
+  - clicking a card in `View` moves the editor into targeted local edit state only; no server write occurs,
+  - save/reset/delete continue to use existing write/reset paths,
+  - repeat collapse state is presentation-only and never mutates canonical step ordering or semantics.
+- Retention and sensitivity:
+  - no new retained client storage is introduced,
+  - no new sensitive data is collected or exposed.
+- Cache/invalidation:
+  - unchanged from current builder behavior; successful save/reset/delete continues to drive the same existing refresh/invalidation logic.
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - workout IDs, step IDs, and repeat-group IDs remain the canonical identities.
+- Human-readable identifiers:
+  - labels such as `MAIN 2 OF 3`, `Repeat block`, and `Session details` are presentation-only and may change without data migration.
+- Mutability rules:
+  - this slice does not rename or repurpose persisted entities.
+- Rename vs repurpose policy:
+  - N/A for persisted entities because no rename/repurpose behavior changes here.
+- Compatibility contract:
+  - test IDs that existing coverage depends on should be preserved unless updated in the same slice.
+- Observability and repair:
+  - regressions are detected by targeted e2e/unit coverage and the standard verify gates.
+
+## Scope
+
+- `components/my-library/workouts/WorkoutEditor.tsx`
+- relevant tests covering:
+  - manual pool repeat blocks,
+  - builder view/edit transitions,
+  - session save/reset/delete action placement,
+  - manual pool `View` mode behavior
+- brief/checkpoint updates tied to this slice
+
+## Out Of Scope
+
+- Drag-and-drop step movement or repeat reordering by gesture.
+- Global desktop header/logo cleanup.
+- Private preview access page redesign.
+- Poolside-note full visual-brand redesign.
+- Dryland / land-training builder work.
+- New Garmin data contracts or repeat/export semantics beyond presentational clarity.
+
+## Acceptance Criteria
+
+1. Manual-pool repeat containers no longer read only as `Repeat set`; they show top-level section identity and explicit repeat-container meaning in a scan-friendly summary.
+2. Repeat containers can collapse/expand in authoring mode without flattening away internal canonical structure.
+3. In `View` mode, clicking a single-step card opens targeted edit for that exact section.
+4. In `View` mode, clicking a repeat-container card opens targeted edit for that repeat container.
+5. `Session details` becomes the home for save/reset/PDF/session-delete actions in the calm manual-pool builder layout.
+6. The separate bottom save-actions card is removed for the calm manual-pool builder layout without losing dirty/saved-state clarity.
+7. Mobile and desktop layouts both stay readable and avoid cramped destructive/primary-action collisions.
+8. Repeat, save, reset, delete, and PDF behaviors remain functionally unchanged apart from the intended interaction and placement updates.
+9. Relevant unit/e2e coverage is updated in the same slice.
+
+## Validation
+
+- `npm run lint:briefs`
+- `npm run lint`
+- `npm run typecheck`
+- targeted unit/e2e for changed builder behavior
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm must be installed on the machine used for local validation.
+- Validation runs from repo root.
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3000/my-library/workouts/<id>?entry=manual-pool`
+- Preview:
+  - Vercel preview URL from the PR checks
+- Recommended browser/device matrix:
+  - iPhone Safari
+  - Android Chromium
+  - iPad/tablet viewport
+  - Desktop Chrome
+  - Desktop Safari/WebKit
+
+## Constraints
+
+- Preserve Garmin-compatible canonical repeat/rest semantics.
+- Do not flatten the repeat group into fake single-step data.
+- Keep destructive actions visually separated from primary save actions.
+- Preserve current builder visual language while making the hierarchy denser and clearer.
+
+## 10/10 Quality Bar
+
+- Repeat blocks should scan like real session sections, not like a permanently expanded nested form.
+- `View` mode should feel like a clean reading surface with immediate targeted edit entry.
+- Session-level actions should live where the user naturally thinks about the workout itself, not in a detached footer card.
+- All changed states must remain clear across `view`, `edit`, `collapsed`, `expanded`, `dirty`, `saved`, `delete pending`, and `reset`.
+- Business logic must remain deterministic:
+  - no change to repeat ordering,
+  - no change to post-set-rest suppression rules,
+  - no silent canonical data mutation from view/edit toggling,
+  - no save-state ambiguity.
+
+## Help / Guide Impact
+
+- `N/A` for public Help/Guide content because this slice changes private builder ergonomics only and does not change a public-facing workflow contract.
+
+## Checkpoint Log
+
+- `2026-04-13 | in-progress | brief created after owner review of residual swim-session-builder findings: repeat containers need top-level section identity and collapse behavior, view cards should enter targeted edit, and save/PDF/reset actions should move into Session details; drag-and-drop remains explicitly deferred | next: implement WorkoutEditor interaction/layout updates, then update targeted tests and run verification gates`
+- `2026-04-13 | in-progress | WorkoutEditor now gives repeat containers first-class section summaries/collapse state, view-mode targeted edit entry, and session-level actions inside Session details; targeted typecheck, unit, builder Playwright, and brief lint are green | next: commit and open PR, but note that full verify:pre-pr is currently blocked by unrelated untouched desktop Chromium e2e failures in admin-notes, course-progress, and athlete-profile suites`
+- `2026-04-13 | in-progress | commit 1b14686 captured the scoped builder slice after targeted validation; full verify:pre-pr still hit unrelated untouched repo E2E blockers outside builder scope | next: push branch, update/open PR, and report merge readiness as blocked by baseline red suites until those are resolved or waived`

--- a/docs/task-briefs/in-progress/2026-04-13-swim-session-builder-repeat-container-targeted-edit-and-session-actions-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-13-swim-session-builder-repeat-container-targeted-edit-and-session-actions-10-10.md
@@ -6,7 +6,7 @@
 - `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-04-13`
-- `updated`: `2026-04-13`
+- `updated`: `2026-04-14`
 
 ## Goal
 
@@ -189,3 +189,4 @@ Critical target categories for `10/10` claim in this brief:
 - `2026-04-13 | in-progress | brief created after owner review of residual swim-session-builder findings: repeat containers need top-level section identity and collapse behavior, view cards should enter targeted edit, and save/PDF/reset actions should move into Session details; drag-and-drop remains explicitly deferred | next: implement WorkoutEditor interaction/layout updates, then update targeted tests and run verification gates`
 - `2026-04-13 | in-progress | WorkoutEditor now gives repeat containers first-class section summaries/collapse state, view-mode targeted edit entry, and session-level actions inside Session details; targeted typecheck, unit, builder Playwright, and brief lint are green | next: commit and open PR, but note that full verify:pre-pr is currently blocked by unrelated untouched desktop Chromium e2e failures in admin-notes, course-progress, and athlete-profile suites`
 - `2026-04-13 | in-progress | commit 1b14686 captured the scoped builder slice after targeted validation; full verify:pre-pr still hit unrelated untouched repo E2E blockers outside builder scope | next: push branch, update/open PR, and report merge readiness as blocked by baseline red suites until those are resolved or waived`
+- `2026-04-14 | in-progress | rebased branch cleanly onto main after merge commit 7b41f3a from PR #425 resolved the shared desktop Chromium baseline instability; this slice no longer has the previously recorded repo-baseline blocker and should now be revalidated through the standard gates | next: run lint:briefs plus verify:pre-pr on the rebased branch, force-push PR #424, then run verify:pre-merge before final merge recommendation`

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -132,6 +132,13 @@ async function openMetadataPanelIfCollapsed(page: Page) {
   }
 }
 
+async function openRepeatGroupIfCollapsed(page: Page, groupIndex: number) {
+  const toggle = page.getByTestId(`session-draft-repeat-toggle-${groupIndex}`);
+  if ((await toggle.getAttribute("aria-expanded")) === "false") {
+    await toggle.click();
+  }
+}
+
 async function triggerCreateSession(page: Page, testId: string) {
   const createButton = page.getByTestId(testId);
   await expect(createButton).toHaveAttribute("data-client-ready", "true", {
@@ -209,6 +216,15 @@ test.describe("my library workout builder", () => {
     await expect(page.getByTestId("session-draft-step-mobile-actions-panel-0")).toBeVisible();
     await expect(page.getByTestId("session-draft-step-mobile-remove-0")).toBeVisible();
 
+    await expect(page.getByTestId("session-draft-repeat-mobile-summary-2")).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+    await page.getByTestId("session-draft-repeat-mobile-summary-2").click();
+    await expect(page.getByTestId("session-draft-repeat-mobile-summary-2")).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
     await expect(page.getByTestId("session-draft-repeat-count-2")).toBeVisible();
     await expect(
       page.getByTestId("session-draft-repeat-mobile-primary-add-step-after-2")
@@ -290,6 +306,19 @@ test.describe("my library workout builder", () => {
     await expect(
       page.getByTestId("workout-editor-metadata-panel").getByText("Untitled pool session")
     ).toBeVisible();
+    await expect(
+      page.getByTestId("workout-editor-metadata-panel").getByRole("button", {
+        name: "View PDF",
+      })
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("workout-editor-metadata-panel").getByRole("button", {
+        name: "Reset to last saved",
+      })
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("workout-editor-metadata-panel").getByTestId("workout-builder-save")
+    ).toBeVisible();
     await expect(page.getByText("Title through equipment")).toHaveCount(0);
     await expect(page.getByTestId("session-draft-title")).toBeVisible();
     await expect(page.getByText("Session details")).toBeVisible();
@@ -328,7 +357,8 @@ test.describe("my library workout builder", () => {
     await expect(page.getByRole("combobox", { name: "Effort" })).toHaveCount(0);
     await expect(page.getByTestId("session-draft-step-summary-0")).toBeVisible();
     await expect(page.getByTestId("session-draft-step-toggle-0")).toBeVisible();
-    await expect(page.getByText("Repeat set")).toBeVisible();
+    await expect(page.getByTestId("session-draft-repeat-summary-2")).toContainText("Main");
+    await expect(page.getByTestId("session-draft-repeat-summary-2")).toContainText("Repeat block");
     const collapsedStepSummaryBox = await page
       .getByTestId("session-draft-step-summary-0")
       .boundingBox();
@@ -497,6 +527,7 @@ test.describe("my library workout builder", () => {
     await expect(page.getByLabel("Exact pool size (yd)")).toHaveValue("25");
     await page.getByTestId("session-draft-step-distance-0").selectOption("custom");
     await page.getByTestId("session-draft-step-distance-custom-0").fill("333");
+    await openRepeatGroupIfCollapsed(page, 2);
     await expect(page.getByTestId("session-draft-repeat-desktop-actions-2")).toHaveAttribute(
       "data-desktop-layout",
       "bottom"
@@ -726,6 +757,7 @@ test.describe("my library workout builder", () => {
     await page.getByTestId("session-draft-step-toggle-0").click();
     await expect(page.getByTestId("session-draft-step-distance-0")).toHaveValue("custom");
     await expect(page.getByTestId("session-draft-step-distance-custom-0")).toHaveValue("333");
+    await openRepeatGroupIfCollapsed(page, 2);
     await expect(page.getByTestId("session-draft-repeat-count-2")).toHaveValue("6");
     await page.getByTestId("session-draft-step-toggle-2").click();
     await expect(page.getByTestId("session-draft-step-distance-2")).toHaveValue("200");

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -530,6 +530,7 @@ describe("WorkoutBuilderHub", () => {
     fireEvent.click(screen.getByTestId("session-draft-step-toggle-0"));
     expect(screen.getByTestId("session-draft-step-distance-0")).toHaveValue("custom");
     expect(screen.getByTestId("session-draft-step-distance-custom-0")).toHaveValue("333");
+    fireEvent.click(screen.getByTestId("session-draft-repeat-toggle-1"));
     fireEvent.click(screen.getByTestId("session-draft-step-toggle-1"));
     expect(screen.getByTestId("session-draft-step-name-1")).toHaveValue("Repeat swim focus");
     expect(screen.getByTestId("session-draft-step-distance-1")).toHaveValue("200");
@@ -717,7 +718,7 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.getByTestId("session-draft-repeat-ending-rest-mode-1")).toHaveValue(
       "skip_last_rest"
     );
-    expect(screen.getByText(/4 rounds/)).toBeVisible();
+    expect(screen.getAllByText(/4 rounds/)[0]).toBeVisible();
     expect(
       screen.queryByText(
         "Fixed Rest Time 1:00 still runs between rounds. It is skipped only after the final round."
@@ -778,7 +779,9 @@ describe("WorkoutBuilderHub", () => {
     fireEvent.click(screen.getByTestId("session-draft-add-repeat"));
     fireEvent.click(screen.getByTestId("session-draft-repeat-duplicate-1"));
 
+    fireEvent.click(screen.getByTestId("session-draft-repeat-toggle-1"));
     expect(screen.getByTestId("session-draft-repeat-count-1")).toHaveValue("4");
+    fireEvent.click(screen.getByTestId("session-draft-repeat-toggle-2"));
     expect(screen.getByTestId("session-draft-repeat-count-2")).toHaveValue("4");
     expect(screen.getByTestId("session-draft-step-name-4")).toHaveValue("Repeat swim");
 
@@ -1342,7 +1345,7 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.queryByTestId("workout-editor-metadata-profile-toggle")).not.toBeInTheDocument();
   });
 
-  it("switches the saved builder into a clean view mode without edit controls", async () => {
+  it("switches the saved builder into a clean view mode with targeted edit entry points", async () => {
     render(
       <WorkoutBuilderHub
         workoutLibrary={buildWorkoutLibrary({
@@ -1375,6 +1378,21 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.getByText("Warmup")).toBeVisible();
     expect(screen.getByText("400m · Freestyle · Easy")).toBeVisible();
     expect(screen.queryByText("Edit step")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /400m · Freestyle · Easy/i }));
+
+    expect(screen.getByTestId("session-draft-step-toggle-0")).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+    expect(screen.getByLabelText("Step Type")).toBeVisible();
+
+    fireEvent.click(screen.getByTestId("session-draft-add-repeat"));
+    fireEvent.click(screen.getByTestId("workout-editor-builder-mode-view"));
+    fireEvent.click(screen.getByRole("button", { name: /Repeat block/i }));
+
+    expect(screen.getByLabelText("Repeat count")).toBeVisible();
+    expect(screen.queryByLabelText("Step Type")).not.toBeInTheDocument();
   });
 
   it("shows clearer kick and drill taxonomy guidance inside the step form", async () => {


### PR DESCRIPTION
## Summary
- User-visible changes: Manual-pool repeat blocks now read as first-class session sections, repeat groups can collapse/expand in edit mode, view cards jump directly into the targeted edit surface, and session-level save/PDF/reset/delete actions now live in Session details instead of a detached footer card.
- Technical changes: Updated `components/my-library/workouts/WorkoutEditor.tsx`, builder unit/E2E coverage, and `docs/task-briefs/in-progress/2026-04-13-swim-session-builder-repeat-container-targeted-edit-and-session-actions-10-10.md`.
- Policy impact: no - this slice only changes private builder UX/state placement and does not change auth, privacy, payments, moderation, or public policy behavior.
- Policy version note: N/A - no policy contract changed in this private builder UX slice.
- Brief link(s): `docs/task-briefs/in-progress/2026-04-13-swim-session-builder-repeat-container-targeted-edit-and-session-actions-10-10.md`

## Scope
- In scope: repeat-container labels/collapse behavior, targeted edit entry from view mode, session action relocation, and matching builder tests/brief updates.
- Out of scope: drag-and-drop, private preview redesign, global logo cleanup, poolside-note brand pass, and dryland/land-training work.

## Risk
- Main risk: WorkoutEditor state regressions in manual-pool edit/view flows because repeat visibility, targeted open state, and save action placement changed together.
- Rollback plan: Revert commit `e244bba` or PR `#424` to restore the previous WorkoutEditor layout and interaction model.

## Test Evidence
- Policy-impact checklist: N/A - private builder UX-only slice with no policy-sensitive paths or contracts changed.
- PASS `npm run typecheck`
- PASS `npx vitest run tests/unit/workout-builder-hub.test.tsx`
- PASS `npx playwright test tests/e2e/my-library-workout-builder.spec.ts`
- PASS `npm run lint:briefs:all`
- FAIL `npm run verify:pre-pr` - full repo lane hit untouched baseline desktop Chromium E2E failures outside this PR scope in `tests/e2e/admin-notes-workflow.spec.ts`, `tests/e2e/course-progress-sync.spec.ts`, and `tests/e2e/my-library-athlete-profile.spec.ts`.
- PENDING `npm run verify:pre-merge` - not run because `verify:pre-pr` is not green on the untouched baseline.

## Checklist
- [x] Scoped builder behavior implemented.
- [x] Relevant unit and E2E coverage updated.
- [x] Brief updated and `npm run lint:briefs:all` passed.
- [ ] Full repo gates are green on this branch.
