### PR TITLE
feat: add builder rearrange mode and repeat view polish

### DIFF
--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -178,7 +178,12 @@ const MANUAL_POOL_VISIBLE_STEP_INTENSITY_PRESETS = [
   "ascending",
   "descending",
 ] as const satisfies readonly SessionDraftStepIntensityPreset[];
-const WORKOUT_VIEW_MODES = ["edit", "view"] as const;
+const WORKOUT_VIEW_MODES = ["edit", "rearrange", "view"] as const;
+const WORKOUT_VIEW_MODE_LABELS: Record<(typeof WORKOUT_VIEW_MODES)[number], string> = {
+  edit: "Edit",
+  rearrange: "Rearrange",
+  view: "View",
+};
 const WORKOUT_PREVIEW_OBJECT_URL_REVOKE_DELAY_MS = 60_000;
 
 type LastRemovedBlock = {
@@ -1845,7 +1850,10 @@ export default function WorkoutEditor({
   const desktopHeaderStackClass = "flex items-start justify-between gap-3";
   const desktopSummaryBlockClass = "min-w-0 flex-1";
   const desktopRepeatControlRowClass = "grid gap-3";
+  const isEditMode = builderViewMode === "edit";
+  const isRearrangeMode = builderViewMode === "rearrange";
   const isViewMode = builderViewMode === "view";
+  const isSummaryOnlyMode = !isEditMode;
   const manualPoolTopLevelSectionDescriptors = useMemo(
     () => (isManualPoolMode ? buildManualPoolTopLevelSectionDescriptors(stepGroups) : []),
     [isManualPoolMode, stepGroups]
@@ -2059,13 +2067,13 @@ export default function WorkoutEditor({
   }, [savedWorkoutId, showCalmBuilderLayout]);
 
   useEffect(() => {
-    if (!isViewMode) return;
+    if (isEditMode) return;
 
     setOpenStepId(null);
     setOpenRepeatGroupId(null);
     setOpenMobileActionKey(null);
     setMetadataOpen(false);
-  }, [isViewMode]);
+  }, [isEditMode]);
 
   useEffect(() => {
     setManualPoolTitleEdited(false);
@@ -3166,7 +3174,7 @@ export default function WorkoutEditor({
   ) {
     const insideRepeatGroup = options?.insideRepeatGroup ?? false;
     const isLinkedPostSetRest = options?.isLinkedPostSetRest ?? false;
-    const isOpen = !isViewMode && openStepId === step.id;
+    const isOpen = isEditMode && openStepId === step.id;
     const toggleLabel = isOpen ? "Done" : "Edit";
     const panelId = `session-draft-step-panel-${step.id}`;
     const normalizedStep = isManualPoolMode ? normalizeManualPoolStepForEditor(step) : step;
@@ -3221,7 +3229,7 @@ export default function WorkoutEditor({
       : step.name || getSessionStepCategoryLabel(step.category);
     const mobileActionKey = `step:${step.id}`;
     const mobileActionsOpen = openMobileActionKey === mobileActionKey;
-    const showMobilePrimaryAddAfter = !isViewMode && isOpen && !isLinkedPostSetRest;
+    const showMobilePrimaryAddAfter = isEditMode && isOpen && !isLinkedPostSetRest;
     const showMobilePrimaryAddRepeatAfter = showMobilePrimaryAddAfter && !insideRepeatGroup;
     const stepCategoryValue = isManualPoolMode ? normalizedStep.category : step.category;
     const stepStrokeValue = isManualPoolMode
@@ -3465,7 +3473,8 @@ export default function WorkoutEditor({
           ) : null}
         </div>
       ) : null;
-    const canUseDesktopCardOpen = desktopCardEditEnabled && !isViewMode && !isOpen;
+    const showRearrangeControls = isRearrangeMode && !insideRepeatGroup && !isLinkedPostSetRest;
+    const canUseDesktopCardOpen = desktopCardEditEnabled && isEditMode && !isOpen;
     const openStepCard = () => {
       setOpenMobileActionKey(null);
       setOpenStepId(step.id);
@@ -3508,7 +3517,7 @@ export default function WorkoutEditor({
       >
         <div className={desktopHeaderStackClass}>
           <div className={desktopSummaryBlockClass}>
-            {isViewMode ? (
+            {isSummaryOnlyMode ? (
               <div data-testid={`session-draft-step-mobile-summary-${index}`} className="sm:hidden">
                 {stepSummaryContent}
               </div>
@@ -3539,7 +3548,7 @@ export default function WorkoutEditor({
               {stepSummaryContent}
             </div>
           </div>
-          {!isViewMode ? (
+          {isEditMode ? (
             <div className="hidden shrink-0 sm:flex">
               <button
                 type="button"
@@ -3562,7 +3571,31 @@ export default function WorkoutEditor({
               </button>
             </div>
           ) : null}
-          {!isViewMode ? (
+          {showRearrangeControls ? (
+            <div
+              data-testid={`session-draft-step-rearrange-controls-${index}`}
+              className="flex shrink-0 flex-wrap gap-2"
+            >
+              <button
+                type="button"
+                onClick={handleMoveUp}
+                disabled={moveUpDisabled}
+                data-testid={`session-draft-step-rearrange-move-up-${index}`}
+                className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Move up
+              </button>
+              <button
+                type="button"
+                onClick={handleMoveDown}
+                disabled={moveDownDisabled}
+                data-testid={`session-draft-step-rearrange-move-down-${index}`}
+                className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Move down
+              </button>
+            </div>
+          ) : isEditMode ? (
             <div className="flex shrink-0 sm:hidden">
               <button
                 type="button"
@@ -3585,34 +3618,12 @@ export default function WorkoutEditor({
           ) : null}
         </div>
 
-        {!isViewMode && mobileActionsOpen ? (
+        {isEditMode && mobileActionsOpen ? (
           <div
             id={`session-draft-step-mobile-actions-panel-${step.id}`}
             data-testid={`session-draft-step-mobile-actions-panel-${index}`}
             className={`${mobileActionPanelClass} sm:hidden`}
           >
-            {!insideRepeatGroup && !isLinkedPostSetRest ? (
-              <div className="grid grid-cols-2 gap-2">
-                <button
-                  type="button"
-                  onClick={handleMoveUp}
-                  disabled={moveUpDisabled}
-                  data-testid={`session-draft-step-mobile-move-up-${index}`}
-                  className={`${mobileSecondaryActionClass} border-slate-200 bg-white text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60`}
-                >
-                  Move up
-                </button>
-                <button
-                  type="button"
-                  onClick={handleMoveDown}
-                  disabled={moveDownDisabled}
-                  data-testid={`session-draft-step-mobile-move-down-${index}`}
-                  className={`${mobileSecondaryActionClass} border-slate-200 bg-white text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60`}
-                >
-                  Move down
-                </button>
-              </div>
-            ) : null}
             <div className="mt-2 grid gap-2">
               {!showMobilePrimaryAddAfter && !isLinkedPostSetRest ? (
                 <button
@@ -3661,7 +3672,7 @@ export default function WorkoutEditor({
           </div>
         ) : null}
 
-        {!isViewMode && showMobilePrimaryAddAfter ? (
+        {isEditMode && showMobilePrimaryAddAfter ? (
           <div className="mt-3 flex flex-wrap gap-2 sm:hidden">
             <button
               type="button"
@@ -4272,32 +4283,12 @@ export default function WorkoutEditor({
 
             {attachedRestEditor}
 
-            {!isViewMode ? (
+            {isEditMode ? (
               <div
                 data-testid={`session-draft-step-desktop-actions-${index}`}
                 data-desktop-layout="bottom"
                 className="hidden flex-wrap items-center gap-2 border-t border-slate-200 pt-3 sm:flex md:col-span-2"
               >
-                {insideRepeatGroup || isLinkedPostSetRest ? null : (
-                  <>
-                    <button
-                      type="button"
-                      onClick={handleMoveUp}
-                      disabled={moveUpDisabled}
-                      className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-                    >
-                      Move up
-                    </button>
-                    <button
-                      type="button"
-                      onClick={handleMoveDown}
-                      disabled={moveDownDisabled}
-                      className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-                    >
-                      Move down
-                    </button>
-                  </>
-                )}
                 {isLinkedPostSetRest ? null : (
                   <button
                     type="button"
@@ -5248,7 +5239,7 @@ export default function WorkoutEditor({
                   {workoutPdfStateLabel}
                 </p>
               ) : null}
-              {!metadataOpen || isViewMode ? (
+              {!metadataOpen || isSummaryOnlyMode ? (
                 <p
                   data-testid="workout-editor-metadata-summary"
                   className="mt-2 text-sm font-medium text-slate-900"
@@ -5259,7 +5250,7 @@ export default function WorkoutEditor({
             </div>
             <div className="flex min-w-0 flex-col gap-2 sm:items-end">
               <div className="flex flex-wrap items-center gap-2 sm:justify-end">
-                {!isViewMode ? (
+                {isEditMode ? (
                   <button
                     type="button"
                     onClick={() => setMetadataOpen((current) => !current)}
@@ -5295,7 +5286,7 @@ export default function WorkoutEditor({
                     Discard changes
                   </button>
                 ) : null}
-                {!isViewMode && savedWorkout && onRequestDeleteCurrent ? (
+                {isEditMode && savedWorkout && onRequestDeleteCurrent ? (
                   <button
                     type="button"
                     onClick={onRequestDeleteCurrent}
@@ -5348,7 +5339,7 @@ export default function WorkoutEditor({
             </p>
           ) : null}
 
-          {!isViewMode && metadataOpen ? <div className="mt-4">{metadataFields}</div> : null}
+          {isEditMode && metadataOpen ? <div className="mt-4">{metadataFields}</div> : null}
         </section>
       ) : (
         metadataFields
@@ -5380,13 +5371,13 @@ export default function WorkoutEditor({
                           : "text-blue-900/70 hover:text-blue-900"
                       }`}
                     >
-                      {mode === "edit" ? "Edit" : "View"}
+                      {WORKOUT_VIEW_MODE_LABELS[mode]}
                     </button>
                   );
                 })}
               </div>
             ) : null}
-            {!isViewMode ? (
+            {isEditMode ? (
               <div className="flex flex-wrap items-center gap-2 border-l border-slate-200 pl-3">
                 <button
                   type="button"
@@ -5476,9 +5467,9 @@ export default function WorkoutEditor({
                       type="button"
                       data-testid={`workout-editor-view-repeat-${section.key}`}
                       onClick={() => openTargetedRepeatEditor(section.target!.repeatGroupId)}
-                      className={`${sectionCardClass} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-300`}
+                      className={`${sectionCardClass} block w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-300`}
                     >
-                      <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="flex flex-wrap items-start gap-3">
                         <div>
                           <p className={sectionHeadingClass}>{section.title}</p>
                           {section.badge ? (
@@ -5489,9 +5480,6 @@ export default function WorkoutEditor({
                             </p>
                           ) : null}
                         </div>
-                        <span className="inline-flex rounded-full border border-blue-200 bg-white px-3 py-1 text-xs font-semibold text-blue-800">
-                          Edit repeat
-                        </span>
                       </div>
                       <div className="mt-3 space-y-2">
                         {section.lines.map((line, lineIndex) => (
@@ -5610,14 +5598,14 @@ export default function WorkoutEditor({
                     data-containment-style="calm"
                     data-desktop-card-clickable={
                       desktopCardEditEnabled &&
-                      !isViewMode &&
+                      isEditMode &&
                       openRepeatGroupId !== group.repeatGroupId
                         ? "true"
                         : "false"
                     }
                     onClick={
                       desktopCardEditEnabled &&
-                      !isViewMode &&
+                      isEditMode &&
                       openRepeatGroupId !== group.repeatGroupId
                         ? (event) => {
                             if (shouldIgnoreCardEditClick(event.target)) {
@@ -5632,7 +5620,7 @@ export default function WorkoutEditor({
                     }
                     className={`rounded-2xl bg-gradient-to-b from-blue-50/70 to-white p-3 ring-1 ring-inset ring-blue-100 sm:p-4 ${
                       desktopCardEditEnabled &&
-                      !isViewMode &&
+                      isEditMode &&
                       openRepeatGroupId !== group.repeatGroupId
                         ? "cursor-pointer hover:shadow-sm"
                         : ""
@@ -5653,7 +5641,7 @@ export default function WorkoutEditor({
                       const repeatLabel = isManualPoolMode
                         ? (repeatDescriptor?.label ?? "Repeat")
                         : "Repeat set";
-                      const isRepeatOpen = !isViewMode && openRepeatGroupId === group.repeatGroupId;
+                      const isRepeatOpen = isEditMode && openRepeatGroupId === group.repeatGroupId;
                       const repeatToggleLabel = isRepeatOpen ? "Done" : "Edit";
                       const hasEditableRepeatEndingRest = Boolean(
                         draft.environment === "pool" &&
@@ -5675,6 +5663,8 @@ export default function WorkoutEditor({
                         hasRepeatRestConflict && !repeatConflictKeptBoth;
                       const showRepeatRestReplacementConfirm =
                         repeatConflictPendingReplacement === group.repeatGroupId;
+                      const repeatMoveUpDisabled = groupIndex === 0;
+                      const repeatMoveDownDisabled = groupIndex === stepGroups.length - 1;
                       const repeatSummaryContent = (
                         <>
                           <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
@@ -5720,7 +5710,7 @@ export default function WorkoutEditor({
                                 {repeatSummaryContent}
                               </div>
                             </div>
-                            {!isViewMode ? (
+                            {isEditMode ? (
                               <div className="hidden shrink-0 sm:flex">
                                 <button
                                   type="button"
@@ -5737,7 +5727,31 @@ export default function WorkoutEditor({
                                 </button>
                               </div>
                             ) : null}
-                            {!isViewMode ? (
+                            {isRearrangeMode ? (
+                              <div
+                                data-testid={`session-draft-repeat-rearrange-controls-${groupIndex}`}
+                                className="flex shrink-0 flex-wrap gap-2"
+                              >
+                                <button
+                                  type="button"
+                                  onClick={() => moveDraftGroup(groupIndex, -1)}
+                                  disabled={repeatMoveUpDisabled}
+                                  data-testid={`session-draft-repeat-rearrange-move-up-${groupIndex}`}
+                                  className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                                >
+                                  Move up
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => moveDraftGroup(groupIndex, 1)}
+                                  disabled={repeatMoveDownDisabled}
+                                  data-testid={`session-draft-repeat-rearrange-move-down-${groupIndex}`}
+                                  className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                                >
+                                  Move down
+                                </button>
+                              </div>
+                            ) : isEditMode ? (
                               <div className="flex shrink-0 sm:hidden">
                                 {isRepeatOpen ? (
                                   <button
@@ -5766,7 +5780,7 @@ export default function WorkoutEditor({
                             ) : null}
                           </div>
 
-                          {!isViewMode && isRepeatOpen ? (
+                          {isEditMode && isRepeatOpen ? (
                             <div className={desktopRepeatControlRowClass}>
                               <div className="grid gap-3 sm:flex sm:flex-wrap sm:items-end sm:gap-2">
                                 <label className="text-sm text-slate-700">
@@ -5789,7 +5803,7 @@ export default function WorkoutEditor({
                                 </label>
                                 {hasEditableRepeatEndingRest ? (
                                   <label className="text-sm text-slate-700">
-                                    Final interval rest
+                                    Rest after last repeat
                                     <select
                                       value={group.repeatEndingRestMode}
                                       onChange={(event) =>
@@ -5826,7 +5840,7 @@ export default function WorkoutEditor({
                                       }
                                       className="inline-flex h-9 items-center justify-center rounded-xl border border-amber-200 bg-white px-3 text-sm font-medium text-amber-900 transition hover:bg-amber-100"
                                     >
-                                      Keep set rest only
+                                      Use separate rest step
                                     </button>
                                     <button
                                       type="button"
@@ -5835,7 +5849,7 @@ export default function WorkoutEditor({
                                       }
                                       className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-50"
                                     >
-                                      Use final interval rest instead
+                                      Use repeat rest time
                                     </button>
                                     <button
                                       type="button"
@@ -5856,7 +5870,7 @@ export default function WorkoutEditor({
                                   {showRepeatRestReplacementConfirm ? (
                                     <div className="mt-3 rounded-xl border border-rose-200 bg-white p-3">
                                       <p className="text-sm font-medium text-rose-950">
-                                        Delete the separate set rest and keep final interval rest?
+                                        Delete the separate rest step and use repeat rest time?
                                       </p>
                                       <div className="mt-3 flex flex-wrap gap-2">
                                         <button
@@ -5866,7 +5880,7 @@ export default function WorkoutEditor({
                                           }
                                           className="inline-flex h-9 items-center justify-center rounded-xl bg-rose-600 px-3 text-sm font-semibold text-white transition hover:bg-rose-500"
                                         >
-                                          Delete set rest
+                                          Delete rest step
                                         </button>
                                         <button
                                           type="button"
@@ -5887,7 +5901,7 @@ export default function WorkoutEditor({
                             </div>
                           ) : null}
 
-                          {!isViewMode && isRepeatOpen ? (
+                          {isEditMode && isRepeatOpen ? (
                             <div className="sm:hidden">
                               <button
                                 type="button"
@@ -5903,38 +5917,12 @@ export default function WorkoutEditor({
                             </div>
                           ) : null}
 
-                          {!isViewMode && isRepeatOpen && repeatMobileActionsOpen ? (
+                          {isEditMode && isRepeatOpen && repeatMobileActionsOpen ? (
                             <div
                               id={`session-draft-repeat-mobile-actions-panel-${group.repeatGroupId}`}
                               data-testid={`session-draft-repeat-mobile-actions-panel-${groupIndex}`}
                               className={`${mobileActionPanelClass} sm:hidden`}
                             >
-                              <div className="grid grid-cols-2 gap-2">
-                                <button
-                                  type="button"
-                                  onClick={() => {
-                                    moveDraftGroup(groupIndex, -1);
-                                    setOpenMobileActionKey(null);
-                                  }}
-                                  disabled={groupIndex === 0}
-                                  data-testid={`session-draft-repeat-mobile-move-up-${groupIndex}`}
-                                  className={`${mobileSecondaryActionClass} border-slate-200 bg-white text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60`}
-                                >
-                                  Move up
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={() => {
-                                    moveDraftGroup(groupIndex, 1);
-                                    setOpenMobileActionKey(null);
-                                  }}
-                                  disabled={groupIndex === stepGroups.length - 1}
-                                  data-testid={`session-draft-repeat-mobile-move-down-${groupIndex}`}
-                                  className={`${mobileSecondaryActionClass} border-slate-200 bg-white text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60`}
-                                >
-                                  Move down
-                                </button>
-                              </div>
                               <div className="mt-2 grid gap-2">
                                 <button
                                   type="button"
@@ -5976,7 +5964,7 @@ export default function WorkoutEditor({
                       );
                     })()}
 
-                    {!isViewMode && openRepeatGroupId === group.repeatGroupId ? (
+                    {isEditMode && openRepeatGroupId === group.repeatGroupId ? (
                       <div className="mt-4 space-y-3">
                         {group.entries.map((entry, repeatIndex) =>
                           renderStepEditorCard(entry.step, entry.index, groupIndex, {
@@ -6061,22 +6049,6 @@ export default function WorkoutEditor({
                           data-desktop-layout="bottom"
                           className="hidden flex-wrap items-end gap-2 border-t border-blue-100 pt-3 sm:flex"
                         >
-                          <button
-                            type="button"
-                            onClick={() => moveDraftGroup(groupIndex, -1)}
-                            disabled={groupIndex === 0}
-                            className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-                          >
-                            Move up
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => moveDraftGroup(groupIndex, 1)}
-                            disabled={groupIndex === stepGroups.length - 1}
-                            className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-                          >
-                            Move down
-                          </button>
                           <button
                             type="button"
                             onClick={() => insertStepAfterGroup(groupIndex)}

--- a/docs/task-briefs/in-progress/2026-04-16-builder-rearrange-mode-repeat-view-clarity-and-last-repeat-rest-copy-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-16-builder-rearrange-mode-repeat-view-clarity-and-last-repeat-rest-copy-10-10.md
@@ -1,0 +1,228 @@
+# Task Brief: Builder Rearrange Mode, Repeat View Clarity, And Last Repeat Rest Copy (10/10)
+
+## Metadata
+
+- `id`: `2026-04-16-builder-rearrange-mode-repeat-view-clarity-and-last-repeat-rest-copy-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-04-16`
+- `updated`: `2026-04-16`
+
+## Goal
+
+Make manual swim-session ordering easier and safer by adding a dedicated `Rearrange` mode, removing repeat edit leakage from `View`, and renaming the final-repeat-rest controls so they read truthfully and instantly.
+
+## Why This Brief Exists
+
+- The builder now has cleaner rest wording and calmer distance controls, but ordering and repeat readability still have avoidable friction:
+  - moving steps still depends on `Move up` and `Move down` controls inside edit surfaces instead of a dedicated ordering mode,
+  - `View` mode still leaks repeat editing through a visible `Edit repeat` affordance and a half-width repeat card,
+  - the repeat rest selector still uses internal phrasing such as `Final interval rest`, `Skip final interval rest`, and `Include final interval rest`,
+  - related conflict prompts still describe the same decision with older terminology.
+- The owner-approved direction is locked:
+  - `Rearrange` must be a separate mode,
+  - in `Rearrange`, card click must not open edit,
+  - in `Rearrange`, only move controls should be shown for top-level ordering,
+  - top-level move controls inside edit surfaces can be removed once `Rearrange` exists,
+  - `View` must not show `Edit repeat`,
+  - repeat cards in `View` must use full width like the other cards,
+  - repeat ending-rest copy should read:
+    - label: `Rest after last repeat`
+    - options: `Use separate rest step` and `Use repeat rest time`
+
+## Dependencies And Boundaries
+
+- Parent builder lineage:
+  - [/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md)
+- Immediate upstream briefs:
+  - [/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-16-builder-rest-labels-custom-distance-and-desktop-click-targets-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-16-builder-rest-labels-custom-distance-and-desktop-click-targets-10-10.md)
+  - [/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-15-swim-session-builder-attached-rest-grouping-and-final-interval-guardrails-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-15-swim-session-builder-attached-rest-grouping-and-final-interval-guardrails-10-10.md)
+  - [/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-13-swim-session-builder-repeat-container-targeted-edit-and-session-actions-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-13-swim-session-builder-repeat-container-targeted-edit-and-session-actions-10-10.md)
+- Primary implementation surfaces:
+  - [/Users/stianvikra/freeswimming/components/my-library/workouts/WorkoutEditor.tsx](/Users/stianvikra/freeswimming/components/my-library/workouts/WorkoutEditor.tsx)
+  - [/Users/stianvikra/freeswimming/lib/session-generator-v1/shared.ts](/Users/stianvikra/freeswimming/lib/session-generator-v1/shared.ts)
+  - [/Users/stianvikra/freeswimming/tests/unit/workout-builder-hub.test.tsx](/Users/stianvikra/freeswimming/tests/unit/workout-builder-hub.test.tsx)
+  - [/Users/stianvikra/freeswimming/tests/e2e/my-library-workout-builder.spec.ts](/Users/stianvikra/freeswimming/tests/e2e/my-library-workout-builder.spec.ts)
+- Locked boundaries:
+  - no schema or API changes,
+  - no Garmin/export payload changes,
+  - no PDF parity work,
+  - no drag-and-drop in this slice,
+  - no change to canonical step identities or save/discard boundaries.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `UX flow clarity`
+- `Visual design quality`
+- `Accessibility (a11y)`
+- `Business logic correctness and data integrity`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold / Scope Rationale                                                                                                                             | Evidence                                  | Expected Closeout Score |
+| --------------------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | Builder mode switch must clearly separate editing, ordering, and read-only scanning without duplicating the same controls in multiple places.                  | brief review + local QA                   | `5/5`                   |
+| UX flow clarity                               | `target`     | Ordering must move to a dedicated `Rearrange` mode, `View` must stop leaking repeat edit affordances, and repeat-rest copy must read instantly without jargon. | unit/e2e + local QA                       | `5/5`                   |
+| Visual design quality                         | `target`     | Repeat view cards must align to full width, controls must feel intentional by mode, and no half-width or mixed-purpose UI should remain.                       | screenshot review + local QA              | `5/5`                   |
+| Business logic correctness and data integrity | `target`     | Reordering must move only top-level blocks, preserve linked rests and repeat groups correctly, and never alter canonical repeat/rest semantics.                | code review + targeted tests              | `5/5`                   |
+| Admin editor ergonomics                       | `N/A`        | N/A because this is the private swim-session builder, not an admin publishing workspace.                                                                       | explicit scope rationale                  | `N/A`                   |
+| Accessibility (a11y)                          | `target`     | Mode switching, move controls, and view-mode repeat cards must remain keyboard-usable with visible focus and truthful semantics.                               | code review + targeted QA                 | `5/5`                   |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: no new dependencies or heavy interaction layers should be added.                                                                              | `npm run build` via verify lanes          | `4/5`                   |
+| Data placement and sync boundaries            | `target`     | All changes stay local-draft UI behavior over the same saved workout model and save/discard contract.                                                          | brief contract + implementation diff      | `5/5`                   |
+| Caching and invalidation strategy             | `supporting` | Supporting only: no new fetch or invalidation behavior is introduced.                                                                                          | code review                               | `4/5`                   |
+| Reliability and failure handling              | `target`     | Reorder controls must behave deterministically at list boundaries and not open edit accidentally while rearranging.                                            | unit/e2e + manual QA                      | `5/5`                   |
+| Security and authz                            | `supporting` | Supporting only: no auth or authorization surface changes.                                                                                                     | code review                               | `4/5`                   |
+| Privacy and compliance                        | `N/A`        | N/A because no personal-data collection or exposure changes here.                                                                                              | explicit scope rationale                  | `N/A`                   |
+| Content governance                            | `target`     | Repeat-rest terminology and conflict prompts must use one clear copy system across the touched repeat surface.                                                 | copy review + targeted tests              | `5/5`                   |
+| Admin workflow and editability                | `N/A`        | N/A because no admin workflow changes.                                                                                                                         | explicit scope rationale                  | `N/A`                   |
+| SEO and crawlability                          | `N/A`        | N/A because this is a private builder surface.                                                                                                                 | explicit scope rationale                  | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because this slice changes no public semantic surface.                                                                                                     | explicit scope rationale                  | `N/A`                   |
+| Analytics and KPI observability               | `N/A`        | N/A because no analytics contract changes are required for this builder-only refinement.                                                                       | explicit scope rationale                  | `N/A`                   |
+| Commerce and revenue ops                      | `N/A`        | N/A because no billing, plan, or revenue flows are touched.                                                                                                    | explicit scope rationale                  | `N/A`                   |
+| Incident response and support operations      | `N/A`        | N/A because this slice changes no incident tooling or support workflow.                                                                                        | explicit scope rationale                  | `N/A`                   |
+| Finance and reporting operations              | `N/A`        | N/A because no finance/reporting surfaces are touched.                                                                                                         | explicit scope rationale                  | `N/A`                   |
+| i18n operational readiness                    | `N/A`        | N/A because this brief standardizes private English builder copy only and does not change localization architecture.                                           | explicit scope rationale                  | `N/A`                   |
+| Stack-fit and dependency discipline           | `target`     | Reuse the existing builder mode and card architecture; add no packages.                                                                                        | dependency diff + code review             | `5/5`                   |
+| Testing and QA automation                     | `target`     | Coverage must protect mode behavior, repeat view rendering, reordering controls, and last-repeat-rest copy without weakening existing builder coverage.        | updated tests + verify lanes              | `5/5`                   |
+| Scalability and cost efficiency               | `N/A`        | N/A because the slice adds no server load or storage.                                                                                                          | explicit scope rationale                  | `N/A`                   |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: rollback remains straightforward because the change stays inside builder UI logic, copy, and tests.                                           | diff review + `verify:pre-merge` evidence | `4/5`                   |
+
+## Data Placement And Sync Contract
+
+- Server-canonical data:
+  - saved workout identity,
+  - canonical ordered `draft.steps`,
+  - repeat metadata and ending-rest mode fields,
+  - linked rest relationships already represented in the draft.
+- Local-only data:
+  - current builder mode (`edit`, `rearrange`, `view`),
+  - open/closed editor state,
+  - local move intent before save.
+- Sync policy:
+  - `Rearrange` only changes the same local draft ordering already saved by the normal save action,
+  - switching modes never writes automatically,
+  - repeat rest copy changes are presentation-only and do not change enum values or persistence shape.
+- Retention and sensitivity:
+  - no new local storage,
+  - no new sensitive data handling,
+  - save/discard remains the retention boundary.
+- Cache/invalidation:
+  - unchanged from current builder behavior.
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - `workout.id`, `step.id`, and `repeatGroupId` remain the source-of-truth identifiers.
+- Human-readable identifiers:
+  - builder mode labels and repeat-rest copy are presentation-only.
+- Mutability rules:
+  - UI labels may change in place,
+  - canonical IDs and saved relationships must not change.
+- Rename vs repurpose policy:
+  - improve presentation in place,
+  - do not repurpose saved step identity, repeat grouping, or Garmin-facing semantics.
+- Compatibility contract:
+  - Garmin/export/poolside generation continues to consume the same canonical draft fields.
+- Observability and repair:
+  - targeted tests must catch mode leakage, top-level move regressions, and repeat-rest copy drift.
+
+## Scope
+
+- Add `Rearrange` as a dedicated builder mode beside `Edit` and `View`.
+- Entering `Rearrange` must:
+  - close open step editors,
+  - close open repeat editors,
+  - close metadata details,
+  - disable card-click edit entry.
+- In `Rearrange`, show only top-level move controls on session cards:
+  - top-level single manual-pool blocks move as one unit with their attached rest,
+  - repeat groups move as one unit,
+  - no add, duplicate, delete, or edit controls are shown inside the session-step list.
+- Remove top-level `Move up` and `Move down` controls from normal edit-mode action rows once `Rearrange` owns ordering.
+- Keep repeat child cards and linked rests out of top-level move mode.
+- Fix manual-pool `View` repeat cards so they:
+  - no longer show visible `Edit repeat` copy,
+  - render full width like the other view cards.
+- Rename repeat ending-rest copy to:
+  - label: `Rest after last repeat`
+  - option: `Use separate rest step`
+  - option: `Use repeat rest time`
+- Align related repeat-rest conflict prompts and confirmation copy to the same terminology.
+
+## Out Of Scope
+
+- Drag-and-drop ordering.
+- Expand-all or collapse-all behavior changes.
+- PDF visual parity work.
+- Poolside note layout or preview changes.
+- Any new analytics, schema, API, or export behavior.
+
+## Acceptance Criteria
+
+1. Builder mode switch now exposes `Edit`, `Rearrange`, and `View`.
+2. Entering `Rearrange` closes open editors and metadata details.
+3. In `Rearrange`, card clicks do not open edit.
+4. In `Rearrange`, top-level step and repeat cards show only move controls for ordering.
+5. In normal edit mode, top-level move controls are no longer shown inside edit action rows.
+6. Reordering still moves top-level single blocks with their attached rest together.
+7. Reordering still moves repeat groups as one unit.
+8. Manual-pool repeat cards in `View` no longer show `Edit repeat`.
+9. Manual-pool repeat cards in `View` render full width like the surrounding cards.
+10. Repeat ending-rest copy reads:
+    - `Rest after last repeat`
+    - `Use separate rest step`
+    - `Use repeat rest time`
+11. Conflict prompts and confirmations use the same terminology as the selector.
+12. Canonical saved workout behavior, repeat metadata, and Garmin/export compatibility remain unchanged.
+13. Relevant tests plus `verify:pre-pr` and `verify:pre-merge` pass.
+
+## Validation
+
+- `npm run lint:briefs`
+- targeted `eslint`:
+  - `npx eslint components/my-library/workouts/WorkoutEditor.tsx lib/session-generator-v1/shared.ts tests/unit/workout-builder-hub.test.tsx tests/e2e/my-library-workout-builder.spec.ts`
+- targeted `vitest`:
+  - `npx vitest run tests/unit/workout-builder-hub.test.tsx tests/unit/workouts-shared.test.ts`
+- targeted `playwright`:
+  - `npx playwright test tests/e2e/my-library-workout-builder.spec.ts`
+- `npm run verify:pre-pr`
+- before merge: `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm installed locally.
+- Validation runs from repo root.
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3000/my-library/workouts/<id>`
+- Preview:
+  - Vercel preview URL from PR checks.
+- Recommended matrix:
+  - iPhone Safari
+  - Desktop Safari
+  - Desktop Chrome
+
+## Constraints
+
+- UI copy stays English.
+- Keep the change scoped to builder mode behavior, repeat readability, and repeat-rest wording only.
+- Do not weaken save/discard clarity or current linked-rest truthfulness.
+- Do not introduce drag-and-drop or a second overlapping ordering model.
+
+## 10/10 Quality Bar
+
+- `Rearrange` must feel like one clear purpose-built mode, not a slight variant of `Edit`.
+- `View` must read like view, without visible edit leakage.
+- Repeat-rest wording must be understandable without internal builder jargon.
+- Ordering controls must be obvious, deterministic, and low-risk at list boundaries.
+- All touched states must remain keyboard-usable, focus-visible, and test-covered.
+
+## Checkpoint Log
+
+- `2026-04-16 | planning | created the agreed follow-up brief for builder ordering and repeat readability: dedicated rearrange mode, no visible repeat edit leakage in view, full-width repeat cards in view, and clearer last-repeat-rest copy | next: implement the mode split, update copy, add tests, and run targeted validation before full repo gates`
+- `2026-04-16 | implementation + validation | added the dedicated Rearrange mode, removed top-level move controls from edit surfaces, fixed repeat view-card leakage/width, renamed last-repeat-rest copy and conflict prompts, and updated unit + e2e coverage; targeted eslint/vitest/playwright plus full verify:pre-pr passed locally | next: commit, push, open PR, watch CI, then run verify:pre-merge before merge`

--- a/lib/session-generator-v1/shared.ts
+++ b/lib/session-generator-v1/shared.ts
@@ -335,8 +335,8 @@ const STEP_TARGET_MODE_LABELS: Record<SessionDraftStepTargetMode, string> = {
 };
 
 const REPEAT_ENDING_REST_MODE_LABELS: Record<SessionDraftRepeatEndingRestMode, string> = {
-  use_last_rest: "Include final interval rest",
-  skip_last_rest: "Skip final interval rest",
+  use_last_rest: "Use repeat rest time",
+  skip_last_rest: "Use separate rest step",
 };
 
 export function getSessionEnvironmentLabel(value: SessionGeneratorEnvironment) {

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -327,6 +327,8 @@ test.describe("my library workout builder", () => {
     await expect(page.getByText("Session details")).toBeVisible();
     await expect(page.getByText("Session note")).toBeVisible();
     await expect(page.getByText("Pool Size", { exact: true })).toBeVisible();
+    await expect(page.getByTestId("workout-editor-builder-mode-rearrange")).toBeVisible();
+    await expect(page.getByTestId("workout-editor-builder-mode-view")).toBeVisible();
     await expect(page.getByRole("button", { name: "Meters" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Yards" })).toBeVisible();
     await expect(
@@ -377,6 +379,32 @@ test.describe("my library workout builder", () => {
     expect(collapsedStepToggleBox!.y).toBeLessThan(
       collapsedStepSummaryBox!.y + collapsedStepSummaryBox!.height
     );
+    await page.getByTestId("workout-editor-builder-mode-view").click();
+    await expect(page.getByTestId("session-draft-add-step")).toHaveCount(0);
+    await expect(page.getByTestId("session-draft-add-repeat")).toHaveCount(0);
+    await expect(page.getByTestId("workout-editor-metadata-toggle")).toHaveCount(0);
+    await expect(page.getByText("Edit repeat")).toHaveCount(0);
+    const viewRepeatCard = page.getByTestId(/workout-editor-view-repeat-/);
+    const viewSectionCard = page.locator('[data-testid^="workout-editor-view-section-"]').first();
+    const viewRepeatCardBox = await viewRepeatCard.boundingBox();
+    const viewSectionCardBox = await viewSectionCard.boundingBox();
+    expect(viewRepeatCardBox).not.toBeNull();
+    expect(viewSectionCardBox).not.toBeNull();
+    expect(Math.abs(viewRepeatCardBox!.width - viewSectionCardBox!.width)).toBeLessThanOrEqual(20);
+    await viewRepeatCard.click();
+    await expect(page.getByTestId("session-draft-repeat-count-2")).toBeVisible();
+    await expect(page.getByLabel("Step Type")).toHaveCount(0);
+    await page.getByTestId("workout-editor-builder-mode-rearrange").click();
+    await expect(page.getByTestId("session-draft-add-step")).toHaveCount(0);
+    await expect(page.getByTestId("session-draft-add-repeat")).toHaveCount(0);
+    await expect(page.getByTestId("session-draft-step-toggle-0")).toHaveCount(0);
+    await expect(page.getByTestId("session-draft-repeat-toggle-2")).toHaveCount(0);
+    await expect(page.getByTestId("session-draft-step-rearrange-controls-0")).toBeVisible();
+    await expect(page.getByTestId("session-draft-repeat-rearrange-controls-2")).toBeVisible();
+    await page.getByTestId("session-draft-step-summary-0").click();
+    await expect(page.getByLabel("Step Type")).toHaveCount(0);
+    await page.getByTestId("workout-editor-builder-mode-edit").click();
+    await expect(page.getByTestId("session-draft-step-toggle-0")).toBeVisible();
     await page.getByTestId("session-draft-step-summary-0").click();
     await expect(page.getByTestId("session-draft-step-desktop-actions-0")).toHaveAttribute(
       "data-desktop-layout",
@@ -557,6 +585,7 @@ test.describe("my library workout builder", () => {
     await expect(page.getByTestId("session-draft-repeat-ending-rest-mode-2")).toHaveValue(
       "skip_last_rest"
     );
+    await expect(page.getByText("Rest after last repeat")).toBeVisible();
     const repeatSummary = page.getByTestId("session-draft-repeat-summary-2");
     await expect(
       repeatSummary.getByText(

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -310,7 +310,7 @@ describe("WorkoutBuilderHub", () => {
     fireEvent.click(screen.getByTestId("session-draft-step-mobile-actions-toggle-0"));
 
     expect(screen.getByTestId("session-draft-step-mobile-actions-panel-0")).toBeVisible();
-    expect(screen.getByTestId("session-draft-step-mobile-move-up-0")).toBeDisabled();
+    expect(screen.queryByTestId("session-draft-step-mobile-move-up-0")).not.toBeInTheDocument();
     expect(screen.getByTestId("session-draft-step-mobile-remove-0")).toBeVisible();
 
     fireEvent.click(screen.getByTestId("session-draft-add-repeat"));
@@ -789,9 +789,9 @@ describe("WorkoutBuilderHub", () => {
       )
     ).not.toBeInTheDocument();
     expect(screen.queryByText(/Final rest skipped/)).not.toBeInTheDocument();
-    expect(screen.getByText("Final interval rest")).toBeVisible();
-    expect(screen.getByRole("option", { name: "Skip final interval rest" })).toBeVisible();
-    expect(screen.getByRole("option", { name: "Include final interval rest" })).toBeVisible();
+    expect(screen.getByText("Rest after last repeat")).toBeVisible();
+    expect(screen.getByRole("option", { name: "Use separate rest step" })).toBeVisible();
+    expect(screen.getByRole("option", { name: "Use repeat rest time" })).toBeVisible();
     expect(
       screen.queryByText("Adjust or remove when you refine the workout.")
     ).not.toBeInTheDocument();
@@ -1054,16 +1054,16 @@ describe("WorkoutBuilderHub", () => {
     });
 
     expect(screen.getByText("This creates two rests in a row.")).toBeVisible();
-    expect(screen.getByRole("button", { name: "Keep set rest only" })).toBeVisible();
-    expect(screen.getByRole("button", { name: "Use final interval rest instead" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Use separate rest step" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Use repeat rest time" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Keep both" })).toBeVisible();
 
-    fireEvent.click(screen.getByRole("button", { name: "Use final interval rest instead" }));
+    fireEvent.click(screen.getByRole("button", { name: "Use repeat rest time" }));
     expect(
-      screen.getByText("Delete the separate set rest and keep final interval rest?")
+      screen.getByText("Delete the separate rest step and use repeat rest time?")
     ).toBeVisible();
 
-    fireEvent.click(screen.getByRole("button", { name: "Delete set rest" }));
+    fireEvent.click(screen.getByRole("button", { name: "Delete rest step" }));
 
     const previewDraft = readPreviewDraft();
     expect(previewDraft.steps.some((step) => step.postSetRestForRepeatGroupId)).toBe(false);
@@ -1764,6 +1764,7 @@ describe("WorkoutBuilderHub", () => {
     });
 
     expect(screen.getByTestId("workout-editor-builder-mode-edit")).toBeVisible();
+    expect(screen.getByTestId("workout-editor-builder-mode-rearrange")).toBeVisible();
     expect(screen.getByTestId("workout-editor-builder-mode-view")).toBeVisible();
 
     fireEvent.click(screen.getByTestId("workout-editor-builder-mode-view"));
@@ -1776,6 +1777,7 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.getByText("Warmup")).toBeVisible();
     expect(screen.getByText("400m · Freestyle · Easy")).toBeVisible();
     expect(screen.queryByText("Edit step")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit repeat")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /400m · Freestyle · Easy/i }));
 
@@ -1787,10 +1789,58 @@ describe("WorkoutBuilderHub", () => {
 
     fireEvent.click(screen.getByTestId("session-draft-add-repeat"));
     fireEvent.click(screen.getByTestId("workout-editor-builder-mode-view"));
-    fireEvent.click(screen.getByTestId(/workout-editor-view-repeat-/));
+    const repeatViewCard = screen.getByTestId(/workout-editor-view-repeat-/);
+    expect(repeatViewCard).toHaveClass("block", "w-full");
+    fireEvent.click(repeatViewCard);
 
     expect(screen.getByLabelText("Repeat count")).toBeVisible();
     expect(screen.queryByLabelText("Step Type")).not.toBeInTheDocument();
+  });
+
+  it("uses rearrange as a separate ordering mode without opening edit and keeps top-level moves in one place", async () => {
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: buildWorkoutRecord({
+            sourceKind: "manual",
+            draft: buildDraft({ sourceFingerprint: "manual-rearrange-mode" }),
+          }),
+          recentWorkouts: [buildWorkoutSummary({ sourceKind: "manual" })],
+        })}
+        preferExpandedDetailsOnLoad
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    openWorkoutMetadataPanel();
+    expect(screen.getByTestId("session-draft-title")).toBeVisible();
+
+    fireEvent.click(screen.getByTestId("session-draft-add-repeat"));
+    fireEvent.click(screen.getByTestId("workout-editor-builder-mode-rearrange"));
+
+    expect(screen.queryByTestId("session-draft-title")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("workout-editor-metadata-toggle")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("session-draft-add-step")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("session-draft-add-repeat")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("session-draft-step-toggle-0")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("session-draft-repeat-toggle-1")).not.toBeInTheDocument();
+    expect(screen.getByTestId("session-draft-step-rearrange-controls-0")).toBeVisible();
+    expect(screen.getByTestId("session-draft-repeat-rearrange-controls-1")).toBeVisible();
+
+    fireEvent.click(getDesktopSummaryCard("session-draft-step-summary-0"));
+    expect(screen.queryByLabelText("Step Type")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("session-draft-step-rearrange-move-down-0"));
+
+    const previewDraft = readPreviewDraft();
+    expect(previewDraft.steps[0]?.repeatGroupId).not.toBeNull();
+    expect(previewDraft.steps.at(-1)?.id).toBe("step-1");
   });
 
   it("keeps existing step summaries stable when switching pool units", async () => {


### PR DESCRIPTION
## Summary

- User-visible changes: The workout builder now has a dedicated `Rearrange` mode for top-level ordering, manual-pool `View` no longer leaks a visible `Edit repeat` affordance, repeat cards stay full width in view, and the repeat ending-rest control now reads `Rest after last repeat` with clearer option labels.
- Technical changes: Updated `WorkoutEditor` mode handling to split `edit` / `rearrange` / `view`, moved top-level move controls out of edit action rows, preserved grouped moves for manual-pool single blocks and repeat groups, updated repeat-rest labels in `lib/session-generator-v1/shared.ts`, and expanded unit + e2e coverage for the new mode and repeat-view contract.
- Policy impact: no (private builder UI-state, wording, and test coverage changes only; no auth, privacy, billing, policy, API, or public-site contract changed).
- Policy version note: N/A (no policy-impacting contract changed).

## Scope

- In scope: Dedicated builder rearrange mode, top-level move-control consolidation, manual-pool repeat-card view cleanup, clearer last-repeat-rest wording, aligned repeat-rest conflict prompts, and matching unit/e2e/brief updates.
- Out of scope: Poolside note print/layout bugs, workout PDF parity, drag-and-drop ordering, schema/API changes, Garmin/export payload changes, and broader builder IA changes outside this slice.

## Risk

- Main risk: Reordering could accidentally open edit or break manual-pool grouping semantics if top-level single blocks, linked rests, and repeat groups are not kept together across mode boundaries.
- Rollback plan: Revert commit `d388003` to restore the previous edit/view-only builder mode behavior and repeat-rest wording if regressions appear after merge.

## Test Evidence

- Brief link(s): `docs/task-briefs/in-progress/2026-04-16-builder-rearrange-mode-repeat-view-clarity-and-last-repeat-rest-copy-10-10.md`
- Policy-impact checklist: N/A (policy impact is `no`; changed files are limited to private builder UI, labels, tests, and task-brief scope).
- `npx eslint components/my-library/workouts/WorkoutEditor.tsx lib/session-generator-v1/shared.ts tests/unit/workout-builder-hub.test.tsx tests/e2e/my-library-workout-builder.spec.ts`: **PASS**
- `npx vitest run tests/unit/workout-builder-hub.test.tsx tests/unit/workouts-shared.test.ts`: **PASS**
- `env NEXT_DIST_DIR=.next-playwright-builder-rearrange npx playwright test tests/e2e/my-library-workout-builder.spec.ts`: **PASS**
- `npm run lint:briefs:all`: **PASS**
- `npm run verify:pre-pr`: **PASS**
- `npm run verify:pre-merge`: **PENDING** (running locally before merge recommendation)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [x] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added
