### PR TITLE
docs: close out recent brief lifecycle reconcile

### DIFF
--- a/docs/task-briefs/done/2026-04-14-recent-brief-lifecycle-closeout-reconcile-10-10.md
+++ b/docs/task-briefs/done/2026-04-14-recent-brief-lifecycle-closeout-reconcile-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-04-14-recent-brief-lifecycle-closeout-reconcile-10-10`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-04-14`
 - `updated`: `2026-04-14`
@@ -94,3 +94,4 @@ Critical target categories for `10/10` claim in this brief:
 ## Checkpoint Log
 
 - `2026-04-14 | in-progress | opened a narrow docs-only reconcile slice after PRs #423, #424, and #425 merged and several recent implementation briefs still remained in in-progress alongside older docs-only verification briefs that were already delivered on main | next: move the stale briefs to done, update closeout checkpoints and links, run docs-only gates, then open a small closeout PR`
+- `2026-04-14 | done | merged via PR #426 on commit 4ddbe5d, which closed out the stale recent briefs and restored truthful lifecycle state across the active swim-session-builder docs track | next: keep later builder work in their own scoped briefs and close each brief in the same merge window when feasible`


### PR DESCRIPTION
## Summary

- Move the recent brief lifecycle reconcile brief itself from `in-progress` to `done` after PR #426 merged.
- User-visible changes: None in runtime product; docs-only lifecycle closeout.
- Technical changes: Rename `docs/task-briefs/in-progress/2026-04-14-recent-brief-lifecycle-closeout-reconcile-10-10.md` to `docs/task-briefs/done/2026-04-14-recent-brief-lifecycle-closeout-reconcile-10-10.md`, set `status: done`, and add PR #426 merge evidence.
- Policy impact: no (docs-only lifecycle bookkeeping; no policy/auth/runtime/content contract change)
- Policy version note: N/A (no policy document or version changed)
- Brief link(s): `docs/task-briefs/done/2026-04-14-recent-brief-lifecycle-closeout-reconcile-10-10.md`

## Scope

- In scope: Close out the reconcile brief after the PR #426 merge and keep lifecycle folders truthful.
- Out of scope: Any product/runtime/UI change, swim-session-builder behavior, private preview, poolside note, dryland, or drag-and-drop work.

## Risk

- Main risk: Low; only brief lifecycle metadata/path could be wrong.
- Rollback plan: Revert this closeout commit to restore the previous in-progress path.

## Test Evidence

- Policy-impact checklist: N/A (docs-only reconcile; no policy-impact paths changed)
- [x] `npm run verify:docs-only`
- [x] `npm run lint:briefs:all`
- [x] `npm run lint:admin-audit`
- [x] `npm run lint:env-parity`
- [x] `npm run lint:pr-body:generated`
- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr` PASS
- [x] `npm run verify:pre-merge` PASS on `8d284dd`
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)
- `npm run verify:docs-only` PASS
- `npm run lint:briefs:all` PASS
- `npm run lint:admin-audit` PASS
- `npm run lint:env-parity` PASS
- `npm run lint:pr-body:generated` PASS

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [x] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [x] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added
