### PR TITLE
feat: attach builder rests to parent steps

### DIFF
--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -2,7 +2,14 @@
 
 import Link from "next/link";
 import { ChevronDown, ChevronUp, Ellipsis } from "lucide-react";
-import { useCallback, useEffect, useRef, useState, type TextareaHTMLAttributes } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type TextareaHTMLAttributes,
+} from "react";
 import { BRAND_FONT_PUBLIC_PATH, getWorkoutPdfLogoPath } from "@/lib/brand";
 import { useAutoDismissNotice } from "@/components/my-library/workouts/useAutoDismissNotice";
 import {
@@ -131,6 +138,7 @@ type PendingRemoval =
   | {
       kind: "step";
       stepId: string;
+      stepIds: string[];
       label: string;
       repeatGroupId: string | null;
     }
@@ -883,23 +891,69 @@ function buildStepSummary(
     .join(" · ");
 }
 
+function resolveManualPoolSummaryUnitFromName(name: string): SessionDraftPoolLengthUnit | null {
+  const normalized = name.trim().toLowerCase();
+
+  if (/^\d+(?:\.\d+)?yd\b/.test(normalized)) {
+    return "yd";
+  }
+
+  if (/^\d+(?:\.\d+)?m\b/.test(normalized)) {
+    return "m";
+  }
+
+  return null;
+}
+
+function resolveManualPoolSummaryUnit(
+  step: SessionDraftStep,
+  fallbackUnit: SessionDraftPoolLengthUnit
+): SessionDraftPoolLengthUnit {
+  if (step.durationMode !== "distance") {
+    return fallbackUnit;
+  }
+
+  return resolveManualPoolSummaryUnitFromName(step.name) ?? fallbackUnit;
+}
+
+function didManualPoolSummaryUnitInputsChange(
+  previousStep: SessionDraftStep | null | undefined,
+  nextStep: SessionDraftStep
+) {
+  if (!previousStep) {
+    return true;
+  }
+
+  return (
+    previousStep.durationMode !== nextStep.durationMode ||
+    previousStep.distanceM !== nextStep.distanceM ||
+    previousStep.targetMode !== nextStep.targetMode ||
+    previousStep.targetPaceSecondsPer100m !== nextStep.targetPaceSecondsPer100m ||
+    previousStep.cssTargetOffsetSeconds !== nextStep.cssTargetOffsetSeconds
+  );
+}
+
 function buildManualPoolStepSummary(
   step: SessionDraftStep,
   basePaceSecondsPer100m: number,
-  poolLengthUnit: SessionDraftPoolLengthUnit
+  poolLengthUnit: SessionDraftPoolLengthUnit,
+  options?: {
+    summaryUnit?: SessionDraftPoolLengthUnit;
+  }
 ) {
   const normalizedStep = normalizeManualPoolStepForEditor(step);
+  const summaryUnit = options?.summaryUnit ?? resolveManualPoolSummaryUnit(step, poolLengthUnit);
   const structuredTarget = buildSessionStepStructuredTargetLabel(
     normalizedStep,
     basePaceSecondsPer100m,
-    poolLengthUnit
+    summaryUnit
   );
 
   return (
     [
       buildWorkoutStepDurationOutputSummary(normalizedStep, basePaceSecondsPer100m, {
         environment: "pool",
-        poolLengthUnit,
+        poolLengthUnit: summaryUnit,
       }),
       buildStepContextLabel(normalizedStep, { environment: "pool" }),
       structuredTarget ?? getSessionStepIntensityLabel(normalizedStep.intensity),
@@ -914,10 +968,10 @@ function buildManualPoolRestInlineSummary(step: SessionDraftStep, basePaceSecond
     environment: "pool",
   });
   if (summary.startsWith("Fixed Rest Time ")) {
-    return `Rest: ${summary.replace("Fixed Rest Time ", "")}`;
+    return `Rest ${summary.replace("Fixed Rest Time ", "")}`;
   }
 
-  return summary === "Fixed Rest Time not set" ? "Rest: not set" : summary;
+  return summary === "Fixed Rest Time not set" ? "Rest not set" : summary;
 }
 
 function buildManualPoolRestValueSummary(step: SessionDraftStep, basePaceSecondsPer100m: number) {
@@ -948,16 +1002,18 @@ function buildManualPoolDisplaySummary(
 function syncManualPoolEditableStep(
   step: SessionDraftStep,
   basePaceSecondsPer100m: number,
-  poolLengthUnit: SessionDraftPoolLengthUnit
+  poolLengthUnit: SessionDraftPoolLengthUnit,
+  options?: {
+    summaryUnit?: SessionDraftPoolLengthUnit;
+  }
 ): SessionDraftStep {
   const normalizedStep = normalizeManualPoolStepForEditor(step);
 
   return {
     ...normalizedStep,
-    name: buildManualPoolStepSummary(normalizedStep, basePaceSecondsPer100m, poolLengthUnit).slice(
-      0,
-      120
-    ),
+    name: buildManualPoolStepSummary(normalizedStep, basePaceSecondsPer100m, poolLengthUnit, {
+      summaryUnit: options?.summaryUnit,
+    }).slice(0, 120),
     targetSummary: "",
   };
 }
@@ -981,7 +1037,7 @@ function buildRepeatSummary(
   entries: StepRenderEntry[],
   repeatCount: number | null,
   basePaceSecondsPer100m: number,
-  repeatEndingRestMode: SessionDraftRepeatEndingRestMode,
+  _repeatEndingRestMode: SessionDraftRepeatEndingRestMode,
   poolLengthUnit: SessionDraftPoolLengthUnit,
   postSetRestStep?: SessionDraftStep | null
 ) {
@@ -1002,10 +1058,18 @@ function buildRepeatSummary(
     basePaceSecondsPer100m,
     {
       environment: "pool",
-      poolLengthUnit,
+      poolLengthUnit: resolveManualPoolSummaryUnit(normalizedWorkStep, poolLengthUnit),
     }
   );
   const parts = [`${repeatCount} x ${workLabel}`];
+  const workStrokeLabel =
+    normalizedWorkStep.stroke !== "choice" && normalizedWorkStep.stroke !== "mixed"
+      ? getSessionStepStrokeLabel(normalizedWorkStep.stroke)
+      : "";
+
+  if (workStrokeLabel) {
+    parts.push(workStrokeLabel);
+  }
 
   if (betweenStep) {
     if (betweenStep.category === "rest") {
@@ -1022,11 +1086,7 @@ function buildRepeatSummary(
     }
   }
 
-  if (
-    postSetRestStep &&
-    repeatEndingRestMode !== "use_last_rest" &&
-    postSetRestStep.category === "rest"
-  ) {
+  if (postSetRestStep && postSetRestStep.category === "rest") {
     const restValue = buildManualPoolRestValueSummary(postSetRestStep, basePaceSecondsPer100m);
     parts.push(`Set rest ${restValue}`);
   }
@@ -1066,6 +1126,27 @@ type ManualPoolTopLevelSectionDescriptor = {
   title: string;
   isRepeat: boolean;
 };
+
+type ManualPoolEditBlock =
+  | {
+      kind: "single";
+      key: string;
+      groupIndex: number;
+      startIndex: number;
+      endIndex: number;
+      entry: StepRenderEntry;
+      linkedRestEntry: StepRenderEntry | null;
+      steps: SessionDraftStep[];
+    }
+  | {
+      kind: "repeat";
+      key: string;
+      groupIndex: number;
+      startIndex: number;
+      endIndex: number;
+      group: Extract<StepRenderGroup, { kind: "repeat" }>;
+      steps: SessionDraftStep[];
+    };
 
 function getManualPoolTopLevelCategory(group: StepRenderGroup) {
   return normalizeManualPoolStepForEditor(group.entries[0].step).category;
@@ -1144,7 +1225,7 @@ function buildManualPoolRepeatViewSection(
     return {
       key: group.repeatGroupId,
       title,
-      badge: "Repeat block",
+      badge: null,
       lines: [{ text: "Set the work interval for this repeat block." }],
       numbered: false,
       variant: "repeat",
@@ -1167,8 +1248,9 @@ function buildManualPoolRepeatViewSection(
 
   if (betweenStep) {
     if (betweenStep.category === "rest") {
+      const restValue = buildManualPoolRestValueSummary(betweenStep, basePaceSecondsPer100m);
       lines[0] = {
-        text: `${lines[0].text} · Rest: ${formatClockDurationLabel(betweenStep.timeMin)}`,
+        text: `${lines[0].text} · Interval rest ${restValue}`,
       };
     } else {
       lines.push({
@@ -1182,9 +1264,13 @@ function buildManualPoolRepeatViewSection(
     }
   }
 
-  if (group.postSetRestEntry?.step && group.repeatEndingRestMode !== "use_last_rest") {
+  if (group.postSetRestEntry?.step) {
+    const restValue = buildManualPoolRestValueSummary(
+      group.postSetRestEntry.step,
+      basePaceSecondsPer100m
+    );
     lines.push({
-      text: `Post-set rest: ${formatClockDurationLabel(group.postSetRestEntry.step.timeMin)}`,
+      text: `Set rest ${restValue}`,
       tone: "rest",
     });
   }
@@ -1192,7 +1278,7 @@ function buildManualPoolRepeatViewSection(
   return {
     key: group.repeatGroupId,
     title,
-    badge: "Repeat block",
+    badge: null,
     lines,
     numbered: false,
     variant: "repeat",
@@ -1331,6 +1417,69 @@ function buildManualPoolViewSections(
   return sections;
 }
 
+function buildManualPoolEditBlocks(
+  stepGroups: StepRenderGroup[],
+  draftSteps: SessionDraftStep[]
+): ManualPoolEditBlock[] {
+  const blocks: ManualPoolEditBlock[] = [];
+  const consumedRestStepIds = new Set<string>();
+
+  stepGroups.forEach((group, groupIndex) => {
+    if (group.kind === "repeat") {
+      const steps = [
+        ...group.entries.map((entry) => entry.step),
+        ...(group.postSetRestEntry ? [group.postSetRestEntry.step] : []),
+      ];
+      const startIndex = group.entries[0]?.index ?? 0;
+      const endIndex =
+        group.postSetRestEntry?.index ??
+        group.entries[group.entries.length - 1]?.index ??
+        startIndex;
+
+      blocks.push({
+        kind: "repeat",
+        key: group.repeatGroupId,
+        groupIndex,
+        startIndex,
+        endIndex,
+        group,
+        steps,
+      });
+      return;
+    }
+
+    const entry = group.entries[0];
+    if (consumedRestStepIds.has(entry.step.id)) {
+      return;
+    }
+
+    const linkedRestStep = findTopLevelLinkedRestStep(draftSteps, entry.step, entry.index);
+    const linkedRestEntry = linkedRestStep
+      ? {
+          step: linkedRestStep,
+          index: entry.index + 1,
+        }
+      : null;
+
+    if (linkedRestEntry) {
+      consumedRestStepIds.add(linkedRestEntry.step.id);
+    }
+
+    blocks.push({
+      kind: "single",
+      key: entry.step.id,
+      groupIndex,
+      startIndex: entry.index,
+      endIndex: linkedRestEntry?.index ?? entry.index,
+      entry,
+      linkedRestEntry,
+      steps: linkedRestEntry ? [entry.step, linkedRestEntry.step] : [entry.step],
+    });
+  });
+
+  return blocks;
+}
+
 function getPaceMinutes(secondsPer100m: number | null | undefined) {
   if (!secondsPer100m || secondsPer100m <= 0) return "";
   return String(Math.floor(secondsPer100m / 60));
@@ -1442,6 +1591,10 @@ export default function WorkoutEditor({
   const [openStepId, setOpenStepId] = useState<string | null>(null);
   const [openRepeatGroupId, setOpenRepeatGroupId] = useState<string | null>(null);
   const [openMobileActionKey, setOpenMobileActionKey] = useState<string | null>(null);
+  const [repeatConflictKeepBoth, setRepeatConflictKeepBoth] = useState<Record<string, boolean>>({});
+  const [repeatConflictPendingReplacement, setRepeatConflictPendingReplacement] = useState<
+    string | null
+  >(null);
   const poolLengthUnit = resolveSessionDraftPoolLengthUnit(draft.poolLengthUnit);
   const [poolLengthInput, setPoolLengthInput] = useState(() =>
     formatEditablePoolLength(
@@ -1666,17 +1819,26 @@ export default function WorkoutEditor({
   const desktopSummaryBlockClass = "min-w-0 flex-1";
   const desktopRepeatControlRowClass = "grid gap-3";
   const isViewMode = builderViewMode === "view";
-  const manualPoolTopLevelSectionDescriptors = isManualPoolMode
-    ? buildManualPoolTopLevelSectionDescriptors(stepGroups)
-    : [];
-  const manualPoolViewSections = isManualPoolMode
-    ? buildManualPoolViewSections(
-        stepGroups,
-        draft.steps,
-        draft.basePaceSecondsPer100m,
-        poolLengthUnit
-      )
-    : [];
+  const manualPoolTopLevelSectionDescriptors = useMemo(
+    () => (isManualPoolMode ? buildManualPoolTopLevelSectionDescriptors(stepGroups) : []),
+    [isManualPoolMode, stepGroups]
+  );
+  const manualPoolEditBlocks = useMemo(
+    () => (isManualPoolMode ? buildManualPoolEditBlocks(stepGroups, draft.steps) : []),
+    [draft.steps, isManualPoolMode, stepGroups]
+  );
+  const manualPoolViewSections = useMemo(
+    () =>
+      isManualPoolMode
+        ? buildManualPoolViewSections(
+            stepGroups,
+            draft.steps,
+            draft.basePaceSecondsPer100m,
+            poolLengthUnit
+          )
+        : [],
+    [draft.basePaceSecondsPer100m, draft.steps, isManualPoolMode, poolLengthUnit, stepGroups]
+  );
 
   const revokeWorkoutPreviewObjectUrl = useCallback((objectUrl: string) => {
     URL.revokeObjectURL(objectUrl);
@@ -1709,6 +1871,23 @@ export default function WorkoutEditor({
   }, [draft.steps, openStepId]);
 
   useEffect(() => {
+    if (!isManualPoolMode || !openStepId) {
+      return;
+    }
+
+    const parentBlock = manualPoolEditBlocks.find(
+      (block) =>
+        block.kind === "single" &&
+        block.linkedRestEntry?.step.id === openStepId &&
+        block.entry.step.id !== openStepId
+    );
+
+    if (parentBlock?.kind === "single") {
+      setOpenStepId(parentBlock.entry.step.id);
+    }
+  }, [isManualPoolMode, manualPoolEditBlocks, openStepId]);
+
+  useEffect(() => {
     if (
       openRepeatGroupId &&
       !stepGroups.some(
@@ -1736,6 +1915,41 @@ export default function WorkoutEditor({
       setOpenMobileActionKey(null);
     }
   }, [draft.steps, openMobileActionKey, stepGroups]);
+
+  useEffect(() => {
+    if (!isManualPoolMode) {
+      return;
+    }
+
+    const validRepeatGroupIds = new Set(
+      stepGroups
+        .filter(
+          (group): group is Extract<StepRenderGroup, { kind: "repeat" }> => group.kind === "repeat"
+        )
+        .map((group) => group.repeatGroupId)
+    );
+
+    setRepeatConflictKeepBoth((current) => {
+      const next = Object.fromEntries(
+        Object.entries(current).filter(([repeatGroupId]) => validRepeatGroupIds.has(repeatGroupId))
+      );
+      const currentEntries = Object.entries(current);
+      const nextEntries = Object.entries(next);
+
+      if (
+        currentEntries.length === nextEntries.length &&
+        currentEntries.every(([key, value]) => next[key] === value)
+      ) {
+        return current;
+      }
+
+      return next;
+    });
+
+    setRepeatConflictPendingReplacement((current) =>
+      current && validRepeatGroupIds.has(current) ? current : null
+    );
+  }, [isManualPoolMode, stepGroups]);
 
   useEffect(() => {
     setTimeDurationInputs((current) => {
@@ -1784,7 +1998,7 @@ export default function WorkoutEditor({
 
     if (
       pendingRemoval.kind === "step" &&
-      !draft.steps.some((step) => step.id === pendingRemoval.stepId)
+      !pendingRemoval.stepIds.some((stepId) => draft.steps.some((step) => step.id === stepId))
     ) {
       setPendingRemoval(null);
       return;
@@ -1866,9 +2080,20 @@ export default function WorkoutEditor({
   const syncDraftSelections = useCallback(
     (nextDraft: SessionDraft) => {
       const nextPoolLengthUnit = resolveSessionDraftPoolLengthUnit(nextDraft.poolLengthUnit);
+      const previousStepsById = new Map(draft.steps.map((step) => [step.id, step]));
       const nextSteps = isManualPoolMode
         ? nextDraft.steps.map((step) =>
-            syncManualPoolEditableStep(step, nextDraft.basePaceSecondsPer100m, nextPoolLengthUnit)
+            syncManualPoolEditableStep(step, nextDraft.basePaceSecondsPer100m, nextPoolLengthUnit, {
+              summaryUnit: didManualPoolSummaryUnitInputsChange(
+                previousStepsById.get(step.id),
+                step
+              )
+                ? nextPoolLengthUnit
+                : resolveManualPoolSummaryUnit(
+                    previousStepsById.get(step.id) ?? step,
+                    nextPoolLengthUnit
+                  ),
+            })
           )
         : nextDraft.steps;
       const requiredStrokes = Array.from(
@@ -1901,7 +2126,7 @@ export default function WorkoutEditor({
         ),
       };
     },
-    [isManualPoolMode]
+    [draft.steps, isManualPoolMode]
   );
 
   useEffect(() => {
@@ -1963,9 +2188,161 @@ export default function WorkoutEditor({
     );
   }
 
+  function findManualPoolSingleBlockByStepId(stepId: string) {
+    return (
+      manualPoolEditBlocks.find(
+        (block) =>
+          block.kind === "single" &&
+          (block.entry.step.id === stepId || block.linkedRestEntry?.step.id === stepId)
+      ) ?? null
+    );
+  }
+
+  function moveManualPoolSingleBlock(stepId: string, direction: -1 | 1) {
+    const sourceBlock = findManualPoolSingleBlockByStepId(stepId);
+    if (!sourceBlock) return;
+
+    const sourceBlockIndex = manualPoolEditBlocks.findIndex(
+      (block) => block.key === sourceBlock.key
+    );
+    const targetBlockIndex = sourceBlockIndex + direction;
+    if (
+      sourceBlockIndex < 0 ||
+      targetBlockIndex < 0 ||
+      targetBlockIndex >= manualPoolEditBlocks.length
+    ) {
+      return;
+    }
+
+    const nextBlocks = [...manualPoolEditBlocks];
+    const [movedBlock] = nextBlocks.splice(sourceBlockIndex, 1);
+    if (!movedBlock) return;
+    nextBlocks.splice(targetBlockIndex, 0, movedBlock);
+
+    onDraftChange(
+      syncDraftSelections({
+        ...draft,
+        steps: nextBlocks.flatMap((block) => block.steps),
+      })
+    );
+  }
+
+  function insertStepAfterManualPoolSingleBlock(stepId: string) {
+    const sourceBlock = findManualPoolSingleBlockByStepId(stepId);
+    if (!sourceBlock) return;
+    insertStepAt(sourceBlock.endIndex + 1);
+  }
+
+  function buildDuplicatedManualPoolSingleBlockSteps(
+    block: Extract<ManualPoolEditBlock, { kind: "single" }>
+  ) {
+    const primaryStep = block.entry.step;
+    const duplicatedPrimary: SessionDraftStep = {
+      ...primaryStep,
+      id: buildStepId(draft.steps.length + 1),
+    };
+
+    const duplicatedLinkedRest = block.linkedRestEntry
+      ? {
+          ...block.linkedRestEntry.step,
+          id: buildStepId(draft.steps.length + 2),
+        }
+      : null;
+
+    return duplicatedLinkedRest ? [duplicatedPrimary, duplicatedLinkedRest] : [duplicatedPrimary];
+  }
+
+  function duplicateManualPoolSingleBlock(stepId: string) {
+    const sourceBlock = findManualPoolSingleBlockByStepId(stepId);
+    if (!sourceBlock || sourceBlock.kind !== "single") return;
+
+    const duplicatedSteps = buildDuplicatedManualPoolSingleBlockSteps(sourceBlock);
+    const nextSteps = [...draft.steps];
+    nextSteps.splice(sourceBlock.endIndex + 1, 0, ...duplicatedSteps);
+
+    setPendingRemoval(null);
+    setLastRemovedBlock(null);
+    setOpenRepeatGroupId(null);
+    setOpenStepId(duplicatedSteps[0]?.id ?? null);
+    onDraftChange(
+      syncDraftSelections({
+        ...draft,
+        steps: nextSteps,
+      })
+    );
+  }
+
+  function insertAttachedRestAfterStep(stepId: string) {
+    const sourceBlock = findManualPoolSingleBlockByStepId(stepId);
+    if (!sourceBlock || sourceBlock.kind !== "single" || sourceBlock.linkedRestEntry) {
+      return;
+    }
+
+    const nextSteps = [...draft.steps];
+    nextSteps.splice(sourceBlock.entry.index + 1, 0, buildAutoRestStep(draft.steps.length + 1));
+    setPendingRemoval(null);
+    setLastRemovedBlock(null);
+    setOpenRepeatGroupId(null);
+    setOpenStepId(sourceBlock.entry.step.id);
+    onDraftChange(
+      syncDraftSelections({
+        ...draft,
+        steps: nextSteps,
+      })
+    );
+  }
+
+  function removeAttachedRestStep(restStepId: string, parentStepId: string) {
+    const nextSteps = draft.steps.filter((step) => step.id !== restStepId);
+
+    setPendingRemoval(null);
+    setLastRemovedBlock(null);
+    if (openStepId === restStepId) {
+      setOpenStepId(parentStepId);
+    }
+    onDraftChange(
+      syncDraftSelections({
+        ...draft,
+        steps: nextSteps,
+      })
+    );
+  }
+
+  function removeRepeatPostSetRestStep(repeatGroupId: string) {
+    const nextSteps = draft.steps.filter(
+      (step) => step.postSetRestForRepeatGroupId !== repeatGroupId
+    );
+    const removedPostSetRest = draft.steps.find(
+      (step) => step.postSetRestForRepeatGroupId === repeatGroupId
+    );
+
+    setRepeatConflictPendingReplacement(null);
+    setRepeatConflictKeepBoth((current) => {
+      const next = { ...current };
+      delete next[repeatGroupId];
+      return next;
+    });
+    if (removedPostSetRest && openStepId === removedPostSetRest.id) {
+      setOpenStepId(null);
+      setOpenRepeatGroupId(repeatGroupId);
+    }
+    onDraftChange(
+      syncDraftSelections({
+        ...draft,
+        steps: nextSteps,
+      })
+    );
+  }
+
   function openTargetedStepEditor(stepId: string) {
     const targetStep = draft.steps.find((step) => step.id === stepId);
     if (!targetStep) return;
+
+    const manualPoolParentBlock = isManualPoolMode
+      ? findManualPoolSingleBlockByStepId(stepId)
+      : null;
+    const targetOpenStepId =
+      manualPoolParentBlock?.kind === "single" ? manualPoolParentBlock.entry.step.id : stepId;
 
     setBuilderViewMode("edit");
     setMetadataOpen(false);
@@ -1973,7 +2350,7 @@ export default function WorkoutEditor({
     setLastRemovedBlock(null);
     setOpenMobileActionKey(null);
     setOpenRepeatGroupId(targetStep.repeatGroupId ?? null);
-    setOpenStepId(stepId);
+    setOpenStepId(targetOpenStepId);
   }
 
   function openTargetedRepeatEditor(repeatGroupId: string) {
@@ -2070,7 +2447,7 @@ export default function WorkoutEditor({
   }
 
   function addStep() {
-    insertStepAt(draft.steps.length, {}, { autoCreateStandaloneRest: true });
+    insertStepAt(draft.steps.length);
   }
 
   function addRepeat() {
@@ -2101,7 +2478,7 @@ export default function WorkoutEditor({
   function insertStepAfterGroup(groupIndex: number) {
     const insertIndex = getGroupInsertIndex(groupIndex);
     if (insertIndex === null) return;
-    insertStepAt(insertIndex, {}, { autoCreateStandaloneRest: true });
+    insertStepAt(insertIndex);
   }
 
   function insertRepeatAfterGroup(groupIndex: number) {
@@ -2182,15 +2559,30 @@ export default function WorkoutEditor({
     if (stepIndex === -1) return;
 
     const step = draft.steps[stepIndex];
+    const manualPoolBlock = isManualPoolMode ? findManualPoolSingleBlockByStepId(stepId) : null;
+    const stepIds =
+      manualPoolBlock?.kind === "single"
+        ? manualPoolBlock.steps.map((blockStep) => blockStep.id)
+        : [stepId];
+    const label =
+      manualPoolBlock?.kind === "single" && manualPoolBlock.linkedRestEntry
+        ? `${buildStepRemovalLabel(step, stepIndex, {
+            isManualPoolMode,
+            basePaceSecondsPer100m: draft.basePaceSecondsPer100m,
+            poolLengthUnit,
+          })} and attached rest`
+        : buildStepRemovalLabel(step, stepIndex, {
+            isManualPoolMode,
+            basePaceSecondsPer100m: draft.basePaceSecondsPer100m,
+            poolLengthUnit,
+          });
+
     setLastRemovedBlock(null);
     setPendingRemoval({
       kind: "step",
       stepId,
-      label: buildStepRemovalLabel(step, stepIndex, {
-        isManualPoolMode,
-        basePaceSecondsPer100m: draft.basePaceSecondsPer100m,
-        poolLengthUnit,
-      }),
+      stepIds,
+      label,
       repeatGroupId: step.repeatGroupId ?? null,
     });
   }
@@ -2222,26 +2614,29 @@ export default function WorkoutEditor({
     if (!pendingRemoval) return;
 
     if (pendingRemoval.kind === "step") {
-      const removeIndex = draft.steps.findIndex((step) => step.id === pendingRemoval.stepId);
+      const removeIndex = draft.steps.findIndex((step) => pendingRemoval.stepIds.includes(step.id));
       if (removeIndex === -1) {
         setPendingRemoval(null);
         return;
       }
 
-      const removedStep = draft.steps[removeIndex];
-      const nextSteps = draft.steps.filter((step) => step.id !== pendingRemoval.stepId);
-      const removedOpenStep = openStepId === pendingRemoval.stepId;
+      const removedSteps = draft.steps.filter((step) => pendingRemoval.stepIds.includes(step.id));
+      const nextSteps = draft.steps.filter((step) => !pendingRemoval.stepIds.includes(step.id));
+      const removedOpenStep = Boolean(openStepId && pendingRemoval.stepIds.includes(openStepId));
+      const restoreOpenStepId = removedOpenStep ? pendingRemoval.stepId : openStepId;
+      const primaryRemovedStep =
+        removedSteps.find((step) => step.id === pendingRemoval.stepId) ?? removedSteps[0];
 
       setPendingRemoval(null);
       setLastRemovedBlock({
         kind: "step",
         label: pendingRemoval.label,
-        steps: [removedStep],
+        steps: removedSteps,
         insertIndex: removeIndex,
-        restoreOpenStepId: removedOpenStep ? removedStep.id : openStepId,
+        restoreOpenStepId,
         restoreOpenRepeatGroupId:
-          removedOpenStep && removedStep.repeatGroupId
-            ? removedStep.repeatGroupId
+          removedOpenStep && primaryRemovedStep?.repeatGroupId
+            ? primaryRemovedStep.repeatGroupId
             : openRepeatGroupId,
       });
       if (removedOpenStep) {
@@ -2343,6 +2738,21 @@ export default function WorkoutEditor({
     repeatGroupId: string,
     value: SessionDraftRepeatEndingRestMode
   ) {
+    if (value !== "use_last_rest") {
+      setRepeatConflictPendingReplacement((current) =>
+        current === repeatGroupId ? null : current
+      );
+      setRepeatConflictKeepBoth((current) => {
+        if (!(repeatGroupId in current)) {
+          return current;
+        }
+
+        const next = { ...current };
+        delete next[repeatGroupId];
+        return next;
+      });
+    }
+
     onDraftChange(
       syncDraftSelections({
         ...draft,
@@ -2456,17 +2866,23 @@ export default function WorkoutEditor({
     }));
   }
 
-  function updateStepDistanceSelection(stepId: string, value: string) {
+  function updateStepDistanceSelection(
+    stepId: string,
+    value: string,
+    unitOverride?: SessionDraftPoolLengthUnit
+  ) {
+    const editorUnit = unitOverride ?? poolLengthUnit;
+
     updateDraftStep(stepId, (current) => ({
       ...current,
       distanceM:
         value === CUSTOM_DISTANCE_VALUE
           ? SESSION_DRAFT_STEP_DISTANCE_PRESETS.some((preset) =>
-              isDistanceQuickChoiceSelected(current.distanceM, preset, poolLengthUnit)
+              isDistanceQuickChoiceSelected(current.distanceM, preset, editorUnit)
             )
             ? null
             : current.distanceM
-          : convertPoolUnitValueToMeters(Number.parseFloat(value), poolLengthUnit),
+          : convertPoolUnitValueToMeters(Number.parseFloat(value), editorUnit),
     }));
   }
 
@@ -2665,6 +3081,7 @@ export default function WorkoutEditor({
       labelOverride?: string;
       descriptionOverride?: string | null;
       isLinkedPostSetRest?: boolean;
+      linkedTopLevelRestEntry?: StepRenderEntry | null;
     }
   ) {
     const insideRepeatGroup = options?.insideRepeatGroup ?? false;
@@ -2677,6 +3094,20 @@ export default function WorkoutEditor({
       isManualPoolMode && !insideRepeatGroup
         ? (manualPoolTopLevelSectionDescriptors[groupIndex] ?? null)
         : null;
+    const linkedTopLevelRestEntry =
+      isManualPoolMode && !insideRepeatGroup ? (options?.linkedTopLevelRestEntry ?? null) : null;
+    const linkedTopLevelRestStep = linkedTopLevelRestEntry?.step ?? null;
+    const manualPoolEditBlock = isManualPoolMode
+      ? findManualPoolSingleBlockByStepId(step.id)
+      : null;
+    const manualPoolBlockIndex = manualPoolEditBlock
+      ? manualPoolEditBlocks.findIndex((block) => block.key === manualPoolEditBlock.key)
+      : -1;
+    const isTopLevelManualPoolBlock =
+      isManualPoolMode &&
+      !insideRepeatGroup &&
+      !isLinkedPostSetRest &&
+      manualPoolEditBlock?.kind === "single";
     const stepLabel =
       options?.labelOverride ??
       (insideRepeatGroup
@@ -2686,13 +3117,27 @@ export default function WorkoutEditor({
         : isManualPoolMode
           ? (topLevelDescriptor?.label ?? getSessionStepCategoryLabel(normalizedStep.category))
           : `Step ${index + 1}`);
+    const stepDistanceUnit = isManualPoolMode
+      ? resolveManualPoolSummaryUnit(normalizedStep, poolLengthUnit)
+      : poolLengthUnit;
     const selectedDistancePreset = SESSION_DRAFT_STEP_DISTANCE_PRESETS.find((value) =>
-      isDistanceQuickChoiceSelected(normalizedStep.distanceM, value, poolLengthUnit)
+      isDistanceQuickChoiceSelected(normalizedStep.distanceM, value, stepDistanceUnit)
     );
     const isMinimalRestEditor = isManualPoolMode && normalizedStep.category === "rest";
     const isRestStepCard = normalizedStep.category === "rest";
     const stepTitle = isManualPoolMode
-      ? buildManualPoolDisplaySummary(normalizedStep, draft.basePaceSecondsPer100m, poolLengthUnit)
+      ? !isRestStepCard && linkedTopLevelRestStep
+        ? buildManualPoolViewLine(
+            normalizedStep,
+            draft.basePaceSecondsPer100m,
+            poolLengthUnit,
+            linkedTopLevelRestStep
+          )
+        : buildManualPoolDisplaySummary(
+            normalizedStep,
+            draft.basePaceSecondsPer100m,
+            poolLengthUnit
+          )
       : step.name || getSessionStepCategoryLabel(step.category);
     const mobileActionKey = `step:${step.id}`;
     const mobileActionsOpen = openMobileActionKey === mobileActionKey;
@@ -2719,7 +3164,8 @@ export default function WorkoutEditor({
     const stepEffortTargetValue = isManualPoolMode
       ? (normalizedStep.effortTarget ?? normalizedStep.intensity)
       : (step.effortTarget ?? step.intensity);
-    const pendingDelete = pendingRemoval?.kind === "step" && pendingRemoval.stepId === step.id;
+    const pendingDelete =
+      pendingRemoval?.kind === "step" && pendingRemoval.stepIds.includes(step.id);
     const stepNotes = isManualPoolMode && isRestStepCard ? "" : step.notes;
     const stepSummaryContent = (
       <>
@@ -2749,6 +3195,198 @@ export default function WorkoutEditor({
         {stepNotes ? <p className="mt-1 text-xs text-slate-400">{stepNotes}</p> : null}
       </>
     );
+    const isTerminalManualPoolBlock =
+      isTopLevelManualPoolBlock && manualPoolBlockIndex === manualPoolEditBlocks.length - 1;
+    const moveUpDisabled = isTopLevelManualPoolBlock ? manualPoolBlockIndex <= 0 : groupIndex === 0;
+    const moveDownDisabled = isTopLevelManualPoolBlock
+      ? manualPoolBlockIndex === -1 || manualPoolBlockIndex >= manualPoolEditBlocks.length - 1
+      : groupIndex === stepGroups.length - 1;
+    const handleMoveUp = () => {
+      if (isTopLevelManualPoolBlock) {
+        moveManualPoolSingleBlock(step.id, -1);
+      } else {
+        moveDraftGroup(groupIndex, -1);
+      }
+      setOpenMobileActionKey(null);
+    };
+    const handleMoveDown = () => {
+      if (isTopLevelManualPoolBlock) {
+        moveManualPoolSingleBlock(step.id, 1);
+      } else {
+        moveDraftGroup(groupIndex, 1);
+      }
+      setOpenMobileActionKey(null);
+    };
+    const handleAddStepAfter = () => {
+      if (isTopLevelManualPoolBlock) {
+        insertStepAfterManualPoolSingleBlock(step.id);
+      } else {
+        insertStepAfterStep(step.id);
+      }
+      setOpenMobileActionKey(null);
+    };
+    const handleAddRepeatAfter = () => {
+      if (isTopLevelManualPoolBlock && manualPoolEditBlock) {
+        insertRepeatAt(manualPoolEditBlock.endIndex + 1);
+      } else {
+        insertRepeatAfterGroup(groupIndex);
+      }
+      setOpenMobileActionKey(null);
+    };
+    const handleDuplicate = () => {
+      if (isTopLevelManualPoolBlock) {
+        duplicateManualPoolSingleBlock(step.id);
+      } else {
+        duplicateStep(step.id);
+      }
+      setOpenMobileActionKey(null);
+    };
+    const restStepDurationModeValue = linkedTopLevelRestStep
+      ? normalizeManualPoolStepForEditor(linkedTopLevelRestStep).durationMode
+      : null;
+    const attachedRestEditor =
+      isTopLevelManualPoolBlock && !isRestStepCard ? (
+        <div
+          data-testid={`session-draft-step-linked-rest-panel-${index}`}
+          className="rounded-xl border border-blue-200 bg-blue-50/60 p-3 md:col-span-2"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
+                Rest after step
+              </p>
+              <p className="mt-2 text-sm font-medium text-slate-900">
+                {linkedTopLevelRestStep
+                  ? buildManualPoolDisplaySummary(
+                      linkedTopLevelRestStep,
+                      draft.basePaceSecondsPer100m,
+                      poolLengthUnit
+                    )
+                  : "No rest after this step."}
+              </p>
+              {!linkedTopLevelRestStep && isTerminalManualPoolBlock ? (
+                <p className="mt-1 text-xs text-slate-500">
+                  Leave it empty when this block ends the session.
+                </p>
+              ) : null}
+            </div>
+            {linkedTopLevelRestStep ? (
+              <button
+                type="button"
+                onClick={() => removeAttachedRestStep(linkedTopLevelRestStep.id, step.id)}
+                data-testid={`session-draft-step-linked-rest-remove-${index}`}
+                className="inline-flex h-9 items-center justify-center rounded-xl border border-rose-200 bg-white px-3 text-sm font-medium text-rose-700 transition hover:bg-rose-50"
+              >
+                Remove rest
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => insertAttachedRestAfterStep(step.id)}
+                data-testid={`session-draft-step-linked-rest-add-${index}`}
+                className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-100"
+              >
+                Add rest
+              </button>
+            )}
+          </div>
+
+          {linkedTopLevelRestStep ? (
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              <label className="text-sm text-slate-700">
+                Rest mode
+                <select
+                  value={restStepDurationModeValue ?? "fixed_rest"}
+                  onChange={(event) =>
+                    updateDraftStep(linkedTopLevelRestStep.id, (current) =>
+                      applyStepDurationModeDefaults(
+                        current,
+                        event.target.value as SessionDraftStepDurationMode
+                      )
+                    )
+                  }
+                  data-testid={`session-draft-step-linked-rest-duration-mode-${index}`}
+                  className="mt-2 block h-11 w-full rounded-xl border border-blue-200 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                >
+                  {MANUAL_POOL_REST_DURATION_MODES.map((value) => (
+                    <option key={value} value={value}>
+                      {getStepDurationModeEditorLabel(value, true)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              {restStepDurationModeValue === "fixed_rest" ||
+              restStepDurationModeValue === "send_off" ? (
+                <label className="text-sm text-slate-700">
+                  {restStepDurationModeValue === "send_off" ? "Send-off time" : "Rest time"}
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    placeholder="MM:SS"
+                    value={timeDurationInputs[linkedTopLevelRestStep.id] ?? ""}
+                    onFocus={() => {
+                      timeDurationInputFocusRef.current[linkedTopLevelRestStep.id] = true;
+                    }}
+                    onBlur={() => {
+                      commitTimeDurationInput(linkedTopLevelRestStep.id);
+                    }}
+                    onChange={(event) =>
+                      handleTimeDurationInputChange(linkedTopLevelRestStep.id, event.target.value)
+                    }
+                    data-testid={`session-draft-step-linked-rest-time-${index}`}
+                    className="mt-2 block h-11 w-full rounded-xl border border-blue-200 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                  />
+                </label>
+              ) : null}
+
+              {restStepDurationModeValue === "css_send_off" ? (
+                <label className="text-sm text-slate-700 md:col-span-2">
+                  CSS send-off offset
+                  <select
+                    value={String(linkedTopLevelRestStep.cssSendOffOffsetSeconds ?? 0)}
+                    onChange={(event) =>
+                      updateDraftStep(linkedTopLevelRestStep.id, (current) => ({
+                        ...current,
+                        cssSendOffOffsetSeconds: Number.parseInt(event.target.value, 10),
+                      }))
+                    }
+                    data-testid={`session-draft-step-linked-rest-css-offset-${index}`}
+                    className="mt-2 block h-11 w-full rounded-xl border border-blue-200 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                  >
+                    {SESSION_DRAFT_STEP_CSS_TARGET_OFFSETS.map((value) => {
+                      const sign = value > 0 ? "+" : "";
+                      return (
+                        <option key={value} value={String(value)}>
+                          {`CSS ${sign}${value}s (${formatClockDurationLabelFromSeconds(
+                            draft.basePaceSecondsPer100m + value
+                          )})`}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </label>
+              ) : null}
+
+              <label className="text-sm text-slate-700 md:col-span-2">
+                Rest notes
+                <AutoGrowingTextarea
+                  aria-label="Rest notes"
+                  value={linkedTopLevelRestStep.notes}
+                  onChange={(event) =>
+                    updateDraftStep(linkedTopLevelRestStep.id, (current) => ({
+                      ...current,
+                      notes: event.target.value,
+                    }))
+                  }
+                  minRows={1}
+                  className="mt-2 block w-full resize-y rounded-xl border border-blue-200 bg-white px-3 py-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                />
+              </label>
+            </div>
+          ) : null}
+        </div>
+      ) : null;
 
     return (
       <article
@@ -2855,11 +3493,8 @@ export default function WorkoutEditor({
               <div className="grid grid-cols-2 gap-2">
                 <button
                   type="button"
-                  onClick={() => {
-                    moveDraftGroup(groupIndex, -1);
-                    setOpenMobileActionKey(null);
-                  }}
-                  disabled={groupIndex === 0}
+                  onClick={handleMoveUp}
+                  disabled={moveUpDisabled}
                   data-testid={`session-draft-step-mobile-move-up-${index}`}
                   className={`${mobileSecondaryActionClass} border-slate-200 bg-white text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60`}
                 >
@@ -2867,11 +3502,8 @@ export default function WorkoutEditor({
                 </button>
                 <button
                   type="button"
-                  onClick={() => {
-                    moveDraftGroup(groupIndex, 1);
-                    setOpenMobileActionKey(null);
-                  }}
-                  disabled={groupIndex === stepGroups.length - 1}
+                  onClick={handleMoveDown}
+                  disabled={moveDownDisabled}
                   data-testid={`session-draft-step-mobile-move-down-${index}`}
                   className={`${mobileSecondaryActionClass} border-slate-200 bg-white text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60`}
                 >
@@ -2883,10 +3515,7 @@ export default function WorkoutEditor({
               {!showMobilePrimaryAddAfter && !isLinkedPostSetRest ? (
                 <button
                   type="button"
-                  onClick={() => {
-                    insertStepAfterStep(step.id);
-                    setOpenMobileActionKey(null);
-                  }}
+                  onClick={handleAddStepAfter}
                   data-testid={`session-draft-step-mobile-add-after-${index}`}
                   className={`${mobileSecondaryActionClass} border-blue-200 bg-white text-blue-800 hover:bg-blue-50`}
                 >
@@ -2896,10 +3525,7 @@ export default function WorkoutEditor({
               {!showMobilePrimaryAddRepeatAfter && !insideRepeatGroup && !isLinkedPostSetRest ? (
                 <button
                   type="button"
-                  onClick={() => {
-                    insertRepeatAfterGroup(groupIndex);
-                    setOpenMobileActionKey(null);
-                  }}
+                  onClick={handleAddRepeatAfter}
                   data-testid={`session-draft-step-mobile-add-repeat-after-${index}`}
                   className={`${mobileSecondaryActionClass} border-blue-200 bg-white text-blue-800 hover:bg-blue-50`}
                 >
@@ -2909,10 +3535,7 @@ export default function WorkoutEditor({
               {isLinkedPostSetRest ? null : (
                 <button
                   type="button"
-                  onClick={() => {
-                    duplicateStep(step.id);
-                    setOpenMobileActionKey(null);
-                  }}
+                  onClick={handleDuplicate}
                   data-testid={`session-draft-step-mobile-duplicate-${index}`}
                   className={`${mobileSecondaryActionClass} border-slate-200 bg-white text-slate-700 hover:bg-slate-100`}
                 >
@@ -2940,10 +3563,7 @@ export default function WorkoutEditor({
           <div className="mt-3 flex flex-wrap gap-2 sm:hidden">
             <button
               type="button"
-              onClick={() => {
-                insertStepAfterStep(step.id);
-                setOpenMobileActionKey(null);
-              }}
+              onClick={handleAddStepAfter}
               data-testid={`session-draft-step-mobile-primary-add-after-${index}`}
               className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-50"
             >
@@ -2952,10 +3572,7 @@ export default function WorkoutEditor({
             {showMobilePrimaryAddRepeatAfter ? (
               <button
                 type="button"
-                onClick={() => {
-                  insertRepeatAfterGroup(groupIndex);
-                  setOpenMobileActionKey(null);
-                }}
+                onClick={handleAddRepeatAfter}
                 data-testid={`session-draft-step-mobile-primary-add-repeat-after-${index}`}
                 className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-blue-50 px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-100"
               >
@@ -3190,13 +3807,17 @@ export default function WorkoutEditor({
                         ? String(selectedDistancePreset)
                         : CUSTOM_DISTANCE_VALUE
                     }
-                    onChange={(event) => updateStepDistanceSelection(step.id, event.target.value)}
+                    onChange={(event) =>
+                      updateStepDistanceSelection(step.id, event.target.value, stepDistanceUnit)
+                    }
                     data-testid={`session-draft-step-distance-${index}`}
                     className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
                   >
                     {SESSION_DRAFT_STEP_DISTANCE_PRESETS.map((value) => (
                       <option key={value} value={String(value)}>
-                        {poolLengthUnit === "yd" ? `${value}yd` : formatDistanceMetersLabel(value)}
+                        {stepDistanceUnit === "yd"
+                          ? `${value}yd`
+                          : formatDistanceMetersLabel(value)}
                       </option>
                     ))}
                     <option value={CUSTOM_DISTANCE_VALUE}>Custom distance</option>
@@ -3204,15 +3825,15 @@ export default function WorkoutEditor({
                 </label>
                 {!selectedDistancePreset ? (
                   <label className="text-sm text-slate-700">
-                    {`Custom distance (${poolLengthUnit})`}
+                    {`Custom distance (${stepDistanceUnit})`}
                     <input
                       type="text"
                       inputMode="decimal"
-                      value={formatEditableDistance(step.distanceM, poolLengthUnit)}
+                      value={formatEditableDistance(step.distanceM, stepDistanceUnit)}
                       onChange={(event) =>
                         updateDraftStep(step.id, (current) => ({
                           ...current,
-                          distanceM: parseDistanceInput(event.target.value, poolLengthUnit),
+                          distanceM: parseDistanceInput(event.target.value, stepDistanceUnit),
                         }))
                       }
                       data-testid={`session-draft-step-distance-custom-${index}`}
@@ -3222,7 +3843,7 @@ export default function WorkoutEditor({
                 ) : (
                   <div className="self-end text-sm text-slate-500">
                     {typeof step.distanceM === "number"
-                      ? formatDistanceMetersLabel(step.distanceM, poolLengthUnit)
+                      ? formatDistanceMetersLabel(step.distanceM, stepDistanceUnit)
                       : null}
                   </div>
                 )}
@@ -3550,6 +4171,8 @@ export default function WorkoutEditor({
               />
             </label>
 
+            {attachedRestEditor}
+
             {!isViewMode ? (
               <div
                 data-testid={`session-draft-step-desktop-actions-${index}`}
@@ -3560,16 +4183,16 @@ export default function WorkoutEditor({
                   <>
                     <button
                       type="button"
-                      onClick={() => moveDraftGroup(groupIndex, -1)}
-                      disabled={groupIndex === 0}
+                      onClick={handleMoveUp}
+                      disabled={moveUpDisabled}
                       className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       Move up
                     </button>
                     <button
                       type="button"
-                      onClick={() => moveDraftGroup(groupIndex, 1)}
-                      disabled={groupIndex === stepGroups.length - 1}
+                      onClick={handleMoveDown}
+                      disabled={moveDownDisabled}
                       className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       Move down
@@ -3579,7 +4202,7 @@ export default function WorkoutEditor({
                 {isLinkedPostSetRest ? null : (
                   <button
                     type="button"
-                    onClick={() => insertStepAfterStep(step.id)}
+                    onClick={handleAddStepAfter}
                     data-testid={`session-draft-step-add-after-${index}`}
                     className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm text-blue-800 transition hover:bg-blue-50"
                   >
@@ -3589,7 +4212,7 @@ export default function WorkoutEditor({
                 {!insideRepeatGroup && !isLinkedPostSetRest ? (
                   <button
                     type="button"
-                    onClick={() => insertRepeatAfterGroup(groupIndex)}
+                    onClick={handleAddRepeatAfter}
                     data-testid={`session-draft-step-add-repeat-after-${index}`}
                     className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm text-blue-800 transition hover:bg-blue-50"
                   >
@@ -3599,7 +4222,7 @@ export default function WorkoutEditor({
                 {isLinkedPostSetRest ? null : (
                   <button
                     type="button"
-                    onClick={() => duplicateStep(step.id)}
+                    onClick={handleDuplicate}
                     data-testid={`session-draft-step-duplicate-${index}`}
                     className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50"
                   >
@@ -4852,7 +5475,35 @@ export default function WorkoutEditor({
               })
             : stepGroups.map((group, groupIndex) =>
                 group.kind === "single" ? (
-                  renderStepEditorCard(group.entries[0].step, group.entries[0].index, groupIndex)
+                  (() => {
+                    if (!isManualPoolMode || isViewMode) {
+                      return renderStepEditorCard(
+                        group.entries[0].step,
+                        group.entries[0].index,
+                        groupIndex
+                      );
+                    }
+
+                    const manualPoolBlock = manualPoolEditBlocks.find(
+                      (block) =>
+                        block.kind === "single" &&
+                        block.groupIndex === groupIndex &&
+                        block.entry.step.id === group.entries[0].step.id
+                    );
+
+                    if (!manualPoolBlock || manualPoolBlock.kind !== "single") {
+                      return null;
+                    }
+
+                    return renderStepEditorCard(
+                      manualPoolBlock.entry.step,
+                      manualPoolBlock.entry.index,
+                      groupIndex,
+                      {
+                        linkedTopLevelRestEntry: manualPoolBlock.linkedRestEntry,
+                      }
+                    );
+                  })()
                 ) : (
                   <section
                     key={group.repeatGroupId}
@@ -4886,12 +5537,23 @@ export default function WorkoutEditor({
                       );
                       const repeatMobileActionKey = `repeat:${group.repeatGroupId}`;
                       const repeatMobileActionsOpen = openMobileActionKey === repeatMobileActionKey;
+                      const hasRepeatRestConflict = Boolean(
+                        hasEditableRepeatEndingRest &&
+                        group.postSetRestEntry?.step &&
+                        group.repeatEndingRestMode === "use_last_rest"
+                      );
+                      const repeatConflictKeptBoth =
+                        repeatConflictKeepBoth[group.repeatGroupId] === true;
+                      const showRepeatRestConflict =
+                        hasRepeatRestConflict && !repeatConflictKeptBoth;
+                      const showRepeatRestReplacementConfirm =
+                        repeatConflictPendingReplacement === group.repeatGroupId;
                       const repeatSummaryContent = (
                         <>
                           <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
                             {repeatLabel}
                           </p>
-                          {isManualPoolMode ? (
+                          {isManualPoolMode && isRepeatOpen ? (
                             <p className="mt-2">
                               <span className="inline-flex rounded-full border border-blue-200 bg-white px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-blue-700">
                                 Repeat block
@@ -5000,7 +5662,7 @@ export default function WorkoutEditor({
                                 </label>
                                 {hasEditableRepeatEndingRest ? (
                                   <label className="text-sm text-slate-700">
-                                    Last rest interval
+                                    Final interval rest
                                     <select
                                       value={group.repeatEndingRestMode}
                                       onChange={(event) =>
@@ -5021,6 +5683,80 @@ export default function WorkoutEditor({
                                   </label>
                                 ) : null}
                               </div>
+                              {showRepeatRestConflict ? (
+                                <div className="rounded-xl border border-amber-200 bg-amber-50/90 p-3">
+                                  <p className="text-sm font-medium text-amber-950">
+                                    This creates two rests in a row.
+                                  </p>
+                                  <div className="mt-3 flex flex-wrap gap-2">
+                                    <button
+                                      type="button"
+                                      onClick={() =>
+                                        updateRepeatGroupEndingRestMode(
+                                          group.repeatGroupId,
+                                          "skip_last_rest"
+                                        )
+                                      }
+                                      className="inline-flex h-9 items-center justify-center rounded-xl border border-amber-200 bg-white px-3 text-sm font-medium text-amber-900 transition hover:bg-amber-100"
+                                    >
+                                      Keep set rest only
+                                    </button>
+                                    <button
+                                      type="button"
+                                      onClick={() =>
+                                        setRepeatConflictPendingReplacement(group.repeatGroupId)
+                                      }
+                                      className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-50"
+                                    >
+                                      Use final interval rest instead
+                                    </button>
+                                    <button
+                                      type="button"
+                                      onClick={() => {
+                                        setRepeatConflictKeepBoth((current) => ({
+                                          ...current,
+                                          [group.repeatGroupId]: true,
+                                        }));
+                                        setRepeatConflictPendingReplacement((current) =>
+                                          current === group.repeatGroupId ? null : current
+                                        );
+                                      }}
+                                      className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+                                    >
+                                      Keep both
+                                    </button>
+                                  </div>
+                                  {showRepeatRestReplacementConfirm ? (
+                                    <div className="mt-3 rounded-xl border border-rose-200 bg-white p-3">
+                                      <p className="text-sm font-medium text-rose-950">
+                                        Delete the separate set rest and keep final interval rest?
+                                      </p>
+                                      <div className="mt-3 flex flex-wrap gap-2">
+                                        <button
+                                          type="button"
+                                          onClick={() =>
+                                            removeRepeatPostSetRestStep(group.repeatGroupId)
+                                          }
+                                          className="inline-flex h-9 items-center justify-center rounded-xl bg-rose-600 px-3 text-sm font-semibold text-white transition hover:bg-rose-500"
+                                        >
+                                          Delete set rest
+                                        </button>
+                                        <button
+                                          type="button"
+                                          onClick={() =>
+                                            setRepeatConflictPendingReplacement((current) =>
+                                              current === group.repeatGroupId ? null : current
+                                            )
+                                          }
+                                          className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+                                        >
+                                          Cancel
+                                        </button>
+                                      </div>
+                                    </div>
+                                  ) : null}
+                                </div>
+                              ) : null}
                             </div>
                           ) : null}
 

--- a/docs/task-briefs/in-progress/2026-04-15-swim-session-builder-attached-rest-grouping-and-final-interval-guardrails-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-15-swim-session-builder-attached-rest-grouping-and-final-interval-guardrails-10-10.md
@@ -1,0 +1,260 @@
+# Task Brief: Swim Session Builder Attached Rest Grouping And Final Interval Guardrails (10/10)
+
+## Metadata
+
+- `id`: `2026-04-15-swim-session-builder-attached-rest-grouping-and-final-interval-guardrails-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-04-15`
+- `updated`: `2026-04-15`
+
+## Goal
+
+Make the manual pool builder treat single-step rest like attached parent-step behavior instead of a separate top-level card, while also making repeat final-interval-rest choices clearer and safer without changing the canonical workout schema.
+
+## Why This Brief Exists
+
+- The builder currently mixes two mental models:
+  - single steps render as one work card plus a separate top-level rest card,
+  - repeat blocks already summarize `Interval rest` and `Set rest` as part of one parent block.
+- That creates poor scanability and misleading hierarchy:
+  - `WARMUP`
+  - then a separate `WARMUP REST` card
+  - even though swimmers read that as one warmup block.
+- Top-level block actions also become semantically fragile when rest is visually separate:
+  - `Move`, `Add step after`, `Duplicate`, and `Delete` can conceptually split work from its attached rest.
+- The repeat editor still uses the old wording:
+  - `Last rest interval`
+  - `Use last rest interval`
+  - `Skip last rest interval`
+    which is weaker and less precise than the agreed final wording.
+- When a repeat block keeps the final interval rest and also has a separate post-set rest step, the builder currently lacks a calm explicit guardrail for the resulting double-rest setup.
+- The owner-approved direction is locked:
+  - top-level single-step rest should be shown and edited as attached to the parent step,
+  - the overview must show the actual rest duration directly in the parent summary,
+  - attached rest must be addable, editable, and removable inside the parent editor,
+  - final repeat wording must change to `Final interval rest`,
+  - conflict handling for double rest must be inline-first, with explicit confirmation only before auto-removing another step,
+  - repeat overview summaries must include the work-stroke when it is explicit and useful for scanning,
+  - the `Repeat block` pill should only appear while the repeat editor itself is open, not in passive overview mode,
+  - switching `Meters` / `Yards` must not silently recalculate existing step overview summaries,
+  - canonical step persistence and Garmin/export structure must stay intact.
+
+## Dependencies And Boundaries
+
+- Parent builder lineage:
+  - [/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md)
+- Relevant delivered briefs this slice extends:
+  - [/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-11-swim-session-builder-garmin-authoring-and-poolside-note-redesign-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-11-swim-session-builder-garmin-authoring-and-poolside-note-redesign-10-10.md)
+  - [/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-15-swim-session-builder-header-delete-and-rest-clarity-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-15-swim-session-builder-header-delete-and-rest-clarity-10-10.md)
+  - [/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-15-poolside-note-header-clarity-and-landscape-parity-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-15-poolside-note-header-clarity-and-landscape-parity-10-10.md)
+- Primary implementation surfaces:
+  - [/Users/stianvikra/freeswimming/components/my-library/workouts/WorkoutEditor.tsx](/Users/stianvikra/freeswimming/components/my-library/workouts/WorkoutEditor.tsx)
+  - [/Users/stianvikra/freeswimming/lib/session-generator-v1/shared.ts](/Users/stianvikra/freeswimming/lib/session-generator-v1/shared.ts)
+  - [/Users/stianvikra/freeswimming/lib/workouts/shared.ts](/Users/stianvikra/freeswimming/lib/workouts/shared.ts)
+  - [/Users/stianvikra/freeswimming/tests/unit/workout-builder-hub.test.tsx](/Users/stianvikra/freeswimming/tests/unit/workout-builder-hub.test.tsx)
+  - [/Users/stianvikra/freeswimming/tests/unit/workouts-shared.test.ts](/Users/stianvikra/freeswimming/tests/unit/workouts-shared.test.ts)
+  - [/Users/stianvikra/freeswimming/tests/e2e/my-library-workout-builder.spec.ts](/Users/stianvikra/freeswimming/tests/e2e/my-library-workout-builder.spec.ts)
+- Locked boundaries:
+  - no canonical DB/schema change,
+  - no API contract change,
+  - no Garmin adapter format change,
+  - no poolside note visual redesign beyond truthful rest wording if needed to match canonical output,
+  - no new dependency.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Visual design quality`
+- `Business logic correctness and data integrity`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold / Scope Rationale                                                                                                                                              | Evidence                                    | Expected Closeout Score |
+| --------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | The manual pool builder must present single-step work plus attached rest as one coherent top-level block, not two competing sections.                                           | brief review + unit/e2e                     | `5/5`                   |
+| UX flow clarity                               | `target`     | Parent summaries must show exact rest duration inline, block actions must preserve parent/rest attachment, and repeat final-rest choices must explain double-rest outcomes.     | targeted unit/e2e + local QA                | `5/5`                   |
+| Visual design quality                         | `target`     | Attached rest must read as secondary to the work step without becoming hidden or card-within-card clutter.                                                                      | screenshot review + local QA                | `5/5`                   |
+| Business logic correctness and data integrity | `target`     | Canonical rest steps remain separate persisted steps, but block-level editing and downstream summaries must stay truthful and deterministic.                                    | code review + unit tests                    | `5/5`                   |
+| Admin editor ergonomics                       | `N/A`        | N/A because this slice changes the authenticated owner swim-session builder, not an admin editorial surface.                                                                    | explicit scope rationale                    | `N/A`                   |
+| Accessibility (a11y)                          | `target`     | Inline rest controls and final-rest conflict choices must remain keyboard reachable, clearly labeled, and screen-reader understandable.                                         | code review + targeted QA                   | `5/5`                   |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: no heavy state machine or dependency should be introduced for this builder-only UX refinement.                                                                 | `npm run build` + interaction QA            | `4/5`                   |
+| Data placement and sync boundaries            | `target`     | The brief must preserve server-canonical step persistence while defining attached-rest UI as a derived local grouping over separate canonical steps.                            | brief contract + implementation diff        | `5/5`                   |
+| Caching and invalidation strategy             | `supporting` | Supporting only: no new fetch/cache behavior is introduced because all changes stay inside existing local draft editing and save flows.                                         | code review                                 | `4/5`                   |
+| Reliability and failure handling              | `target`     | Add/remove/edit rest operations and repeat conflict resolution must stay deterministic, undoable through existing local save/discard semantics, and not orphan canonical steps. | targeted unit/e2e + manual QA               | `5/5`                   |
+| Security and authz                            | `supporting` | Supporting only: no auth boundary changes; existing owner-only save routes remain intact.                                                                                       | route review                                | `4/5`                   |
+| Privacy and compliance                        | `N/A`        | N/A because this builder UX slice changes no personal-data collection or sharing behavior.                                                                                      | explicit scope rationale                    | `N/A`                   |
+| Content governance                            | `target`     | Builder wording must consistently use `Rest`, `Interval rest`, `Set rest`, and `Final interval rest` with no stale `last rest interval` copy.                                   | copy review + targeted tests                | `5/5`                   |
+| Admin workflow and editability                | `N/A`        | N/A because no admin moderation, publishing, or operator-only flow changes here.                                                                                                | explicit scope rationale                    | `N/A`                   |
+| SEO and crawlability                          | `N/A`        | N/A because this is an authenticated My Library surface.                                                                                                                        | explicit scope rationale                    | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because this private builder slice changes no public semantic surface.                                                                                                      | explicit scope rationale                    | `N/A`                   |
+| Analytics and KPI observability               | `N/A`        | N/A because no new analytics contract is required for this builder refinement.                                                                                                  | explicit scope rationale                    | `N/A`                   |
+| Commerce and revenue ops                      | `N/A`        | N/A because no entitlement, checkout, or billing path changes here.                                                                                                             | explicit scope rationale                    | `N/A`                   |
+| Incident response and support operations      | `N/A`        | N/A because this slice does not change support tooling, incident paths, or runbook flows.                                                                                       | explicit scope rationale                    | `N/A`                   |
+| Finance and reporting operations              | `N/A`        | N/A because no finance or reporting system is touched.                                                                                                                          | explicit scope rationale                    | `N/A`                   |
+| i18n operational readiness                    | `N/A`        | N/A because this slice standardizes private English builder copy only and does not alter localization architecture.                                                             | explicit scope rationale                    | `N/A`                   |
+| Stack-fit and dependency discipline           | `target`     | Reuse the current React/Tailwind builder patterns and helper functions without adding new packages.                                                                             | dependency diff + code review               | `5/5`                   |
+| Testing and QA automation                     | `target`     | Unit/e2e coverage must protect attached-rest summaries, block-level actions, final-interval-rest wording, and double-rest guardrails.                                           | updated tests + `verify:pre-pr` / pre-merge | `5/5`                   |
+| Scalability and cost efficiency               | `N/A`        | N/A because this slice adds no server cost, no background jobs, and no new storage.                                                                                             | explicit scope rationale                    | `N/A`                   |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: rollback stays straightforward because the slice is UI/state-logic only with no migration.                                                                     | diff review + `verify:pre-merge` evidence   | `4/5`                   |
+
+## Data Placement And Sync Contract
+
+- Server-canonical data:
+  - saved workout identity and save/delete flow,
+  - canonical ordered `draft.steps`,
+  - top-level rest steps as distinct canonical rows,
+  - repeat-group relationships and `repeatEndingRestMode`,
+  - downstream Garmin/export/handoff/poolside derivation from canonical steps.
+- Local-only data:
+  - top-level block grouping that attaches a rest step to its parent work step in the builder UI,
+  - local open/closed edit state,
+  - inline final-rest conflict guidance/confirmation state.
+- Sync policy:
+  - adding attached rest creates a canonical rest step directly after the parent step inside the local draft,
+  - removing attached rest deletes that canonical rest step from the local draft only until save,
+  - parent-block move/duplicate/delete/add-after operations must preserve or intentionally remove the attached canonical rest step with the parent block.
+- Retention and sensitivity:
+  - no new local storage,
+  - no new sensitive data,
+  - existing save/discard behavior remains the retention boundary.
+- Cache/invalidation:
+  - unchanged from current local draft save flow.
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - `workout.id` remains the saved-session identity,
+  - canonical `step.id` and `repeatGroupId` remain the source-of-truth identifiers.
+- Human-readable identifiers:
+  - step labels, rest labels, summary lines, and repeat copy are presentation-only and may change in place.
+- Mutability rules:
+  - UI wording is mutable,
+  - canonical IDs are unchanged,
+  - canonical rest rows remain separate rows even when rendered as attached UI.
+- Rename vs repurpose policy:
+  - improve presentation in place,
+  - do not repurpose canonical rest rows into inline-only metadata fields.
+- Compatibility contract:
+  - Garmin/export/handoff/poolside code must continue to derive from canonical steps,
+  - if `Keep both` is chosen for repeat final-rest conflicts, downstream summaries must stay truthful to both rests instead of silently suppressing one.
+- Observability and repair:
+  - tests must catch orphaned rest-step regressions, stale labels, and false downstream summary suppression.
+
+## Scope
+
+- In manual pool edit mode, treat a top-level work step plus its immediate following top-level rest step as one visual/edit block.
+- Show attached single-step rest duration directly in the parent summary, for example:
+  - `400m · Freestyle · Easy · Rest 0:30`
+- Stop rendering that linked top-level rest as a separate sibling card in edit mode.
+- In repeat overview summaries, include the work stroke when it is explicit and helpful, for example:
+  - `4 x 50m · Freestyle · Interval rest 0:20 · Set rest 0:30`
+- Hide the `Repeat block` pill in passive overview/view states and show it only while the repeat block is open in edit mode.
+- Inside the parent edit form:
+  - show attached rest controls,
+  - allow add, edit, and remove,
+  - keep rest configuration secondary to the main step.
+- Make top-level block actions parent-rest aware:
+  - move,
+  - add step after,
+  - duplicate,
+  - delete.
+- Preserve each step's authored distance unit across a global `Meters` / `Yards` switch unless that step is explicitly re-authored in the new unit:
+  - summary lines stay stable,
+  - custom distance inputs and presets inside the step editor stay in the authored unit too.
+- Ensure the final top-level single step does not auto-seed a trailing rest by default when adding a new single step at the end of the session.
+- Rename repeat copy:
+  - `Final interval rest`
+  - `Skip final interval rest`
+  - `Include final interval rest`
+- When `Include final interval rest` is selected while a separate post-set rest still exists:
+  - show inline conflict guidance,
+  - offer:
+    - `Keep set rest only`
+    - `Use final interval rest instead`
+    - `Keep both`
+  - require explicit confirmation before auto-removing the separate post-set rest step.
+- Keep downstream summaries truthful when both interval rest and set rest exist.
+
+## Out Of Scope
+
+- Poolside note composition/layout redesign.
+- Full-session PDF visual redesign.
+- New schema fields or migrations.
+- Changing Garmin readiness policy for `use_last_rest` beyond making the surfaced data truthful.
+- New undo/history beyond current local draft semantics.
+
+## Acceptance Criteria
+
+1. In manual pool edit mode, a top-level work step with a linked rest renders as one top-level card, not two sibling cards.
+2. That parent card summary shows the actual rest duration or rest mode inline.
+3. Opening the parent card exposes an attached rest editor with `Add rest` when absent and `Remove rest` when present.
+4. Removing attached rest deletes the canonical adjacent top-level rest step without orphaning the block.
+5. Top-level `Move`, `Add step after`, `Duplicate`, and `Delete` operate on the parent block plus its attached rest together.
+6. Adding a new top-level single step at the end of the session no longer auto-creates a trailing rest step by default.
+7. Repeat wording changes to `Final interval rest`, `Skip final interval rest`, and `Include final interval rest`.
+8. Selecting `Include final interval rest` while a separate post-set rest exists shows inline conflict handling instead of an immediate popup.
+9. Choosing to auto-remove the separate post-set rest requires explicit confirmation first.
+10. Choosing `Keep both` preserves both rest segments in builder summaries and downstream handoff/poolside derivation.
+11. Canonical step schema and Garmin/export payload structure remain intact.
+12. Repeat overview summaries include an explicit work stroke when the repeat work step has one.
+13. The `Repeat block` pill is absent in passive overview/view states and appears only while the repeat editor is open.
+14. Switching global pool units resets pool-size defaults but does not silently convert existing step overview summaries or authored step distance inputs.
+15. Relevant tests and `verify:pre-pr` / `verify:pre-merge` pass.
+
+## Validation
+
+- `npm run lint:briefs`
+- targeted `vitest`:
+  - `npx vitest run tests/unit/workout-builder-hub.test.tsx tests/unit/workouts-shared.test.ts`
+- targeted `playwright`:
+  - `npx playwright test tests/e2e/my-library-workout-builder.spec.ts`
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm installed locally.
+- Validation runs from repo root.
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3000/my-library/workouts/<id>`
+- Preview:
+  - Vercel preview URL from PR checks.
+- Recommended matrix:
+  - iPhone Safari
+  - Desktop Safari
+  - Desktop Chrome
+
+## Constraints
+
+- Builder copy stays in English.
+- Preserve the canonical rest-step model and Garmin/export compatibility.
+- Keep attached-rest UI calm and secondary; do not create a nested card stack that fights the main step.
+- Do not hide rest existence behind `Edit`; the summary must stay truthful.
+- Keep changes scoped to this builder/rest slice.
+
+## 10/10 Quality Bar
+
+- Single-step top-level blocks must scan as clearly as repeat blocks.
+- Rest belongs visually to the step it follows, but must remain easy to remove or adjust.
+- The builder must not let block-level actions silently split work from its rest.
+- Final-interval-rest conflict handling must be calm, local, and explicit.
+- Required states remain clear:
+  - loading: unchanged,
+  - empty: unchanged,
+  - error: existing save flow unchanged,
+  - retry: explicit confirmation before auto-removing another step,
+  - offline: unchanged.
+
+## Checkpoint Log
+
+- `2026-04-15 | planning | created the attached-rest grouping and final-interval-rest guardrail brief from owner-approved scope: group top-level rest under parent steps in manual pool edit mode, make block actions preserve that grouping, and add inline repeat double-rest conflict handling without changing canonical schema | next: implement builder/state changes, update tests, and run repo gates`
+- `2026-04-15 | implementation | attached top-level rest is now grouped under its parent step in manual pool edit mode, repeat wording/guardrails were updated, and downstream summaries keep both rests truthful when chosen | validation: npx vitest run tests/unit/workout-builder-hub.test.tsx tests/unit/workouts-shared.test.ts; npx playwright test tests/e2e/my-library-workout-builder.spec.ts; npm run lint:briefs:all; npm run verify:pre-pr | next: commit, push, open/update PR, monitor CI, and run verify:pre-merge before merge recommendation`
+- `2026-04-15 | implementation | added explicit repeat-work stroke summaries, hid the passive repeat pill outside open repeat editing, and preserved authored step units in both summaries and custom distance inputs across global pool-unit toggles | validation: npx eslint components/my-library/workouts/WorkoutEditor.tsx tests/unit/workout-builder-hub.test.tsx tests/e2e/my-library-workout-builder.spec.ts; npx vitest run tests/unit/workout-builder-hub.test.tsx tests/unit/workouts-shared.test.ts; env NEXT_DIST_DIR=.next-playwright-builder-full-rerun npx playwright test tests/e2e/my-library-workout-builder.spec.ts | next: run npm run verify:pre-pr, then commit/push/update PR`
+- `2026-04-15 | validation | full builder-targeted validation is green; npm run verify:pre-pr reached the full lane and only failed on an unrelated flaky rerun of tests/e2e/my-library-program-export.spec.ts while all builder coverage passed; isolated rerun of that export spec then passed cleanly, so builder scope is PR-ready but the broader repo gate should still be watched on CI | validation: npm run verify:pre-pr; env NEXT_DIST_DIR=.next-playwright-program-export-rerun npx playwright test tests/e2e/my-library-program-export.spec.ts --project=desktop-chromium | next: stage scoped files, open/update PR, and monitor CI before merge recommendation`

--- a/docs/task-briefs/planned/2026-04-15-workout-pdf-visual-parity-with-poolside-note-10-10.md
+++ b/docs/task-briefs/planned/2026-04-15-workout-pdf-visual-parity-with-poolside-note-10-10.md
@@ -1,0 +1,236 @@
+# Task Brief: Workout PDF Visual Parity With Poolside Note (10/10)
+
+## Metadata
+
+- `id`: `2026-04-15-workout-pdf-visual-parity-with-poolside-note-10-10`
+- `status`: `planned`
+- `owner`: `stianvikra`
+- `created`: `2026-04-15`
+- `updated`: `2026-04-15`
+
+## Goal
+
+Make the standard workout PDF feel like the same premium FreeSwimming print system as the Poolside Note, while preserving the PDF's distinct job as the fuller reference artifact.
+
+## Why This Brief Exists
+
+- The Poolside Note has now been pushed toward a much stronger brand and layout standard.
+- The standard workout PDF still risks reading like an older parallel print surface instead of part of the same system.
+- That gap creates avoidable brand inconsistency:
+  - different header language,
+  - different hierarchy,
+  - different spacing and card treatment,
+  - different print impression for two artifacts the same swimmer may see in the same workflow.
+- The owner-approved direction is explicit:
+  - finish and close the current builder brief first,
+  - then create a separate brief for Workout PDF visual parity with Poolside Note.
+- This brief exists to lock the next design/implementation slice before code changes begin.
+
+## Dependencies And Boundaries
+
+- Builder/runtime parent brief:
+  - [/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md)
+- Upstream workout PDF/export delivery:
+  - [/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-02-28-workout-export-adapters-garmin-ready-pdf-10-10.md)
+- Upstream poolside-note design system direction:
+  - [/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-15-poolside-note-brand-surface-reframe-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-15-poolside-note-brand-surface-reframe-10-10.md)
+  - [/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-15-poolside-note-header-clarity-and-landscape-parity-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-15-poolside-note-header-clarity-and-landscape-parity-10-10.md)
+  - [/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-15-poolside-note-layout-and-preview-favicon-polish-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-15-poolside-note-layout-and-preview-favicon-polish-10-10.md)
+- Likely implementation surfaces when execution starts:
+  - [/Users/stianvikra/freeswimming/lib/workouts/shared.ts](/Users/stianvikra/freeswimming/lib/workouts/shared.ts)
+  - [/Users/stianvikra/freeswimming/lib/brand.ts](/Users/stianvikra/freeswimming/lib/brand.ts)
+  - [/Users/stianvikra/freeswimming/components/my-library/workouts/WorkoutEditor.tsx](/Users/stianvikra/freeswimming/components/my-library/workouts/WorkoutEditor.tsx)
+  - [/Users/stianvikra/freeswimming/tests/unit/workouts-shared.test.ts](/Users/stianvikra/freeswimming/tests/unit/workouts-shared.test.ts)
+  - [/Users/stianvikra/freeswimming/tests/unit/workout-builder-hub.test.tsx](/Users/stianvikra/freeswimming/tests/unit/workout-builder-hub.test.tsx)
+  - [/Users/stianvikra/freeswimming/tests/e2e/my-library-workout-builder.spec.ts](/Users/stianvikra/freeswimming/tests/e2e/my-library-workout-builder.spec.ts)
+- Locked boundaries:
+  - no workout schema change,
+  - no Garmin/export payload contract change,
+  - no builder authoring logic change unless strictly needed for PDF truthfulness,
+  - no poolside-note redesign inside this brief,
+  - no new dependency.
+
+## Product Direction Locked By This Brief
+
+1. The standard workout PDF and Poolside Note must feel like one FreeSwimming print family.
+2. They must not become copies of each other.
+3. The workout PDF keeps the richer reference role:
+   - fuller step detail,
+   - stronger full-session readability,
+   - print-safe reference use beyond pool deck glanceing.
+4. The Poolside Note keeps the faster lane-side glance role.
+5. Brand parity should come through:
+   - shared logo system,
+   - shared typographic discipline,
+   - shared spacing logic,
+   - shared color logic,
+   - shared terminology,
+   - shared print polish.
+6. The PDF must not regress canonical truthfulness, export reliability, or Garmin readiness.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Visual design quality`
+- `Business logic correctness and data integrity`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold / Scope Rationale                                                                                                                                  | Evidence                               | Expected Closeout Score |
+| --------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | Workout PDF must clearly read as the fuller reference artifact within the same print family as Poolside Note, with no identity confusion between the two artifacts. | design review + screenshot QA          | `5/5`                   |
+| UX flow clarity                               | `target`     | Header, totals, focus, swimmer identity, and step hierarchy must scan immediately on first read in both preview and print.                                          | local QA + e2e screenshot review       | `5/5`                   |
+| Visual design quality                         | `target`     | Workout PDF must match Poolside Note brand quality without becoming a layout clone; spacing, typography, border treatment, and hierarchy must feel intentional.     | local visual QA + preview review       | `5/5`                   |
+| Business logic correctness and data integrity | `target`     | PDF copy and layout changes must preserve exact workout content, distances, rests, repeats, and canonical ordering with no export-data drift.                       | unit tests + e2e assertions            | `5/5`                   |
+| Admin editor ergonomics                       | `supporting` | Supporting only: builder authoring controls may be touched only insofar as PDF preview truthfulness or naming parity requires it.                                   | scope review + code review             | `4/5`                   |
+| Accessibility (a11y)                          | `target`     | Preview and print semantics must remain readable, keyboard reachable, and visually high-contrast, with no layout that hides core workout data.                      | manual QA + code review                | `5/5`                   |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: preview rendering should not introduce new heavy assets, extra fetches, or obvious route regressions.                                              | `npm run build` + local preview QA     | `4/5`                   |
+| Data placement and sync boundaries            | `target`     | Local preview state and saved canonical workout data must stay clearly separated so PDF output remains deterministic for draft vs saved states.                     | code review + e2e/manual QA            | `5/5`                   |
+| Caching and invalidation strategy             | `supporting` | Supporting only: save/reset/open-preview actions must invalidate stale PDF preview composition deterministically.                                                   | manual QA + existing preview tests     | `4/5`                   |
+| Reliability and failure handling              | `target`     | Preview/pop-up/print flow must not blank, hang, or print empty pages on changed PDF surfaces.                                                                       | Playwright regression + manual QA      | `5/5`                   |
+| Security and authz                            | `supporting` | Supporting only: private workout preview/export access model remains unchanged and must continue to fail closed.                                                    | existing auth review + scope rationale | `4/5`                   |
+| Privacy and compliance                        | `supporting` | Supporting only: visible swimmer/session information must remain intentional and limited to already-approved owner-facing print data.                               | copy review + scope rationale          | `4/5`                   |
+| Content governance                            | `target`     | PDF wording and labels must align with Poolside Note terminology and canonical workout semantics; no stale internal labels or divergent naming may remain.          | copy audit + unit/e2e assertions       | `5/5`                   |
+| Admin workflow and editability                | `supporting` | Supporting only: no new workflow stage is introduced; the task refines output clarity and preview parity.                                                           | scope rationale                        | `4/5`                   |
+| SEO and crawlability                          | `N/A`        | N/A because this is a private authenticated preview/print artifact, not a public crawl surface.                                                                     | explicit scope rationale               | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because the brief changes no public metadata or public semantic surface for model retrieval.                                                                    | explicit scope rationale               | `N/A`                   |
+| Analytics and KPI observability               | `N/A`        | N/A because no new analytics contract is required; success is judged through design QA and regression coverage rather than new events.                              | explicit scope rationale               | `N/A`                   |
+| Commerce and revenue ops                      | `N/A`        | N/A because the brief does not change pricing, entitlement, billing, or conversion behavior.                                                                        | explicit scope rationale               | `N/A`                   |
+| Incident response and support operations      | `N/A`        | N/A because this slice does not change support runbooks or alerting; it improves a private print preview artifact and should remain operationally simple.           | explicit scope rationale               | `N/A`                   |
+| Finance and reporting operations              | `N/A`        | N/A because no finance, payout, refund, or reconciliation path is changed by PDF visual parity work.                                                                | explicit scope rationale               | `N/A`                   |
+| i18n operational readiness                    | `N/A`        | N/A because the task tightens one English-only private print artifact contract and adds no locale architecture or translation storage.                              | explicit scope rationale               | `N/A`                   |
+| Stack-fit and dependency discipline           | `target`     | The redesign must reuse the existing PDF rendering/export stack and brand manifest with no unnecessary dependency or alternate print engine.                        | dependency diff + code review          | `5/5`                   |
+| Testing and QA automation                     | `target`     | Unit/e2e coverage must lock the new PDF hierarchy, terminology parity, preview stability, and non-empty printable output; repo verification gates must stay green.  | updated tests + verification gates     | `5/5`                   |
+| Scalability and cost efficiency               | `supporting` | Supporting only: parity work must not add duplicate render passes, large image bloat, or avoidable CI/runtime overhead.                                             | diff review + build review             | `4/5`                   |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: the work remains code-only, rollback-safe, and isolated from data/schema migrations.                                                               | PR diff + rollback note                | `4/5`                   |
+
+## Data Placement And Sync Contract
+
+- Server-canonical data:
+  - saved workout content, step order, and swimmer/session metadata already used by the PDF and Poolside Note flows.
+- Local-only data:
+  - current builder draft values before save,
+  - preview-open state,
+  - any local print-layout or print-style selection already supported by the surface.
+- Sync policy:
+  - PDF preview may reflect current local draft immediately,
+  - saved canonical output must remain available and clearly distinguished where the product already separates draft vs saved,
+  - visual parity work must not write back presentation-only choices into canonical workout storage.
+- Retention and sensitivity:
+  - no new persistent settings entity,
+  - no expanded personal data footprint,
+  - only already-approved owner-facing print data may appear.
+- Cache/invalidation:
+  - save, discard/reset, and preview reopen must rebuild deterministic PDF output from the latest applicable source state.
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - `workout.id` remains the canonical identity behind both the standard PDF and Poolside Note.
+- Human-readable identifiers:
+  - workout title and swimmer name remain renameable presentation fields,
+  - PDF section labels and heading copy are presentation-only and may be improved in place.
+- Mutability rules:
+  - presentation labels are mutable,
+  - canonical IDs and export identity remain unchanged.
+- Rename vs repurpose policy:
+  - visual/header/copy parity is an in-place presentation refinement,
+  - it must not create a second canonical workout-PDF entity or a divergent export model.
+- Compatibility contract:
+  - existing preview/open/print routes must keep working,
+  - PDF visual parity must not break existing print/share/export entry points.
+- Observability and repair:
+  - tests must catch stale labels, missing brand assets, empty preview regressions, and layout truthfulness issues.
+
+## Scope
+
+- Align the standard workout PDF header system with the Poolside Note brand family.
+- Audit and unify terminology across the two print artifacts:
+  - totals,
+  - focus,
+  - swimmer identity,
+  - rest/repeat wording,
+  - artifact labels where relevant.
+- Rework PDF hierarchy, spacing, and emphasis so the page feels equally premium and deliberate.
+- Ensure the PDF uses the correct brand asset/lockup strategy relative to print mode.
+- Validate that the PDF preview remains stable, nonblank, and print-safe after the redesign.
+- Update tests to lock the new visual/content contract.
+
+## Out Of Scope
+
+- Poolside Note redesign.
+- Builder step-authoring UX redesign beyond PDF-truthfulness needs.
+- New workout schema fields or export adapter contracts.
+- Garmin-ready JSON logic changes.
+- New analytics events.
+- New dependency or alternate PDF engine.
+
+## Acceptance Criteria
+
+1. The standard workout PDF reads as the same FreeSwimming print family as the Poolside Note.
+2. The PDF retains a distinct full-reference role and is not a visual clone of the Poolside Note.
+3. Header hierarchy, brand treatment, and session summary blocks are visually deliberate and consistently composed.
+4. Rest/repeat/totals/focus terminology is aligned where the two artifacts represent the same underlying meaning.
+5. Preview/open/print flow remains stable and does not blank or print empty output.
+6. Canonical workout content remains truthful and unchanged by the redesign.
+7. Relevant tests and `verify:pre-pr` / `verify:pre-merge` pass when this brief is executed.
+
+## Validation
+
+- `npm run lint:briefs`
+- targeted `vitest` for PDF/poolside shared print-model logic
+- targeted `playwright` for workout PDF preview and print stability
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm installed locally.
+- Validation runs from repo root.
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3000/my-library/workouts/<id>`
+- Preview:
+  - Vercel preview URL from PR checks when the brief is executed
+- Recommended matrix:
+  - iPhone Safari
+  - Desktop Safari
+  - Desktop Chrome
+
+## Constraints
+
+- UI/print copy stays in English.
+- Preserve canonical workout truthfulness and existing export entry points.
+- Reuse the existing brand system instead of inventing a parallel PDF language.
+- Do not make the workout PDF a copy-paste of Poolside Note.
+- Keep the scope to PDF visual parity and print reliability.
+
+## 10/10 Quality Bar
+
+- The workout PDF must look intentional, premium, and fully professional in both preview and printed form.
+- The reading order must be obvious within one glance.
+- The page must stay calm and information-dense without feeling cramped.
+- Required states remain clear:
+  - loading: preview indicates progress without looking broken,
+  - empty: no misleading blank artifact,
+  - error: actionable message and stable UI,
+  - retry: preview can be reopened without stale/blank output,
+  - offline: no false success state.
+- Accessibility must remain strong:
+  - readable type sizes,
+  - clear hierarchy,
+  - high contrast,
+  - keyboard-safe preview actions.
+- Business logic correctness must remain deterministic:
+  - no silent content drift,
+  - no missing rests or repeats,
+  - no preview/export mismatch.
+
+## Checkpoint Log
+
+- `2026-04-15 | planning | created the dedicated planned brief for aligning the standard workout PDF with the newer Poolside Note brand and print-system quality bar, while explicitly keeping the two artifacts distinct in job and composition | next: execute this brief separately after the current builder slice is merged or explicitly handed off`

--- a/lib/session-generator-v1/shared.ts
+++ b/lib/session-generator-v1/shared.ts
@@ -335,8 +335,8 @@ const STEP_TARGET_MODE_LABELS: Record<SessionDraftStepTargetMode, string> = {
 };
 
 const REPEAT_ENDING_REST_MODE_LABELS: Record<SessionDraftRepeatEndingRestMode, string> = {
-  use_last_rest: "Use last rest interval",
-  skip_last_rest: "Skip last rest interval",
+  use_last_rest: "Include final interval rest",
+  skip_last_rest: "Skip final interval rest",
 };
 
 export function getSessionEnvironmentLabel(value: SessionGeneratorEnvironment) {

--- a/lib/workouts/shared.ts
+++ b/lib/workouts/shared.ts
@@ -3572,19 +3572,11 @@ function buildWorkoutEnvironmentSummary(draft: SessionDraft) {
 
 function buildWorkoutHandoffGroups(steps: SessionDraftStep[]): WorkoutHandoffGroup[] {
   const groups: WorkoutHandoffGroup[] = [];
-  const suppressedPostSetRestGroupIds = collectSuppressedWorkoutPostSetRestGroupIds(steps);
 
   for (let index = 0; index < steps.length; index += 1) {
     const step = steps[index];
 
     if (!step) continue;
-
-    if (
-      isSessionDraftRepeatPostSetRestStep(step) &&
-      suppressedPostSetRestGroupIds.has(step.postSetRestForRepeatGroupId ?? "")
-    ) {
-      continue;
-    }
 
     if (!step.repeatGroupId) {
       groups.push({
@@ -3619,55 +3611,12 @@ function buildWorkoutHandoffGroups(steps: SessionDraftStep[]): WorkoutHandoffGro
   return groups;
 }
 
-function collectSuppressedWorkoutPostSetRestGroupIds(steps: SessionDraftStep[]) {
-  const groupIds = new Set<string>();
-
-  for (let index = 0; index < steps.length; index += 1) {
-    const step = steps[index];
-    if (!step?.repeatGroupId) continue;
-
-    const entries: WorkoutHandoffEntry[] = [{ step, index }];
-    let nextIndex = index + 1;
-    while (nextIndex < steps.length && steps[nextIndex]?.repeatGroupId === step.repeatGroupId) {
-      const nextStep = steps[nextIndex];
-      if (!nextStep) break;
-      entries.push({ step: nextStep, index: nextIndex });
-      nextIndex += 1;
-    }
-
-    if (
-      shouldSuppressWorkoutRepeatPostSetRest(
-        entries,
-        resolveSessionDraftRepeatEndingRestMode(step.repeatEndingRestMode ?? null)
-      )
-    ) {
-      groupIds.add(step.repeatGroupId);
-    }
-
-    index = nextIndex - 1;
-  }
-
-  return groupIds;
-}
-
 function shouldSkipWorkoutRepeatEndingRest(
   entries: WorkoutHandoffEntry[],
   repeatCount: number | null,
   repeatEndingRestMode: SessionDraftRepeatEndingRestMode
 ) {
   if (repeatEndingRestMode !== "skip_last_rest" || !repeatCount || repeatCount <= 1) {
-    return false;
-  }
-
-  const lastEntry = entries[entries.length - 1];
-  return Boolean(lastEntry && isSessionDraftRepeatEndingRestStep(lastEntry.step));
-}
-
-function shouldSuppressWorkoutRepeatPostSetRest(
-  entries: WorkoutHandoffEntry[],
-  repeatEndingRestMode: SessionDraftRepeatEndingRestMode
-) {
-  if (repeatEndingRestMode !== "use_last_rest") {
     return false;
   }
 

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -361,7 +361,10 @@ test.describe("my library workout builder", () => {
     await expect(page.getByTestId("session-draft-step-summary-0")).toBeVisible();
     await expect(page.getByTestId("session-draft-step-toggle-0")).toBeVisible();
     await expect(page.getByTestId("session-draft-repeat-summary-2")).toContainText("Main");
-    await expect(page.getByTestId("session-draft-repeat-summary-2")).toContainText("Repeat block");
+    await expect(page.getByTestId("session-draft-repeat-summary-2")).toContainText("Freestyle");
+    await expect(page.getByTestId("session-draft-repeat-summary-2")).not.toContainText(
+      "Repeat block"
+    );
     const collapsedStepSummaryBox = await page
       .getByTestId("session-draft-step-summary-0")
       .boundingBox();
@@ -396,7 +399,7 @@ test.describe("my library workout builder", () => {
     await expect(page.getByLabel("Drill Type")).toBeVisible();
     await expect(page.getByLabel("Duration")).toBeVisible();
     await expect(page.getByRole("combobox", { name: "Target" })).toBeVisible();
-    await expect(page.getByRole("textbox", { name: "Notes" })).toBeVisible();
+    await expect(page.getByLabel("Notes", { exact: true })).toBeVisible();
     await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText("Distance");
     await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText("Time");
     await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
@@ -565,6 +568,10 @@ test.describe("my library workout builder", () => {
       )
     ).toHaveCount(0);
     await expect(repeatSummary.getByText("Final rest skipped")).toHaveCount(0);
+    await expect(repeatSummary).toContainText(
+      "6 x 100m · Freestyle · Interval rest 0:30 · Set rest 0:30"
+    );
+    await expect(repeatSummary).not.toContainText("109.36yd");
     await expect(page.getByText("Keeps the blue surfaces")).toBeVisible();
     await expect(page.getByText("Uses white surfaces.")).toBeVisible();
     await expect(page.getByText("Edit this into the exact repeat you want to hold.")).toHaveCount(
@@ -574,7 +581,21 @@ test.describe("my library workout builder", () => {
       page.getByText("Adjust or remove this recovery once the set is dialed in.")
     ).toHaveCount(0);
     await expect(page.getByText("Move the full repeat block from the header.")).toHaveCount(0);
+    await page.getByRole("button", { name: "Meters" }).click();
+    await expect(page.getByTestId("session-draft-step-summary-0")).toContainText(
+      "333yd · Freestyle · Easy"
+    );
+    await expect(page.getByTestId("session-draft-step-summary-0")).not.toContainText(
+      /304(?:\.49|\.5)m/
+    );
+    await expect(page.getByTestId("session-draft-repeat-summary-2")).toContainText(
+      "6 x 100m · Freestyle · Interval rest 0:30 · Set rest 0:30"
+    );
+    await expect(page.getByTestId("session-draft-repeat-summary-2")).not.toContainText("109.36yd");
     await page.getByTestId("session-draft-step-toggle-2").click();
+    await expect(
+      page.getByTestId("session-draft-repeat-summary-2").getByText("Repeat block")
+    ).toBeVisible();
     await page.getByTestId("session-draft-step-distance-2").selectOption("200");
     await page.getByTestId("session-draft-step-stroke-2").selectOption("backstroke");
     await page.getByTestId("session-draft-step-drill-type-2").selectOption("pull");
@@ -588,7 +609,7 @@ test.describe("my library workout builder", () => {
     await page
       .getByTestId("session-draft-step-summary-3")
       .locator("xpath=ancestor::article[1]")
-      .getByRole("textbox", { name: "Notes" })
+      .getByLabel("Notes", { exact: true })
       .fill("Leave on the top and count strokes.");
     await page.getByTestId("session-draft-title").fill(uniqueTitle);
     await expect(page.getByRole("button", { name: "Discard changes" })).toBeVisible();
@@ -702,7 +723,7 @@ test.describe("my library workout builder", () => {
     await expect(pdfPopup.locator('[data-testid="workout-pdf-title"]')).toContainText(uniqueTitle);
     await expect(pdfPopup.locator("body")).toContainText("Workout PDF");
     await expect(pdfPopup.locator("body")).toContainText("Print / Save PDF");
-    await expect(pdfPopup.locator("body")).toContainText("200yd");
+    await expect(pdfPopup.locator("body")).toContainText("200m");
     await expect(pdfPopup.locator("body")).toContainText("Backstroke");
     await pdfPopup.close();
 

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -726,7 +726,7 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.getByTestId("workout-builder-save")).toBeEnabled();
   });
 
-  it("shows repeat summary and final-rest clarification in the manual pool builder while defaulting to skip last rest", async () => {
+  it("shows repeat summary and final-interval-rest wording in the manual pool builder", async () => {
     render(
       <WorkoutBuilderHub
         workoutLibrary={buildWorkoutLibrary({
@@ -748,19 +748,23 @@ describe("WorkoutBuilderHub", () => {
     });
 
     fireEvent.click(screen.getByTestId("session-draft-add-repeat"));
-    expect(screen.getByTestId("session-draft-repeat-ending-rest-mode-1")).toHaveValue(
-      "skip_last_rest"
+    const repeatEndingRestMode = screen.getAllByTestId(/session-draft-repeat-ending-rest-mode-/)[0];
+    const repeatSummary = screen.getAllByTestId(/session-draft-repeat-summary-/)[0];
+
+    expect(repeatEndingRestMode).toHaveValue("skip_last_rest");
+    expect(repeatSummary).toHaveTextContent(
+      "4 x 100m · Freestyle · Interval rest 0:30 · Set rest 0:30"
     );
-    expect(screen.getByTestId("session-draft-repeat-summary-1")).toHaveTextContent(
-      "4 x 100m · Interval rest 0:30 · Set rest 0:30"
-    );
+    expect(repeatSummary).toHaveTextContent("Repeat block");
     expect(
       screen.queryByText(
         "Fixed Rest Time 1:00 still runs between rounds. It is skipped only after the final round."
       )
     ).not.toBeInTheDocument();
     expect(screen.queryByText(/Final rest skipped/)).not.toBeInTheDocument();
-    fireEvent.click(screen.getByTestId("session-draft-repeat-toggle-1"));
+    expect(screen.getByText("Final interval rest")).toBeVisible();
+    expect(screen.getByRole("option", { name: "Skip final interval rest" })).toBeVisible();
+    expect(screen.getByRole("option", { name: "Include final interval rest" })).toBeVisible();
     expect(
       screen.queryByText("Adjust or remove when you refine the workout.")
     ).not.toBeInTheDocument();
@@ -775,7 +779,7 @@ describe("WorkoutBuilderHub", () => {
     expect(repeatSteps.every((step) => step.repeatEndingRestMode === "skip_last_rest")).toBe(true);
   });
 
-  it("links standalone rest cards to their parent step labels in the manual pool builder", async () => {
+  it("shows attached rest inline in parent summaries and edits it inside the parent card", async () => {
     render(
       <WorkoutBuilderHub
         workoutLibrary={buildWorkoutLibrary({
@@ -850,17 +854,190 @@ describe("WorkoutBuilderHub", () => {
 
     expect(screen.getByTestId("session-draft-step-summary-0")).toHaveTextContent("Warmup");
     expect(screen.getByTestId("session-draft-step-summary-0")).toHaveTextContent(
+      "400m · Freestyle · Easy · Rest 0:30"
+    );
+    expect(screen.queryByTestId("session-draft-step-summary-1")).not.toBeInTheDocument();
+    expect(screen.getByTestId("session-draft-step-summary-2")).toHaveTextContent("Cooldown");
+    expect(screen.getByTestId("session-draft-step-summary-2")).toHaveTextContent("Rest 1:00");
+    expect(screen.queryByTestId("session-draft-step-summary-3")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("session-draft-step-toggle-0"));
+    expect(screen.getByTestId("session-draft-step-linked-rest-panel-0")).toBeVisible();
+    expect(screen.getByTestId("session-draft-step-linked-rest-time-0")).toHaveValue("0:30");
+
+    fireEvent.click(screen.getByTestId("session-draft-step-linked-rest-remove-0"));
+    expect(screen.getByTestId("session-draft-step-summary-0")).toHaveTextContent(
       "400m · Freestyle · Easy"
     );
-    expect(screen.getByTestId("session-draft-step-summary-0")).not.toHaveTextContent("Rest:");
-    expect(screen.getByTestId("session-draft-step-summary-1")).toHaveTextContent("Warmup Rest");
-    expect(screen.getByTestId("session-draft-step-summary-1")).toHaveTextContent("0:30");
-    expect(screen.getByTestId("session-draft-step-summary-1")).not.toHaveTextContent(
-      "Use this as a simple fixed rest block."
+    expect(screen.getByTestId("session-draft-step-summary-0")).not.toHaveTextContent("Rest 0:30");
+    expect(screen.getByTestId("session-draft-step-linked-rest-add-0")).toBeVisible();
+
+    fireEvent.click(screen.getByTestId("session-draft-step-linked-rest-add-0"));
+    expect(screen.getByTestId("session-draft-step-summary-0")).toHaveTextContent(
+      "400m · Freestyle · Easy · Rest 0:30"
     );
-    expect(screen.getByTestId("session-draft-step-summary-2")).toHaveTextContent("Cooldown");
-    expect(screen.getByTestId("session-draft-step-summary-3")).toHaveTextContent("Cooldown Rest");
-    expect(screen.getByTestId("session-draft-step-summary-3")).toHaveTextContent("1:00");
+  });
+
+  it("keeps attached rest tied to the parent block for delete and add-after actions", async () => {
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: buildWorkoutRecord({
+            sourceKind: "manual",
+            draft: buildDraft({
+              sourceFingerprint: "manual-attached-rest-actions",
+              steps: [
+                {
+                  id: "warmup-1",
+                  category: "warmup",
+                  name: "Warmup swim",
+                  stroke: "freestyle",
+                  intensity: "easy",
+                  durationMode: "distance",
+                  distanceM: 400,
+                  timeMin: null,
+                  targetSummary: "",
+                  notes: "",
+                },
+                {
+                  id: "warmup-rest-1",
+                  category: "rest",
+                  name: "Warmup rest",
+                  stroke: "choice",
+                  intensity: "easy",
+                  durationMode: "fixed_rest",
+                  distanceM: null,
+                  timeMin: 0.5,
+                  targetSummary: "",
+                  notes: "",
+                },
+                {
+                  id: "main-1",
+                  category: "main",
+                  name: "Main swim",
+                  stroke: "freestyle",
+                  intensity: "moderate",
+                  durationMode: "distance",
+                  distanceM: 200,
+                  timeMin: null,
+                  targetSummary: "",
+                  notes: "",
+                },
+              ],
+            }),
+          }),
+          recentWorkouts: [buildWorkoutSummary({ sourceKind: "manual" })],
+        })}
+        preferExpandedDetailsOnLoad
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("session-draft-step-toggle-0"));
+    fireEvent.click(screen.getByTestId("session-draft-step-add-after-0"));
+
+    let previewDraft = readPreviewDraft();
+    expect(previewDraft.steps.map((step) => step.id)).toEqual([
+      "warmup-1",
+      "warmup-rest-1",
+      expect.stringMatching(/^step-/),
+      "main-1",
+    ]);
+
+    fireEvent.click(screen.getByTestId("session-draft-step-toggle-0"));
+    fireEvent.click(screen.getByTestId("session-draft-step-remove-0"));
+    fireEvent.click(screen.getByTestId("workout-editor-removal-confirm-button"));
+
+    previewDraft = readPreviewDraft();
+    expect(previewDraft.steps).toHaveLength(2);
+    expect(previewDraft.steps.some((step) => step.id === "warmup-1")).toBe(false);
+    expect(previewDraft.steps.some((step) => step.id === "warmup-rest-1")).toBe(false);
+  });
+
+  it("does not auto-create a trailing rest when adding a new top-level step at the end", async () => {
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: buildWorkoutRecord({
+            sourceKind: "manual",
+            draft: buildDraft({ sourceFingerprint: "manual-add-step-no-rest" }),
+          }),
+          recentWorkouts: [buildWorkoutSummary({ sourceKind: "manual" })],
+        })}
+        preferExpandedDetailsOnLoad
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("session-draft-add-step"));
+
+    const previewDraft = readPreviewDraft();
+    const lastStep = previewDraft.steps.at(-1);
+
+    expect(lastStep?.category).not.toBe("rest");
+    expect(
+      previewDraft.steps.filter((step) => !step.repeatGroupId && !step.postSetRestForRepeatGroupId)
+    ).toHaveLength(2);
+    expect(screen.getByTestId("session-draft-step-linked-rest-add-1")).toBeVisible();
+  });
+
+  it("shows inline conflict handling before removing post-set rest from repeats", async () => {
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: buildWorkoutRecord({
+            sourceKind: "manual",
+            draft: buildDraft({ sourceFingerprint: "manual-repeat-rest-conflict" }),
+          }),
+          recentWorkouts: [buildWorkoutSummary({ sourceKind: "manual" })],
+        })}
+        preferExpandedDetailsOnLoad
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("session-draft-add-repeat"));
+    const repeatEndingRestMode = screen.getAllByTestId(/session-draft-repeat-ending-rest-mode-/)[0];
+    const repeatSummary = screen.getAllByTestId(/session-draft-repeat-summary-/)[0];
+
+    fireEvent.change(repeatEndingRestMode, {
+      target: { value: "use_last_rest" },
+    });
+
+    expect(screen.getByText("This creates two rests in a row.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Keep set rest only" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Use final interval rest instead" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Keep both" })).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Use final interval rest instead" }));
+    expect(
+      screen.getByText("Delete the separate set rest and keep final interval rest?")
+    ).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete set rest" }));
+
+    const previewDraft = readPreviewDraft();
+    expect(previewDraft.steps.some((step) => step.postSetRestForRepeatGroupId)).toBe(false);
+    expect(screen.queryByText("This creates two rests in a row.")).not.toBeInTheDocument();
+    expect(repeatSummary).toHaveTextContent("4 x 100m · Freestyle · Interval rest 0:30");
   });
 
   it("does not seed scaffold note copy into a fresh manual pool session", async () => {
@@ -1180,7 +1357,7 @@ describe("WorkoutBuilderHub", () => {
       .spyOn(URL, "createObjectURL")
       .mockReturnValueOnce("blob:http://127.0.0.1/mock-workout-pdf")
       .mockReturnValueOnce("blob:http://127.0.0.1/mock-poolside-pdf");
-    const revokeUrlSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
     const openSpy = vi.spyOn(window, "open").mockReturnValue(printWindow as unknown as Window);
 
     render(
@@ -1285,8 +1462,6 @@ describe("WorkoutBuilderHub", () => {
     expect(poolsideHtml.indexOf('<section class="poolside-steps">')).toBeLessThan(
       poolsideHtml.indexOf('<aside class="poolside-meta">')
     );
-    expect(revokeUrlSpy).toHaveBeenCalledTimes(0);
-
     expect(screen.getByText("Keeps the blue surfaces")).toBeVisible();
     expect(screen.getByText("Uses white surfaces.")).toBeVisible();
     expect(screen.getByText("Print options")).toBeVisible();
@@ -1581,10 +1756,94 @@ describe("WorkoutBuilderHub", () => {
 
     fireEvent.click(screen.getByTestId("session-draft-add-repeat"));
     fireEvent.click(screen.getByTestId("workout-editor-builder-mode-view"));
-    fireEvent.click(screen.getByRole("button", { name: /Repeat block/i }));
+    fireEvent.click(screen.getByTestId(/workout-editor-view-repeat-/));
 
     expect(screen.getByLabelText("Repeat count")).toBeVisible();
     expect(screen.queryByLabelText("Step Type")).not.toBeInTheDocument();
+  });
+
+  it("keeps existing step summaries stable when switching pool units", async () => {
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: buildWorkoutRecord({ sourceKind: "manual" }),
+          recentWorkouts: [buildWorkoutSummary({ sourceKind: "manual" })],
+        })}
+        preferExpandedDetailsOnLoad
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    expect(screen.getByTestId("session-draft-step-summary-0")).toHaveTextContent(
+      "400m · Freestyle · Easy"
+    );
+    fireEvent.click(screen.getByTestId("session-draft-add-repeat"));
+
+    const repeatSummary = screen.getAllByTestId(/session-draft-repeat-summary-/)[0];
+
+    expect(repeatSummary).toHaveTextContent(
+      "4 x 100m · Freestyle · Interval rest 0:30 · Set rest 0:30"
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Yards" }));
+
+    expect(screen.getByTestId("session-draft-step-summary-0")).toHaveTextContent(
+      "400m · Freestyle · Easy"
+    );
+    expect(screen.getByTestId("session-draft-step-summary-0")).not.toHaveTextContent("437.45yd");
+    expect(screen.getAllByTestId(/session-draft-repeat-summary-/)[0]).toHaveTextContent(
+      "4 x 100m · Freestyle · Interval rest 0:30 · Set rest 0:30"
+    );
+    expect(screen.getAllByTestId(/session-draft-repeat-summary-/)[0]).not.toHaveTextContent(
+      "109.36yd"
+    );
+  });
+
+  it("keeps custom step distance inputs in their authored unit after a global unit switch", async () => {
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: buildWorkoutRecord({ sourceKind: "manual" }),
+          recentWorkouts: [buildWorkoutSummary({ sourceKind: "manual" })],
+        })}
+        preferExpandedDetailsOnLoad
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Yards" }));
+    fireEvent.click(screen.getByTestId("session-draft-step-toggle-0"));
+    fireEvent.change(screen.getByTestId("session-draft-step-distance-0"), {
+      target: { value: "custom" },
+    });
+    fireEvent.change(screen.getByTestId("session-draft-step-distance-custom-0"), {
+      target: { value: "333" },
+    });
+
+    expect(screen.getByLabelText("Custom distance (yd)")).toHaveValue("333");
+    expect(screen.getByTestId("session-draft-step-summary-0")).toHaveTextContent(
+      "333yd · Freestyle · Easy"
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Meters" }));
+
+    expect(screen.getByLabelText("Custom distance (yd)")).toHaveValue("333");
+    expect(screen.getByTestId("session-draft-step-summary-0")).toHaveTextContent(
+      "333yd · Freestyle · Easy"
+    );
+    expect(screen.getByTestId("session-draft-step-summary-0")).not.toHaveTextContent("304.5m");
   });
 
   it("shows clearer kick and drill taxonomy guidance inside the step form", async () => {

--- a/tests/unit/workouts-shared.test.ts
+++ b/tests/unit/workouts-shared.test.ts
@@ -1194,6 +1194,82 @@ describe("workouts shared readiness", () => {
     expect(poolsideModel.poolsideLines).toEqual(["200m · Choice · Easy · Rest 0:30"]);
   });
 
+  it("keeps both interval rest and set rest truthful when repeats include both", () => {
+    const draft: SessionDraft = {
+      ...buildDraft(),
+      title: "Keep both repeat rests",
+      steps: [
+        {
+          id: "step-1",
+          category: "main",
+          name: "Repeat work",
+          stroke: "freestyle",
+          intensity: "moderate",
+          durationMode: "distance",
+          distanceM: 100,
+          timeMin: null,
+          targetSummary: "",
+          notes: "",
+          repeatGroupId: "repeat-1",
+          repeatCount: 4,
+          repeatEndingRestMode: "use_last_rest",
+        },
+        {
+          id: "step-2",
+          category: "rest",
+          name: "Repeat rest",
+          stroke: "choice",
+          intensity: "easy",
+          durationMode: "fixed_rest",
+          distanceM: null,
+          timeMin: 0.5,
+          targetSummary: "",
+          notes: "",
+          repeatGroupId: "repeat-1",
+          repeatCount: 4,
+          repeatEndingRestMode: "use_last_rest",
+        },
+        {
+          id: "step-3",
+          category: "rest",
+          name: "Post set rest",
+          stroke: "choice",
+          intensity: "easy",
+          durationMode: "fixed_rest",
+          distanceM: null,
+          timeMin: 0.67,
+          targetSummary: "",
+          notes: "",
+          postSetRestForRepeatGroupId: "repeat-1",
+        },
+      ],
+    };
+
+    const poolsideModel = buildWorkoutPdfModel(draft, {
+      draftState: "canonical",
+      variant: "poolside",
+    });
+    const exportPayload = buildWorkoutGarminReadyExport(draft, {
+      draftState: "canonical",
+      workoutId: "workout-keep-both",
+    });
+
+    expect(poolsideModel.poolsideLines).toContain(
+      "4 x 100m · Freestyle · Moderate · Interval rest 0:30 · Set rest 0:40"
+    );
+
+    if (exportPayload.blocks[0]?.kind !== "repeat") {
+      throw new Error("Expected first block to be a repeat export.");
+    }
+
+    if (exportPayload.blocks[1]?.kind !== "single") {
+      throw new Error("Expected second block to be a single-step export.");
+    }
+
+    expect(exportPayload.blocks[0].roundSummary).toBe("4 rounds · 100m + 0:30 per round");
+    expect(exportPayload.blocks[1].step.duration.summary).toBe("Fixed Rest Time 0:40");
+  });
+
   it("prefers the primary poolside focus by default and resolves titles from explicit ids", () => {
     expect(
       getDefaultWorkoutPoolsideFocusIds([


### PR DESCRIPTION
## Summary

- What changed and why? Improve the swim session builder so attached rest reads like part of the parent step, make repeat rest choices clearer/safer, preserve authored units across global pool-unit toggles, and document the next Workout PDF parity slice separately.
- User-visible changes: In manual pool mode, single-step rest is grouped under the parent step instead of reading like a separate sibling block; repeat summaries and final interval rest copy are clearer; existing step summaries/custom distance inputs no longer silently recalculate when the global pool unit toggle changes.
- Technical changes: Updated builder state/rendering logic in components/my-library/workouts/WorkoutEditor.tsx, adjusted shared workout summary helpers/tests, added the active builder brief, and added a separate planned brief for later Workout PDF visual parity work.
- Policy impact: no (no auth/session/account, consent, data-rights, or processor policy surface changed)
- Policy version note: N/A (no policy-controlled behavior changed)

## Scope

- In scope: attached-rest grouping for top-level manual-pool steps, repeat final-interval-rest wording/guardrails, repeat summary truthfulness, authored-unit stability across global pool-unit switches, and a separate planned PDF parity brief.
- Out of scope: workout schema changes, Garmin/export payload contract changes, new dependencies, and any implementation of the future Workout PDF parity brief.

## Risk

- Main risk: parent-step grouping could drift from the canonical adjacent rest-step model and create misleading summaries or action behavior if the attachment logic regresses.
- Rollback plan: revert commits `706d301` and `4e57c70` to restore the previous builder behavior and remove the planned PDF-parity brief.

## Test Evidence

- Brief link(s): docs/task-briefs/in-progress/2026-04-15-swim-session-builder-attached-rest-grouping-and-final-interval-guardrails-10-10.md ; docs/task-briefs/planned/2026-04-15-workout-pdf-visual-parity-with-poolside-note-10-10.md
- Policy-impact checklist: N/A (no policy checklist review needed because the PR does not touch policy-triggering surfaces listed in docs/checklists/policy-impact-release-review.md)
- `npx eslint components/my-library/workouts/WorkoutEditor.tsx tests/unit/workout-builder-hub.test.tsx tests/e2e/my-library-workout-builder.spec.ts`: PASS
- `npx vitest run tests/unit/workout-builder-hub.test.tsx tests/unit/workouts-shared.test.ts`: PASS
- `env NEXT_DIST_DIR=.next-playwright-builder-full-rerun npx playwright test tests/e2e/my-library-workout-builder.spec.ts`: PASS
- `npm run lint:briefs:all`: PASS
- `npm run verify:pre-pr`: PASS (GitHub Actions `verify` check is green on current head `4e57c70`; earlier local program-export flake did not reproduce)
- `env NEXT_DIST_DIR=.next-playwright-program-export-rerun npx playwright test tests/e2e/my-library-program-export.spec.ts --project=desktop-chromium`: PASS
- `npm run verify:pre-merge`: PASS on current head `4e57c70ca138c45c61a7f2f98676c457992b6a3a`
- Local manual QA: PENDING
- Vercel preview manual QA: PENDING https://vercel.com/stian-vikras-projects/freeswimming-org/H5LXgPrLEZBWZy1xzY1wL2Zck4r5

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/442`
- [x] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d feat/builder-attached-rest-grouping-final-interval-rest`
- [ ] Optional: `git fetch --prune`