### PR TITLE
feat: keep manual workout drafts local until first save

### DIFF
--- a/app/my-library/workouts/[workoutId]/page.tsx
+++ b/app/my-library/workouts/[workoutId]/page.tsx
@@ -116,6 +116,7 @@ export default async function WorkoutBuilderPage({ params, searchParams }: Props
               }
               manualPoolCssPaceLabel={athleteProfileSnapshot.cssMetric?.paceLabel ?? null}
               swimmerName={athleteProfileSnapshot.profile?.primaryName ?? null}
+              userId={user.id}
               hideShellIntro
               preferExpandedDetailsOnLoad={preferExpandedDetailsOnLoad}
             />

--- a/app/my-library/workouts/page.tsx
+++ b/app/my-library/workouts/page.tsx
@@ -5,12 +5,32 @@ import WorkoutBuilderHub from "@/components/my-library/workouts/WorkoutBuilderHu
 import { loadAthleteProfileSnapshot } from "@/lib/athlete-profile/server";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { loadTrainingContextSnapshot } from "@/lib/training-context/server";
+import type { ManualWorkoutBuilderMode } from "@/lib/workouts/manual";
 import type { WorkoutPoolsideFocusOption } from "@/lib/workouts/shared";
 import { loadWorkoutLibrarySnapshot } from "@/lib/workouts/server";
 
 export const dynamic = "force-dynamic";
 
-export default async function WorkoutSessionsPage() {
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+type Props = {
+  searchParams: SearchParams;
+};
+
+function readSearchParamValue(
+  searchParams: Record<string, string | string[] | undefined>,
+  key: string
+): string {
+  const raw = searchParams[key];
+  return Array.isArray(raw) ? (raw[0] ?? "") : (raw ?? "");
+}
+
+export default async function WorkoutSessionsPage({ searchParams }: Props) {
+  const resolvedSearchParams = await searchParams;
+  const entryMode = readSearchParamValue(resolvedSearchParams, "entry");
+  const rawDraftMode = readSearchParamValue(resolvedSearchParams, "draft");
+  const localDraftMode: ManualWorkoutBuilderMode | null =
+    rawDraftMode === "pool" || rawDraftMode === "open_water" ? rawDraftMode : null;
   const supabase = await createServerSupabaseClient();
   const {
     data: { user },
@@ -34,6 +54,17 @@ export default async function WorkoutSessionsPage() {
           isPrimary: focus.isPrimary,
         }))
       : [];
+  const builderHeading =
+    localDraftMode === "pool"
+      ? "Pool session builder"
+      : localDraftMode === "open_water"
+        ? "Open-water session builder"
+        : "My Swim Sessions";
+  const preferExpandedDetailsOnLoad =
+    localDraftMode !== null ||
+    entryMode === "manual-create" ||
+    entryMode === "manual-pool" ||
+    entryMode === "manual-open-water";
 
   return (
     <SiteChrome>
@@ -53,7 +84,7 @@ export default async function WorkoutSessionsPage() {
                 My Library
               </p>
               <h1 className="mt-2 text-2xl font-bold text-slate-900 sm:text-3xl">
-                My Swim Sessions
+                {builderHeading}
               </h1>
             </div>
             <div className="flex flex-wrap gap-2">
@@ -76,7 +107,11 @@ export default async function WorkoutSessionsPage() {
               }
               manualPoolCssPaceLabel={athleteProfileSnapshot.cssMetric?.paceLabel ?? null}
               swimmerName={athleteProfileSnapshot.profile?.primaryName ?? null}
-              browseOnly
+              browseOnly={localDraftMode === null}
+              hideShellIntro={localDraftMode !== null}
+              preferExpandedDetailsOnLoad={preferExpandedDetailsOnLoad}
+              userId={user.id}
+              manualLocalDraftMode={localDraftMode}
             />
           </div>
         </div>

--- a/components/my-library/workouts/CreateManualWorkoutButton.tsx
+++ b/components/my-library/workouts/CreateManualWorkoutButton.tsx
@@ -2,13 +2,7 @@
 
 import { startTransition, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import {
-  buildManualOpenWaterWorkoutEmptyDraft,
-  buildManualPoolWorkoutEmptyDraft,
-  type ManualWorkoutDraftDefaults,
-  type ManualWorkoutBuilderMode,
-} from "@/lib/workouts/manual";
-import type { WorkoutSaveApiResponse } from "@/lib/workouts/shared";
+import type { ManualWorkoutBuilderMode } from "@/lib/workouts/manual";
 
 type Props = {
   label?: string;
@@ -16,9 +10,9 @@ type Props = {
   className?: string;
   testId?: string;
   builderMode?: ManualWorkoutBuilderMode;
-  createdWorkoutHrefBuilder?: (workoutId: string) => string;
   manualPoolCssMetricSecondsPer100m?: number | null;
   manualPoolCssPaceLabel?: string | null;
+  draftHrefBuilder?: (builderMode: ManualWorkoutBuilderMode) => string;
 };
 
 export default function CreateManualWorkoutButton({
@@ -27,91 +21,55 @@ export default function CreateManualWorkoutButton({
   className = "",
   testId = "create-manual-workout",
   builderMode = "pool",
-  createdWorkoutHrefBuilder,
-  manualPoolCssMetricSecondsPer100m = null,
-  manualPoolCssPaceLabel = null,
+  draftHrefBuilder,
 }: Props) {
   const router = useRouter();
   const [clientReady, setClientReady] = useState(false);
-  const [isCreating, setIsCreating] = useState(false);
+  const [isOpening, setIsOpening] = useState(false);
   const [error, setError] = useState("");
   const resolvedLabel =
     label ?? (builderMode === "pool" ? "Build pool session" : "Build open water session");
   const resolvedPendingLabel =
     pendingLabel ??
-    (builderMode === "pool" ? "Building pool session..." : "Building open water session...");
-  const manualPoolDefaults: ManualWorkoutDraftDefaults | undefined =
-    builderMode === "pool" &&
-    typeof manualPoolCssMetricSecondsPer100m === "number" &&
-    Number.isFinite(manualPoolCssMetricSecondsPer100m) &&
-    manualPoolCssMetricSecondsPer100m > 0
-      ? {
-          basePaceSecondsPer100m: manualPoolCssMetricSecondsPer100m,
-          usedCssPaceLabel: manualPoolCssPaceLabel,
-        }
-      : undefined;
-  const buildWorkoutHref =
-    createdWorkoutHrefBuilder ??
-    ((workoutId: string) =>
-      `/my-library/workouts/${workoutId}?entry=${
-        builderMode === "pool" ? "manual-pool" : "manual-open-water"
+    (builderMode === "pool" ? "Opening pool session..." : "Opening open water session...");
+  const buildDraftHref =
+    draftHrefBuilder ??
+    ((mode: ManualWorkoutBuilderMode) =>
+      `/my-library/workouts?draft=${mode}&entry=${
+        mode === "pool" ? "manual-pool" : "manual-open-water"
       }`);
 
   useEffect(() => {
     setClientReady(true);
   }, []);
 
-  async function handleCreateManualSession() {
-    setIsCreating(true);
+  function handleCreateManualSession() {
+    setIsOpening(true);
     setError("");
 
     try {
-      const response = await fetch("/api/my-library/workouts", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          sourceKind: "manual",
-          draft:
-            builderMode === "pool"
-              ? buildManualPoolWorkoutEmptyDraft(new Date(), manualPoolDefaults)
-              : buildManualOpenWaterWorkoutEmptyDraft(),
-        }),
-      });
-      const responseBody = (await response
-        .json()
-        .catch(() => null)) as WorkoutSaveApiResponse | null;
-      const genericFailureMessage =
-        builderMode === "pool"
-          ? "Could not build pool session."
-          : "Could not build open water session.";
-
-      if (!response.ok || !responseBody?.ok) {
-        setError(responseBody && !responseBody.ok ? responseBody.error : genericFailureMessage);
-        return;
-      }
-
-      const workoutHref = buildWorkoutHref(responseBody.workout.id);
+      const draftHref = buildDraftHref(builderMode);
 
       startTransition(() => {
-        router.push(workoutHref);
+        router.push(draftHref);
         router.refresh();
       });
 
       window.setTimeout(() => {
-        if (window.location.pathname === "/my-library") {
-          window.location.assign(workoutHref);
+        const resolvedHref = new URL(draftHref, window.location.origin).toString();
+
+        if (window.location.href !== resolvedHref) {
+          window.location.assign(draftHref);
         }
       }, 250);
     } catch {
       setError(
         builderMode === "pool"
-          ? "Could not build pool session."
-          : "Could not build open water session."
+          ? "Could not open pool session builder."
+          : "Could not open open-water session builder."
       );
     } finally {
-      setIsCreating(false);
+      setIsOpening(false);
     }
   }
 
@@ -121,11 +79,11 @@ export default function CreateManualWorkoutButton({
         type="button"
         data-testid={testId}
         data-client-ready={clientReady ? "true" : "false"}
-        onClick={() => void handleCreateManualSession()}
-        disabled={!clientReady || isCreating}
+        onClick={handleCreateManualSession}
+        disabled={!clientReady || isOpening}
         className={className}
       >
-        {isCreating ? resolvedPendingLabel : resolvedLabel}
+        {isOpening ? resolvedPendingLabel : resolvedLabel}
       </button>
       {error ? (
         <p data-testid={`${testId}-error`} className="text-sm text-rose-700">

--- a/components/my-library/workouts/WorkoutBuilderHub.tsx
+++ b/components/my-library/workouts/WorkoutBuilderHub.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import CreateManualWorkoutButton from "@/components/my-library/workouts/CreateManualWorkoutButton";
 import SavedWorkoutsPanel from "@/components/my-library/workouts/SavedWorkoutsPanel";
 import WorkoutEditor from "@/components/my-library/workouts/WorkoutEditor";
@@ -10,6 +10,12 @@ import {
   useAutoDismissNotice,
   WORKOUT_NOTICE_AUTO_DISMISS_MS,
 } from "@/components/my-library/workouts/useAutoDismissNotice";
+import type { ManualWorkoutBuilderMode, ManualWorkoutDraftDefaults } from "@/lib/workouts/manual";
+import {
+  clearStoredManualWorkoutDraft,
+  loadOrCreateStoredManualWorkoutDraft,
+  writeStoredManualWorkoutDraft,
+} from "@/lib/workouts/manual-local-draft";
 import type {
   WorkoutDeleteApiResponse,
   WorkoutEditorRecord,
@@ -29,6 +35,8 @@ type Props = {
   browseOnly?: boolean;
   hideShellIntro?: boolean;
   preferExpandedDetailsOnLoad?: boolean;
+  userId?: string | null;
+  manualLocalDraftMode?: ManualWorkoutBuilderMode | null;
 };
 
 function upsertRecentWorkoutSummary(current: WorkoutSummary[], next: WorkoutSummary) {
@@ -47,6 +55,8 @@ export default function WorkoutBuilderHub({
   browseOnly = false,
   hideShellIntro = false,
   preferExpandedDetailsOnLoad = false,
+  userId = null,
+  manualLocalDraftMode = null,
 }: Props) {
   const router = useRouter();
   const [savedWorkout, setSavedWorkout] = useState<WorkoutEditorRecord | null>(
@@ -61,11 +71,31 @@ export default function WorkoutBuilderHub({
   const [deletingWorkoutId, setDeletingWorkoutId] = useState<string | null>(null);
   const [bulkDeleting, setBulkDeleting] = useState(false);
   const [pendingCurrentDelete, setPendingCurrentDelete] = useState(false);
+  const [pendingCurrentDraftDiscard, setPendingCurrentDraftDiscard] = useState(false);
   const [discardUndoDraft, setDiscardUndoDraft] = useState<WorkoutEditorRecord["draft"] | null>(
     null
   );
   const [clientReady, setClientReady] = useState(false);
-  const hasUnsavedChanges = haveWorkoutDraftChanges(draft, savedWorkout?.draft ?? null);
+  const [activeLocalDraftMode, setActiveLocalDraftMode] = useState<ManualWorkoutBuilderMode | null>(
+    workoutLibrary.selectedWorkout ? null : manualLocalDraftMode
+  );
+  const [localDraftRecovered, setLocalDraftRecovered] = useState(false);
+  const hasUnsavedChanges =
+    savedWorkout !== null ? haveWorkoutDraftChanges(draft, savedWorkout.draft) : false;
+  const manualPoolDraftDefaults = useMemo<ManualWorkoutDraftDefaults | undefined>(() => {
+    if (
+      typeof manualPoolCssMetricSecondsPer100m === "number" &&
+      Number.isFinite(manualPoolCssMetricSecondsPer100m) &&
+      manualPoolCssMetricSecondsPer100m > 0
+    ) {
+      return {
+        basePaceSecondsPer100m: manualPoolCssMetricSecondsPer100m,
+        usedCssPaceLabel: manualPoolCssPaceLabel,
+      };
+    }
+
+    return undefined;
+  }, [manualPoolCssMetricSecondsPer100m, manualPoolCssPaceLabel]);
 
   useAutoDismissNotice(success, setSuccess);
 
@@ -74,6 +104,8 @@ export default function WorkoutBuilderHub({
   }, []);
 
   useEffect(() => {
+    const nextLocalDraftMode = workoutLibrary.selectedWorkout ? null : manualLocalDraftMode;
+
     setSavedWorkout(workoutLibrary.selectedWorkout);
     setDraft(workoutLibrary.selectedWorkout?.draft ?? null);
     setRecentWorkouts(workoutLibrary.recentWorkouts);
@@ -84,7 +116,11 @@ export default function WorkoutBuilderHub({
     setDeletingWorkoutId(null);
     setBulkDeleting(false);
     setPendingCurrentDelete(false);
+    setPendingCurrentDraftDiscard(false);
+    setActiveLocalDraftMode(nextLocalDraftMode);
+    setLocalDraftRecovered(false);
   }, [
+    manualLocalDraftMode,
     workoutLibrary.recentWorkouts,
     workoutLibrary.selectedWorkout,
     workoutLibrary.selectedWorkoutMissing,
@@ -102,24 +138,62 @@ export default function WorkoutBuilderHub({
     };
   }, [discardUndoDraft]);
 
+  useEffect(() => {
+    if (!clientReady || !userId || !activeLocalDraftMode || savedWorkout) {
+      return;
+    }
+
+    const loadedDraft = loadOrCreateStoredManualWorkoutDraft(
+      userId,
+      activeLocalDraftMode,
+      manualPoolDraftDefaults
+    );
+
+    setDraft(loadedDraft.draft);
+    setLocalDraftRecovered(loadedDraft.recovered);
+  }, [activeLocalDraftMode, clientReady, manualPoolDraftDefaults, savedWorkout, userId]);
+
+  useEffect(() => {
+    if (!clientReady || !userId || !activeLocalDraftMode || savedWorkout || !draft) {
+      return;
+    }
+
+    writeStoredManualWorkoutDraft(userId, activeLocalDraftMode, draft);
+  }, [activeLocalDraftMode, clientReady, draft, savedWorkout, userId]);
+
   async function saveWorkout() {
-    if (!draft || !savedWorkout) return;
+    const isFirstCanonicalSave = !savedWorkout && activeLocalDraftMode !== null;
+    const savedWorkoutId = savedWorkout?.id ?? null;
+    if (!draft || (!isFirstCanonicalSave && !savedWorkoutId)) return;
 
     setIsSaving(true);
     setError("");
     setSuccess("");
     setDiscardUndoDraft(null);
+    setPendingCurrentDraftDiscard(false);
 
     try {
-      const response = await fetch(`/api/my-library/workouts/${savedWorkout.id}`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          draft,
-        }),
-      });
+      const response = await fetch(
+        isFirstCanonicalSave
+          ? "/api/my-library/workouts"
+          : `/api/my-library/workouts/${savedWorkoutId}`,
+        {
+          method: isFirstCanonicalSave ? "POST" : "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(
+            isFirstCanonicalSave
+              ? {
+                  draft,
+                  sourceKind: "manual",
+                }
+              : {
+                  draft,
+                }
+          ),
+        }
+      );
       const responseBody = (await response
         .json()
         .catch(() => null)) as WorkoutSaveApiResponse | null;
@@ -131,10 +205,30 @@ export default function WorkoutBuilderHub({
         return;
       }
 
-      setSavedWorkout(responseBody.workout);
-      setDraft(responseBody.workout.draft);
+      if (isFirstCanonicalSave && userId && activeLocalDraftMode) {
+        clearStoredManualWorkoutDraft(userId, activeLocalDraftMode);
+      }
+
+      const canonicalWorkout = responseBody.workout;
+      const canonicalMode = draft.environment === "open_water" ? "open_water" : "pool";
+
+      setSavedWorkout(canonicalWorkout);
+      setDraft(canonicalWorkout.draft);
       setRecentWorkouts((current) => upsertRecentWorkoutSummary(current, responseBody.summary));
-      setSuccess("Changes saved to this session.");
+      setActiveLocalDraftMode(null);
+      setLocalDraftRecovered(false);
+      setSuccess(
+        isFirstCanonicalSave ? "Saved to My Swim Sessions." : "Changes saved to this session."
+      );
+
+      if (isFirstCanonicalSave) {
+        router.replace(
+          `/my-library/workouts/${canonicalWorkout.id}?entry=${
+            canonicalMode === "pool" ? "manual-pool" : "manual-open-water"
+          }`
+        );
+        router.refresh();
+      }
     } catch {
       setError("Could not save workout right now.");
     } finally {
@@ -174,6 +268,28 @@ export default function WorkoutBuilderHub({
     setDiscardUndoDraft(null);
     setError("");
     setSuccess("");
+  }
+
+  function confirmDiscardLocalDraft() {
+    if (!userId || !activeLocalDraftMode) return;
+
+    const discardedMode = activeLocalDraftMode;
+
+    clearStoredManualWorkoutDraft(userId, discardedMode);
+    setDraft(null);
+    setSavedWorkout(null);
+    setActiveLocalDraftMode(null);
+    setLocalDraftRecovered(false);
+    setPendingCurrentDraftDiscard(false);
+    setDiscardUndoDraft(null);
+    setError("");
+    setSuccess(
+      discardedMode === "pool"
+        ? "Discarded the local pool draft."
+        : "Discarded the local open-water draft."
+    );
+    router.replace("/my-library/workouts");
+    router.refresh();
   }
 
   async function confirmDeleteWorkout(workout: Pick<WorkoutSummary, "id" | "title">) {
@@ -381,6 +497,16 @@ export default function WorkoutBuilderHub({
         </div>
       ) : null}
 
+      {activeLocalDraftMode && !savedWorkout && localDraftRecovered ? (
+        <div className="rounded-2xl border border-emerald-200 bg-emerald-50/80 p-3 sm:p-4">
+          <p className="text-sm text-emerald-900">
+            {activeLocalDraftMode === "pool"
+              ? "Recovered your unsaved local pool draft on this device."
+              : "Recovered your unsaved local open-water draft on this device."}
+          </p>
+        </div>
+      ) : null}
+
       <div className="space-y-4 sm:space-y-5">
         {!browseOnly && savedWorkout && pendingCurrentDelete ? (
           <div
@@ -419,6 +545,37 @@ export default function WorkoutBuilderHub({
           </div>
         ) : null}
 
+        {!browseOnly && !savedWorkout && activeLocalDraftMode && pendingCurrentDraftDiscard ? (
+          <div
+            data-testid="workout-builder-current-draft-actions"
+            className="rounded-2xl border border-amber-200 bg-amber-50/80 p-3 sm:p-4"
+          >
+            <p className="text-sm font-medium text-amber-900">Discard this local draft?</p>
+            <p className="mt-1 text-sm text-amber-900/90">
+              {activeLocalDraftMode === "pool"
+                ? "This removes the unsaved pool draft from this device. Nothing is deleted from My Swim Sessions."
+                : "This removes the unsaved open-water draft from this device. Nothing is deleted from My Swim Sessions."}
+            </p>
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={confirmDiscardLocalDraft}
+                data-testid="workout-builder-confirm-discard-current-draft"
+                className="inline-flex h-10 items-center justify-center rounded-xl bg-amber-500 px-4 text-sm font-semibold text-white transition hover:bg-amber-400 active:bg-amber-600"
+              >
+                Discard draft
+              </button>
+              <button
+                type="button"
+                onClick={() => setPendingCurrentDraftDiscard(false)}
+                className="inline-flex h-10 items-center justify-center rounded-xl border border-amber-200 bg-white px-4 text-sm font-medium text-amber-900 transition hover:bg-amber-50 active:bg-amber-100"
+              >
+                Keep editing
+              </button>
+            </div>
+          </div>
+        ) : null}
+
         {browseOnly ? (
           recentWorkouts.length > 0 ? (
             <SavedWorkoutsPanel
@@ -448,6 +605,7 @@ export default function WorkoutBuilderHub({
               onRequestDeleteWorkout={(workout) => {
                 setPendingDeleteWorkoutId(workout.id);
                 setPendingCurrentDelete(false);
+                setPendingCurrentDraftDiscard(false);
                 setError("");
                 setSuccess("");
               }}
@@ -469,7 +627,7 @@ export default function WorkoutBuilderHub({
               </p>
             </div>
           )
-        ) : !savedWorkout ? (
+        ) : !savedWorkout && !activeLocalDraftMode ? (
           <div className="space-y-4 sm:space-y-5">
             <div className="rounded-2xl border border-amber-200 bg-amber-50/80 p-3 sm:p-4">
               <p className="text-sm font-medium text-amber-900">
@@ -525,7 +683,7 @@ export default function WorkoutBuilderHub({
           </div>
         ) : null}
 
-        {draft && savedWorkout ? (
+        {draft && (savedWorkout || activeLocalDraftMode) ? (
           <div>
             <WorkoutEditor
               draft={draft}
@@ -537,7 +695,19 @@ export default function WorkoutBuilderHub({
               onSave={saveWorkout}
               hasUnsavedChanges={hasUnsavedChanges}
               onDraftChange={handleDraftChange}
-              onDiscardChanges={discardDraftChanges}
+              onDiscardChanges={savedWorkout ? discardDraftChanges : null}
+              onRequestDiscardDraft={
+                !savedWorkout && activeLocalDraftMode
+                  ? () => {
+                      setDiscardUndoDraft(null);
+                      setPendingCurrentDelete(false);
+                      setPendingDeleteWorkoutId(null);
+                      setPendingCurrentDraftDiscard(true);
+                      setError("");
+                      setSuccess("");
+                    }
+                  : null
+              }
               showDiscardUndoNotice={discardUndoDraft !== null}
               onUndoDiscardChanges={undoDiscardDraftChanges}
               startNewDraftHref={null}
@@ -547,11 +717,12 @@ export default function WorkoutBuilderHub({
               onRequestDeleteCurrent={() => {
                 setDiscardUndoDraft(null);
                 setPendingCurrentDelete(true);
+                setPendingCurrentDraftDiscard(false);
                 setPendingDeleteWorkoutId(null);
                 setError("");
                 setSuccess("");
               }}
-              isDeletingCurrent={deletingWorkoutId === savedWorkout.id}
+              isDeletingCurrent={savedWorkout ? deletingWorkoutId === savedWorkout.id : false}
               swimmerName={swimmerName}
               recentWorkoutsDescription="Edit another saved session when you want to switch what you are working on."
               workoutHrefBuilder={(workoutId) => `/my-library/workouts/${workoutId}`}

--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -100,6 +100,7 @@ type Props = {
   onSave: () => void;
   onDraftChange: (draft: SessionDraft) => void;
   onDiscardChanges?: (() => void) | null;
+  onRequestDiscardDraft?: (() => void) | null;
   showDiscardUndoNotice?: boolean;
   onUndoDiscardChanges?: (() => void) | null;
   startNewDraftHref?: string | null;
@@ -1586,6 +1587,7 @@ export default function WorkoutEditor({
   onSave,
   onDraftChange,
   onDiscardChanges = null,
+  onRequestDiscardDraft = null,
   showDiscardUndoNotice = false,
   onUndoDiscardChanges = null,
   startNewDraftHref = null,
@@ -1656,8 +1658,7 @@ export default function WorkoutEditor({
     useState<WorkoutPoolsidePrintLayout>("portrait");
   const [poolsideNotationMode, setPoolsideNotationMode] =
     useState<WorkoutPoolsideNotationMode>("auto");
-  const [poolsideRestLayout, setPoolsideRestLayout] =
-    useState<WorkoutPoolsideRestLayout>("auto");
+  const [poolsideRestLayout, setPoolsideRestLayout] = useState<WorkoutPoolsideRestLayout>("auto");
   const [selectedPoolsideFocusIds, setSelectedPoolsideFocusIds] = useState<string[]>(() =>
     getDefaultWorkoutPoolsideFocusIds(trainingFocusOptions)
   );
@@ -1718,6 +1719,8 @@ export default function WorkoutEditor({
           savedWorkoutSavedState: "All changes are saved to this session.",
           unsavedDraftPendingState: "This session is not saved yet.",
         };
+  const unsavedSaveButtonLabel =
+    copyVariant === "generator" ? "Accept and save workout" : "Save session";
   const poolLengthQuickChoices =
     poolLengthUnit === "yd" ? YARD_POOL_SIZE_QUICK_CHOICES : MANUAL_POOL_SIZE_QUICK_CHOICES;
   const parsedPoolLengthInput = parsePoolLengthInput(poolLengthInput, poolLengthUnit);
@@ -5222,6 +5225,17 @@ export default function WorkoutEditor({
                     Discard changes
                   </button>
                 ) : null}
+                {isEditMode && !savedWorkout && onRequestDiscardDraft ? (
+                  <button
+                    type="button"
+                    onClick={onRequestDiscardDraft}
+                    disabled={isSaving || pendingRemoval !== null}
+                    data-testid="workout-builder-discard-current-draft"
+                    className="inline-flex h-10 items-center justify-center rounded-xl border border-amber-200 bg-white px-4 text-sm font-medium text-amber-900 transition hover:bg-amber-50 active:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    Discard draft
+                  </button>
+                ) : null}
                 {isEditMode && savedWorkout && onRequestDeleteCurrent ? (
                   <button
                     type="button"
@@ -5250,11 +5264,7 @@ export default function WorkoutEditor({
                   data-testid={saveButtonTestId}
                   className="inline-flex h-10 items-center justify-center rounded-xl bg-emerald-600 px-4 text-sm font-semibold text-white transition hover:bg-emerald-500 active:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
                 >
-                  {isSaving
-                    ? "Saving..."
-                    : savedWorkout
-                      ? "Save changes"
-                      : "Accept and save workout"}
+                  {isSaving ? "Saving..." : savedWorkout ? "Save changes" : unsavedSaveButtonLabel}
                 </button>
               </div>
             </div>
@@ -6100,6 +6110,17 @@ export default function WorkoutEditor({
                     Discard changes
                   </button>
                 ) : null}
+                {!savedWorkout && onRequestDiscardDraft ? (
+                  <button
+                    type="button"
+                    onClick={onRequestDiscardDraft}
+                    disabled={isSaving || pendingRemoval !== null}
+                    data-testid="workout-builder-discard-current-draft"
+                    className="inline-flex h-11 items-center justify-center rounded-xl border border-amber-200 bg-white px-4 text-sm font-medium text-amber-900 transition hover:bg-amber-50 active:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    Discard draft
+                  </button>
+                ) : null}
                 <button
                   type="button"
                   onClick={() => {
@@ -6117,11 +6138,7 @@ export default function WorkoutEditor({
                   data-testid={saveButtonTestId}
                   className="inline-flex h-11 items-center justify-center rounded-xl bg-emerald-600 px-4 text-sm font-semibold text-white transition hover:bg-emerald-500 active:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
                 >
-                  {isSaving
-                    ? "Saving..."
-                    : savedWorkout
-                      ? "Save changes"
-                      : "Accept and save workout"}
+                  {isSaving ? "Saving..." : savedWorkout ? "Save changes" : unsavedSaveButtonLabel}
                 </button>
               </div>
             </div>

--- a/docs/task-briefs/in-progress/2026-04-18-swim-session-builder-local-draft-first-save-boundary-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-18-swim-session-builder-local-draft-first-save-boundary-10-10.md
@@ -1,0 +1,220 @@
+# Task Brief: Swim Session Builder Local Draft First-Save Boundary (10/10)
+
+## Metadata
+
+- `id`: `2026-04-18-swim-session-builder-local-draft-first-save-boundary-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-04-18`
+- `updated`: `2026-04-18`
+
+## Goal
+
+Redesign manual swim-session entry so `Build pool session` and `Build open water session` start from a local-only draft, while canonical saved sessions and stable IDs are created only on the first explicit save.
+
+## Why This Brief Exists
+
+- Current builder behavior still creates a canonical saved session immediately when the user starts a manual session.
+- That creates clutter in `My Swim Sessions`, weakens the mental model between “I opened the builder” and “I saved a session,” and makes cleanup harder than it should be.
+- The owner chose a stricter product/data boundary:
+  - local draft first,
+  - no canonical row until first save,
+  - no placeholder canonical row just because the builder was opened.
+- This is not copy polish. It is a product-flow, storage-boundary, identity-contract, and test-contract change.
+
+## Dependencies And Boundaries
+
+- Parent builder/runtime lineage:
+  - [2026-02-28-workout-builder-and-poolside-execution-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-02-28-workout-builder-and-poolside-execution-10-10.md)
+- Earlier create-vs-edit slice whose truthfulness boundary now needs to be superseded by this product decision:
+  - [2026-04-05-swim-session-builder-create-vs-edit-clarity-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-05-swim-session-builder-create-vs-edit-clarity-10-10.md)
+- Locked product decisions for this brief:
+  - starting a manual session creates a local-only draft first,
+  - no row appears in `My Swim Sessions` until the first explicit save,
+  - canonical stable ID is created only on first save,
+  - at most one recoverable local draft per builder mode (`pool`, `open_water`),
+  - clicking the same create action should resume the existing local draft if present,
+  - local drafts use `Discard draft`,
+  - existing saved sessions keep `Save changes` / `Discard changes`,
+  - do not introduce `Delete draft` wording for existing canonical sessions.
+
+## Must Now
+
+- Define and ship the local-draft vs canonical-session boundary truthfully.
+- Keep unsaved manual builder work local-only on this device/browser.
+- Prevent accidental placeholder rows in `My Swim Sessions`.
+- Add a clear recover/resume/discard path for local drafts.
+
+## Before Live
+
+- Verify both pool and open-water manual entry follow the same first-save boundary.
+- Verify return/recovery behavior after leaving and reopening the builder.
+- Confirm saved-session editing still behaves normally after the first save.
+
+## Ongoing Cadence
+
+- Future builder entry changes must preserve the same first-save truth unless explicitly rebriefed.
+- Any new manual builder mode must declare:
+  - local-draft behavior,
+  - first-save canonical boundary,
+  - recovery/discard behavior,
+  - list visibility contract.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim in this brief:
+
+- `Business logic correctness and data integrity`
+- `Data placement and sync boundaries`
+- `Reliability and failure handling`
+- `Testing and QA automation`
+- `Product goals and IA`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                                                  | Evidence                                  | Expected Closeout Score |
+| --------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | Manual builder clearly separates `local draft` from `saved session`, and `My Swim Sessions` only lists canonical saved sessions.                                | product flow review + manual QA + e2e     | `5/5`                   |
+| UX flow clarity                               | `target`     | Starting, resuming, first save, discard draft, and saved-session edit paths each have one obvious meaning with no duplicated or misleading persistence.         | manual QA + e2e                           | `5/5`                   |
+| Visual design quality                         | `supporting` | Supporting only: draft-vs-saved states should remain visually calm and truthful without new clutter or accidental duplicate controls.                           | screenshot review + component QA          | `4/5`                   |
+| Business logic correctness and data integrity | `target`     | No canonical session row or stable ID is created before first explicit save, and first save creates exactly one canonical row deterministically.                | unit/integration tests + API/state review | `5/5`                   |
+| Admin editor ergonomics                       | `N/A`        | N/A because this brief changes owner-facing swim-session authoring, not admin/editor workflows.                                                                 | explicit scope rationale                  | `N/A`                   |
+| Accessibility (a11y)                          | `supporting` | Supporting only: draft recovery/discard and save states must remain keyboard/touch accessible with clear labels and semantics.                                  | targeted QA + a11y review                 | `4/5`                   |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: moving to local-first draft start must not introduce heavy client cost or obvious builder-route lag.                                           | diff review + targeted QA                 | `4/5`                   |
+| Data placement and sync boundaries            | `target`     | Local draft is device-local only, canonical session is server-saved only after first save, and the first save is the explicit boundary between them.            | brief contract + implementation review    | `5/5`                   |
+| Caching and invalidation strategy             | `target`     | `My Swim Sessions` remains canonical-only, and cache/list invalidation occurs only after first save or later canonical edits/deletes.                           | list behavior tests + route review        | `5/5`                   |
+| Reliability and failure handling              | `target`     | Local draft remains recoverable on return, first-save failure does not create a ghost canonical row, and discard draft removes only the local draft.            | unit/e2e failure-path coverage            | `5/5`                   |
+| Security and authz                            | `supporting` | Supporting only: canonical save/write remains owner-scoped/authenticated, and local draft recovery must not leak between users or identities.                   | auth review + negative-path tests         | `4/5`                   |
+| Privacy and compliance                        | `supporting` | Supporting only: local drafts stay on the current device/browser and do not introduce broader unintended persistence or disclosure.                             | storage review + scope rationale          | `4/5`                   |
+| Content governance                            | `supporting` | Supporting only: list wording, builder copy, and saved/draft naming must stay aligned with the underlying data truth.                                           | copy review + flow review                 | `4/5`                   |
+| Admin workflow and editability                | `N/A`        | N/A because no admin CRUD/status workflow changes in this brief.                                                                                                | explicit scope rationale                  | `N/A`                   |
+| SEO and crawlability                          | `N/A`        | N/A because this is an authenticated builder flow with no public crawl contract.                                                                                | explicit scope rationale                  | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because this brief changes no public semantic route or discoverability contract.                                                                            | explicit scope rationale                  | `N/A`                   |
+| Analytics and KPI observability               | `supporting` | Supporting only: builder events should still distinguish local draft start, first save, resume, and discard if instrumentation exists or is later added.        | event contract review + scope note        | `4/5`                   |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, checkout, entitlement, or revenue path changes.                                                                                         | explicit scope rationale                  | `N/A`                   |
+| Incident response and support operations      | `supporting` | Supporting only: draft vs saved state should be diagnosable enough that future support/debug flows can tell which side of the boundary failed.                  | error-state review + docs if needed       | `4/5`                   |
+| Finance and reporting operations              | `N/A`        | N/A because no finance/reporting flow changes in this brief.                                                                                                    | explicit scope rationale                  | `N/A`                   |
+| i18n operational readiness                    | `N/A`        | N/A because this slice changes English owner-facing workflow copy and state logic only and should not block future localization architecture.                   | explicit scope rationale                  | `N/A`                   |
+| Stack-fit and dependency discipline           | `target`     | Reuse the current builder stack and local storage/state patterns where possible; do not add unnecessary dependencies or a second server-side placeholder model. | architecture review + dependency diff     | `5/5`                   |
+| Testing and QA automation                     | `target`     | Coverage locks local-draft creation, resume, discard, first save, post-save edit behavior, and `My Swim Sessions` visibility boundaries.                        | unit/e2e coverage + verify gates          | `5/5`                   |
+| Scalability and cost efficiency               | `supporting` | Supporting only: removing accidental placeholder rows should reduce list clutter and wasted storage churn rather than creating more hidden complexity.          | product review + data-boundary review     | `4/5`                   |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: the change should remain reversible without data migration surprises or orphan canonical rows.                                                 | rollback notes + PR slicing plan          | `4/5`                   |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - saved swim session record,
+  - stable canonical session ID,
+  - `My Swim Sessions` list membership.
+- Local-only:
+  - unsaved builder draft for the current mode (`pool` or `open_water`),
+  - local draft recovery marker/state,
+  - local discard action before first save.
+- Sync policy:
+  - opening the builder starts or resumes a local draft,
+  - first explicit save creates the canonical session and switches the editor into normal saved-session mode,
+  - after first save, the current canonical save/discard-changes model remains authoritative.
+- Retention and sensitivity:
+  - local drafts are device/browser-local only,
+  - at most one recoverable local draft per builder mode.
+- Cache/invalidation:
+  - no list invalidation on local draft start/resume/discard,
+  - invalidate canonical list/detail views only after first save or later canonical mutation.
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - created only on first save.
+- Human-readable identifiers:
+  - draft title/copy may exist locally before save but is not canonical identity.
+- Mutability rules:
+  - local draft has no canonical session ID,
+  - saved session follows the existing canonical edit model after first save.
+- Rename vs repurpose policy:
+  - editing an existing saved session remains in-place canonical editing,
+  - local draft before first save is not a canonical entity and must not be repurposed as a ghost saved row.
+- Compatibility contract:
+  - existing saved sessions remain in `My Swim Sessions`,
+  - new manual sessions do not appear there until first save.
+- Observability and repair:
+  - failed first save should report failure clearly and keep the draft local,
+  - no placeholder canonical row should require cleanup after an aborted create.
+
+## Scope
+
+- Manual `Build pool session` and `Build open water session` entry behavior.
+- Local draft recovery/discard behavior before first save.
+- First-save canonical creation boundary.
+- `My Swim Sessions` visibility contract for unsaved vs saved sessions.
+- Builder wording/state distinctions between:
+  - local draft,
+  - saved session,
+  - discard draft,
+  - save changes,
+  - discard changes.
+- Targeted tests and state-management updates needed to make this truthful end to end.
+
+## Out Of Scope
+
+- AI-generated session draft flow unless it directly collides with the manual local-draft model.
+- Broader builder layout polish unrelated to this data boundary.
+- Poolside print/panel polish.
+- Maintenance/tooling/ops/governance work.
+
+## Acceptance Criteria
+
+1. Clicking `Build pool session` or `Build open water session` does not create a canonical saved row immediately.
+2. No new row appears in `My Swim Sessions` until the first explicit save.
+3. Local draft has no canonical session ID before first save.
+4. At most one recoverable local draft exists per builder mode.
+5. Re-clicking the same create action resumes the existing local draft instead of creating another one.
+6. Local drafts expose a clear `Discard draft` action.
+7. After first save, the session becomes canonical, appears in `My Swim Sessions`, and uses the normal saved-session model.
+8. Existing saved sessions do not adopt `Delete draft` wording.
+
+## Validation
+
+- `npm run lint:briefs`
+- targeted unit coverage for local draft state and canonical creation boundary
+- targeted e2e coverage for:
+  - start manual session,
+  - resume local draft,
+  - discard draft,
+  - first save creates list row,
+  - post-save edit flow
+- `npm run verify:pre-pr`
+- `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js LTS and npm installed locally.
+- Local validation from repo root.
+
+## Manual QA Environments
+
+- Local:
+  - `/my-library`
+  - `/my-library/workouts`
+  - manual pool/open-water builder entry
+- Preview:
+  - PR preview URL after implementation
+
+## Constraints
+
+- Treat this as product-flow and data-boundary work, not copy-only polish.
+- Keep list truthfulness strict.
+- Do not ship a hidden server placeholder model under local-draft wording.
+- Prefer one narrow implementation slice sequence rather than a giant builder rewrite.
+
+## 10/10 Quality Bar
+
+- Zero accidental clutter in `My Swim Sessions`.
+- Clear mental model between local draft and saved session.
+- No accidental server persistence before first save.
+- Clear recovery path if the user leaves and returns.
+- No confusing duplication between local draft state and canonical session state.
+
+## Checkpoint Log
+
+- `2026-04-18 | working tree | implemented device-local manual draft storage, routed manual pool/open-water entry through local draft URLs, delayed canonical workout creation until the first explicit save, and updated targeted unit + Playwright coverage for resume/discard/first-save list boundaries; targeted validation is green via npx vitest run tests/unit/create-manual-workout-button.test.tsx tests/unit/workout-builder-hub.test.tsx and npx playwright test tests/e2e/my-library-workout-builder.spec.ts --project=desktop-chromium --project=mobile-chromium | next: run full brief lint + npm run verify:pre-pr, then commit, push, and open/update the PR`
+- `2026-04-18 | verification checkpoint | full \`npm run verify:pre-pr\` passed after updating the program-export Playwright flow to follow the same local-draft-first-save boundary; validation finished green with \`158\` unit files / \`805\` tests, full public Playwright \`101 passed\` / \`331 skipped\`, and perf-budget recommendation \`hold\` because the weekly tighten threshold is still at runs \`1/2\` despite a healthy \`36.0%\` margin | next: commit the scoped changes, push the feature branch, open/update the PR, watch CI, then run \`npm run verify:pre-merge\` before merge recommendation`

--- a/lib/workouts/manual-local-draft.ts
+++ b/lib/workouts/manual-local-draft.ts
@@ -1,0 +1,146 @@
+import type { SessionDraft } from "@/lib/session-generator-v1/shared";
+import {
+  buildManualOpenWaterWorkoutEmptyDraft,
+  buildManualPoolWorkoutEmptyDraft,
+  type ManualWorkoutBuilderMode,
+  type ManualWorkoutDraftDefaults,
+} from "@/lib/workouts/manual";
+
+const MANUAL_WORKOUT_LOCAL_DRAFT_STORAGE_PREFIX = "my-library-manual-workout-draft-v1:";
+
+type StoredManualWorkoutDraft = {
+  version: 1;
+  mode: ManualWorkoutBuilderMode;
+  draft: SessionDraft;
+  updatedAt: number;
+};
+
+function isBrowser() {
+  return typeof window !== "undefined";
+}
+
+function buildFallbackDraft(
+  mode: ManualWorkoutBuilderMode,
+  defaults?: ManualWorkoutDraftDefaults
+): SessionDraft {
+  return mode === "pool"
+    ? buildManualPoolWorkoutEmptyDraft(new Date(), defaults)
+    : buildManualOpenWaterWorkoutEmptyDraft(new Date(), defaults);
+}
+
+function isStoredManualWorkoutDraft(
+  value: unknown,
+  mode: ManualWorkoutBuilderMode
+): value is StoredManualWorkoutDraft {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<StoredManualWorkoutDraft>;
+  const draft = candidate.draft as Partial<SessionDraft> | undefined;
+  const expectedEnvironment = mode === "pool" ? "pool" : "open_water";
+
+  return (
+    candidate.version === 1 &&
+    candidate.mode === mode &&
+    typeof candidate.updatedAt === "number" &&
+    draft !== undefined &&
+    typeof draft.title === "string" &&
+    typeof draft.sourceFingerprint === "string" &&
+    draft.environment === expectedEnvironment &&
+    Array.isArray(draft.steps)
+  );
+}
+
+export function buildManualWorkoutLocalDraftStorageKey(
+  userId: string,
+  mode: ManualWorkoutBuilderMode
+) {
+  return `${MANUAL_WORKOUT_LOCAL_DRAFT_STORAGE_PREFIX}${userId}:${mode}`;
+}
+
+export function readStoredManualWorkoutDraft(
+  userId: string,
+  mode: ManualWorkoutBuilderMode
+): SessionDraft | null {
+  if (!isBrowser()) {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(buildManualWorkoutLocalDraftStorageKey(userId, mode));
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isStoredManualWorkoutDraft(parsed, mode)) {
+      return null;
+    }
+
+    return parsed.draft;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredManualWorkoutDraft(
+  userId: string,
+  mode: ManualWorkoutBuilderMode,
+  draft: SessionDraft
+) {
+  if (!isBrowser()) {
+    return;
+  }
+
+  try {
+    const snapshot: StoredManualWorkoutDraft = {
+      version: 1,
+      mode,
+      draft,
+      updatedAt: Date.now(),
+    };
+
+    window.localStorage.setItem(
+      buildManualWorkoutLocalDraftStorageKey(userId, mode),
+      JSON.stringify(snapshot)
+    );
+  } catch {
+    // local draft persistence is best effort only
+  }
+}
+
+export function clearStoredManualWorkoutDraft(userId: string, mode: ManualWorkoutBuilderMode) {
+  if (!isBrowser()) {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(buildManualWorkoutLocalDraftStorageKey(userId, mode));
+  } catch {
+    // local draft persistence is best effort only
+  }
+}
+
+export function loadOrCreateStoredManualWorkoutDraft(
+  userId: string,
+  mode: ManualWorkoutBuilderMode,
+  defaults?: ManualWorkoutDraftDefaults
+): { draft: SessionDraft; recovered: boolean } {
+  const storedDraft = readStoredManualWorkoutDraft(userId, mode);
+
+  if (storedDraft) {
+    return {
+      draft: storedDraft,
+      recovered: true,
+    };
+  }
+
+  const draft = buildFallbackDraft(mode, defaults);
+  writeStoredManualWorkoutDraft(userId, mode, draft);
+
+  return {
+    draft,
+    recovered: false,
+  };
+}

--- a/tests/e2e/my-library-program-export.spec.ts
+++ b/tests/e2e/my-library-program-export.spec.ts
@@ -101,7 +101,7 @@ async function waitForWorkoutBuilderSaveReady(page: Page) {
   const saveVisible = await saveButton.isVisible({ timeout: 15_000 }).catch(() => false);
   if (!saveVisible) {
     await page.reload({ waitUntil: "domcontentloaded" });
-    await waitForWorkoutBuilderRoute(page);
+    await waitForAnyWorkoutBuilderRoute(page);
     await waitForRouteToSettle(page);
     await waitForWorkoutBuilderClientReady(page);
   }
@@ -109,7 +109,26 @@ async function waitForWorkoutBuilderSaveReady(page: Page) {
   await expect(saveButton).toBeVisible({ timeout: 15_000 });
 }
 
-async function waitForWorkoutBuilderRoute(page: Page) {
+async function waitForAnyWorkoutBuilderRoute(page: Page) {
+  await page.waitForURL(/\/my-library\/workouts(?:\/[0-9a-f-]+)?(?:\?.*)?$/, {
+    timeout: 60_000,
+    waitUntil: "commit",
+  });
+  await page.waitForLoadState("domcontentloaded");
+}
+
+async function waitForLocalWorkoutBuilderRoute(page: Page) {
+  await page.waitForURL(
+    /\/my-library\/workouts\?draft=(?:pool|open_water)&entry=manual-(?:pool|open-water)$/,
+    {
+      timeout: 60_000,
+      waitUntil: "commit",
+    }
+  );
+  await page.waitForLoadState("domcontentloaded");
+}
+
+async function waitForSavedWorkoutBuilderRoute(page: Page) {
   await page.waitForURL(/\/my-library\/workouts\/[0-9a-f-]+(?:\?entry=manual-pool)?$/, {
     timeout: 60_000,
     waitUntil: "commit",
@@ -214,35 +233,39 @@ test.describe("my library program export", () => {
       return;
     }
 
-    const createWorkoutResponsePromise = page.waitForResponse(
-      (response) =>
-        response.url().includes("/api/my-library/workouts") &&
-        response.request().method() === "POST" &&
-        response.status() === 200
-    );
-
     await triggerCreateSession(page, "my-library-create-pool-workout");
-    await createWorkoutResponsePromise;
-    await waitForWorkoutBuilderRoute(page);
-    const workoutId = page.url().match(/\/my-library\/workouts\/([0-9a-f-]+)/i)?.[1];
-    expect(workoutId).toBeTruthy();
+    await waitForLocalWorkoutBuilderRoute(page);
     await waitForWorkoutBuilderClientReady(page);
     await waitForWorkoutBuilderSaveReady(page);
     await ensureWorkoutMetadataOpen(page);
     await expect(page.getByTestId("session-draft-step-toggle-0")).toBeVisible({ timeout: 15_000 });
 
     await page.getByTestId("session-draft-title").fill(uniqueWorkoutTitle);
+    await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
+      "This session is not saved yet."
+    );
 
     const saveWorkoutResponsePromise = page.waitForResponse(
       (response) =>
-        /\/api\/my-library\/workouts\/[0-9a-f-]+$/.test(response.url()) &&
-        response.request().method() === "PATCH" &&
+        response.url().endsWith("/api/my-library/workouts") &&
+        response.request().method() === "POST" &&
         response.status() === 200
     );
 
     await page.getByTestId("workout-builder-save").click();
-    await saveWorkoutResponsePromise;
-    await expect(page.getByText("Changes saved to this session.")).toBeVisible();
+    const saveWorkoutResponse = await saveWorkoutResponsePromise;
+    const saveWorkoutBody = (await saveWorkoutResponse.json().catch(() => null)) as {
+      ok?: boolean;
+    } | null;
+    expect(saveWorkoutBody?.ok).toBe(true);
+    await waitForSavedWorkoutBuilderRoute(page);
+    await waitForWorkoutBuilderClientReady(page);
+    await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
+      "All changes are saved to this session."
+    );
+
+    const workoutId = page.url().match(/\/my-library\/workouts\/([0-9a-f-]+)/i)?.[1];
+    expect(workoutId).toBeTruthy();
 
     await gotoWithTransientRetry(page, "/my-library", 60_000);
     await expect(page.getByRole("heading", { name: "My Library" })).toBeVisible();

--- a/tests/e2e/my-library-workout-builder.spec.ts
+++ b/tests/e2e/my-library-workout-builder.spec.ts
@@ -1,7 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import {
-  clickHrefAndAwaitUrlOrRetryGoto,
   gotoWithTransientRetry,
   prewarmRoute,
   waitForRouteToSettle,
@@ -105,35 +104,30 @@ async function waitForWorkoutBuilderSaveReady(page: Page) {
   await expect(saveButton).toBeVisible({ timeout: 15_000 });
 }
 
-async function waitForWorkoutBuilderRoute(page: Page) {
-  await page.waitForURL(/\/my-library\/workouts\/[0-9a-f-]+(?:\?entry=manual-pool)?$/, {
-    timeout: 60_000,
-    waitUntil: "commit",
-  });
+async function waitForLocalWorkoutBuilderRoute(page: Page) {
+  await page.waitForURL(
+    /\/my-library\/workouts\?draft=(?:pool|open_water)&entry=manual-(?:pool|open-water)$/,
+    {
+      timeout: 60_000,
+      waitUntil: "commit",
+    }
+  );
   await page.waitForLoadState("domcontentloaded");
 }
 
-async function openSupportToolsPanel(page: Page) {
-  const toggle = page.getByTestId("workout-editor-support-tools-toggle");
-
-  if ((await toggle.count()) === 0) {
-    return;
-  }
-
-  if ((await toggle.getAttribute("aria-expanded")) === "false") {
-    await toggle.click();
-  }
+async function waitForSavedWorkoutBuilderRoute(page: Page) {
+  await page.waitForURL(
+    /\/my-library\/workouts\/[0-9a-f-]+(?:\?entry=manual-(?:pool|open-water))?$/,
+    {
+      timeout: 60_000,
+      waitUntil: "commit",
+    }
+  );
+  await page.waitForLoadState("domcontentloaded");
 }
 
 async function openMetadataPanelIfCollapsed(page: Page) {
   const toggle = page.getByTestId("workout-editor-metadata-toggle");
-  if ((await toggle.getAttribute("aria-expanded")) === "false") {
-    await toggle.click();
-  }
-}
-
-async function openRepeatGroupIfCollapsed(page: Page, groupIndex: number) {
-  const toggle = page.getByTestId(`session-draft-repeat-toggle-${groupIndex}`);
   if ((await toggle.getAttribute("aria-expanded")) === "false") {
     await toggle.click();
   }
@@ -172,16 +166,8 @@ test.describe("my library workout builder", () => {
       return;
     }
 
-    const createResponsePromise = page.waitForResponse(
-      (response) =>
-        response.url().includes("/api/my-library/workouts") &&
-        response.request().method() === "POST" &&
-        response.status() === 200
-    );
-
     await triggerCreateSession(page, "my-library-create-pool-workout");
-    await createResponsePromise;
-    await waitForWorkoutBuilderRoute(page);
+    await waitForLocalWorkoutBuilderRoute(page);
     await waitForWorkoutBuilderClientReady(page);
     await waitForWorkoutBuilderSaveReady(page);
 
@@ -241,14 +227,11 @@ test.describe("my library workout builder", () => {
   }, testInfo) => {
     runOnceOnDesktopChromium(testInfo.project.name);
     test.slow();
-    test.setTimeout(180_000);
+    test.setTimeout(120_000);
 
-    const uniqueTitle = `QA manual workout ${Date.now()}`;
+    const uniqueTitle = `QA local draft ${Date.now()}`;
 
     await loginToMyLibraryViaDevBypass(page);
-    await expect(page.getByRole("link", { name: "Jump to owned items" })).toHaveCount(0);
-    await expect(page.getByRole("link", { name: "Jump to explore section" })).toHaveCount(0);
-    await expect(page.getByRole("heading", { name: "Program builder preview" })).toBeVisible();
 
     const createButton = page.getByTestId("my-library-create-pool-workout");
     const schemaReady = await createButton.isVisible().catch(() => false);
@@ -260,604 +243,63 @@ test.describe("my library workout builder", () => {
       return;
     }
 
-    const createResponsePromise = page.waitForResponse(
-      (response) =>
-        response.url().includes("/api/my-library/workouts") &&
-        response.request().method() === "POST" &&
-        response.status() === 200
-    );
-
     await triggerCreateSession(page, "my-library-create-pool-workout");
-    await createResponsePromise;
-    await waitForWorkoutBuilderRoute(page);
+    await waitForLocalWorkoutBuilderRoute(page);
     await waitForWorkoutBuilderClientReady(page);
     await waitForWorkoutBuilderSaveReady(page);
+
     await expect(
       page.getByRole("heading", { level: 1, name: "Pool session builder" })
     ).toBeVisible();
-    await expect(page.getByTestId("workout-builder-hub")).toHaveAttribute(
-      "data-containment-style",
-      "flat"
-    );
-    await expect(page.getByTestId("workout-editor-pool-size-panel")).toHaveAttribute(
-      "data-containment-style",
-      "integrated"
-    );
-    await expect(page.getByTestId("workout-editor-support-tools-panel")).toHaveAttribute(
-      "data-containment-style",
-      "sectioned"
-    );
-    await expect(page.getByTestId("workout-editor-poolside-panel")).toHaveAttribute(
-      "data-containment-style",
-      "split"
-    );
-
-    await expect(page.getByTestId("workout-editor-metadata-toggle")).toHaveAttribute(
-      "aria-expanded",
-      "true"
-    );
-    await expect(page.getByTestId("workout-editor-danger-zone")).toHaveCount(0);
-    await expect(page.getByTestId("workout-builder-delete-current-workout")).toHaveText(
-      "Delete session"
-    );
-    await expect(page.getByRole("link", { name: "My Swim Sessions" })).toBeVisible();
-    await expect(page.getByRole("link", { name: "AI-generated session" })).toHaveCount(0);
-    await expect(page.getByTestId("workout-builder-create-pool")).toHaveCount(0);
-    await expect(page.getByTestId("workout-builder-create-open-water")).toHaveCount(0);
-    await expect(
-      page.getByTestId("workout-editor-metadata-panel").getByText("Untitled pool session")
-    ).toBeVisible();
-    await expect(
-      page.getByTestId("workout-editor-metadata-panel").getByRole("button", {
-        name: "View PDF",
-      })
-    ).toBeVisible();
-    await expect(
-      page.getByTestId("workout-editor-metadata-panel").getByRole("button", {
-        name: "Discard changes",
-      })
-    ).toHaveCount(0);
-    await expect(
-      page.getByTestId("workout-editor-metadata-panel").getByTestId("workout-builder-save")
-    ).toBeVisible();
-    await expect(page.getByText("Canonical full-session PDF")).toHaveCount(0);
-    await expect(page.getByText("canonical workout")).toHaveCount(0);
-    await expect(page.getByText("Title through equipment")).toHaveCount(0);
-    await expect(page.getByTestId("session-draft-title")).toBeVisible();
-    await expect(page.getByText("Session details")).toBeVisible();
-    await expect(page.getByText("Session note")).toBeVisible();
-    await expect(page.getByText("Pool Size", { exact: true })).toBeVisible();
-    await expect(page.getByTestId("workout-editor-builder-mode-rearrange")).toBeVisible();
-    await expect(page.getByTestId("workout-editor-builder-mode-view")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Meters" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Yards" })).toBeVisible();
-    await expect(
-      page.getByTestId("workout-editor-pool-size-panel").getByText("Unit", { exact: true })
-    ).toHaveCount(0);
-    await expect(
-      page.getByTestId("workout-editor-pool-size-panel").getByText("Common sizes", {
-        exact: true,
-      })
-    ).toHaveCount(0);
-    await expect(
-      page.getByTestId("workout-editor-pool-size-panel").getByText("Exact size", { exact: true })
-    ).toHaveCount(0);
-    await expect(page.getByLabel("Exact pool size (m)")).toHaveValue("25");
-    const poolSizePanelBox = await page.getByTestId("workout-editor-pool-size-panel").boundingBox();
-    const poolSizePresetBox = await page.getByRole("button", { name: "50m" }).boundingBox();
-    const poolSizeInputBox = await page.getByLabel("Exact pool size (m)").boundingBox();
-    expect(poolSizePanelBox).not.toBeNull();
-    expect(poolSizePresetBox).not.toBeNull();
-    expect(poolSizeInputBox).not.toBeNull();
-    expect(poolSizeInputBox!.width).toBeLessThan(180);
-    expect(poolSizeInputBox!.x).toBeLessThan(poolSizePanelBox!.x + poolSizePanelBox!.width * 0.7);
-    expect(poolSizeInputBox!.x).toBeLessThanOrEqual(
-      poolSizePresetBox!.x + poolSizePresetBox!.width + 120
-    );
-    await expect(page.getByRole("group", { name: "Environment" })).toHaveCount(0);
-    await expect(page.getByText("Training profile")).toHaveCount(0);
-    await expect(page.locator("fieldset").filter({ hasText: "Session strokes" })).toHaveCount(0);
-    await expect(page.locator("fieldset").filter({ hasText: "Equipment" })).toHaveCount(0);
-    await expect(page.getByRole("combobox", { name: "Session type" })).toHaveCount(0);
-    await expect(page.getByRole("combobox", { name: "Effort" })).toHaveCount(0);
-    await expect(page.getByTestId("session-draft-step-summary-0")).toBeVisible();
-    await expect(page.getByTestId("session-draft-step-toggle-0")).toBeVisible();
-    await expect(page.getByTestId("session-draft-repeat-summary-2")).toContainText("Main");
-    await expect(page.getByTestId("session-draft-repeat-summary-2")).toContainText("Freestyle");
-    await expect(page.getByTestId("session-draft-repeat-summary-2")).not.toContainText(
-      "Repeat block"
-    );
-    const collapsedStepSummaryBox = await page
-      .getByTestId("session-draft-step-summary-0")
-      .boundingBox();
-    const collapsedStepToggleBox = await page
-      .getByTestId("session-draft-step-toggle-0")
-      .boundingBox();
-    expect(collapsedStepSummaryBox).not.toBeNull();
-    expect(collapsedStepToggleBox).not.toBeNull();
-    expect(collapsedStepToggleBox!.x).toBeGreaterThan(collapsedStepSummaryBox!.x + 120);
-    expect(collapsedStepToggleBox!.y).toBeLessThan(
-      collapsedStepSummaryBox!.y + collapsedStepSummaryBox!.height
-    );
-    await page.getByTestId("workout-editor-builder-mode-view").click();
-    await expect(page.getByTestId("session-draft-add-step")).toHaveCount(0);
-    await expect(page.getByTestId("session-draft-add-repeat")).toHaveCount(0);
-    await expect(page.getByTestId("workout-editor-metadata-toggle")).toHaveCount(0);
-    await expect(page.getByText("Edit repeat")).toHaveCount(0);
-    const viewSections = page.locator('[data-testid^="workout-editor-view-section-"]');
-    await expect(viewSections.first()).toBeVisible();
-    expect(await viewSections.count()).toBeGreaterThanOrEqual(3);
-    const firstViewSectionBox = await viewSections.nth(0).boundingBox();
-    const secondViewSectionBox = await viewSections.nth(1).boundingBox();
-    expect(firstViewSectionBox).not.toBeNull();
-    expect(secondViewSectionBox).not.toBeNull();
-    expect(Math.abs(firstViewSectionBox!.width - secondViewSectionBox!.width)).toBeLessThanOrEqual(
-      20
-    );
-    const viewRepeatCard = page.getByTestId(/workout-editor-view-repeat-/);
-    await viewRepeatCard.click();
-    await expect(page.getByTestId("session-draft-repeat-count-2")).toBeVisible();
-    await expect(page.getByLabel("Step Type")).toHaveCount(0);
-    await page.getByTestId("workout-editor-builder-mode-rearrange").click();
-    await expect(page.getByTestId("session-draft-add-step")).toHaveCount(0);
-    await expect(page.getByTestId("session-draft-add-repeat")).toHaveCount(0);
-    await expect(page.getByTestId("session-draft-step-toggle-0")).toHaveCount(0);
-    await expect(page.getByTestId("session-draft-repeat-toggle-2")).toHaveCount(0);
-    await expect(page.getByTestId("session-draft-step-rearrange-controls-0")).toBeVisible();
-    await expect(page.getByTestId("session-draft-repeat-rearrange-controls-2")).toBeVisible();
-    await page.getByTestId("session-draft-step-summary-0").click();
-    await expect(page.getByLabel("Step Type")).toHaveCount(0);
-    await page.getByTestId("workout-editor-builder-mode-edit").click();
-    await expect(page.getByTestId("session-draft-step-toggle-0")).toBeVisible();
-    await page.getByTestId("session-draft-step-summary-0").click();
-    await expect(page.getByTestId("session-draft-step-desktop-actions-0")).toHaveAttribute(
-      "data-desktop-layout",
-      "bottom"
-    );
-    const stepSummaryBox = await page.getByTestId("session-draft-step-summary-0").boundingBox();
-    const stepActionsBox = await page
-      .getByTestId("session-draft-step-desktop-actions-0")
-      .boundingBox();
-    expect(stepSummaryBox).not.toBeNull();
-    expect(stepActionsBox).not.toBeNull();
-    expect(stepActionsBox!.y).toBeGreaterThanOrEqual(
-      stepSummaryBox!.y + stepSummaryBox!.height - 2
-    );
-    await expect(
-      page.getByTestId("workout-editor-panel").getByRole("heading", { name: "Session steps" })
-    ).toBeVisible();
-    await expect(page.getByLabel("Step Type")).toBeVisible();
-    await expect(page.getByLabel("Stroke Type")).toBeVisible();
-    await expect(page.getByLabel("Drill Type")).toBeVisible();
-    await expect(page.getByLabel("Duration")).toBeVisible();
-    await expect(page.getByRole("combobox", { name: "Target" })).toBeVisible();
-    await expect(page.getByLabel("Notes", { exact: true })).toBeVisible();
-    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText("Distance");
-    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText("Time");
-    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
-      "Lap Button Press"
-    );
-    await expect(page.getByTestId("session-draft-step-duration-mode-0")).not.toContainText(
-      "Fixed Rest Time"
-    );
-    await expect(page.getByTestId("session-draft-step-duration-mode-0")).not.toContainText(
-      "Send-Off Time"
-    );
-    await expect(page.getByTestId("session-draft-step-duration-mode-0")).not.toContainText(
-      "CSS-Based Send-Off Time"
-    );
-    await expect(page.locator("label").filter({ hasText: /^Step name$/ })).toHaveCount(0);
-    await expect(page.locator("label").filter({ hasText: /^Effort cue$/ })).toHaveCount(0);
-    await expect(page.locator("label").filter({ hasText: /^Target summary$/ })).toHaveCount(0);
-    await expect(page.locator("label").filter({ hasText: /^Target notes$/ })).toHaveCount(0);
-    await page.getByLabel("Step Type").selectOption("rest");
-    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toHaveValue("fixed_rest");
-    await expect(page.getByLabel("Stroke Type")).toHaveCount(0);
-    await expect(page.getByLabel("Drill Type")).toHaveCount(0);
-    await expect(page.getByRole("combobox", { name: "Target" })).toHaveCount(0);
-    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
-      "Fixed Rest Time"
-    );
-    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
-      "Send-Off Time"
-    );
-    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
-      "CSS-Based Send-Off Time"
-    );
-    await expect(page.getByTestId("session-draft-step-duration-mode-0")).toContainText(
-      "Lap Button Press"
-    );
-    const restDurationOptions = page
-      .getByTestId("session-draft-step-duration-mode-0")
-      .locator("option");
-    await expect(restDurationOptions.filter({ hasText: /^Distance$/ })).toHaveCount(0);
-    await expect(restDurationOptions.filter({ hasText: /^Time$/ })).toHaveCount(0);
-    await page.getByLabel("Step Type").selectOption("main");
-    await page.getByTestId("session-draft-step-duration-mode-0").selectOption("time");
-    await page.getByTestId("session-draft-step-time-0").fill("1:30");
-    await page.getByTestId("session-draft-step-time-0").blur();
-    await expect(page.getByTestId("session-draft-step-time-0")).toHaveValue("1:30");
-    await page.getByTestId("session-draft-step-duration-mode-0").selectOption("distance");
-    await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
-      "Unsaved changes stay local until you save this session."
-    );
-    await expect(page.getByTestId("workout-editor-support-tools-toggle")).toHaveAttribute(
-      "aria-expanded",
-      "false"
-    );
-    await expect(page.getByTestId("workout-editor-support-tools-status")).toHaveText("Ready");
-    await expect(
-      page.getByText("Advanced export and support tools stay here when you need them.")
-    ).toHaveCount(0);
-    await openSupportToolsPanel(page);
-    await expect(
-      page.getByText("Advanced export and support tools stay here when you need them.")
-    ).toBeVisible();
-    await expect(page.getByText("Open, copy, or download here without saving.")).toBeVisible();
-    await page.getByTestId("workout-editor-garmin-export-toggle").click();
-    await page.getByTestId("workout-editor-handoff-toggle").click();
-    await expect(page.getByTestId("workout-editor-handoff-source")).toHaveAttribute(
-      "data-handoff-state",
-      "local_draft"
-    );
-    await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(
-      "Source: Local draft"
-    );
-    await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(
-      "Title: Untitled pool session"
-    );
-    await expect(page.getByTestId("workout-editor-garmin-export-source")).toHaveAttribute(
-      "data-export-state",
-      "local_draft"
-    );
-    await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
-      '"kind": "freeswimming_garmin_ready_workout_v1"'
-    );
-    await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
-      '"draftState": "local_draft"'
-    );
-    await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
-      '"label": "Distance"'
-    );
-    await expect(page.getByTestId("workout-builder-save")).toBeEnabled();
-
-    const savedWorkoutPdfPopupPromise = page.waitForEvent("popup");
-    await page.getByTestId("workout-editor-pdf-open").click();
-    const savedWorkoutPdfPopup = await savedWorkoutPdfPopupPromise;
-    await expect(
-      savedWorkoutPdfPopup.locator('[data-testid="workout-pdf-print-view"]')
-    ).toBeVisible();
-    await expect(savedWorkoutPdfPopup.locator('[data-testid="workout-pdf-source"]')).toContainText(
-      "Source: Local draft"
-    );
-    await expect(savedWorkoutPdfPopup.locator('[data-testid="workout-pdf-title"]')).toContainText(
-      "Untitled pool session"
-    );
-    await savedWorkoutPdfPopup.close();
-
-    await page.getByTestId("session-draft-step-remove-0").click();
-    await expect(page.getByTestId("workout-editor-removal-confirm")).toContainText(
-      "Delete 100m · Freestyle"
-    );
-    await expect(page.getByTestId("workout-builder-save")).toBeDisabled();
-    await page.getByTestId("workout-editor-removal-cancel-button").click();
-    await expect(page.getByTestId("workout-editor-removal-confirm")).toHaveCount(0);
-    await page.getByTestId("session-draft-step-remove-0").click();
-    await page.getByTestId("workout-editor-removal-confirm-button").click();
-    await expect(page.getByTestId("workout-editor-removal-undo")).toContainText(
-      "Deleted 100m · Freestyle"
-    );
-    await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
-      "Unsaved changes stay local until you save this session."
-    );
-    await page.getByTestId("workout-editor-removal-undo-button").click();
-    await expect(page.getByTestId("workout-editor-removal-undo")).toHaveCount(0);
-    await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
-      "Unsaved changes stay local until you save this session."
-    );
-    await expect(page.getByTestId("workout-builder-save")).toBeEnabled();
-
+    await expect(page.getByTestId("workout-builder-delete-current-workout")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Discard draft" })).toBeVisible();
     await openMetadataPanelIfCollapsed(page);
-    await expect(page.getByTestId("session-draft-title")).toHaveValue("");
-    await page.getByLabel("Exact pool size (m)").fill("33.33");
-    await expect(page.getByLabel("Exact pool size (m)")).toHaveValue("33.33");
-    await page.getByTestId("workout-editor-pool-length-unit-yd").click();
-    await expect(page.getByLabel("Exact pool size (yd)")).toBeVisible();
-    await expect(page.getByLabel("Exact pool size (yd)")).toHaveValue("25");
-    await page.getByTestId("workout-editor-pool-length-unit-m").click();
-    await expect(page.getByLabel("Exact pool size (m)")).toHaveValue("25");
-    await page.getByTestId("workout-editor-pool-length-unit-yd").click();
-    await expect(page.getByLabel("Exact pool size (yd)")).toHaveValue("25");
-    await page.getByTestId("session-draft-step-distance-0").selectOption("custom");
-    await expect(page.getByTestId("session-draft-step-distance-custom-0")).toBeFocused();
-    await page.getByTestId("session-draft-step-distance-custom-0").fill("333");
-    await openRepeatGroupIfCollapsed(page, 2);
-    await expect(page.getByTestId("session-draft-repeat-desktop-actions-2")).toHaveAttribute(
-      "data-desktop-layout",
-      "bottom"
-    );
-    const repeatSummaryBox = await page.getByTestId("session-draft-repeat-summary-2").boundingBox();
-    const repeatActionsBox = await page
-      .getByTestId("session-draft-repeat-desktop-actions-2")
-      .boundingBox();
-    expect(repeatSummaryBox).not.toBeNull();
-    expect(repeatActionsBox).not.toBeNull();
-    expect(repeatActionsBox!.y).toBeGreaterThanOrEqual(
-      repeatSummaryBox!.y + repeatSummaryBox!.height - 2
-    );
-    await page.getByTestId("session-draft-repeat-count-2").fill("6");
-    await expect(page.getByTestId("session-draft-repeat-ending-rest-mode-2")).toHaveValue(
-      "skip_last_rest"
-    );
-    await expect(page.getByText("Rest after last repeat")).toBeVisible();
-    const repeatSummary = page.getByTestId("session-draft-repeat-summary-2");
-    await expect(
-      repeatSummary.getByText(
-        "Fixed Rest Time 1:00 still runs between rounds. It is skipped only after the final round."
-      )
-    ).toHaveCount(0);
-    await expect(
-      repeatSummary.getByText(
-        "Fixed Rest Time 1:00 stays outside the repeat block as the post-set rest after the set."
-      )
-    ).toHaveCount(0);
-    await expect(repeatSummary.getByText("Final rest skipped")).toHaveCount(0);
-    await expect(repeatSummary).toContainText(
-      "6 x 100m · Freestyle · Moderate · Interval rest 0:30 · Set rest 0:30"
-    );
-    await expect(repeatSummary).not.toContainText("109.36yd");
-    await expect(page.getByText("Keeps the blue surfaces")).toBeVisible();
-    await expect(page.getByText("Uses white surfaces.")).toBeVisible();
-    await expect(page.getByText("Edit this into the exact repeat you want to hold.")).toHaveCount(
-      0
-    );
-    await expect(
-      page.getByText("Adjust or remove this recovery once the set is dialed in.")
-    ).toHaveCount(0);
-    await expect(page.getByText("Move the full repeat block from the header.")).toHaveCount(0);
-    await page.getByRole("button", { name: "Meters" }).click();
-    await expect(page.getByTestId("session-draft-step-summary-0")).toContainText(
-      "333yd · Freestyle · Easy"
-    );
-    await expect(page.getByTestId("session-draft-step-summary-0")).not.toContainText(
-      /304(?:\.49|\.5)m/
-    );
-    await expect(page.getByTestId("session-draft-repeat-summary-2")).toContainText(
-      "6 x 100m · Freestyle · Moderate · Interval rest 0:30 · Set rest 0:30"
-    );
-    await expect(page.getByTestId("session-draft-repeat-summary-2")).not.toContainText("109.36yd");
-    await page.getByTestId("session-draft-step-toggle-2").click();
-    await expect(
-      page.getByTestId("session-draft-repeat-summary-2").getByText("Repeat block")
-    ).toBeVisible();
-    await page.getByTestId("session-draft-step-distance-2").selectOption("200");
-    await page.getByTestId("session-draft-step-stroke-2").selectOption("backstroke");
-    await page.getByTestId("session-draft-step-drill-type-2").selectOption("pull");
-    await page.getByTestId("session-draft-step-equipment-2").selectOption("fins");
-    await page.getByTestId("session-draft-step-target-mode-2").selectOption("target_pace");
-    await page.getByTestId("session-draft-step-target-pace-minutes-2").fill("1");
-    await page.getByTestId("session-draft-step-target-pace-seconds-2").fill("35");
-    await page.getByTestId("session-draft-step-toggle-3").click();
-    await page.getByTestId("session-draft-step-rest-time-3").fill("0:45");
-    await page.getByTestId("session-draft-step-rest-time-3").blur();
-    await page
-      .getByTestId("session-draft-step-summary-3")
-      .locator("xpath=ancestor::article[1]")
-      .getByLabel("Notes", { exact: true })
-      .fill("Leave on the top and count strokes.");
     await page.getByTestId("session-draft-title").fill(uniqueTitle);
-    await expect(page.getByRole("button", { name: "Discard changes" })).toBeVisible();
-    await page.getByRole("button", { name: "Discard changes" }).click();
-    await expect(page.getByTestId("workout-editor-discard-undo")).toContainText(
-      "Changes discarded."
-    );
-    await expect(page.getByTestId("session-draft-title")).toHaveValue("Untitled pool session");
-    await expect(page.getByRole("button", { name: "Discard changes" })).toHaveCount(0);
-    await page.getByTestId("workout-editor-discard-undo-button").click();
-    await expect(page.getByTestId("workout-editor-discard-undo")).toHaveCount(0);
-    await expect(page.getByTestId("session-draft-title")).toHaveValue(uniqueTitle);
-    await expect(page.getByRole("button", { name: "Discard changes" })).toBeVisible();
     await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
-      "Unsaved changes stay local until you save this session."
+      "This session is not saved yet."
     );
-    await expect(page.getByTestId("workout-editor-support-tools-status")).toHaveText(
-      "1 review item"
-    );
-    await openSupportToolsPanel(page);
-    await expect(page.getByTestId("workout-editor-garmin-readiness")).toHaveAttribute(
-      "data-readiness-status",
-      "review"
-    );
-    await expect(page.getByTestId("workout-editor-garmin-readiness-summary")).toHaveText(
-      "Review 1 Garmin/export mapping detail before you treat this workout as handoff-ready."
-    );
-    await expect(page.getByText(/open focuses will be included on the poolside note/i)).toHaveCount(
-      0
-    );
-    await expect(
-      page.getByText(
-        "Color-first output. Turn on Print backgrounds in your browser if you want the blue fills."
-      )
-    ).toHaveCount(0);
-    await page.getByTestId("workout-editor-garmin-readiness-toggle").click();
-    await expect(page.getByTestId("workout-editor-garmin-readiness-issue-0")).toContainText("Fins");
-    await expect(page.getByTestId("workout-editor-garmin-readiness-issue-0")).toContainText(
-      "Manual Garmin translation is still required"
-    );
-    await expect(page.getByTestId("workout-editor-garmin-readiness-issue-1")).toHaveCount(0);
-    await expect(page.getByTestId("workout-editor-handoff-source")).toHaveAttribute(
-      "data-handoff-state",
-      "local_draft"
-    );
-    await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(
-      "Source: Local draft"
-    );
-    await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(uniqueTitle);
-    await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(
-      "Review before export/send"
-    );
-    await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(
-      "Final rest skipped"
-    );
-    await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(
-      "Notes: Leave on the top and count strokes."
-    );
-    await expect(page.getByTestId("workout-editor-garmin-export-source")).toHaveAttribute(
-      "data-export-state",
-      "local_draft"
-    );
-    await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
-      '"draftState": "local_draft"'
-    );
-    await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
-      '"repeatEndingRestMode": "skip_last_rest"'
-    );
-    await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
-      `"title": "${uniqueTitle}"`
-    );
-    await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
-      '"label": "Fixed Rest Time"'
-    );
-    await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
-      '"reviewIssueIds": ['
-    );
-    await expect(page.getByTestId("workout-editor-pdf-source")).toHaveAttribute(
-      "data-pdf-state",
-      "local_draft"
-    );
-    await expect(page.getByTestId("workout-editor-pdf-open")).toBeVisible();
-    await expect(page.getByRole("button", { name: "View PDF" })).toBeVisible();
-    await expect(page.getByTestId("workout-editor-poolside-pdf-open")).toBeVisible();
-    await page.getByTestId("workout-editor-poolside-style-ink-saver").click();
-    await page.getByTestId("workout-editor-poolside-layout-landscape").click();
-    await expect(page.getByText("Print options")).toBeVisible();
-    await expect(
-      page.getByTestId("workout-editor-poolside-panel").getByText("Style", { exact: true })
-    ).toBeVisible();
-    await expect(
-      page.getByTestId("workout-editor-poolside-panel").getByText("Layout", { exact: true })
-    ).toBeVisible();
-    await expect(
-      page.getByText(
-        "Optional. Use this for the whole-session purpose or one short coaching note that applies across the session."
-      )
-    ).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Save session" })).toBeVisible();
     await expect(page.getByTestId("workout-builder-save")).toBeEnabled();
 
-    const pdfPopupPromise = page.waitForEvent("popup");
-    await page.getByTestId("workout-editor-pdf-open").click();
-    const pdfPopup = await pdfPopupPromise;
-    await pdfPopup.waitForLoadState("domcontentloaded");
-    await expect(page.getByTestId("workout-editor-pdf-notice")).toContainText("Opened PDF");
-    await expect(pdfPopup.locator('[data-testid="workout-pdf-print-view"]')).toBeVisible();
-    await expect.poll(async () => pdfPopup.title()).toContain("FreeSwimming");
-    await expect(pdfPopup.locator('[data-testid="workout-pdf-source"]')).toContainText(
-      "Source: Local draft"
-    );
-    await expect(pdfPopup.locator('[data-testid="workout-pdf-title"]')).toContainText(uniqueTitle);
-    await expect(pdfPopup.locator("body")).toContainText("Workout PDF");
-    await expect(pdfPopup.locator("body")).toContainText("Print / Save PDF");
-    await expect(pdfPopup.locator("body")).toContainText("200m");
-    await expect(pdfPopup.locator("body")).toContainText("Backstroke");
-    await pdfPopup.close();
+    await gotoWithTransientRetry(page, "/my-library/workouts");
+    await waitForWorkoutBuilderClientReady(page);
+    await expect(page.getByRole("heading", { level: 1, name: "My Swim Sessions" })).toBeVisible();
+    await expect(
+      page.locator("[data-testid^='saved-workout-card-']", { hasText: uniqueTitle })
+    ).toHaveCount(0);
 
-    const poolsidePopupPromise = page.waitForEvent("popup");
-    await page.getByTestId("workout-editor-poolside-pdf-open").click();
-    const poolsidePopup = await poolsidePopupPromise;
-    await poolsidePopup.waitForLoadState("domcontentloaded");
-    await expect(poolsidePopup.locator('[data-testid="workout-pdf-print-view"]')).toHaveAttribute(
-      "data-pdf-variant",
-      "poolside"
-    );
-    await expect.poll(async () => poolsidePopup.title()).toContain("FreeSwimming");
-    await expect(poolsidePopup.locator('[data-testid="workout-pdf-print-view"]')).toHaveAttribute(
-      "data-poolside-print-style",
-      "ink_saver"
-    );
-    await expect(poolsidePopup.locator('[data-testid="workout-pdf-print-view"]')).toHaveAttribute(
-      "data-poolside-print-layout",
-      "landscape"
-    );
-    await expect(poolsidePopup.locator("body")).toContainText(uniqueTitle);
-    await expect(poolsidePopup.locator("body")).toContainText("Print Preview");
-    await expect(poolsidePopup.locator("body")).not.toContainText("Poolside Note");
-    await expect(poolsidePopup.locator("body")).not.toContainText("Color mode");
-    await expect(poolsidePopup.locator("body")).not.toContainText("Ink saver");
-    await expect(poolsidePopup.locator("body")).not.toContainText("Portrait");
-    await expect(poolsidePopup.locator("body")).not.toContainText("Landscape");
-    await expect(poolsidePopup.locator("body")).not.toContainText("Source: Local draft");
-    await expect(poolsidePopup.locator("body")).not.toContainText("Pool session execution");
-    await expect(poolsidePopup.locator("body")).toContainText("Total");
-    await expect(poolsidePopup.locator("body")).toContainText(/rest/i);
-    await expect(poolsidePopup.locator('[data-testid="workout-pdf-total"]')).toBeVisible();
-    await expect(poolsidePopup.locator('link[rel="icon"]')).toHaveAttribute("href", "/favicon.ico");
-    await expect(poolsidePopup.locator("body")).not.toContainText("P:");
-    await expect(poolsidePopup.locator("body")).not.toContainText("~");
-    await expect(poolsidePopup.locator("main.shell")).toBeVisible();
-    await expect(poolsidePopup.locator("article.page")).toBeVisible();
-    await page.waitForTimeout(1200);
-    await expect(poolsidePopup.locator('[data-testid="workout-pdf-print-view"]')).toBeVisible();
-    await poolsidePopup.close();
+    await triggerCreateSession(page, "workout-builder-browse-create-pool");
+    await waitForLocalWorkoutBuilderRoute(page);
+    await waitForWorkoutBuilderClientReady(page);
+    await waitForWorkoutBuilderSaveReady(page);
+    await openMetadataPanelIfCollapsed(page);
+    await expect(page.getByTestId("session-draft-title")).toHaveValue(uniqueTitle);
 
-    const patchResponsePromise = page.waitForResponse(
+    const firstSaveResponsePromise = page.waitForResponse(
       (response) =>
-        /\/api\/my-library\/workouts\/[0-9a-f-]+$/.test(response.url()) &&
-        response.request().method() === "PATCH"
+        response.url().endsWith("/api/my-library/workouts") &&
+        response.request().method() === "POST"
     );
 
     await page.getByTestId("workout-builder-save").click();
-    const patchResponse = await patchResponsePromise;
-    const patchPayload = (await patchResponse.json().catch(() => null)) as { ok?: boolean } | null;
+    const firstSaveResponse = await firstSaveResponsePromise;
+    const firstSavePayload = (await firstSaveResponse.json().catch(() => null)) as {
+      ok?: boolean;
+    } | null;
 
-    expect(patchResponse.status()).toBe(200);
-    expect(patchPayload?.ok).toBe(true);
+    expect(firstSaveResponse.status()).toBe(200);
+    expect(firstSavePayload?.ok).toBe(true);
+    await waitForSavedWorkoutBuilderRoute(page);
+    await waitForWorkoutBuilderClientReady(page);
 
-    await expect(page.getByText("Changes saved to this session.")).toBeVisible();
-    await openSupportToolsPanel(page);
+    await expect(page.getByRole("button", { name: "Discard draft" })).toHaveCount(0);
+    await expect(page.getByTestId("workout-builder-delete-current-workout")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Save changes" })).toBeVisible();
     await expect(page.getByTestId("workout-editor-save-state")).toHaveText(
       "All changes are saved to this session."
     );
-    await expect(page.getByTestId("workout-editor-garmin-readiness")).toHaveAttribute(
-      "data-readiness-status",
-      "review"
-    );
-    await expect(page.getByTestId("workout-editor-handoff-source")).toHaveAttribute(
-      "data-handoff-state",
-      "canonical"
-    );
-    await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(
-      "Source: Canonical workout"
-    );
-    await expect(page.getByTestId("workout-editor-handoff-preview")).toContainText(uniqueTitle);
-    await expect(page.getByTestId("workout-editor-garmin-export-source")).toHaveAttribute(
-      "data-export-state",
-      "canonical"
-    );
-    await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
-      '"draftState": "canonical"'
-    );
-    await expect(page.getByTestId("workout-editor-garmin-export-preview")).toContainText(
-      `"title": "${uniqueTitle}"`
-    );
-    await expect(page.getByTestId("workout-builder-save")).toBeDisabled();
-    await expect(page.getByRole("button", { name: "Discard changes" })).toHaveCount(0);
+    await openMetadataPanelIfCollapsed(page);
     await expect(page.getByTestId("session-draft-title")).toHaveValue(uniqueTitle);
-    await expect(page.getByTestId("session-draft-pool-length-input")).toHaveValue("25");
-    await page.getByTestId("session-draft-step-toggle-0").click();
-    await expect(page.getByTestId("session-draft-step-distance-0")).toHaveValue("custom");
-    await expect(page.getByTestId("session-draft-step-distance-custom-0")).toHaveValue("333");
-    await openRepeatGroupIfCollapsed(page, 2);
-    await expect(page.getByTestId("session-draft-repeat-count-2")).toHaveValue("6");
-    await page.getByTestId("session-draft-step-toggle-2").click();
-    await expect(page.getByTestId("session-draft-step-distance-2")).toHaveValue("200");
-    await expect(page.getByTestId("session-draft-step-stroke-2")).toHaveValue("backstroke");
-    await expect(page.getByTestId("session-draft-step-drill-type-2")).toHaveValue("pull");
-    await expect(page.getByTestId("session-draft-step-equipment-2")).toHaveValue("fins");
-    await expect(page.getByTestId("session-draft-step-target-mode-2")).toHaveValue("target_pace");
-    await expect(page.getByTestId("session-draft-step-target-pace-minutes-2")).toHaveValue("1");
-    await expect(page.getByTestId("session-draft-step-target-pace-seconds-2")).toHaveValue("35");
-    await expect(page.locator("fieldset").filter({ hasText: "Session strokes" })).toHaveCount(0);
-    await expect(page.locator("fieldset").filter({ hasText: "Equipment" })).toHaveCount(0);
 
     const workoutMatch = new URL(page.url()).pathname.match(
       /\/my-library\/workouts\/([0-9a-f-]+)$/
@@ -865,91 +307,73 @@ test.describe("my library workout builder", () => {
     expect(workoutMatch?.[1]).toBeTruthy();
     const workoutId = workoutMatch![1];
 
-    const viewSessionsLink = page.getByTestId("workout-builder-view-sessions-link");
-    const viewSessionsHref = await viewSessionsLink.getAttribute("href");
-    if (viewSessionsHref) {
-      await clickHrefAndAwaitUrlOrRetryGoto({
-        page,
-        trigger: viewSessionsLink,
-        href: viewSessionsHref,
-        expectedUrl: /\/my-library\/workouts(?:\?.*)?$/,
-        clickNavigationTimeoutMs: 10_000,
-      });
-    } else {
-      await Promise.all([
-        page.waitForURL(/\/my-library\/workouts(?:\?.*)?$/, {
-          timeout: 20_000,
-          waitUntil: "domcontentloaded",
-        }),
-        viewSessionsLink.click(),
-      ]);
-    }
-    await waitForRouteToSettle(page);
+    await gotoWithTransientRetry(page, "/my-library/workouts");
     await waitForWorkoutBuilderClientReady(page);
     await expect(page.getByRole("heading", { level: 1, name: "My Swim Sessions" })).toBeVisible();
     await expect(page.getByTestId(`saved-workout-card-${workoutId}`)).toBeVisible();
-    await expect(page.getByTestId(`saved-workout-card-${workoutId}`)).not.toContainText("Updated");
+    await expect(page.getByTestId(`saved-workout-card-${workoutId}`)).toContainText(uniqueTitle);
     const savedWorkoutPreview = await openSavedWorkoutPreview(page, workoutId);
-    await expect(savedWorkoutPreview).not.toContainText("Quick preview");
     await expect(savedWorkoutPreview).toContainText("Total");
-    await expect(savedWorkoutPreview).toContainText("Rest");
-    await page.getByTestId(`saved-workouts-poolside-${workoutId}`).click();
-    await expect(page.getByTestId(`saved-workout-poolside-${workoutId}-panel`)).toBeVisible();
-    await expect(
-      page.getByTestId(`saved-workout-poolside-${workoutId}-print-preview`)
-    ).toHaveAttribute("href", /focusMode=custom/);
-    await expect(
-      page.getByTestId(`saved-workout-poolside-${workoutId}-print-preview`)
-    ).toHaveAttribute("href", /notationMode=auto/);
-    await expect(
-      page.getByTestId(`saved-workout-poolside-${workoutId}-print-preview`)
-    ).toHaveAttribute("href", /restLayout=auto/);
-    const editWorkoutLink = page.getByTestId(`workout-builder-edit-workout-${workoutId}`);
-    const editWorkoutHref = await editWorkoutLink.getAttribute("href");
-    if (editWorkoutHref) {
-      await clickHrefAndAwaitUrlOrRetryGoto({
-        page,
-        trigger: editWorkoutLink,
-        href: editWorkoutHref,
-        expectedUrl: new RegExp(`/my-library/workouts/${workoutId}$`),
-        clickNavigationTimeoutMs: 10_000,
-      });
-    } else {
-      await editWorkoutLink.click();
-      await page.waitForURL(new RegExp(`/my-library/workouts/${workoutId}$`), {
-        timeout: 20_000,
-        waitUntil: "domcontentloaded",
-      });
+  });
+
+  test("resumes and discards a local pool draft without adding it to My Swim Sessions first", async ({
+    page,
+  }, testInfo) => {
+    runOnceOnDesktopChromium(testInfo.project.name);
+    test.slow();
+
+    await loginToMyLibraryViaDevBypass(page);
+
+    const createButton = page.getByTestId("my-library-create-pool-workout");
+    const schemaReady = await createButton.isVisible().catch(() => false);
+
+    if (!schemaReady) {
+      await expect(
+        page.getByText("This canonical swim-session layer is still syncing in this environment.")
+      ).toBeVisible();
+      return;
     }
+
+    const resumeTitle = `Recovered local draft ${Date.now()}`;
+
+    await triggerCreateSession(page, "my-library-create-pool-workout");
+    await waitForLocalWorkoutBuilderRoute(page);
     await waitForWorkoutBuilderClientReady(page);
+    await waitForWorkoutBuilderSaveReady(page);
+
     await openMetadataPanelIfCollapsed(page);
-    await expect(page.getByTestId("workout-editor-danger-zone")).toHaveCount(0);
+    await page.getByTestId("session-draft-title").fill(resumeTitle);
+    await expect(page.getByRole("button", { name: "Discard draft" })).toBeVisible();
 
-    const deleteResponsePromise = page.waitForResponse(
-      (response) =>
-        response.url().endsWith(`/api/my-library/workouts/${workoutId}`) &&
-        response.request().method() === "DELETE"
-    );
+    await gotoWithTransientRetry(page, "/my-library/workouts");
+    await waitForWorkoutBuilderClientReady(page);
+    await expect(page.getByRole("heading", { level: 1, name: "My Swim Sessions" })).toBeVisible();
+    await expect(page.getByText(resumeTitle)).toHaveCount(0);
 
-    const deleteCurrentButton = page.getByRole("button", { name: "Delete session" }).first();
-    await expect(deleteCurrentButton).toBeVisible();
-    await deleteCurrentButton.click();
-    const confirmDeleteButton = page.getByTestId("workout-builder-confirm-delete-current-workout");
-    await confirmDeleteButton.scrollIntoViewIfNeeded();
-    await expect(confirmDeleteButton).toBeVisible();
-    await expect(confirmDeleteButton).toBeEnabled();
-    await Promise.all([deleteResponsePromise, confirmDeleteButton.click({ timeout: 15_000 })]);
+    await triggerCreateSession(page, "workout-builder-browse-create-pool");
+    await waitForLocalWorkoutBuilderRoute(page);
+    await waitForWorkoutBuilderClientReady(page);
+    await waitForWorkoutBuilderSaveReady(page);
+    await openMetadataPanelIfCollapsed(page);
+    await expect(page.getByTestId("session-draft-title")).toHaveValue(resumeTitle);
 
-    const deleteResponse = await deleteResponsePromise;
-    const deletePayload = (await deleteResponse.json().catch(() => null)) as {
-      ok?: boolean;
-    } | null;
+    await page.getByRole("button", { name: "Discard draft" }).click();
+    await expect(page.getByText("Discard this local draft?")).toBeVisible();
+    await page.getByTestId("workout-builder-confirm-discard-current-draft").click();
+    await page.waitForURL(/\/my-library\/workouts(?:\?.*)?$/, {
+      timeout: 20_000,
+      waitUntil: "domcontentloaded",
+    });
+    await waitForWorkoutBuilderClientReady(page);
+    await expect(page.getByText("Discarded the local pool draft.")).toBeVisible();
+    await expect(page.getByTestId("session-draft-title")).toHaveCount(0);
 
-    expect(deleteResponse.status()).toBe(200);
-    expect(deletePayload?.ok).toBe(true);
-    await expect(
-      page.getByText("No saved swim session is loaded in this route yet.")
-    ).toBeVisible();
-    await expect(page.getByRole("button", { name: "Build pool session" })).toBeVisible();
+    await triggerCreateSession(page, "workout-builder-browse-create-pool");
+    await waitForLocalWorkoutBuilderRoute(page);
+    await waitForWorkoutBuilderClientReady(page);
+    await waitForWorkoutBuilderSaveReady(page);
+    await openMetadataPanelIfCollapsed(page);
+    await expect(page.getByTestId("session-draft-title")).toHaveValue("Untitled pool session");
+    await expect(page.getByText(resumeTitle)).toHaveCount(0);
   });
 });

--- a/tests/unit/create-manual-workout-button.test.tsx
+++ b/tests/unit/create-manual-workout-button.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import CreateManualWorkoutButton from "@/components/my-library/workouts/CreateManualWorkoutButton";
 
 const navigationState = vi.hoisted(() => ({
@@ -12,154 +12,52 @@ vi.mock("next/navigation", () => ({
 }));
 
 describe("CreateManualWorkoutButton", () => {
-  beforeEach(() => {
-    vi.stubGlobal("fetch", vi.fn());
-  });
-
   afterEach(() => {
     cleanup();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
 
-  it("creates a manual workout and routes into the builder", async () => {
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        ok: true,
-        workout: {
-          id: "11111111-1111-4111-8111-111111111111",
-        },
-      }),
-    } as Response);
-
+  it("routes a pool entry into the local-draft builder flow", async () => {
     render(<CreateManualWorkoutButton />);
 
     fireEvent.click(screen.getByRole("button", { name: "Build pool session" }));
 
     await waitFor(() => {
-      expect(fetch).toHaveBeenCalledWith(
-        "/api/my-library/workouts",
-        expect.objectContaining<Record<string, unknown>>({
-          method: "POST",
-          body: expect.stringContaining('"title":"Untitled pool session"'),
-        })
-      );
-    });
-
-    const [requestUrl, requestInit] = vi.mocked(fetch).mock.calls[0] ?? [];
-    expect(requestUrl).toBe("/api/my-library/workouts");
-    const requestBody = JSON.parse(String(requestInit?.body ?? "{}")) as {
-      draft?: {
-        steps?: Array<{
-          category?: string;
-          repeatGroupId?: string | null;
-          postSetRestForRepeatGroupId?: string | null;
-          timeMin?: number | null;
-        }>;
-      };
-    };
-    expect(requestBody.draft?.steps).toHaveLength(7);
-    expect(requestBody.draft?.steps?.[0]?.category).toBe("warmup");
-    expect(requestBody.draft?.steps?.filter((step) => step.repeatGroupId)).toHaveLength(2);
-    expect(requestBody.draft?.steps?.some((step) => step.postSetRestForRepeatGroupId)).toBe(true);
-    expect(
-      requestBody.draft?.steps
-        ?.filter((step) => step.category === "rest")
-        .every((step) => step.timeMin === 0.5)
-    ).toBe(true);
-
-    await waitFor(() => {
       expect(navigationState.push).toHaveBeenCalledWith(
-        "/my-library/workouts/11111111-1111-4111-8111-111111111111?entry=manual-pool"
+        "/my-library/workouts?draft=pool&entry=manual-pool"
       );
     });
     expect(navigationState.refresh).toHaveBeenCalled();
   });
 
-  it("shows an inline error when manual creation fails", async () => {
-    vi.mocked(fetch).mockResolvedValue({
-      ok: false,
-      json: async () => ({
-        ok: false,
-        error: "Could not create workout right now.",
-      }),
-    } as Response);
-
-    render(<CreateManualWorkoutButton />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Build pool session" }));
-
-    await waitFor(() => {
-      expect(screen.getByText("Could not create workout right now.")).toBeVisible();
-    });
-    expect(navigationState.push).not.toHaveBeenCalled();
-  });
-
-  it("supports a custom href builder for fresh manual entry", async () => {
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        ok: true,
-        workout: {
-          id: "33333333-3333-4333-8333-333333333333",
-        },
-      }),
-    } as Response);
-
+  it("supports a custom href builder for manual draft entry", async () => {
     render(
       <CreateManualWorkoutButton
-        createdWorkoutHrefBuilder={(workoutId) => `/my-library/workouts/${workoutId}?from=overview`}
+        draftHrefBuilder={(builderMode) =>
+          `/my-library/workouts?draft=${builderMode}&from=overview`
+        }
       />
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Build pool session" }));
 
     await waitFor(() => {
-      expect(fetch).toHaveBeenCalledWith(
-        "/api/my-library/workouts",
-        expect.objectContaining<Record<string, unknown>>({
-          method: "POST",
-          body: expect.stringContaining('"title":"Untitled pool session"'),
-        })
-      );
-    });
-    await waitFor(() => {
       expect(navigationState.push).toHaveBeenCalledWith(
-        "/my-library/workouts/33333333-3333-4333-8333-333333333333?from=overview"
+        "/my-library/workouts?draft=pool&from=overview"
       );
     });
     expect(navigationState.refresh).toHaveBeenCalled();
   });
 
-  it("creates an open water workout from the dedicated open-water entry", async () => {
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        ok: true,
-        workout: {
-          id: "44444444-4444-4444-8444-444444444444",
-        },
-      }),
-    } as Response);
-
+  it("routes an open-water entry into the local-draft builder flow", async () => {
     render(<CreateManualWorkoutButton builderMode="open_water" />);
 
     fireEvent.click(screen.getByRole("button", { name: "Build open water session" }));
 
     await waitFor(() => {
-      expect(fetch).toHaveBeenCalledWith(
-        "/api/my-library/workouts",
-        expect.objectContaining<Record<string, unknown>>({
-          method: "POST",
-          body: expect.stringContaining('"title":"Untitled open water session"'),
-        })
-      );
-    });
-
-    await waitFor(() => {
       expect(navigationState.push).toHaveBeenCalledWith(
-        "/my-library/workouts/44444444-4444-4444-8444-444444444444?entry=manual-open-water"
+        "/my-library/workouts?draft=open_water&entry=manual-open-water"
       );
     });
     expect(navigationState.refresh).toHaveBeenCalled();

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import WorkoutBuilderHub from "@/components/my-library/workouts/WorkoutBuilderHub";
 import { WORKOUT_NOTICE_AUTO_DISMISS_MS } from "@/components/my-library/workouts/useAutoDismissNotice";
 import { buildManualWorkoutEmptyDraft } from "@/lib/workouts/manual";
+import { buildManualWorkoutLocalDraftStorageKey } from "@/lib/workouts/manual-local-draft";
 import type { SessionDraft } from "@/lib/session-generator-v1/shared";
 import type {
   WorkoutEditorRecord,
@@ -203,6 +204,7 @@ describe("WorkoutBuilderHub", () => {
 
   afterEach(() => {
     cleanup();
+    window.localStorage.clear();
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
@@ -2827,26 +2829,8 @@ describe("WorkoutBuilderHub", () => {
     );
   });
 
-  it("seeds new manual pool sessions from the provided CSS pace", async () => {
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        ok: true,
-        workout: buildWorkoutRecord({
-          id: "workout-created",
-          sourceKind: "manual",
-          draft: buildDraft({
-            sourceFingerprint: "manual-empty-pool-seeded",
-            basePaceSecondsPer100m: 118,
-            usedCssPaceLabel: "1:58",
-          }),
-        }),
-        summary: buildWorkoutSummary({
-          id: "workout-created",
-          sourceKind: "manual",
-        }),
-      }),
-    } as Response);
+  it("seeds a new local pool draft from the provided CSS pace", async () => {
+    const storageKey = buildManualWorkoutLocalDraftStorageKey("user-1", "pool");
 
     render(
       <WorkoutBuilderHub
@@ -2855,7 +2839,8 @@ describe("WorkoutBuilderHub", () => {
         })}
         manualPoolCssMetricSecondsPer100m={118}
         manualPoolCssPaceLabel="1:58"
-        browseOnly
+        userId="user-1"
+        manualLocalDraftMode="pool"
       />
     );
 
@@ -2866,20 +2851,19 @@ describe("WorkoutBuilderHub", () => {
       );
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Build pool session" }));
-
     await waitFor(() => {
-      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("session-draft-title")).toBeVisible();
     });
 
-    const request = vi.mocked(fetch).mock.calls[0]?.[1] as RequestInit | undefined;
-    const body = JSON.parse(String(request?.body ?? "{}")) as { draft?: SessionDraft };
+    const storedRaw = window.localStorage.getItem(storageKey);
+    expect(storedRaw).not.toBeNull();
 
-    expect(body.draft?.basePaceSecondsPer100m).toBe(118);
-    expect(body.draft?.usedCssPaceLabel).toBe("1:58");
-    expect(navigationState.push).toHaveBeenCalledWith(
-      "/my-library/workouts/workout-created?entry=manual-pool"
-    );
+    const storedSnapshot = JSON.parse(String(storedRaw)) as {
+      draft?: SessionDraft;
+    };
+
+    expect(storedSnapshot.draft?.basePaceSecondsPer100m).toBe(118);
+    expect(storedSnapshot.draft?.usedCssPaceLabel).toBe("1:58");
   });
 
   it("can force session details open for a fresh manual-entry route", async () => {
@@ -3008,5 +2992,176 @@ describe("WorkoutBuilderHub", () => {
         method: "DELETE",
       });
     });
+  });
+
+  it("recovers an existing local pool draft without loading a canonical session", async () => {
+    const storageKey = buildManualWorkoutLocalDraftStorageKey("user-1", "pool");
+    const recoveredDraft = buildManualWorkoutEmptyDraft(new Date("2026-04-18T09:00:00.000Z"));
+
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        version: 1,
+        mode: "pool",
+        draft: {
+          ...recoveredDraft,
+          title: "Recovered local draft",
+        },
+        updatedAt: Date.now(),
+      })
+    );
+
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: null,
+        })}
+        userId="user-1"
+        manualLocalDraftMode="pool"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session-draft-title")).toBeVisible();
+    });
+
+    expect(
+      screen.getByText("Recovered your unsaved local pool draft on this device.")
+    ).toBeVisible();
+    expect(screen.getByTestId("session-draft-title")).toHaveValue("Recovered local draft");
+    expect(screen.queryByTestId("saved-workout-card-workout-1")).not.toBeInTheDocument();
+    expect(screen.getByTestId("workout-builder-view-sessions-link")).toHaveAttribute(
+      "href",
+      "/my-library/workouts"
+    );
+  });
+
+  it("discards the current local draft without deleting any saved session", async () => {
+    const storageKey = buildManualWorkoutLocalDraftStorageKey("user-1", "pool");
+    const recoveredDraft = buildManualWorkoutEmptyDraft(new Date("2026-04-18T09:00:00.000Z"));
+
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        version: 1,
+        mode: "pool",
+        draft: recoveredDraft,
+        updatedAt: Date.now(),
+      })
+    );
+
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: null,
+        })}
+        userId="user-1"
+        manualLocalDraftMode="pool"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-discard-current-draft")).toBeVisible();
+    });
+
+    fireEvent.click(screen.getByTestId("workout-builder-discard-current-draft"));
+    expect(screen.getByText("Discard this local draft?")).toBeVisible();
+
+    fireEvent.click(screen.getByTestId("workout-builder-confirm-discard-current-draft"));
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(storageKey)).toBeNull();
+    });
+
+    expect(navigationState.replace).toHaveBeenCalledWith("/my-library/workouts");
+    expect(screen.getByText("Discarded the local pool draft.")).toBeVisible();
+    expect(screen.getByText("No saved swim session is loaded in this route yet.")).toBeVisible();
+    expect(screen.queryByTestId("session-draft-title")).not.toBeInTheDocument();
+  });
+
+  it("creates the canonical workout only on the first explicit save from a local draft", async () => {
+    vi.mocked(fetch).mockImplementation(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        draft: SessionDraft;
+        sourceKind?: string;
+      };
+
+      return {
+        ok: true,
+        json: async () => ({
+          ok: true,
+          workout: buildWorkoutRecord({
+            id: "workout-created",
+            sourceKind: "manual",
+            draft: {
+              ...body.draft,
+              sourceFingerprint: "manual-empty-pool-saved",
+            },
+          }),
+          summary: buildWorkoutSummary({
+            id: "workout-created",
+            sourceKind: "manual",
+            title: body.draft.title,
+          }),
+        }),
+      } as Response;
+    });
+
+    const storageKey = buildManualWorkoutLocalDraftStorageKey("user-1", "pool");
+
+    render(
+      <WorkoutBuilderHub
+        workoutLibrary={buildWorkoutLibrary({
+          selectedWorkout: null,
+        })}
+        userId="user-1"
+        manualLocalDraftMode="pool"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session-draft-title")).toBeVisible();
+    });
+
+    fireEvent.change(screen.getByTestId("session-draft-title"), {
+      target: { value: "Saved from local draft" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save session" }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/my-library/workouts",
+        expect.objectContaining({
+          method: "POST",
+        })
+      );
+    });
+
+    const request = vi.mocked(fetch).mock.calls[0]?.[1] as RequestInit | undefined;
+    const body = JSON.parse(String(request?.body ?? "{}")) as {
+      draft?: SessionDraft;
+      sourceKind?: string;
+    };
+
+    expect(body.sourceKind).toBe("manual");
+    expect(body.draft?.title).toBe("Saved from local draft");
+
+    await waitFor(() => {
+      expect(navigationState.replace).toHaveBeenCalledWith(
+        "/my-library/workouts/workout-created?entry=manual-pool"
+      );
+    });
+
+    expect(window.localStorage.getItem(storageKey)).toBeNull();
+    expect(screen.queryByTestId("workout-builder-discard-current-draft")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save changes" })).toBeVisible();
+    expect(screen.getByTestId("workout-builder-delete-current-workout")).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-04-18T18:11:53.290Z for branch `feat/swim-session-builder-local-draft-first-save-boundary` (base ref `origin/main`).
- Latest commit: `794c424` - feat: keep manual workout drafts local until first save.
- User-visible changes: User/admin runtime behavior may change on touched routes/components.
- Technical changes: Updated 11 file(s): `app/my-library/workouts/[workoutId]/page.tsx`, `app/my-library/workouts/page.tsx`, `components/my-library/workouts/CreateManualWorkoutButton.tsx`, `components/my-library/workouts/WorkoutBuilderHub.tsx`, `components/my-library/workouts/WorkoutEditor.tsx`, `... and 6 more file(s)`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-04-18-swim-session-builder-local-draft-first-save-boundary-10-10.md`
- Scorecard target outcomes: 8 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (1); tests (4); runtime UI/routes/components (6).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (11):
  - `app/my-library/workouts/[workoutId]/page.tsx`
  - `app/my-library/workouts/page.tsx`
  - `components/my-library/workouts/CreateManualWorkoutButton.tsx`
  - `components/my-library/workouts/WorkoutBuilderHub.tsx`
  - `components/my-library/workouts/WorkoutEditor.tsx`
  - `docs/task-briefs/in-progress/2026-04-18-swim-session-builder-local-draft-first-save-boundary-10-10.md`
  - `lib/workouts/manual-local-draft.ts`
  - `tests/e2e/my-library-program-export.spec.ts`
  - `... and 3 more file(s)`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `794c424` (`git revert 794c424`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **FAIL** (artifacts/test-runs/20260418-194624, lane: full-public)
- `npm run verify:pre-merge`: **PENDING** for `794c424` (last green marker: `40ebf7e` at 2026-04-18T15:38:07Z; rerun on current HEAD).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  -   1) [desktop-chromium] › tests/e2e/admin-notes-workflow.spec.ts:294:7 › admin notes workflow › allowlisted admin can create, edit, toggle, and delete notes 
  -     Error: [2mexpect([22m[31mlocator[39m[2m).[22mtoBeVisible[2m([22m[2m)[22m failed
  -         at /Users/stianvikra/freeswimming/tests/e2e/admin-notes-workflow.spec.ts:516:31
  -   1 failed
  -     [desktop-chromium] › tests/e2e/admin-notes-workflow.spec.ts:294:7 › admin notes workflow › allowlisted admin can create, edit, toggle, and delete notes 
  -   101 passed (20.1m)
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
