### PR TITLE
feat: simplify builder rest labels and edit targets

### DIFF
--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -199,9 +199,16 @@ type SupportSectionKey = "readiness" | "garminExport" | "handoff";
 
 const CUSTOM_DISTANCE_VALUE = "custom";
 const EMPTY_WORKOUT_POOLSIDE_FOCUS_OPTIONS: WorkoutPoolsideFocusOption[] = [];
+const DESKTOP_CARD_EDIT_MEDIA_QUERY = "(hover: hover) and (pointer: fine)";
+const CARD_EDIT_IGNORE_SELECTOR =
+  "button, a, input, select, textarea, summary, [role='button'], [role='link'], [data-card-edit-ignore='true']";
 
 function getPoolBuilderAutoTitle(environment: SessionGeneratorEnvironment | null | undefined) {
   return environment === "pool" ? "Untitled pool session" : null;
+}
+
+function shouldIgnoreCardEditClick(target: EventTarget | null) {
+  return target instanceof Element && Boolean(target.closest(CARD_EDIT_IGNORE_SELECTOR));
 }
 
 function syncAutoGrowingTextareaHeight(node: HTMLTextAreaElement, minRows: number) {
@@ -1152,11 +1159,16 @@ function getManualPoolTopLevelCategory(group: StepRenderGroup) {
   return normalizeManualPoolStepForEditor(group.entries[0].step).category;
 }
 
-function buildLinkedRestLabel(parentLabel: string, restKind: "rest" | "interval" | "set") {
-  const suffix =
-    restKind === "interval" ? "Interval Rest" : restKind === "set" ? "Set Rest" : "Rest";
+function buildLinkedRestLabel(_parentLabel: string, restKind: "rest" | "interval" | "set") {
+  if (restKind === "interval") {
+    return "REST BETWEEN REPEATS";
+  }
 
-  return /\d of \d/.test(parentLabel) ? `${parentLabel} - ${suffix}` : `${parentLabel} ${suffix}`;
+  if (restKind === "set") {
+    return "REST AFTER SET";
+  }
+
+  return "REST";
 }
 
 function findTopLevelLinkedRestStep(
@@ -1635,6 +1647,20 @@ export default function WorkoutEditor({
     handoff: false,
   });
   const [supportToolsOpen, setSupportToolsOpen] = useState(() => copyVariant !== "default");
+  const [pendingCustomDistanceFocusStepId, setPendingCustomDistanceFocusStepId] = useState<
+    string | null
+  >(null);
+  const [desktopCardEditEnabled, setDesktopCardEditEnabled] = useState(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+
+    if (typeof window.matchMedia !== "function") {
+      return true;
+    }
+
+    return window.matchMedia(DESKTOP_CARD_EDIT_MEDIA_QUERY).matches;
+  });
   const savedWorkoutId = savedWorkout?.id ?? null;
   const isManualSourceDraft = draft.sourceFingerprint.startsWith("manual-");
   const simplifyManualMetadata = showCalmBuilderLayout && isManualSourceDraft;
@@ -1643,6 +1669,7 @@ export default function WorkoutEditor({
     getDefaultWorkoutPoolsideFocusIds(trainingFocusOptions).join("|");
   const metadataStartsCollapsed =
     showCalmBuilderLayout && savedWorkoutId !== null && !forceMetadataOpenOnLoad;
+  const customDistanceInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
   const editorCopy =
     copyVariant === "generator"
       ? {
@@ -1886,6 +1913,57 @@ export default function WorkoutEditor({
       setOpenStepId(parentBlock.entry.step.id);
     }
   }, [isManualPoolMode, manualPoolEditBlocks, openStepId]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (typeof window.matchMedia !== "function") {
+      setDesktopCardEditEnabled(true);
+      return;
+    }
+
+    const mediaQueryList = window.matchMedia(DESKTOP_CARD_EDIT_MEDIA_QUERY);
+    const syncDesktopCardEdit = () => {
+      setDesktopCardEditEnabled(mediaQueryList.matches);
+    };
+
+    syncDesktopCardEdit();
+
+    if (typeof mediaQueryList.addEventListener === "function") {
+      mediaQueryList.addEventListener("change", syncDesktopCardEdit);
+      return () => {
+        mediaQueryList.removeEventListener("change", syncDesktopCardEdit);
+      };
+    }
+
+    mediaQueryList.addListener(syncDesktopCardEdit);
+    return () => {
+      mediaQueryList.removeListener(syncDesktopCardEdit);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!pendingCustomDistanceFocusStepId) {
+      return;
+    }
+
+    if (!draft.steps.some((step) => step.id === pendingCustomDistanceFocusStepId)) {
+      setPendingCustomDistanceFocusStepId(null);
+      return;
+    }
+
+    const targetInput = customDistanceInputRefs.current[pendingCustomDistanceFocusStepId];
+
+    if (!targetInput) {
+      return;
+    }
+
+    targetInput.focus();
+    targetInput.select();
+    setPendingCustomDistanceFocusStepId(null);
+  }, [draft.steps, openStepId, pendingCustomDistanceFocusStepId]);
 
   useEffect(() => {
     if (
@@ -2873,6 +2951,8 @@ export default function WorkoutEditor({
   ) {
     const editorUnit = unitOverride ?? poolLengthUnit;
 
+    setPendingCustomDistanceFocusStepId(value === CUSTOM_DISTANCE_VALUE ? stepId : null);
+
     updateDraftStep(stepId, (current) => ({
       ...current,
       distanceM:
@@ -3252,9 +3332,7 @@ export default function WorkoutEditor({
         >
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div>
-              <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
-                Rest after step
-              </p>
+              <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Rest</p>
               <p className="mt-2 text-sm font-medium text-slate-900">
                 {linkedTopLevelRestStep
                   ? buildManualPoolDisplaySummary(
@@ -3387,11 +3465,31 @@ export default function WorkoutEditor({
           ) : null}
         </div>
       ) : null;
+    const canUseDesktopCardOpen = desktopCardEditEnabled && !isViewMode && !isOpen;
+    const openStepCard = () => {
+      setOpenMobileActionKey(null);
+      setOpenStepId(step.id);
+      if (insideRepeatGroup && normalizedStep.repeatGroupId) {
+        setOpenRepeatGroupId(normalizedStep.repeatGroupId);
+      }
+    };
 
     return (
       <article
         key={step.id}
         data-mobile-actions="progressive"
+        data-desktop-card-clickable={canUseDesktopCardOpen ? "true" : "false"}
+        onClick={
+          canUseDesktopCardOpen
+            ? (event) => {
+                if (shouldIgnoreCardEditClick(event.target)) {
+                  return;
+                }
+
+                openStepCard();
+              }
+            : undefined
+        }
         className={`rounded-2xl border p-3 transition sm:p-4 ${
           isOpen
             ? isRestStepCard
@@ -3402,6 +3500,10 @@ export default function WorkoutEditor({
               : insideRepeatGroup
                 ? "border-blue-200 bg-white"
                 : "border-slate-200 bg-slate-50/70"
+        } ${
+          canUseDesktopCardOpen
+            ? "cursor-pointer hover:border-blue-200 hover:bg-white hover:shadow-sm"
+            : ""
         }`}
       >
         <div className={desktopHeaderStackClass}>
@@ -3798,7 +3900,7 @@ export default function WorkoutEditor({
             </label>
 
             {step.durationMode === "distance" ? (
-              <div className="grid gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-3 sm:p-4 md:col-span-2 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
+              <div className="grid gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-3 sm:p-4 md:col-span-2 md:grid-cols-2">
                 <label className="text-sm text-slate-700">
                   Distance
                   <select
@@ -3827,6 +3929,9 @@ export default function WorkoutEditor({
                   <label className="text-sm text-slate-700">
                     {`Custom distance (${stepDistanceUnit})`}
                     <input
+                      ref={(node) => {
+                        customDistanceInputRefs.current[step.id] = node;
+                      }}
                       type="text"
                       inputMode="decimal"
                       value={formatEditableDistance(step.distanceM, stepDistanceUnit)}
@@ -3840,13 +3945,7 @@ export default function WorkoutEditor({
                       className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
                     />
                   </label>
-                ) : (
-                  <div className="self-end text-sm text-slate-500">
-                    {typeof step.distanceM === "number"
-                      ? formatDistanceMetersLabel(step.distanceM, stepDistanceUnit)
-                      : null}
-                  </div>
-                )}
+                ) : null}
               </div>
             ) : step.durationMode === "fixed_rest" && isManualPoolMode ? (
               <label className="text-sm text-slate-700">
@@ -5509,7 +5608,35 @@ export default function WorkoutEditor({
                     key={group.repeatGroupId}
                     data-testid={`workout-editor-repeat-group-${groupIndex}`}
                     data-containment-style="calm"
-                    className="rounded-2xl bg-gradient-to-b from-blue-50/70 to-white p-3 ring-1 ring-inset ring-blue-100 sm:p-4"
+                    data-desktop-card-clickable={
+                      desktopCardEditEnabled &&
+                      !isViewMode &&
+                      openRepeatGroupId !== group.repeatGroupId
+                        ? "true"
+                        : "false"
+                    }
+                    onClick={
+                      desktopCardEditEnabled &&
+                      !isViewMode &&
+                      openRepeatGroupId !== group.repeatGroupId
+                        ? (event) => {
+                            if (shouldIgnoreCardEditClick(event.target)) {
+                              return;
+                            }
+
+                            setOpenMobileActionKey(null);
+                            setOpenStepId(null);
+                            setOpenRepeatGroupId(group.repeatGroupId);
+                          }
+                        : undefined
+                    }
+                    className={`rounded-2xl bg-gradient-to-b from-blue-50/70 to-white p-3 ring-1 ring-inset ring-blue-100 sm:p-4 ${
+                      desktopCardEditEnabled &&
+                      !isViewMode &&
+                      openRepeatGroupId !== group.repeatGroupId
+                        ? "cursor-pointer hover:shadow-sm"
+                        : ""
+                    }`}
                   >
                     {(() => {
                       const repeatSummary = buildRepeatSummary(

--- a/docs/task-briefs/in-progress/2026-04-16-builder-rest-labels-custom-distance-and-desktop-click-targets-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-16-builder-rest-labels-custom-distance-and-desktop-click-targets-10-10.md
@@ -1,0 +1,213 @@
+# Task Brief: Builder Rest Labels, Custom Distance, And Desktop Click Targets (10/10)
+
+## Metadata
+
+- `id`: `2026-04-16-builder-rest-labels-custom-distance-and-desktop-click-targets-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-04-16`
+- `updated`: `2026-04-16`
+
+## Goal
+
+Make the manual swim-session builder read more cleanly by simplifying rest labels inside repeat editors, hiding redundant distance text, and letting desktop users open step cards by clicking the card itself without weakening mobile UX or canonical workout behavior.
+
+## Why This Brief Exists
+
+- The latest builder slice fixed rest grouping and overview truthfulness, but a few UI seams still remain:
+  - nested repeat rest cards still show parent-prefixed labels such as `MAIN INTERVAL REST`,
+  - fixed distance presets still render redundant passive text such as `400m` beside the dropdown,
+  - `Custom distance` input visibility is better kept conditional, but the current layout still needs the agreed autofocus and hide/show behavior,
+  - desktop edit mode still makes users aim for the small `Edit` button even though the whole card reads like one interaction target.
+- The owner-approved direction is locked:
+  - repeat child rest labels should drop redundant parent prefixes and read as generic rest types inside the repeat context,
+  - the repeat overview summary should remain explicit and scan-friendly,
+  - `Custom distance` should only appear when selected and should autofocus when revealed,
+  - fixed preset selections should not show duplicate passive meter/yard text,
+  - desktop/fine-pointer users may click the whole card to edit, while mobile/coarse-pointer users keep the explicit button-only interaction model,
+  - open/collapse behavior for step editors and repeat containers is not part of this brief.
+
+## Dependencies And Boundaries
+
+- Parent builder lineage:
+  - [/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md)
+- Immediate upstream builder briefs:
+  - [/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-15-swim-session-builder-attached-rest-grouping-and-final-interval-guardrails-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-15-swim-session-builder-attached-rest-grouping-and-final-interval-guardrails-10-10.md)
+  - [/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-13-swim-session-builder-repeat-container-targeted-edit-and-session-actions-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-13-swim-session-builder-repeat-container-targeted-edit-and-session-actions-10-10.md)
+- Primary implementation surfaces:
+  - [/Users/stianvikra/freeswimming/components/my-library/workouts/WorkoutEditor.tsx](/Users/stianvikra/freeswimming/components/my-library/workouts/WorkoutEditor.tsx)
+  - [/Users/stianvikra/freeswimming/tests/unit/workout-builder-hub.test.tsx](/Users/stianvikra/freeswimming/tests/unit/workout-builder-hub.test.tsx)
+  - [/Users/stianvikra/freeswimming/tests/e2e/my-library-workout-builder.spec.ts](/Users/stianvikra/freeswimming/tests/e2e/my-library-workout-builder.spec.ts)
+- Locked boundaries:
+  - no PDF visual parity work in this brief,
+  - no poolside note layout work in this brief,
+  - no schema or API changes,
+  - no Garmin/export payload changes,
+  - no change to the current one-open-editor interaction model.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Visual design quality`
+- `Accessibility (a11y)`
+- `Business logic correctness and data integrity`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold / Scope Rationale                                                                                                                              | Evidence                                  | Expected Closeout Score |
+| --------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | Builder overview and edit cards must scan more clearly without adding a second interaction model or new structural clutter.                                     | brief review + targeted QA                | `5/5`                   |
+| UX flow clarity                               | `target`     | Rest names, distance controls, and desktop edit affordances must remove avoidable friction while keeping the same mental model for saved workouts.              | unit/e2e + local QA                       | `5/5`                   |
+| Visual design quality                         | `target`     | Repeat rest labels and distance controls must look calmer and less redundant, and desktop click states must feel intentional rather than accidental.            | screenshot review + local QA              | `5/5`                   |
+| Business logic correctness and data integrity | `target`     | Label cleanup and distance-field visibility must not alter canonical step ordering, saved distances, repeat metadata, or Garmin/export behavior.                | code review + targeted tests              | `5/5`                   |
+| Admin editor ergonomics                       | `N/A`        | N/A because this is the authenticated swim-session builder, not an admin publishing surface.                                                                    | explicit scope rationale                  | `N/A`                   |
+| Accessibility (a11y)                          | `target`     | Desktop full-card edit affordances must preserve keyboard reachability, focus visibility, and non-conflicting semantics with the explicit `Edit` button.        | code review + targeted QA                 | `5/5`                   |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: no new dependency or heavy client behavior should be introduced for this builder-only refinement.                                              | `npm run build` via verify lanes          | `4/5`                   |
+| Data placement and sync boundaries            | `target`     | All changes remain local-draft presentation and interaction refinements over the same saved workout model and save/discard boundaries.                          | brief contract + implementation diff      | `5/5`                   |
+| Caching and invalidation strategy             | `supporting` | Supporting only: no new fetch, cache, or invalidation behavior is introduced.                                                                                   | code review                               | `4/5`                   |
+| Reliability and failure handling              | `target`     | Desktop click targets and distance-field toggling must behave deterministically and never open the wrong editor or leak stale custom-distance UI state.         | unit/e2e + manual QA                      | `5/5`                   |
+| Security and authz                            | `supporting` | Supporting only: no auth or authorization surface changes.                                                                                                      | code review                               | `4/5`                   |
+| Privacy and compliance                        | `N/A`        | N/A because no personal-data collection or exposure changes here.                                                                                               | explicit scope rationale                  | `N/A`                   |
+| Content governance                            | `target`     | Builder copy must use the agreed rest labels consistently and remove stale or duplicate explanatory text in the touched controls.                               | copy review + targeted tests              | `5/5`                   |
+| Admin workflow and editability                | `N/A`        | N/A because no admin workflow is changed.                                                                                                                       | explicit scope rationale                  | `N/A`                   |
+| SEO and crawlability                          | `N/A`        | N/A because this is a private builder surface.                                                                                                                  | explicit scope rationale                  | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because this slice changes no public semantic surface.                                                                                                      | explicit scope rationale                  | `N/A`                   |
+| Analytics and KPI observability               | `N/A`        | N/A because no analytics contract changes are required for this builder-only refinement.                                                                        | explicit scope rationale                  | `N/A`                   |
+| Commerce and revenue ops                      | `N/A`        | N/A because no billing, plan, or revenue flows are touched.                                                                                                     | explicit scope rationale                  | `N/A`                   |
+| Incident response and support operations      | `N/A`        | N/A because this slice changes no incident tooling or support workflow.                                                                                         | explicit scope rationale                  | `N/A`                   |
+| Finance and reporting operations              | `N/A`        | N/A because no finance/reporting surfaces are touched.                                                                                                          | explicit scope rationale                  | `N/A`                   |
+| i18n operational readiness                    | `N/A`        | N/A because this brief only standardizes private English builder copy and does not change localization architecture.                                            | explicit scope rationale                  | `N/A`                   |
+| Stack-fit and dependency discipline           | `target`     | Reuse existing React/Tailwind/editor patterns and avoid new packages.                                                                                           | dependency diff + code review             | `5/5`                   |
+| Testing and QA automation                     | `target`     | Coverage must protect rest-label rendering, custom-distance visibility/autofocus, and desktop card click-target behavior without weakening existing rest tests. | updated tests + verify lanes              | `5/5`                   |
+| Scalability and cost efficiency               | `N/A`        | N/A because the slice adds no server load or storage.                                                                                                           | explicit scope rationale                  | `N/A`                   |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: rollback remains straightforward because the change is isolated to builder UI logic and tests.                                                 | diff review + `verify:pre-merge` evidence | `4/5`                   |
+
+## Data Placement And Sync Contract
+
+- Server-canonical data:
+  - saved workout identity,
+  - canonical ordered `draft.steps`,
+  - repeat metadata and rest-mode fields,
+  - saved distance values and authored units already represented in the draft.
+- Local-only data:
+  - open/closed editor state,
+  - desktop vs mobile edit affordance behavior,
+  - conditional visibility and autofocus state for custom-distance inputs.
+- Sync policy:
+  - switching between preset distance and custom distance only updates the existing local draft step fields,
+  - clicking a desktop card only changes local edit state,
+  - save/discard boundaries remain unchanged.
+- Retention and sensitivity:
+  - no new local storage,
+  - no new sensitive data handling,
+  - existing save/discard behavior remains the retention boundary.
+- Cache/invalidation:
+  - unchanged from current builder behavior.
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - `workout.id`, `step.id`, and `repeatGroupId` remain unchanged and continue to drive persistence and relationships.
+- Human-readable identifiers:
+  - labels such as `REST BETWEEN REPEATS` and `REST AFTER SET` are presentation-only copy.
+- Mutability rules:
+  - UI labels may change in place,
+  - canonical IDs and persisted relationships must not change.
+- Rename vs repurpose policy:
+  - improve presentation in place,
+  - do not repurpose canonical step identity or repeat metadata.
+- Compatibility contract:
+  - downstream Garmin/export/poolside generation continues to derive from canonical steps exactly as before.
+- Observability and repair:
+  - targeted tests must catch summary, click-target, and custom-distance regressions before merge.
+
+## Scope
+
+- Rename nested repeat child rest cards in the open repeat editor to generic contextual labels:
+  - `REST BETWEEN REPEATS`
+  - `REST AFTER SET`
+- Keep repeat overview summaries explicit and scan-friendly, using neutral rest phrasing such as:
+  - `4 x 100m · Freestyle · Interval rest 0:30 · Set rest 0:30`
+- Keep single top-level step summaries truthful with inline `Rest 0:30` wording.
+- Show `Custom distance (m|yd)` only when `Custom distance` is selected.
+- Autofocus the custom-distance input when it appears.
+- Hide the custom-distance input again when the user returns to a preset distance.
+- Remove redundant passive duplicate preset text beside the distance dropdown when a fixed preset is selected.
+- On desktop/fine-pointer contexts, allow the full top-level step card, repeat summary card, and nested repeat child cards to open edit, while preserving explicit action buttons and preventing click conflicts with nested controls.
+- Keep mobile/coarse-pointer behavior button-driven to avoid scroll/tap conflicts.
+
+## Out Of Scope
+
+- Expand/collapse-all controls.
+- Changing the one-open-editor model.
+- Opening all repeat child cards automatically.
+- PDF visual parity or poolside-note layout work.
+- Any new analytics or backend behavior.
+
+## Acceptance Criteria
+
+1. Open repeat editors no longer show parent-prefixed child rest labels such as `MAIN INTERVAL REST` or `MAIN SET REST`.
+2. Repeat child rest labels read `REST BETWEEN REPEATS` and `REST AFTER SET`.
+3. Repeat overview summaries still show explicit rest semantics and durations.
+4. The builder only renders the custom-distance input when `Custom distance` is selected.
+5. The custom-distance input autofocuses when it is revealed.
+6. Selecting a preset distance hides the custom-distance input again.
+7. Fixed preset selections no longer show redundant passive duplicate text such as `400m` beside the dropdown.
+8. Desktop/fine-pointer users can click the full card body to open the relevant step/repeat editor.
+9. Mobile/coarse-pointer users do not get the full-card click behavior.
+10. Clicking nested action buttons or controls does not also trigger the parent card open handler.
+11. Keyboard and focus behavior remain valid and visible for the touched interactions.
+12. Canonical saved workout behavior, repeat metadata, and Garmin/export compatibility remain unchanged.
+13. Relevant tests plus `verify:pre-pr` and `verify:pre-merge` pass.
+
+## Validation
+
+- `npm run lint:briefs`
+- targeted `eslint`:
+  - `npx eslint components/my-library/workouts/WorkoutEditor.tsx tests/unit/workout-builder-hub.test.tsx tests/e2e/my-library-workout-builder.spec.ts`
+- targeted `vitest`:
+  - `npx vitest run tests/unit/workout-builder-hub.test.tsx tests/unit/workouts-shared.test.ts`
+- targeted `playwright`:
+  - `npx playwright test tests/e2e/my-library-workout-builder.spec.ts`
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm installed locally.
+- Validation runs from repo root.
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3000/my-library/workouts/<id>`
+- Preview:
+  - Vercel preview URL from PR checks.
+- Recommended matrix:
+  - iPhone Safari
+  - Desktop Safari
+  - Desktop Chrome
+
+## Constraints
+
+- UI copy stays English.
+- Do not weaken existing rest grouping, rest truthfulness, or Garmin readiness behavior.
+- Do not add a second mobile interaction model.
+- Keep the visual language aligned with the current calm builder.
+- Keep the change scoped to the agreed builder slice only.
+
+## 10/10 Quality Bar
+
+- Rest wording must be instantly understandable without internal-model jargon.
+- Distance editing must show only the controls the user currently needs.
+- Desktop edit affordances must feel easier without becoming ambiguous.
+- Mobile usability must not regress from broader click targets.
+- Builder state changes must stay deterministic, keyboard-usable, and test-covered.
+
+## Checkpoint Log
+
+- `2026-04-16 | planning | created the brief for the agreed builder cleanup slice: generic nested rest labels, conditional custom-distance input with autofocus, removal of redundant preset text, and desktop-only full-card edit affordances | next: implement the UI changes, update tests, and run targeted validation before full repo gates`
+- `2026-04-16 | validation | implemented the agreed builder cleanup slice: nested repeat rests now use generic contextual labels, fixed distance presets no longer show duplicate passive text, custom-distance input is conditional with autofocus, and fine-pointer desktop cards open edit from the full card body while coarse-pointer/mobile stays button-driven | validation: npm run lint:briefs:all; npx vitest run tests/unit/workout-builder-hub.test.tsx tests/unit/workouts-shared.test.ts; env NEXT_DIST_DIR=.next-playwright-builder-rest-labels npx playwright test tests/e2e/my-library-workout-builder.spec.ts; npm run verify:pre-pr | next: commit, push, open PR, monitor CI, and merge once pre-merge gate + required checks are green`

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -377,7 +377,7 @@ test.describe("my library workout builder", () => {
     expect(collapsedStepToggleBox!.y).toBeLessThan(
       collapsedStepSummaryBox!.y + collapsedStepSummaryBox!.height
     );
-    await page.getByTestId("session-draft-step-toggle-0").click();
+    await page.getByTestId("session-draft-step-summary-0").click();
     await expect(page.getByTestId("session-draft-step-desktop-actions-0")).toHaveAttribute(
       "data-desktop-layout",
       "bottom"
@@ -537,6 +537,7 @@ test.describe("my library workout builder", () => {
     await page.getByTestId("workout-editor-pool-length-unit-yd").click();
     await expect(page.getByLabel("Exact pool size (yd)")).toHaveValue("25");
     await page.getByTestId("session-draft-step-distance-0").selectOption("custom");
+    await expect(page.getByTestId("session-draft-step-distance-custom-0")).toBeFocused();
     await page.getByTestId("session-draft-step-distance-custom-0").fill("333");
     await openRepeatGroupIfCollapsed(page, 2);
     await expect(page.getByTestId("session-draft-repeat-desktop-actions-2")).toHaveAttribute(

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -172,6 +172,33 @@ function openSupportToolsPanel() {
   }
 }
 
+function stubMatchMedia(matches: boolean) {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation(() => ({
+      matches,
+      media: "(hover: hover) and (pointer: fine)",
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  );
+}
+
+function getDesktopSummaryCard(testId: string) {
+  const summary = screen.getByTestId(testId);
+  const card = summary.closest("article, section");
+
+  if (!card) {
+    throw new Error(`No desktop summary card found for ${testId}.`);
+  }
+
+  return card as HTMLElement;
+}
+
 describe("WorkoutBuilderHub", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
@@ -771,6 +798,10 @@ describe("WorkoutBuilderHub", () => {
     expect(
       screen.queryByText("Separate canonical rest after the set, outside the repeat block itself.")
     ).not.toBeInTheDocument();
+    expect(screen.getAllByText("REST BETWEEN REPEATS").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("REST AFTER SET").length).toBeGreaterThan(0);
+    expect(screen.queryByText("MAIN INTERVAL REST")).not.toBeInTheDocument();
+    expect(screen.queryByText("MAIN SET REST")).not.toBeInTheDocument();
 
     const previewDraft = readPreviewDraft();
     const repeatSteps = previewDraft.steps.filter((step) => step.repeatGroupId);
@@ -1828,6 +1859,11 @@ describe("WorkoutBuilderHub", () => {
     fireEvent.change(screen.getByTestId("session-draft-step-distance-0"), {
       target: { value: "custom" },
     });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session-draft-step-distance-custom-0")).toHaveFocus();
+    });
+
     fireEvent.change(screen.getByTestId("session-draft-step-distance-custom-0"), {
       target: { value: "333" },
     });
@@ -1844,6 +1880,126 @@ describe("WorkoutBuilderHub", () => {
       "333yd · Freestyle · Easy"
     );
     expect(screen.getByTestId("session-draft-step-summary-0")).not.toHaveTextContent("304.5m");
+  });
+
+  it("shows custom distance only when selected and hides it again when a preset is restored", async () => {
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: buildWorkoutRecord({ sourceKind: "manual" }),
+          recentWorkouts: [buildWorkoutSummary({ sourceKind: "manual" })],
+        })}
+        preferExpandedDetailsOnLoad
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("session-draft-step-toggle-0"));
+
+    expect(screen.queryByTestId("session-draft-step-distance-custom-0")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId("session-draft-step-distance-0"), {
+      target: { value: "custom" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session-draft-step-distance-custom-0")).toHaveFocus();
+    });
+
+    fireEvent.change(screen.getByTestId("session-draft-step-distance-0"), {
+      target: { value: "200" },
+    });
+
+    expect(screen.queryByTestId("session-draft-step-distance-custom-0")).not.toBeInTheDocument();
+  });
+
+  it("opens desktop step and repeat cards from the card body on fine-pointer layouts", async () => {
+    stubMatchMedia(true);
+
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: buildWorkoutRecord({ sourceKind: "manual" }),
+          recentWorkouts: [buildWorkoutSummary({ sourceKind: "manual" })],
+        })}
+        preferExpandedDetailsOnLoad
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    await waitFor(() => {
+      expect(getDesktopSummaryCard("session-draft-step-summary-0")).toHaveAttribute(
+        "data-desktop-card-clickable",
+        "true"
+      );
+    });
+
+    fireEvent.click(getDesktopSummaryCard("session-draft-step-summary-0"));
+    expect(screen.getByLabelText("Step Type")).toBeVisible();
+
+    fireEvent.click(screen.getByTestId("session-draft-step-toggle-0"));
+    fireEvent.click(screen.getByTestId("session-draft-add-repeat"));
+    fireEvent.click(screen.getByTestId("session-draft-repeat-toggle-1"));
+
+    await waitFor(() => {
+      expect(getDesktopSummaryCard("session-draft-repeat-summary-1")).toHaveAttribute(
+        "data-desktop-card-clickable",
+        "true"
+      );
+    });
+
+    fireEvent.click(getDesktopSummaryCard("session-draft-repeat-summary-1"));
+
+    expect(screen.getByLabelText("Repeat count")).toBeVisible();
+
+    fireEvent.click(getDesktopSummaryCard("session-draft-step-summary-1"));
+    expect(screen.getByTestId("session-draft-step-duration-mode-1")).toBeVisible();
+  });
+
+  it("keeps desktop full-card edit disabled on coarse-pointer layouts", async () => {
+    stubMatchMedia(false);
+
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: buildWorkoutRecord({ sourceKind: "manual" }),
+          recentWorkouts: [buildWorkoutSummary({ sourceKind: "manual" })],
+        })}
+        preferExpandedDetailsOnLoad
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    await waitFor(() => {
+      expect(getDesktopSummaryCard("session-draft-step-summary-0")).toHaveAttribute(
+        "data-desktop-card-clickable",
+        "false"
+      );
+    });
+
+    fireEvent.click(getDesktopSummaryCard("session-draft-step-summary-0"));
+    expect(screen.queryByLabelText("Step Type")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("session-draft-step-toggle-0"));
+    expect(screen.getByLabelText("Step Type")).toBeVisible();
   });
 
   it("shows clearer kick and drill taxonomy guidance inside the step form", async () => {


### PR DESCRIPTION
## Summary

- What changed and why? This slice makes the private workout builder easier to scan and edit by simplifying rest naming, hiding custom-distance input until it is actually needed, and letting desktop users open cards from the card surface.
- User-visible changes: Closed builder cards now use clearer rest wording, custom distance only appears when `Custom distance` is selected, and desktop or fine-pointer users can open closed cards by clicking the card body instead of aiming only for `Edit`.
- Technical changes: Updated `components/my-library/workouts/WorkoutEditor.tsx` rest-label generation, conditional custom-distance rendering and autofocus, pointer-aware card-open behavior, plus targeted unit and Playwright coverage and the active task brief.
- Policy impact: no (private builder UI, tests, and task-brief lifecycle only; no auth, billing, privacy, analytics, legal, or public-policy surface changed).
- Policy version note: N/A (no policy-impacting contract changed).

## Scope

- In scope: Builder rest-label cleanup, conditional custom-distance visibility and focus behavior, desktop or fine-pointer card-click editing for closed cards, targeted tests, and the corresponding task brief.
- Out of scope: Rearrange mode, drag and drop, PDF visual parity work, poolside note layout, Garmin export contracts, and any public-site or policy-surface changes.

## Risk

- Main risk: Desktop card-click editing could interfere with nested controls or unintentionally change touch behavior if pointer detection is too broad.
- Rollback plan: Revert commit `5198970` to restore explicit-button-only editing and the previous rest and custom-distance rendering behavior.

## Test Evidence

- Brief link(s): `docs/task-briefs/in-progress/2026-04-16-builder-rest-labels-custom-distance-and-desktop-click-targets-10-10.md`
- Policy-impact checklist: N/A (policy impact is `no`; changed files are limited to private builder UI, tests, and task-brief lifecycle docs).
- `npm run lint:briefs:all`: **PASS**
- `npx eslint components/my-library/workouts/WorkoutEditor.tsx tests/unit/workout-builder-hub.test.tsx tests/e2e/my-library-workout-builder.spec.ts`: **PASS**
- `npx vitest run tests/unit/workout-builder-hub.test.tsx tests/unit/workouts-shared.test.ts`: **PASS**
- `env NEXT_DIST_DIR=.next-playwright-builder-rest-labels npx playwright test tests/e2e/my-library-workout-builder.spec.ts`: **PASS**
- `npm run verify:pre-pr`: **PASS** for `5198970`
- `npm run verify:pre-merge`: **PASS** for `5198970` (`artifacts/verify-pre-merge/20260416-083803.json`)
- [ ] `npm run verify:docs-only` (pure docs/governance diffs only)
- [ ] `npm run lint:briefs:all` (required for docs-only lane)
- [ ] `npm run lint:admin-audit` (required for docs-only lane)
- [ ] `npm run lint:env-parity` (required for docs-only lane)
- [ ] `npm run lint:pr-body:generated` (required for docs-only lane)
- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge` (must be `PASS` on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [x] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [x] Mobile behavior checked (if UI changed)

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [x] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [x] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/444`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d feat/builder-rest-labels-custom-distance-click-targets`
- [ ] Optional: `git fetch --prune`
