### PR TITLE
docs: close out pr 440 briefs

### DIFF
--- a/docs/task-briefs/done/2026-04-15-poolside-note-layout-and-preview-favicon-polish-10-10.md
+++ b/docs/task-briefs/done/2026-04-15-poolside-note-layout-and-preview-favicon-polish-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-04-15-poolside-note-layout-and-preview-favicon-polish-10-10`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-04-15`
 - `updated`: `2026-04-15`
@@ -198,3 +198,4 @@ Critical target categories for `10/10` claim in this brief:
 
 - `2026-04-15 | planning | created final poolside polish brief from owner-approved follow-up scope: restore favicon/tab identity and lock portrait/landscape placement around steps-first readability | next: patch generated poolside HTML/CSS, add assertions, and validate through targeted tests plus full pre-PR gate`
 - `2026-04-15 | implementation | completed poolside preview favicon/head metadata plus portrait/landscape ordering polish so steps lead the reading flow; targeted unit/e2e plus full verify:pre-pr passed locally | next: commit, push, open/update PR, then run verify:pre-merge and monitor CI`
+- `2026-04-15 | done | merged to main in PR #440 via commit f476bd8 after local verify:pre-pr, local verify:pre-merge, and all required GitHub checks passed; the poolside favicon/layout polish is shipped and no longer owns active work | closeout: move brief to done`

--- a/docs/task-briefs/done/2026-04-15-swim-session-builder-header-delete-and-rest-clarity-10-10.md
+++ b/docs/task-briefs/done/2026-04-15-swim-session-builder-header-delete-and-rest-clarity-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-04-15-swim-session-builder-header-delete-and-rest-clarity-10-10`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-04-15`
 - `updated`: `2026-04-15`
@@ -229,3 +229,4 @@ Critical target categories for `10/10` claim in this brief:
 
 - `2026-04-15 | planning | created combined builder cleanup brief from owner-approved follow-up scope: remove visible details narration, remove the always-visible danger zone, restore compact delete placement with confirm, clean up manual-pool rest naming/summaries, and remove scaffold note filler from fresh pool drafts without touching Garmin structure | next: implement the UI cleanup and verify with targeted unit/e2e plus full gates`
 - `2026-04-15 | implementation | completed builder-header cleanup, compact delete action placement, parent-linked rest naming/summary cleanup, and removal of seeded scaffold note copy from fresh manual pool drafts; targeted unit/e2e plus full verify:pre-pr passed locally | next: commit, push, open/update PR, then run verify:pre-merge and monitor CI`
+- `2026-04-15 | done | merged to main in PR #440 via commit f476bd8 after local verify:pre-pr, local verify:pre-merge, and all required GitHub checks passed; this brief now reflects shipped builder cleanup rather than active scope | closeout: move brief to done`


### PR DESCRIPTION
## Summary

- What changed and why? Close the stale lifecycle gap left after PR #440 merged by moving its two delivered briefs from `in-progress` to `done` and recording the actual merge closeout in each checkpoint log.
- User-visible changes: none; this PR updates brief lifecycle state only.
- Technical changes: moved `2026-04-15-swim-session-builder-header-delete-and-rest-clarity-10-10.md` and `2026-04-15-poolside-note-layout-and-preview-favicon-polish-10-10.md` into `docs/task-briefs/done/`, flipped their metadata status to `done`, and added explicit PR #440 / commit `f476bd8` closeout entries.
- Policy impact: no (docs-only lifecycle closeout; no auth/session/account, analytics/consent, user-data-rights, or processor-policy scope changed)
- Policy version note: N/A (no policy document or policy-governed runtime contract changed)

## Scope

- In scope: brief lifecycle closeout for the two PR #440 implementation briefs under `docs/task-briefs/`.
- Out of scope: runtime code, tests, workflows, merge behavior, and any additional builder or poolside product changes.

## Risk

- Main risk: the only realistic risk is leaving lifecycle state inconsistent if the briefs are not moved and logged truthfully.
- Rollback plan: revert commit `fc26ba2` or close the PR without merge; no runtime or schema changes are involved.

## Test Evidence

- Brief link(s): `docs/task-briefs/done/2026-04-15-swim-session-builder-header-delete-and-rest-clarity-10-10.md`, `docs/task-briefs/done/2026-04-15-poolside-note-layout-and-preview-favicon-polish-10-10.md`
- Policy-impact checklist: N/A (docs-only lifecycle closeout; no policy-impact file scope in this diff)
- `npm run verify:docs-only` PASS
- `npm run lint:briefs:all` PASS
- `npm run lint:admin-audit` PASS
- `npm run lint:env-parity` PASS
- `npm run lint:pr-body:generated` PASS
- `npm run verify:pre-pr` PASS
- `npm run verify:pre-merge` PASS on `fc26ba2`
- [x] `npm run verify:docs-only` (pure docs/governance diffs only)
- [x] `npm run lint:briefs:all` (required for docs-only lane)
- [x] `npm run lint:admin-audit` (required for docs-only lane)
- [x] `npm run lint:env-parity` (required for docs-only lane)
- [x] `npm run lint:pr-body:generated` (required for docs-only lane)
- [x] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge` (must be `PASS` on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (not needed for docs-only closeout)
- [ ] Vercel preview manual QA done (not needed for docs-only closeout)
- [ ] QA covered relevant matrix for this change (not needed for docs-only closeout)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [x] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [x] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d docs/pr440-brief-closeout`
- [ ] Optional: `git fetch --prune`