### PR TITLE
docs: close out builder brief lifecycle

### DIFF
--- a/docs/task-briefs/done/2026-04-15-swim-session-builder-attached-rest-grouping-and-final-interval-guardrails-10-10.md
+++ b/docs/task-briefs/done/2026-04-15-swim-session-builder-attached-rest-grouping-and-final-interval-guardrails-10-10.md
@@ -3,10 +3,10 @@
 ## Metadata
 
 - `id`: `2026-04-15-swim-session-builder-attached-rest-grouping-and-final-interval-guardrails-10-10`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-04-15`
-- `updated`: `2026-04-15`
+- `updated`: `2026-04-16`
 
 ## Goal
 
@@ -258,3 +258,4 @@ Critical target categories for `10/10` claim in this brief:
 - `2026-04-15 | implementation | attached top-level rest is now grouped under its parent step in manual pool edit mode, repeat wording/guardrails were updated, and downstream summaries keep both rests truthful when chosen | validation: npx vitest run tests/unit/workout-builder-hub.test.tsx tests/unit/workouts-shared.test.ts; npx playwright test tests/e2e/my-library-workout-builder.spec.ts; npm run lint:briefs:all; npm run verify:pre-pr | next: commit, push, open/update PR, monitor CI, and run verify:pre-merge before merge recommendation`
 - `2026-04-15 | implementation | added explicit repeat-work stroke summaries, hid the passive repeat pill outside open repeat editing, and preserved authored step units in both summaries and custom distance inputs across global pool-unit toggles | validation: npx eslint components/my-library/workouts/WorkoutEditor.tsx tests/unit/workout-builder-hub.test.tsx tests/e2e/my-library-workout-builder.spec.ts; npx vitest run tests/unit/workout-builder-hub.test.tsx tests/unit/workouts-shared.test.ts; env NEXT_DIST_DIR=.next-playwright-builder-full-rerun npx playwright test tests/e2e/my-library-workout-builder.spec.ts | next: run npm run verify:pre-pr, then commit/push/update PR`
 - `2026-04-15 | validation | full builder-targeted validation is green; npm run verify:pre-pr reached the full lane and only failed on an unrelated flaky rerun of tests/e2e/my-library-program-export.spec.ts while all builder coverage passed; isolated rerun of that export spec then passed cleanly, so builder scope is PR-ready but the broader repo gate should still be watched on CI | validation: npm run verify:pre-pr; env NEXT_DIST_DIR=.next-playwright-program-export-rerun npx playwright test tests/e2e/my-library-program-export.spec.ts --project=desktop-chromium | next: stage scoped files, open/update PR, and monitor CI before merge recommendation`
+- `2026-04-16 | merged | PR #442 merged to main as commit f9c2db3; GitHub required checks passed, local npm run verify:pre-merge passed on head 4e57c70ca138c45c61a7f2f98676c457992b6a3a, and the brief lifecycle moved from in-progress to done while the separate Workout PDF parity brief stayed planned | next: execute the dedicated Workout PDF visual parity brief as its own follow-up slice when approved`


### PR DESCRIPTION
## Summary

- What changed and why? Move the merged builder brief from `in-progress` to `done` so the task-brief lifecycle matches the work already shipped in PR #442.
- User-visible changes: No product behavior changes.
- Technical changes: Renamed the brief file into `docs/task-briefs/done/`, updated metadata to `status: done`, and added the merge closeout checkpoint entry.
- Policy impact: no (docs-only lifecycle cleanup with no policy-triggering surface change)
- Policy version note: N/A (no policy-controlled behavior changed)

## Scope

- In scope: task-brief lifecycle closeout for the already-merged builder slice from PR #442.
- Out of scope: any runtime code, tests, configs, workflows, or the separate planned Workout PDF parity brief implementation.

## Risk

- Main risk: brief lifecycle drift if the cleanup is left unmerged, which makes repo planning state inaccurate.
- Rollback plan: revert commit `047bd99` to restore the pre-closeout brief location and metadata.

## Test Evidence

- Brief link(s): docs/task-briefs/done/2026-04-15-swim-session-builder-attached-rest-grouping-and-final-interval-guardrails-10-10.md
- Policy-impact checklist: N/A (no policy checklist review needed because this PR is docs-only and does not touch policy-triggering surfaces listed in docs/checklists/policy-impact-release-review.md)
- `npm run lint:briefs:all`: PASS
- `npm run verify:docs-only`: NOT RUN
- `npm run verify:pre-pr`: NOT RUN
- `npm run verify:pre-merge`: NOT RUN
- Local manual QA: N/A (docs-only lifecycle cleanup)
- Vercel preview manual QA: N/A (docs-only lifecycle cleanup)

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [x] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d docs/builder-brief-lifecycle-closeout-442`
- [ ] Optional: `git fetch --prune`