### PR TITLE
docs: close out builder rest labels brief

### DIFF
--- a/docs/task-briefs/done/2026-04-16-builder-rest-labels-custom-distance-and-desktop-click-targets-10-10.md
+++ b/docs/task-briefs/done/2026-04-16-builder-rest-labels-custom-distance-and-desktop-click-targets-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-04-16-builder-rest-labels-custom-distance-and-desktop-click-targets-10-10`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-04-16`
 - `updated`: `2026-04-16`
@@ -211,3 +211,4 @@ Critical target categories for `10/10` claim in this brief:
 
 - `2026-04-16 | planning | created the brief for the agreed builder cleanup slice: generic nested rest labels, conditional custom-distance input with autofocus, removal of redundant preset text, and desktop-only full-card edit affordances | next: implement the UI changes, update tests, and run targeted validation before full repo gates`
 - `2026-04-16 | validation | implemented the agreed builder cleanup slice: nested repeat rests now use generic contextual labels, fixed distance presets no longer show duplicate passive text, custom-distance input is conditional with autofocus, and fine-pointer desktop cards open edit from the full card body while coarse-pointer/mobile stays button-driven | validation: npm run lint:briefs:all; npx vitest run tests/unit/workout-builder-hub.test.tsx tests/unit/workouts-shared.test.ts; env NEXT_DIST_DIR=.next-playwright-builder-rest-labels npx playwright test tests/e2e/my-library-workout-builder.spec.ts; npm run verify:pre-pr | next: commit, push, open PR, monitor CI, and merge once pre-merge gate + required checks are green`
+- `2026-04-16 | done | merged via PR #444 as squash commit e3eabd1; local npm run verify:pre-merge passed on 5198970 with marker artifacts/verify-pre-merge/20260416-083803.json, required GitHub checks were green, and the brief was moved from in-progress to done in a docs-only closeout | next: none`


### PR DESCRIPTION
## Summary

- What changed and why? This docs-only closeout moves the shipped builder cleanup brief from `in-progress` to `done` so repo lifecycle state matches the already-merged delivery from PR `#444`.
- User-visible changes: No user-facing product behavior changes. This PR only closes the task-brief lifecycle for an already-shipped builder slice.
- Technical changes: Moved the task brief from `docs/task-briefs/in-progress/` to `docs/task-briefs/done/` and recorded the final merge, verification, and checkpoint details for PR `#444`.
- Policy impact: no (docs-only lifecycle reconciliation; no runtime, policy, auth, privacy, billing, or public-surface behavior changed).
- Policy version note: N/A (no policy-impacting contract changed).

## Scope

- In scope: Moving the builder cleanup brief to `done` and adding the final closeout checkpoint entry with PR, commit, and verification evidence.
- Out of scope: Any product code, tests, builder behavior, Rearrange mode work, or follow-up implementation beyond lifecycle reconciliation.

## Risk

- Main risk: Lifecycle docs could stay stale or point at incorrect merge evidence if the brief is not formally closed after the already-shipped PR.
- Rollback plan: Revert commit `630e74e` to move the brief back if the closeout metadata is found to be incorrect.

## Test Evidence

- Brief link(s): `docs/task-briefs/done/2026-04-16-builder-rest-labels-custom-distance-and-desktop-click-targets-10-10.md`
- Policy-impact checklist: N/A (policy impact is `no`; changed files are docs-only lifecycle records under `docs/task-briefs/`).
- `npm run verify:docs-only`: **PASS** for `630e74e`
- `npm run lint:briefs:all`: **PASS**
- `npm run lint:admin-audit`: **PASS**
- `npm run lint:env-parity`: **PASS**
- `npm run lint:pr-body:generated`: **PASS**
- `npm run lint`: **N/A** (docs-only lane)
- `npm run typecheck`: **N/A** (docs-only lane)
- `npm run test:unit`: **N/A** (docs-only lane)
- `npm run build`: **N/A** (docs-only lane)
- `npm run test:e2e`: **N/A** (docs-only lane)
- `npm run verify:pre-pr`: **PASS** for `630e74e`
- `npm run verify:pre-merge`: **PASS** for `630e74e` (`artifacts/verify-pre-merge/20260416-084521.json`)
- [x] `npm run verify:docs-only` (pure docs/governance diffs only)
- [x] `npm run lint:briefs:all` (required for docs-only lane)
- [x] `npm run lint:admin-audit` (required for docs-only lane)
- [x] `npm run lint:env-parity` (required for docs-only lane)
- [x] `npm run lint:pr-body:generated` (required for docs-only lane)
- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge` (must be `PASS` on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [x] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [x] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d docs/close-out-builder-rest-labels-brief`
- [ ] Optional: `git fetch --prune`
