### PR TITLE
Move poolside print settings into preview

### DIFF
--- a/app/api/my-library/workouts/[workoutId]/export/pdf/route.ts
+++ b/app/api/my-library/workouts/[workoutId]/export/pdf/route.ts
@@ -8,6 +8,7 @@ import {
   normalizeWorkoutPoolsideNotationMode,
   normalizeWorkoutPoolsidePrintLayout,
   normalizeWorkoutPoolsidePrintStyle,
+  normalizeWorkoutPdfPreviewChrome,
   normalizeWorkoutPoolsideRestLayout,
   selectWorkoutPoolsideFocusPoints,
   type WorkoutPoolsideFocusOption,
@@ -62,6 +63,9 @@ export async function GET(request: Request, context: RouteContext) {
   );
   const poolsideRestLayout = normalizeWorkoutPoolsideRestLayout(
     requestUrl.searchParams.get("restLayout")
+  );
+  const previewChrome = normalizeWorkoutPdfPreviewChrome(
+    requestUrl.searchParams.get("previewChrome")
   );
   const { workoutId } = await context.params;
   if (!UUID_PATTERN.test(workoutId)) {
@@ -142,6 +146,7 @@ export async function GET(request: Request, context: RouteContext) {
           requestUrl
         ).toString(),
         fontUrl: new URL(BRAND_FONT_PUBLIC_PATH, requestUrl).toString(),
+        previewChrome,
       })
     )
   );

--- a/app/my-library/workouts/poolside-preview/page.tsx
+++ b/app/my-library/workouts/poolside-preview/page.tsx
@@ -1,0 +1,51 @@
+import { redirect } from "next/navigation";
+import PoolsidePreviewPageClient from "@/components/my-library/workouts/PoolsidePreviewPageClient";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+type Props = {
+  searchParams: SearchParams;
+};
+
+function buildCurrentSearch(searchParams: Record<string, string | string[] | undefined>) {
+  const resolved = new URLSearchParams();
+
+  Object.entries(searchParams).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      value.forEach((entry) => {
+        if (typeof entry === "string") {
+          resolved.append(key, entry);
+        }
+      });
+      return;
+    }
+
+    if (typeof value === "string") {
+      resolved.set(key, value);
+    }
+  });
+
+  const query = resolved.toString();
+  return query ? `?${query}` : "";
+}
+
+export default async function PoolsidePreviewPage({ searchParams }: Props) {
+  const resolvedSearchParams = await searchParams;
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(
+      `/auth/sign-in?next=${encodeURIComponent(
+        `/my-library/workouts/poolside-preview${buildCurrentSearch(resolvedSearchParams)}`
+      )}`
+    );
+  }
+
+  return <PoolsidePreviewPageClient />;
+}

--- a/components/my-library/workouts/PoolsideNotePanel.tsx
+++ b/components/my-library/workouts/PoolsideNotePanel.tsx
@@ -1,14 +1,10 @@
 "use client";
 
 import { useState, type ReactNode } from "react";
-import type {
-  WorkoutPoolsideNotationMode,
-  WorkoutPoolsideFocusOption,
-  WorkoutPoolsideRestLayout,
-  WorkoutPoolsidePrintLayout,
-  WorkoutPoolsidePrintStyle,
+import {
+  WORKOUT_POOLSIDE_ABBREVIATION_LEGEND,
+  type WorkoutPoolsideFocusOption,
 } from "@/lib/workouts/shared";
-import { WORKOUT_POOLSIDE_ABBREVIATION_LEGEND } from "@/lib/workouts/shared";
 
 type Props = {
   className?: string;
@@ -17,14 +13,6 @@ type Props = {
   focusOptions: WorkoutPoolsideFocusOption[];
   selectedFocusIds: string[];
   onToggleFocus: (focusId: string) => void;
-  printStyle: WorkoutPoolsidePrintStyle;
-  onPrintStyleChange: (style: WorkoutPoolsidePrintStyle) => void;
-  printLayout: WorkoutPoolsidePrintLayout;
-  onPrintLayoutChange: (layout: WorkoutPoolsidePrintLayout) => void;
-  notationMode: WorkoutPoolsideNotationMode;
-  onNotationModeChange: (mode: WorkoutPoolsideNotationMode) => void;
-  restLayout: WorkoutPoolsideRestLayout;
-  onRestLayoutChange: (layout: WorkoutPoolsideRestLayout) => void;
   actionSlot: ReactNode;
 };
 
@@ -35,14 +23,6 @@ export default function PoolsideNotePanel({
   focusOptions,
   selectedFocusIds,
   onToggleFocus,
-  printStyle,
-  onPrintStyleChange,
-  printLayout,
-  onPrintLayoutChange,
-  notationMode,
-  onNotationModeChange,
-  restLayout,
-  onRestLayoutChange,
   actionSlot,
 }: Props) {
   const [abbreviationsOpen, setAbbreviationsOpen] = useState(false);
@@ -58,11 +38,7 @@ export default function PoolsideNotePanel({
   const focusSectionClass = prefersStackedLayout
     ? "min-w-0 space-y-3"
     : "min-w-0 space-y-3 xl:border-r xl:border-blue-200/70 xl:pr-5";
-  const optionsSectionClass = prefersStackedLayout ? "min-w-0" : "min-w-0 xl:pl-5";
-  const printOptionsGridClass = prefersStackedLayout ? "grid gap-4 xl:grid-cols-2" : "space-y-4";
-  const abbreviationsPreview = ["Free", "IR", "SR", "Mod"]
-    .filter((short) => WORKOUT_POOLSIDE_ABBREVIATION_LEGEND.some((entry) => entry.short === short))
-    .join(", ");
+  const referenceSectionClass = prefersStackedLayout ? "min-w-0" : "min-w-0 xl:pl-5";
   const legendGridClass = prefersStackedLayout
     ? "mt-3 grid gap-2 sm:grid-cols-2 xl:grid-cols-3"
     : "mt-3 grid gap-2 sm:grid-cols-2";
@@ -120,226 +96,58 @@ export default function PoolsideNotePanel({
           )}
         </div>
 
-        <div className={optionsSectionClass}>
-          <div className="space-y-4 rounded-2xl border border-slate-200 bg-white p-4">
-            <p className="text-sm font-semibold text-slate-900">Print options</p>
-            <div
-              className={printOptionsGridClass}
-              data-testid={`${testIdPrefix}-print-options-grid`}
-              data-layout-mode={layoutMode}
+        <div
+          className={referenceSectionClass}
+          data-testid={`${testIdPrefix}-reference-panel`}
+          data-layout-mode={layoutMode}
+        >
+          <div className="rounded-xl border border-slate-200 bg-slate-50/70 text-sm text-slate-700">
+            <button
+              type="button"
+              onClick={() => setAbbreviationsOpen((current) => !current)}
+              data-testid={`${testIdPrefix}-abbreviations-toggle`}
+              aria-expanded={abbreviationsOpen}
+              aria-controls={`${testIdPrefix}-abbreviations-panel`}
+              className="flex w-full items-center justify-between gap-3 rounded-xl px-3 py-3 text-left transition hover:border-blue-200 hover:bg-blue-50/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
             >
-              <fieldset className="space-y-3">
-                <legend className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                  Style
-                </legend>
-                <div className="grid gap-3">
-                  <label className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-700">
-                    <input
-                      type="radio"
-                      name={`${testIdPrefix}-print-style`}
-                      checked={printStyle === "color"}
-                      onChange={() => onPrintStyleChange("color")}
-                      data-testid={`${testIdPrefix}-style-color`}
-                      className="h-4 w-4 border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-200"
-                    />
-                    <span>
-                      <span className="block font-medium text-slate-900">Color mode</span>
-                      <span className="mt-1 block text-xs text-slate-500">
-                        Keeps the blue surfaces
-                      </span>
-                    </span>
-                  </label>
-                  <label className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-700">
-                    <input
-                      type="radio"
-                      name={`${testIdPrefix}-print-style`}
-                      checked={printStyle === "ink_saver"}
-                      onChange={() => onPrintStyleChange("ink_saver")}
-                      data-testid={`${testIdPrefix}-style-ink-saver`}
-                      className="h-4 w-4 border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-200"
-                    />
-                    <span>
-                      <span className="block font-medium text-slate-900">Ink saver</span>
-                      <span className="mt-1 block text-xs text-slate-500">
-                        Uses white surfaces.
-                      </span>
-                    </span>
-                  </label>
-                </div>
-              </fieldset>
-
-              <fieldset className="space-y-3">
-                <legend className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                  Layout
-                </legend>
-                <div className="grid gap-3">
-                  <label className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-700">
-                    <input
-                      type="radio"
-                      name={`${testIdPrefix}-print-layout`}
-                      checked={printLayout === "portrait"}
-                      onChange={() => onPrintLayoutChange("portrait")}
-                      data-testid={`${testIdPrefix}-layout-portrait`}
-                      className="h-4 w-4 border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-200"
-                    />
-                    <span className="block font-medium text-slate-900">Portrait</span>
-                  </label>
-                  <label className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-700">
-                    <input
-                      type="radio"
-                      name={`${testIdPrefix}-print-layout`}
-                      checked={printLayout === "landscape"}
-                      onChange={() => onPrintLayoutChange("landscape")}
-                      data-testid={`${testIdPrefix}-layout-landscape`}
-                      className="h-4 w-4 border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-200"
-                    />
-                    <span className="block font-medium text-slate-900">Landscape</span>
-                  </label>
-                </div>
-              </fieldset>
-
-              <fieldset className="space-y-3">
-                <legend className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                  Notation
-                </legend>
-                <div className="grid gap-3">
-                  <label className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-700">
-                    <input
-                      type="radio"
-                      name={`${testIdPrefix}-notation-mode`}
-                      checked={notationMode === "auto"}
-                      onChange={() => onNotationModeChange("auto")}
-                      data-testid={`${testIdPrefix}-notation-auto`}
-                      className="h-4 w-4 border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-200"
-                    />
-                    <span>
-                      <span className="block font-medium text-slate-900">Auto</span>
-                      <span className="mt-1 block text-xs text-slate-500">
-                        Keeps full labels until the line needs shorthand.
-                      </span>
-                    </span>
-                  </label>
-                  <label className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-700">
-                    <input
-                      type="radio"
-                      name={`${testIdPrefix}-notation-mode`}
-                      checked={notationMode === "full"}
-                      onChange={() => onNotationModeChange("full")}
-                      data-testid={`${testIdPrefix}-notation-full`}
-                      className="h-4 w-4 border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-200"
-                    />
-                    <span className="block font-medium text-slate-900">Full</span>
-                  </label>
-                  <label className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-700">
-                    <input
-                      type="radio"
-                      name={`${testIdPrefix}-notation-mode`}
-                      checked={notationMode === "abbreviated"}
-                      onChange={() => onNotationModeChange("abbreviated")}
-                      data-testid={`${testIdPrefix}-notation-abbreviated`}
-                      className="h-4 w-4 border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-200"
-                    />
-                    <span className="block font-medium text-slate-900">Abbreviated</span>
-                  </label>
-                </div>
-              </fieldset>
-
-              <fieldset className="space-y-3">
-                <legend className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                  Rest layout
-                </legend>
-                <div className="grid gap-3">
-                  <label className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-700">
-                    <input
-                      type="radio"
-                      name={`${testIdPrefix}-rest-layout`}
-                      checked={restLayout === "auto"}
-                      onChange={() => onRestLayoutChange("auto")}
-                      data-testid={`${testIdPrefix}-rest-layout-auto`}
-                      className="h-4 w-4 border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-200"
-                    />
-                    <span>
-                      <span className="block font-medium text-slate-900">Auto</span>
-                      <span className="mt-1 block text-xs text-slate-500">
-                        Keeps rests inline when they fit.
-                      </span>
-                    </span>
-                  </label>
-                  <label className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-700">
-                    <input
-                      type="radio"
-                      name={`${testIdPrefix}-rest-layout`}
-                      checked={restLayout === "inline"}
-                      onChange={() => onRestLayoutChange("inline")}
-                      data-testid={`${testIdPrefix}-rest-layout-inline`}
-                      className="h-4 w-4 border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-200"
-                    />
-                    <span className="block font-medium text-slate-900">Inline</span>
-                  </label>
-                  <label className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-700">
-                    <input
-                      type="radio"
-                      name={`${testIdPrefix}-rest-layout`}
-                      checked={restLayout === "below_step"}
-                      onChange={() => onRestLayoutChange("below_step")}
-                      data-testid={`${testIdPrefix}-rest-layout-below`}
-                      className="h-4 w-4 border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-200"
-                    />
-                    <span className="block font-medium text-slate-900">Below step</span>
-                  </label>
-                </div>
-              </fieldset>
-            </div>
-
-            <div className="rounded-xl border border-slate-200 bg-slate-50/70 text-sm text-slate-700">
-              <button
-                type="button"
-                onClick={() => setAbbreviationsOpen((current) => !current)}
-                data-testid={`${testIdPrefix}-abbreviations-toggle`}
-                aria-expanded={abbreviationsOpen}
-                aria-controls={`${testIdPrefix}-abbreviations-panel`}
-                className="flex w-full items-center justify-between gap-3 rounded-xl px-3 py-3 text-left transition hover:border-blue-200 hover:bg-blue-50/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+              <span className="min-w-0">
+                <span className="block font-medium text-slate-900">Abbreviations</span>
+              </span>
+              <span
+                aria-hidden="true"
+                className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500 transition duration-200 motion-reduce:transform-none ${
+                  abbreviationsOpen ? "rotate-180" : ""
+                }`}
               >
-                <span className="min-w-0">
-                  <span className="block font-medium text-slate-900">Abbreviations</span>
-                  <span className="mt-1 block text-xs text-slate-500">{abbreviationsPreview}</span>
-                </span>
-                <span
-                  aria-hidden="true"
-                  className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500 transition duration-200 motion-reduce:transform-none ${
-                    abbreviationsOpen ? "rotate-180" : ""
-                  }`}
-                >
-                  <svg viewBox="0 0 16 16" className="h-4 w-4 fill-current">
-                    <path d="M4.22 5.97a.75.75 0 0 1 1.06 0L8 8.69l2.72-2.72a.75.75 0 1 1 1.06 1.06L8.53 10.28a.75.75 0 0 1-1.06 0L4.22 7.03a.75.75 0 0 1 0-1.06Z" />
-                  </svg>
-                </span>
-              </button>
+                <svg viewBox="0 0 16 16" className="h-4 w-4 fill-current">
+                  <path d="M4.22 5.97a.75.75 0 0 1 1.06 0L8 8.69l2.72-2.72a.75.75 0 1 1 1.06 1.06L8.53 10.28a.75.75 0 0 1-1.06 0L4.22 7.03a.75.75 0 0 1 0-1.06Z" />
+                </svg>
+              </span>
+            </button>
 
-              {abbreviationsOpen ? (
-                <div
-                  id={`${testIdPrefix}-abbreviations-panel`}
-                  data-testid={`${testIdPrefix}-abbreviations-panel`}
-                  className="border-t border-slate-200 px-3 pb-3 pt-3"
+            {abbreviationsOpen ? (
+              <div
+                id={`${testIdPrefix}-abbreviations-panel`}
+                data-testid={`${testIdPrefix}-abbreviations-panel`}
+                className="border-t border-slate-200 px-3 pb-3 pt-3"
+              >
+                <dl
+                  className={legendGridClass}
+                  data-testid={`${testIdPrefix}-abbreviations-list`}
+                  data-column-mode={prefersStackedLayout ? "up-to-3" : "up-to-2"}
                 >
-                  <dl
-                    className={legendGridClass}
-                    data-testid={`${testIdPrefix}-abbreviations-list`}
-                    data-column-mode={prefersStackedLayout ? "up-to-3" : "up-to-2"}
-                  >
-                    {WORKOUT_POOLSIDE_ABBREVIATION_LEGEND.map((entry) => (
-                      <div
-                        key={entry.short}
-                        className="grid grid-cols-[56px_minmax(0,1fr)] gap-2 rounded-lg bg-white px-3 py-2"
-                      >
-                        <dt className="font-semibold text-blue-800">{entry.short}</dt>
-                        <dd className="m-0 text-slate-600">{entry.full}</dd>
-                      </div>
-                    ))}
-                  </dl>
-                </div>
-              ) : null}
-            </div>
+                  {WORKOUT_POOLSIDE_ABBREVIATION_LEGEND.map((entry) => (
+                    <div
+                      key={entry.short}
+                      className="grid grid-cols-[56px_minmax(0,1fr)] gap-2 rounded-lg bg-white px-3 py-2"
+                    >
+                      <dt className="font-semibold text-blue-800">{entry.short}</dt>
+                      <dd className="m-0 text-slate-600">{entry.full}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </div>
+            ) : null}
           </div>
         </div>
       </div>

--- a/components/my-library/workouts/PoolsidePreviewPageClient.tsx
+++ b/components/my-library/workouts/PoolsidePreviewPageClient.tsx
@@ -1,0 +1,484 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { BRAND_FONT_PUBLIC_PATH, getWorkoutPdfLogoPath } from "@/lib/brand";
+import {
+  applyWorkoutPoolsidePreviewSettings,
+  buildWorkoutPoolsidePrintFrameHref,
+  normalizeWorkoutPoolsidePreviewSettings,
+  readStoredWorkoutPoolsidePreviewDraft,
+  type StoredWorkoutPoolsidePreviewDraft,
+  type WorkoutPoolsidePreviewSettings,
+} from "@/lib/workouts/poolside-preview";
+import { buildWorkoutPdfHtmlDocument } from "@/lib/workouts/shared";
+
+const CSS_PIXELS_PER_MM = 96 / 25.4;
+const EMBEDDED_PREVIEW_MIN_HEIGHT = 680;
+const EMBEDDED_PREVIEW_FRAME_PADDING = 48;
+const EMBEDDED_PREVIEW_STAGE_GUTTER = 12;
+
+function getEmbeddedPreviewFallbackWidth(layout: WorkoutPoolsidePreviewSettings["printLayout"]) {
+  return layout === "landscape" ? 644 : 388;
+}
+
+function readSingleSearchParam(searchParams: URLSearchParams, key: string) {
+  const value = searchParams.get(key);
+  return value && value.trim().length > 0 ? value : null;
+}
+
+function arePreviewSettingsEqual(
+  left: WorkoutPoolsidePreviewSettings,
+  right: WorkoutPoolsidePreviewSettings
+) {
+  return (
+    left.printStyle === right.printStyle &&
+    left.printLayout === right.printLayout &&
+    left.notationMode === right.notationMode &&
+    left.restLayout === right.restLayout
+  );
+}
+
+export default function PoolsidePreviewPageClient() {
+  const searchParams = useSearchParams();
+  const searchSignature = searchParams.toString();
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const previewViewportRef = useRef<HTMLDivElement | null>(null);
+  const previewSource = useMemo(() => {
+    const params = new URLSearchParams(searchSignature);
+    return {
+      workoutId: readSingleSearchParam(params, "workoutId"),
+      previewId: readSingleSearchParam(params, "previewId"),
+      focusIds: params.getAll("focusId"),
+    };
+  }, [searchSignature]);
+  const [settings, setSettings] = useState<WorkoutPoolsidePreviewSettings>(() =>
+    normalizeWorkoutPoolsidePreviewSettings({
+      printStyle: searchParams.get("printStyle"),
+      printLayout: searchParams.get("printLayout"),
+      notationMode: searchParams.get("notationMode"),
+      restLayout: searchParams.get("restLayout"),
+    })
+  );
+  const [localPreviewDraft, setLocalPreviewDraft] = useState<
+    StoredWorkoutPoolsidePreviewDraft | null | undefined
+  >(undefined);
+  const [previewViewportWidth, setPreviewViewportWidth] = useState(() =>
+    typeof window === "undefined" ? 0 : Math.max(0, window.innerWidth - 56)
+  );
+  const [embeddedPreviewHeight, setEmbeddedPreviewHeight] = useState(EMBEDDED_PREVIEW_MIN_HEIGHT);
+  const [embeddedPreviewViewportWidth, setEmbeddedPreviewViewportWidth] = useState(() =>
+    getEmbeddedPreviewFallbackWidth(settings.printLayout)
+  );
+
+  useEffect(() => {
+    const params = new URLSearchParams(searchSignature);
+    const nextSettings = normalizeWorkoutPoolsidePreviewSettings({
+      printStyle: params.get("printStyle"),
+      printLayout: params.get("printLayout"),
+      notationMode: params.get("notationMode"),
+      restLayout: params.get("restLayout"),
+    });
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- URL changes are the external source of truth for preview settings.
+    setSettings((current) =>
+      arePreviewSettingsEqual(current, nextSettings) ? current : nextSettings
+    );
+
+    if (typeof window !== "undefined") {
+      const url = new URL(window.location.href);
+      const currentPath = `${url.pathname}${url.search}`;
+      applyWorkoutPoolsidePreviewSettings(url.searchParams, nextSettings);
+      const nextPath = `${url.pathname}?${url.searchParams.toString()}`;
+
+      if (nextPath !== currentPath) {
+        window.history.replaceState(null, "", nextPath);
+      }
+    }
+  }, [searchSignature]);
+
+  useEffect(() => {
+    if (!previewSource.previewId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- clearing preview draft when the external preview id disappears is an effect sync.
+      setLocalPreviewDraft(undefined);
+      return;
+    }
+    setLocalPreviewDraft(readStoredWorkoutPoolsidePreviewDraft(previewSource.previewId));
+  }, [previewSource.previewId]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset embedded width fallback when layout mode changes before iframe metrics arrive.
+    setEmbeddedPreviewViewportWidth(getEmbeddedPreviewFallbackWidth(settings.printLayout));
+  }, [settings.printLayout]);
+
+  useLayoutEffect(() => {
+    const viewport = previewViewportRef.current;
+
+    if (!viewport || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const measure = () => {
+      setPreviewViewportWidth(viewport.getBoundingClientRect().width);
+    };
+
+    const observer = new ResizeObserver((entries) => {
+      const nextWidth = entries[0]?.contentRect.width ?? 0;
+      setPreviewViewportWidth((current) =>
+        Math.abs(current - nextWidth) < 1 ? current : nextWidth
+      );
+    });
+
+    observer.observe(viewport);
+    measure();
+    const rafId = window.requestAnimationFrame(measure);
+
+    return () => {
+      window.cancelAnimationFrame(rafId);
+      observer.disconnect();
+    };
+  }, []);
+
+  const previewSourceLabel = previewSource.workoutId ? "Saved workout" : "Current builder state";
+  const previewUnavailable =
+    !previewSource.workoutId && (!previewSource.previewId || localPreviewDraft === null);
+  const previewFrameHref = useMemo(() => {
+    if (!previewSource.workoutId) {
+      return null;
+    }
+
+    return buildWorkoutPoolsidePrintFrameHref(previewSource.workoutId, {
+      selectedFocusIds: previewSource.focusIds,
+      settings,
+    });
+  }, [previewSource.focusIds, previewSource.workoutId, settings]);
+  const previewFrameDoc = useMemo(() => {
+    if (!localPreviewDraft || typeof window === "undefined") {
+      return null;
+    }
+
+    return buildWorkoutPdfHtmlDocument(localPreviewDraft.draft, {
+      draftState: localPreviewDraft.draftState,
+      variant: "poolside",
+      focusPoints: localPreviewDraft.focusPoints,
+      poolsidePrintStyle: settings.printStyle,
+      poolsidePrintLayout: settings.printLayout,
+      poolsideNotationMode: settings.notationMode,
+      poolsideRestLayout: settings.restLayout,
+      swimmerName: localPreviewDraft.swimmerName,
+      logoUrl: new URL(
+        getWorkoutPdfLogoPath({
+          variant: "poolside",
+          poolsidePrintStyle: settings.printStyle,
+        }),
+        window.location.origin
+      ).toString(),
+      fontUrl: new URL(BRAND_FONT_PUBLIC_PATH, window.location.origin).toString(),
+      previewChrome: "embedded",
+    });
+  }, [localPreviewDraft, settings]);
+
+  function syncPreviewSettings(nextSettings: WorkoutPoolsidePreviewSettings) {
+    setSettings(nextSettings);
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const url = new URL(window.location.href);
+    applyWorkoutPoolsidePreviewSettings(url.searchParams, nextSettings);
+    window.history.replaceState(null, "", `${url.pathname}?${url.searchParams.toString()}`);
+  }
+
+  function updateSetting<Key extends keyof WorkoutPoolsidePreviewSettings>(
+    key: Key,
+    value: WorkoutPoolsidePreviewSettings[Key]
+  ) {
+    syncPreviewSettings({
+      ...settings,
+      [key]: value,
+    });
+  }
+
+  function handlePrint() {
+    const previewWindow = iframeRef.current?.contentWindow;
+
+    if (previewWindow) {
+      previewWindow.focus?.();
+      previewWindow.print();
+      return;
+    }
+
+    window.print();
+  }
+
+  function handleClose() {
+    if (window.opener) {
+      window.close();
+      return;
+    }
+
+    if (window.history.length > 1) {
+      window.history.back();
+      return;
+    }
+
+    window.location.assign("/my-library/workouts");
+  }
+
+  function syncEmbeddedPreviewMetrics() {
+    const frame = iframeRef.current;
+    const frameWindow = frame?.contentWindow;
+    const frameDocument = frameWindow?.document;
+
+    if (!frameDocument) {
+      return;
+    }
+
+    const measure = () => {
+      const root = frameDocument.documentElement;
+      const body = frameDocument.body;
+      const article = frameDocument.querySelector<HTMLElement>(
+        '[data-testid="workout-pdf-print-view"]'
+      );
+      const shell = frameDocument.querySelector<HTMLElement>(".shell");
+      const renderedPageWidthMm = Number(
+        article?.getAttribute("data-poolside-page-width-mm") ?? ""
+      );
+      const nextHeight = Math.max(
+        EMBEDDED_PREVIEW_MIN_HEIGHT,
+        Math.ceil(
+          Math.max(
+            root?.scrollHeight ?? 0,
+            body?.scrollHeight ?? 0,
+            shell?.scrollHeight ?? 0,
+            article?.offsetHeight ?? 0
+          )
+        )
+      );
+      const measuredViewportWidth = Math.ceil(
+        Math.max(
+          root?.scrollWidth ?? 0,
+          body?.scrollWidth ?? 0,
+          shell?.scrollWidth ?? 0,
+          (article?.offsetWidth ?? 0) + EMBEDDED_PREVIEW_FRAME_PADDING
+        )
+      );
+      const expectedViewportWidth = Number.isFinite(renderedPageWidthMm)
+        ? Math.max(
+            320,
+            Math.ceil(renderedPageWidthMm * CSS_PIXELS_PER_MM + EMBEDDED_PREVIEW_FRAME_PADDING)
+          )
+        : getEmbeddedPreviewFallbackWidth(settings.printLayout);
+      const nextViewportWidth = Math.max(expectedViewportWidth, measuredViewportWidth);
+
+      setEmbeddedPreviewHeight((current) => (current === nextHeight ? current : nextHeight));
+      setEmbeddedPreviewViewportWidth((current) =>
+        current === nextViewportWidth ? current : nextViewportWidth
+      );
+    };
+
+    measure();
+    frameWindow.setTimeout(measure, 160);
+  }
+
+  const embeddedPreviewScale =
+    previewViewportWidth > 0
+      ? Math.min(
+          1,
+          Math.max(0, previewViewportWidth - EMBEDDED_PREVIEW_STAGE_GUTTER * 2) /
+            embeddedPreviewViewportWidth
+        )
+      : 1;
+  const embeddedStageWidth = embeddedPreviewViewportWidth * embeddedPreviewScale;
+  const embeddedStageHeight = embeddedPreviewHeight * embeddedPreviewScale;
+  const embeddedPreviewReady = previewViewportWidth > 0;
+
+  return (
+    <main
+      data-testid="poolside-preview-page"
+      className="min-h-screen overflow-x-hidden bg-slate-100"
+    >
+      <div className="mx-auto flex min-h-screen w-full max-w-[1500px] flex-col gap-4 px-3 py-4 sm:px-5 lg:px-6">
+        <section className="overflow-hidden rounded-2xl border border-blue-200/80 bg-white shadow-[0_20px_60px_rgba(24,58,107,0.12)]">
+          <div className="border-b border-blue-100 bg-blue-50/75 px-4 py-4 sm:px-5">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
+                  Poolside Note
+                </p>
+                <h1 className="mt-2 text-2xl font-bold text-slate-900 sm:text-[2rem]">
+                  Print Preview
+                </h1>
+                <p data-testid="poolside-preview-source" className="mt-2 text-sm text-slate-600">
+                  {previewSourceLabel}
+                </p>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handlePrint}
+                  disabled={previewUnavailable}
+                  data-testid="poolside-preview-print"
+                  className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Print / Save PDF
+                </button>
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  data-testid="poolside-preview-close"
+                  className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+
+            <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              <label className="grid gap-2" htmlFor="poolside-preview-style">
+                <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Ink usage
+                </span>
+                <select
+                  id="poolside-preview-style"
+                  value={settings.printStyle}
+                  onChange={(event) =>
+                    updateSetting(
+                      "printStyle",
+                      event.target.value as WorkoutPoolsidePreviewSettings["printStyle"]
+                    )
+                  }
+                  data-testid="poolside-preview-style"
+                  className="h-11 rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-blue-300 focus:ring-2 focus:ring-blue-100"
+                >
+                  <option value="color">Color mode</option>
+                  <option value="ink_saver">Ink saver</option>
+                </select>
+              </label>
+
+              <label className="grid gap-2" htmlFor="poolside-preview-layout">
+                <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Layout
+                </span>
+                <select
+                  id="poolside-preview-layout"
+                  value={settings.printLayout}
+                  onChange={(event) =>
+                    updateSetting(
+                      "printLayout",
+                      event.target.value as WorkoutPoolsidePreviewSettings["printLayout"]
+                    )
+                  }
+                  data-testid="poolside-preview-layout"
+                  className="h-11 rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-blue-300 focus:ring-2 focus:ring-blue-100"
+                >
+                  <option value="portrait">Portrait</option>
+                  <option value="landscape">Landscape</option>
+                </select>
+              </label>
+
+              <label className="grid gap-2" htmlFor="poolside-preview-notation">
+                <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Abbreviations
+                </span>
+                <select
+                  id="poolside-preview-notation"
+                  value={settings.notationMode}
+                  onChange={(event) =>
+                    updateSetting(
+                      "notationMode",
+                      event.target.value as WorkoutPoolsidePreviewSettings["notationMode"]
+                    )
+                  }
+                  data-testid="poolside-preview-notation"
+                  className="h-11 rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-blue-300 focus:ring-2 focus:ring-blue-100"
+                >
+                  <option value="auto">Auto</option>
+                  <option value="full">Complete words</option>
+                  <option value="abbreviated">Abbreviated</option>
+                </select>
+              </label>
+
+              <label className="grid gap-2" htmlFor="poolside-preview-rest-layout">
+                <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Rest placement
+                </span>
+                <select
+                  id="poolside-preview-rest-layout"
+                  value={settings.restLayout}
+                  onChange={(event) =>
+                    updateSetting(
+                      "restLayout",
+                      event.target.value as WorkoutPoolsidePreviewSettings["restLayout"]
+                    )
+                  }
+                  data-testid="poolside-preview-rest-layout"
+                  className="h-11 rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-blue-300 focus:ring-2 focus:ring-blue-100"
+                >
+                  <option value="auto">Auto</option>
+                  <option value="inline">Inline</option>
+                  <option value="below_step">Separate line</option>
+                </select>
+              </label>
+            </div>
+          </div>
+
+          <div className="p-3 sm:p-4">
+            {previewSource.previewId &&
+            localPreviewDraft === undefined &&
+            !previewSource.workoutId ? (
+              <div className="rounded-2xl border border-slate-200 bg-white px-4 py-4 text-sm text-slate-600">
+                Loading preview...
+              </div>
+            ) : previewUnavailable ? (
+              <div className="rounded-2xl border border-amber-200 bg-amber-50/80 px-4 py-4 text-sm text-amber-900">
+                This preview is no longer available. Open Print Preview again from the builder or
+                from My Swim Sessions.
+              </div>
+            ) : (
+              <div
+                ref={previewViewportRef}
+                className="overflow-hidden rounded-2xl border border-slate-200 bg-slate-100 px-2 py-2 sm:px-3 sm:py-3"
+              >
+                <div
+                  className="mx-auto"
+                  style={{
+                    width: `${embeddedStageWidth}px`,
+                    height: `${embeddedStageHeight}px`,
+                    opacity: embeddedPreviewReady ? 1 : 0,
+                    transition: "opacity 120ms ease",
+                  }}
+                >
+                  <div
+                    className="relative origin-top-left"
+                    style={{
+                      width: `${embeddedPreviewViewportWidth}px`,
+                      height: `${embeddedPreviewHeight}px`,
+                      transform: `scale(${embeddedPreviewScale})`,
+                      transformOrigin: "top left",
+                    }}
+                  >
+                    <iframe
+                      ref={iframeRef}
+                      title="Poolside note preview"
+                      data-testid="poolside-preview-frame"
+                      src={previewFrameHref ?? undefined}
+                      srcDoc={previewFrameHref ? undefined : (previewFrameDoc ?? undefined)}
+                      onLoad={syncEmbeddedPreviewMetrics}
+                      className="block border-0 bg-slate-100"
+                      style={{
+                        width: `${embeddedPreviewViewportWidth}px`,
+                        height: `${embeddedPreviewHeight}px`,
+                      }}
+                    />
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/components/my-library/workouts/SavedWorkoutsPanel.tsx
+++ b/components/my-library/workouts/SavedWorkoutsPanel.tsx
@@ -7,14 +7,8 @@ import {
   formatDistanceMetersLabel,
   resolveSessionDraftPoolLengthUnit,
 } from "@/lib/session-generator-v1/shared";
-import type {
-  WorkoutPoolsideFocusOption,
-  WorkoutPoolsideNotationMode,
-  WorkoutPoolsideRestLayout,
-  WorkoutPoolsidePrintLayout,
-  WorkoutPoolsidePrintStyle,
-  WorkoutSummary,
-} from "@/lib/workouts/shared";
+import { buildWorkoutPoolsidePreviewHref } from "@/lib/workouts/poolside-preview";
+import type { WorkoutPoolsideFocusOption, WorkoutSummary } from "@/lib/workouts/shared";
 
 type Props = {
   workouts: WorkoutSummary[];
@@ -129,29 +123,6 @@ function buildQuickPreviewSections(workout: WorkoutSummary): QuickPreviewSection
     : [];
 }
 
-function buildPoolsidePreviewHref(
-  baseHref: string,
-  options: {
-    selectedFocusIds: string[];
-    printStyle: WorkoutPoolsidePrintStyle;
-    printLayout: WorkoutPoolsidePrintLayout;
-    notationMode: WorkoutPoolsideNotationMode;
-    restLayout: WorkoutPoolsideRestLayout;
-  }
-) {
-  const url = new URL(baseHref, "http://localhost");
-  url.searchParams.set("focusMode", "custom");
-  url.searchParams.set("printStyle", options.printStyle);
-  url.searchParams.set("printLayout", options.printLayout);
-  url.searchParams.set("notationMode", options.notationMode);
-  url.searchParams.set("restLayout", options.restLayout);
-  url.searchParams.delete("focusId");
-  options.selectedFocusIds.forEach((focusId) => {
-    url.searchParams.append("focusId", focusId);
-  });
-  return `${url.pathname}${url.search}`;
-}
-
 export default function SavedWorkoutsPanel({
   workouts,
   description,
@@ -192,13 +163,6 @@ export default function SavedWorkoutsPanel({
   const [bulkSelectionMode, setBulkSelectionMode] = useState(false);
   const [pendingBulkDelete, setPendingBulkDelete] = useState(false);
   const [selectedWorkoutIds, setSelectedWorkoutIds] = useState<string[]>([]);
-  const [poolsidePrintStyle, setPoolsidePrintStyle] = useState<WorkoutPoolsidePrintStyle>("color");
-  const [poolsidePrintLayout, setPoolsidePrintLayout] =
-    useState<WorkoutPoolsidePrintLayout>("portrait");
-  const [poolsideNotationMode, setPoolsideNotationMode] =
-    useState<WorkoutPoolsideNotationMode>("auto");
-  const [poolsideRestLayout, setPoolsideRestLayout] =
-    useState<WorkoutPoolsideRestLayout>("auto");
   const [selectedPoolsideFocusIds, setSelectedPoolsideFocusIds] = useState<string[]>(() =>
     trainingFocusOptions.map((focus) => focus.id)
   );
@@ -410,12 +374,8 @@ export default function SavedWorkoutsPanel({
                 : `${workout.totalDistanceM}m`
               : null;
             const workoutPoolsidePreviewHref = workoutPoolsidePdfHref
-              ? buildPoolsidePreviewHref(workoutPoolsidePdfHref, {
+              ? buildWorkoutPoolsidePreviewHref(workoutPoolsidePdfHref, {
                   selectedFocusIds: selectedPoolsideFocusIds,
-                  printStyle: poolsidePrintStyle,
-                  printLayout: poolsidePrintLayout,
-                  notationMode: poolsideNotationMode,
-                  restLayout: poolsideRestLayout,
                 })
               : null;
 
@@ -575,14 +535,6 @@ export default function SavedWorkoutsPanel({
                           : [...current, focusId]
                       )
                     }
-                    printStyle={poolsidePrintStyle}
-                    onPrintStyleChange={setPoolsidePrintStyle}
-                    printLayout={poolsidePrintLayout}
-                    onPrintLayoutChange={setPoolsidePrintLayout}
-                    notationMode={poolsideNotationMode}
-                    onNotationModeChange={setPoolsideNotationMode}
-                    restLayout={poolsideRestLayout}
-                    onRestLayoutChange={setPoolsideRestLayout}
                     actionSlot={
                       <Link
                         href={workoutPoolsidePreviewHref}

--- a/components/my-library/workouts/WorkoutBuilderHub.tsx
+++ b/components/my-library/workouts/WorkoutBuilderHub.tsx
@@ -586,7 +586,7 @@ export default function WorkoutBuilderHub({
                 `/api/my-library/workouts/${workoutId}/export/pdf`
               }
               workoutPoolsidePdfHrefBuilder={(workoutId) =>
-                `/api/my-library/workouts/${workoutId}/export/pdf?variant=poolside`
+                `/my-library/workouts/poolside-preview?workoutId=${workoutId}`
               }
               editLabel="Edit"
               testId="workout-builder-saved-sessions"

--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -72,22 +72,23 @@ import {
   buildWorkoutStepDurationOutputSummary,
   buildWorkoutPdfFileName,
   buildWorkoutPdfHtmlDocument,
-  getDefaultWorkoutPoolsideFocusIds,
   buildWorkoutGarminReadyExport,
   buildWorkoutGarminReadyExportFileName,
   buildWorkoutGarminReadinessReport,
   buildWorkoutHandoffFileName,
   buildWorkoutHandoffText,
+  getDefaultWorkoutPoolsideFocusIds,
   selectWorkoutPoolsideFocusPoints,
   type WorkoutEditorRecord,
   type WorkoutHandoffDraftState,
   type WorkoutPoolsideFocusOption,
-  type WorkoutPoolsideNotationMode,
-  type WorkoutPoolsideRestLayout,
-  type WorkoutPoolsidePrintLayout,
-  type WorkoutPoolsidePrintStyle,
   type WorkoutSummary,
 } from "@/lib/workouts/shared";
+import {
+  buildWorkoutPoolsidePreviewHref,
+  createWorkoutPoolsidePreviewId,
+  writeStoredWorkoutPoolsidePreviewDraft,
+} from "@/lib/workouts/poolside-preview";
 
 type Props = {
   draft: SessionDraft;
@@ -1677,12 +1678,6 @@ export default function WorkoutEditor({
   );
   const [builderViewMode, setBuilderViewMode] =
     useState<(typeof WORKOUT_VIEW_MODES)[number]>("edit");
-  const [poolsidePrintStyle, setPoolsidePrintStyle] = useState<WorkoutPoolsidePrintStyle>("color");
-  const [poolsidePrintLayout, setPoolsidePrintLayout] =
-    useState<WorkoutPoolsidePrintLayout>("portrait");
-  const [poolsideNotationMode, setPoolsideNotationMode] =
-    useState<WorkoutPoolsideNotationMode>("auto");
-  const [poolsideRestLayout, setPoolsideRestLayout] = useState<WorkoutPoolsideRestLayout>("auto");
   const [selectedPoolsideFocusIds, setSelectedPoolsideFocusIds] = useState<string[]>(() =>
     getDefaultWorkoutPoolsideFocusIds(trainingFocusOptions)
   );
@@ -2135,10 +2130,6 @@ export default function WorkoutEditor({
   useEffect(() => {
     setMetadataOpen(forceMetadataOpenOnLoad || !metadataStartsCollapsed);
     setBuilderViewMode("edit");
-    setPoolsidePrintStyle("color");
-    setPoolsidePrintLayout("portrait");
-    setPoolsideNotationMode("auto");
-    setPoolsideRestLayout("auto");
     setSelectedPoolsideFocusIds(parseSignatureValues(defaultPoolsideFocusIdSignature));
   }, [
     copyVariant,
@@ -2170,10 +2161,6 @@ export default function WorkoutEditor({
     handoffDraftState,
     savedWorkoutId,
     savedWorkout?.updatedAt,
-    poolsidePrintStyle,
-    poolsidePrintLayout,
-    poolsideNotationMode,
-    poolsideRestLayout,
     selectedPoolsideFocusSignature,
     swimmerName,
   ]);
@@ -3144,29 +3131,30 @@ export default function WorkoutEditor({
         throw new Error("Window unavailable.");
       }
 
-      const html =
-        variant === "poolside"
-          ? buildWorkoutPdfHtmlDocument(draft, {
-              draftState: handoffDraftState,
-              variant: "poolside",
-              focusPoints: selectedPoolsideFocusPoints,
-              poolsidePrintStyle,
-              poolsidePrintLayout,
-              poolsideNotationMode,
-              poolsideRestLayout,
-              swimmerName,
-              logoUrl: new URL(
-                getWorkoutPdfLogoPath({
-                  variant: "poolside",
-                  poolsidePrintStyle,
-                }),
-                window.location.origin
-              ).toString(),
-              fontUrl: new URL(BRAND_FONT_PUBLIC_PATH, window.location.origin).toString(),
-            })
-          : workoutPdfHtml;
-      const fileName = variant === "poolside" ? workoutPoolsidePdfFileName : workoutPdfFileName;
-      const variantLabel = variant === "poolside" ? "Print Preview" : "PDF";
+      if (variant === "poolside") {
+        const previewId = createWorkoutPoolsidePreviewId();
+        writeStoredWorkoutPoolsidePreviewDraft(previewId, {
+          draft,
+          draftState: handoffDraftState,
+          focusPoints: selectedPoolsideFocusPoints,
+          swimmerName: swimmerName ?? null,
+        });
+        const previewHref = buildWorkoutPoolsidePreviewHref(
+          `/my-library/workouts/poolside-preview?previewId=${encodeURIComponent(previewId)}`
+        );
+        const previewWindow = window.open(previewHref, "_blank", "noopener,noreferrer");
+
+        if (!previewWindow) {
+          throw new Error("Popup blocked.");
+        }
+
+        previewWindow.focus?.();
+        setWorkoutPdfNotice(
+          `Opened Print Preview for ${workoutPoolsidePdfFileName}. Finish layout and print settings in that tab.`
+        );
+        return;
+      }
+
       const printWindow = window.open("", "_blank");
 
       if (!printWindow?.document) {
@@ -3174,11 +3162,11 @@ export default function WorkoutEditor({
       }
 
       printWindow.document.open();
-      printWindow.document.write(html);
+      printWindow.document.write(workoutPdfHtml);
       printWindow.document.close();
       printWindow.focus?.();
       setWorkoutPdfNotice(
-        `Opened ${variantLabel} for ${fileName}. Use Print / Save PDF in that tab.`
+        `Opened PDF for ${workoutPdfFileName}. Use Print / Save PDF in that tab.`
       );
     } catch {
       setWorkoutPdfError(
@@ -5017,14 +5005,6 @@ export default function WorkoutEditor({
       focusOptions={trainingFocusOptions}
       selectedFocusIds={selectedPoolsideFocusIds}
       onToggleFocus={togglePoolsideFocusSelection}
-      printStyle={poolsidePrintStyle}
-      onPrintStyleChange={setPoolsidePrintStyle}
-      printLayout={poolsidePrintLayout}
-      onPrintLayoutChange={setPoolsidePrintLayout}
-      notationMode={poolsideNotationMode}
-      onNotationModeChange={setPoolsideNotationMode}
-      restLayout={poolsideRestLayout}
-      onRestLayoutChange={setPoolsideRestLayout}
       actionSlot={
         <button
           type="button"

--- a/docs/task-briefs/in-progress/2026-04-19-poolside-note-preview-owned-print-settings-and-builder-simplification-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-19-poolside-note-preview-owned-print-settings-and-builder-simplification-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-04-19-poolside-note-preview-owned-print-settings-and-builder-simplification-10-10`
-- `status`: `planned`
+- `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-04-19`
 - `updated`: `2026-04-19`
@@ -211,3 +211,6 @@ Critical target categories for `10/10` claim in this brief:
 ## Checkpoint Log
 
 - `2026-04-19 | planning | created the dedicated follow-up brief after PR #473 closeout to lock the next poolside ownership change: keep Session Focus in builder, move print settings to the preview surface, and remove duplicate builder-side print controls only after preview parity exists | next: if approved, move this brief to in-progress and implement the builder/preview ownership cleanup end to end`
+- `2026-04-19 | implementation | moved the brief to in-progress, removed builder-side print settings from the poolside panel, added the owner-facing poolside preview route with preview-owned settings, kept saved-workout previews URL-driven, and added local preview draft storage so the live editor opens the same preview surface with current draft content | next: run visual QA, capture reference/after screenshots, and stop for owner approval before verify:pre-pr`
+- `2026-04-19 | implementation | tightened the embedded preview renderer after screenshot review so mobile preview keeps the poolside note in its print-faithful composition instead of triggering the standalone responsive stack; the preview frame now scales the rendered note while preserving the top-right Learn. Drill. Swim. lockup inside the note surface | next: hand off updated mobile/desktop screenshots for owner approval before verify:pre-pr`
+- `2026-04-19 | implementation | finished the last mobile preview micro-fix by moving viewport measurement earlier, clamping embedded scale before first visible paint, and tightening embedded padding so the note surface stays optically centered without clipping on the right edge | next: owner review of the refreshed after-screenshots, then verify:pre-pr if approved`

--- a/lib/workouts/poolside-preview.ts
+++ b/lib/workouts/poolside-preview.ts
@@ -1,0 +1,189 @@
+import type { SessionDraft } from "@/lib/session-generator-v1/shared";
+import type {
+  WorkoutHandoffDraftState,
+  WorkoutPoolsideNotationMode,
+  WorkoutPoolsidePrintLayout,
+  WorkoutPoolsidePrintStyle,
+  WorkoutPoolsideRestLayout,
+} from "@/lib/workouts/shared";
+import {
+  normalizeWorkoutPoolsideNotationMode,
+  normalizeWorkoutPoolsidePrintLayout,
+  normalizeWorkoutPoolsidePrintStyle,
+  normalizeWorkoutPoolsideRestLayout,
+} from "@/lib/workouts/shared";
+
+const WORKOUT_POOLSIDE_PREVIEW_STORAGE_PREFIX = "my-library-workout-poolside-preview-v1:";
+
+export type WorkoutPoolsidePreviewSettings = {
+  printStyle: WorkoutPoolsidePrintStyle;
+  printLayout: WorkoutPoolsidePrintLayout;
+  notationMode: WorkoutPoolsideNotationMode;
+  restLayout: WorkoutPoolsideRestLayout;
+};
+
+export type StoredWorkoutPoolsidePreviewDraft = {
+  version: 1;
+  updatedAt: number;
+  draft: SessionDraft;
+  draftState: WorkoutHandoffDraftState;
+  focusPoints: string[];
+  swimmerName: string | null;
+};
+
+export const DEFAULT_WORKOUT_POOLSIDE_PREVIEW_SETTINGS: WorkoutPoolsidePreviewSettings = {
+  printStyle: "color",
+  printLayout: "portrait",
+  notationMode: "auto",
+  restLayout: "auto",
+};
+
+function isBrowser() {
+  return typeof window !== "undefined";
+}
+
+function buildWorkoutPoolsidePreviewStorageKey(previewId: string) {
+  return `${WORKOUT_POOLSIDE_PREVIEW_STORAGE_PREFIX}${previewId}`;
+}
+
+function isStoredWorkoutPoolsidePreviewDraft(
+  value: unknown
+): value is StoredWorkoutPoolsidePreviewDraft {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<StoredWorkoutPoolsidePreviewDraft>;
+  const draft = candidate.draft as Partial<SessionDraft> | undefined;
+
+  return (
+    candidate.version === 1 &&
+    typeof candidate.updatedAt === "number" &&
+    draft !== undefined &&
+    typeof draft.title === "string" &&
+    typeof draft.sourceFingerprint === "string" &&
+    Array.isArray(draft.steps) &&
+    (candidate.draftState === "canonical" || candidate.draftState === "local_draft") &&
+    Array.isArray(candidate.focusPoints) &&
+    candidate.focusPoints.every((point) => typeof point === "string") &&
+    (candidate.swimmerName === null || typeof candidate.swimmerName === "string")
+  );
+}
+
+export function createWorkoutPoolsidePreviewId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return `poolside-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function normalizeWorkoutPoolsidePreviewSettings(input?: {
+  printStyle?: string | null | undefined;
+  printLayout?: string | null | undefined;
+  notationMode?: string | null | undefined;
+  restLayout?: string | null | undefined;
+}): WorkoutPoolsidePreviewSettings {
+  return {
+    printStyle: normalizeWorkoutPoolsidePrintStyle(input?.printStyle),
+    printLayout: normalizeWorkoutPoolsidePrintLayout(input?.printLayout),
+    notationMode: normalizeWorkoutPoolsideNotationMode(input?.notationMode),
+    restLayout: normalizeWorkoutPoolsideRestLayout(input?.restLayout),
+  };
+}
+
+export function applyWorkoutPoolsidePreviewSettings(
+  searchParams: URLSearchParams,
+  settings?: Partial<WorkoutPoolsidePreviewSettings>
+) {
+  const normalized = normalizeWorkoutPoolsidePreviewSettings(settings);
+  searchParams.set("printStyle", normalized.printStyle);
+  searchParams.set("printLayout", normalized.printLayout);
+  searchParams.set("notationMode", normalized.notationMode);
+  searchParams.set("restLayout", normalized.restLayout);
+}
+
+export function buildWorkoutPoolsidePreviewHref(
+  baseHref: string,
+  options?: {
+    selectedFocusIds?: string[];
+    settings?: Partial<WorkoutPoolsidePreviewSettings>;
+  }
+) {
+  const url = new URL(baseHref, "http://localhost");
+  applyWorkoutPoolsidePreviewSettings(url.searchParams, options?.settings);
+
+  if (Array.isArray(options?.selectedFocusIds)) {
+    url.searchParams.set("focusMode", "custom");
+    url.searchParams.delete("focusId");
+    options.selectedFocusIds.forEach((focusId) => {
+      url.searchParams.append("focusId", focusId);
+    });
+  }
+
+  return `${url.pathname}${url.search}`;
+}
+
+export function buildWorkoutPoolsidePrintFrameHref(
+  workoutId: string,
+  options?: {
+    selectedFocusIds?: string[];
+    settings?: Partial<WorkoutPoolsidePreviewSettings>;
+  }
+) {
+  const url = new URL(`/api/my-library/workouts/${workoutId}/export/pdf`, "http://localhost");
+  url.searchParams.set("variant", "poolside");
+  url.searchParams.set("previewChrome", "embedded");
+  applyWorkoutPoolsidePreviewSettings(url.searchParams, options?.settings);
+
+  if (Array.isArray(options?.selectedFocusIds)) {
+    url.searchParams.set("focusMode", "custom");
+    url.searchParams.delete("focusId");
+    options.selectedFocusIds.forEach((focusId) => {
+      url.searchParams.append("focusId", focusId);
+    });
+  }
+
+  return `${url.pathname}${url.search}`;
+}
+
+export function writeStoredWorkoutPoolsidePreviewDraft(
+  previewId: string,
+  payload: Omit<StoredWorkoutPoolsidePreviewDraft, "version" | "updatedAt">
+) {
+  if (!isBrowser()) {
+    return;
+  }
+
+  try {
+    const snapshot: StoredWorkoutPoolsidePreviewDraft = {
+      version: 1,
+      updatedAt: Date.now(),
+      ...payload,
+    };
+    window.localStorage.setItem(
+      buildWorkoutPoolsidePreviewStorageKey(previewId),
+      JSON.stringify(snapshot)
+    );
+  } catch {
+    // preview storage is best effort only
+  }
+}
+
+export function readStoredWorkoutPoolsidePreviewDraft(previewId: string) {
+  if (!isBrowser()) {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(buildWorkoutPoolsidePreviewStorageKey(previewId));
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as unknown;
+    return isStoredWorkoutPoolsidePreviewDraft(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}

--- a/lib/workouts/shared.ts
+++ b/lib/workouts/shared.ts
@@ -172,6 +172,7 @@ function formatWorkoutDistanceLabel(
 
 export type WorkoutHandoffDraftState = "canonical" | "local_draft";
 export type WorkoutPdfVariant = "standard" | "poolside";
+export type WorkoutPdfPreviewChrome = "standalone" | "embedded";
 export const WORKOUT_POOLSIDE_PRINT_STYLES = ["color", "ink_saver"] as const;
 export const WORKOUT_POOLSIDE_PRINT_LAYOUTS = ["portrait", "landscape"] as const;
 export const WORKOUT_POOLSIDE_NOTATION_MODES = ["auto", "full", "abbreviated"] as const;
@@ -991,17 +992,24 @@ export function buildWorkoutPdfHtmlDocument(
     swimmerName?: string | null;
     logoUrl?: string | null;
     fontUrl?: string | null;
+    previewChrome?: WorkoutPdfPreviewChrome;
   }
 ) {
   const model = buildWorkoutPdfModel(draft, options);
+  const previewChrome = normalizeWorkoutPdfPreviewChrome(options?.previewChrome);
   if (model.variant === "poolside") {
-    return buildPoolsideWorkoutPdfHtmlDocument(model, options?.fontUrl ?? BRAND_FONT_PUBLIC_PATH);
+    return buildPoolsideWorkoutPdfHtmlDocument(
+      model,
+      options?.fontUrl ?? BRAND_FONT_PUBLIC_PATH,
+      previewChrome
+    );
   }
 
   return buildStandardWorkoutPdfHtmlDocument(
     model,
     options?.fontUrl ?? BRAND_FONT_PUBLIC_PATH,
-    getWorkoutStepDetailLabels(draft?.environment)
+    getWorkoutStepDetailLabels(draft?.environment),
+    previewChrome
   );
 }
 
@@ -1054,10 +1062,12 @@ function buildPdfBrandLockupHtml(
 function buildStandardWorkoutPdfHtmlDocument(
   model: WorkoutPdfModel,
   fontUrl: string | null,
-  detailLabels: WorkoutStepDetailLabels
+  detailLabels: WorkoutStepDetailLabels,
+  previewChrome: WorkoutPdfPreviewChrome
 ) {
   const fontFaceCss = buildPdfBrandFontFaceCss(fontUrl);
   const logoHtml = buildPdfBrandLockupHtml(model.logoUrl);
+  const isEmbeddedPreview = previewChrome === "embedded";
   const reviewDetailsHtml =
     model.readiness.issues.length > 0
       ? `
@@ -1546,6 +1556,10 @@ function buildStandardWorkoutPdfHtmlDocument(
     </style>
   </head>
   <body>
+    ${
+      isEmbeddedPreview
+        ? ""
+        : `
     <div class="toolbar">
       <div class="toolbar-copy">
         <span class="toolbar-kicker">FreeSwimming</span>
@@ -1560,6 +1574,8 @@ function buildStandardWorkoutPdfHtmlDocument(
         </button>
       </div>
     </div>
+    `
+    }
     <main class="shell">
       <article class="page" data-testid="workout-pdf-print-view" data-pdf-variant="standard">
         <header class="hero">
@@ -1606,10 +1622,15 @@ function buildStandardWorkoutPdfHtmlDocument(
 </html>`;
 }
 
-function buildPoolsideWorkoutPdfHtmlDocument(model: WorkoutPdfModel, fontUrl: string | null) {
+function buildPoolsideWorkoutPdfHtmlDocument(
+  model: WorkoutPdfModel,
+  fontUrl: string | null,
+  previewChrome: WorkoutPdfPreviewChrome
+) {
   const isInkSaver = model.poolsidePrintStyle === "ink_saver";
   const isLandscape = model.poolsidePrintLayout === "landscape";
   const hasFocusPoints = model.focusPoints.length > 0;
+  const isEmbeddedPreview = previewChrome === "embedded";
   const fontFaceCss = buildPdfBrandFontFaceCss(fontUrl);
   const sizingProfile = getWorkoutPoolsideSizingProfile(model, { isLandscape });
   const logoHtml = buildPdfBrandLockupHtml(model.logoUrl, { variant: "poolside" });
@@ -1827,7 +1848,7 @@ function buildPoolsideWorkoutPdfHtmlDocument(model: WorkoutPdfModel, fontUrl: st
       }
 
       .shell {
-        padding: 8px 8px 10px;
+        ${isEmbeddedPreview ? "display: flex; justify-content: center; padding: 4px 0 6px;" : "padding: 8px 8px 10px;"}
       }
 
       .page {
@@ -2230,6 +2251,10 @@ function buildPoolsideWorkoutPdfHtmlDocument(model: WorkoutPdfModel, fontUrl: st
         margin: 8mm;
       }
 
+      ${
+        isEmbeddedPreview
+          ? ""
+          : `
       @media (max-width: 900px) {
         .hero-top-row {
           align-items: flex-start;
@@ -2260,15 +2285,21 @@ function buildPoolsideWorkoutPdfHtmlDocument(model: WorkoutPdfModel, fontUrl: st
           white-space: normal;
         }
       }
+      `
+      }
     </style>
   </head>
   <body>
+    ${
+      isEmbeddedPreview
+        ? ""
+        : `
     <div class="toolbar">
       <div class="toolbar-copy">
         <span class="toolbar-kicker">FreeSwimming</span>
         <span class="toolbar-title">Print Preview</span>
       </div>
-        <div class="toolbar-actions">
+      <div class="toolbar-actions">
         <button class="toolbar-button toolbar-button-primary" type="button" onclick="window.print()">
           Print / Save PDF
         </button>
@@ -2277,6 +2308,8 @@ function buildPoolsideWorkoutPdfHtmlDocument(model: WorkoutPdfModel, fontUrl: st
         </button>
       </div>
     </div>
+    `
+    }
     <main class="shell">
       <article
         class="page"
@@ -3370,6 +3403,12 @@ export function normalizeWorkoutPoolsideRestLayout(
   }
 
   return "auto";
+}
+
+export function normalizeWorkoutPdfPreviewChrome(
+  value: string | null | undefined
+): WorkoutPdfPreviewChrome {
+  return value === "embedded" ? "embedded" : "standalone";
 }
 
 function normalizeWorkoutSwimmerName(value: string | null | undefined) {

--- a/tests/unit/poolside-note-panel.test.tsx
+++ b/tests/unit/poolside-note-panel.test.tsx
@@ -2,22 +2,12 @@ import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import PoolsideNotePanel from "@/components/my-library/workouts/PoolsideNotePanel";
-import type {
-  WorkoutPoolsideFocusOption,
-  WorkoutPoolsideNotationMode,
-  WorkoutPoolsidePrintLayout,
-  WorkoutPoolsidePrintStyle,
-  WorkoutPoolsideRestLayout,
-} from "@/lib/workouts/shared";
+import type { WorkoutPoolsideFocusOption } from "@/lib/workouts/shared";
 
 function renderPoolsideNotePanel(
   focusOptions: WorkoutPoolsideFocusOption[],
   options?: {
     selectedFocusIds?: string[];
-    printStyle?: WorkoutPoolsidePrintStyle;
-    printLayout?: WorkoutPoolsidePrintLayout;
-    notationMode?: WorkoutPoolsideNotationMode;
-    restLayout?: WorkoutPoolsideRestLayout;
   }
 ) {
   return render(
@@ -27,14 +17,6 @@ function renderPoolsideNotePanel(
       focusOptions={focusOptions}
       selectedFocusIds={options?.selectedFocusIds ?? []}
       onToggleFocus={vi.fn()}
-      printStyle={options?.printStyle ?? "color"}
-      onPrintStyleChange={vi.fn()}
-      printLayout={options?.printLayout ?? "portrait"}
-      onPrintLayoutChange={vi.fn()}
-      notationMode={options?.notationMode ?? "auto"}
-      onNotationModeChange={vi.fn()}
-      restLayout={options?.restLayout ?? "auto"}
-      onRestLayoutChange={vi.fn()}
       actionSlot={<button type="button">Print Preview</button>}
     />
   );
@@ -52,11 +34,12 @@ describe("PoolsideNotePanel", () => {
       "data-layout-mode",
       "stacked"
     );
-    expect(screen.getByTestId("poolside-note-test-print-options-grid")).toHaveAttribute(
+    expect(screen.getByTestId("poolside-note-test-reference-panel")).toHaveAttribute(
       "data-layout-mode",
       "stacked"
     );
     expect(screen.getByText(/No open focuses are available/i)).toBeInTheDocument();
+    expect(screen.queryByText("Print Preview owns the final layout")).not.toBeInTheDocument();
   });
 
   it("keeps long focus lists on a stacked page-scroll-first layout", () => {
@@ -77,7 +60,7 @@ describe("PoolsideNotePanel", () => {
       "stacked"
     );
     expect(screen.getByTestId("poolside-note-test-focus-list")).not.toHaveClass("overflow-y-auto");
-    expect(screen.getByTestId("poolside-note-test-print-options-grid")).toHaveAttribute(
+    expect(screen.getByTestId("poolside-note-test-reference-panel")).toHaveAttribute(
       "data-layout-mode",
       "stacked"
     );

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -4,6 +4,7 @@ import WorkoutBuilderHub from "@/components/my-library/workouts/WorkoutBuilderHu
 import { WORKOUT_NOTICE_AUTO_DISMISS_MS } from "@/components/my-library/workouts/useAutoDismissNotice";
 import { buildManualWorkoutEmptyDraft } from "@/lib/workouts/manual";
 import { buildManualWorkoutLocalDraftStorageKey } from "@/lib/workouts/manual-local-draft";
+import { readStoredWorkoutPoolsidePreviewDraft } from "@/lib/workouts/poolside-preview";
 import type { SessionDraft } from "@/lib/session-generator-v1/shared";
 import type {
   WorkoutEditorRecord,
@@ -1427,7 +1428,7 @@ describe("WorkoutBuilderHub", () => {
   it("opens truthful PDF and poolside note views for the current draft state", async () => {
     const writtenDocuments: string[] = [];
     const pdfWindow = buildMockPrintWindow(writtenDocuments);
-    const poolsideWindow = buildMockPrintWindow(writtenDocuments);
+    const poolsideWindow = { focus: vi.fn() };
     const createObjectUrlSpy = vi.spyOn(URL, "createObjectURL");
     const openSpy = vi
       .spyOn(window, "open")
@@ -1494,69 +1495,46 @@ describe("WorkoutBuilderHub", () => {
       )}. Use Print / Save PDF in that tab.`
     );
 
-    fireEvent.click(screen.getByTestId("workout-editor-poolside-focus-focus-2"));
-    fireEvent.click(screen.getByTestId("workout-editor-poolside-style-ink-saver"));
-    fireEvent.click(screen.getByTestId("workout-editor-poolside-layout-landscape"));
+    expect(screen.queryByText("Print options")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Style, layout, notation, and rest layout stay in Print Preview.")
+    ).not.toBeInTheDocument();
     fireEvent.click(screen.getByTestId("workout-editor-poolside-pdf-open"));
 
     await waitFor(() => {
       expect(openSpy).toHaveBeenCalledTimes(2);
     });
 
-    const poolsideHtml = writtenDocuments[1] ?? "";
+    const poolsidePreviewHref = openSpy.mock.calls[1]?.[0] as string;
+    expect(poolsidePreviewHref).toContain("/my-library/workouts/poolside-preview?previewId=");
+    expect(poolsidePreviewHref).toContain("printStyle=color");
+    expect(poolsidePreviewHref).toContain("printLayout=portrait");
+    expect(poolsidePreviewHref).toContain("notationMode=auto");
+    expect(poolsidePreviewHref).toContain("restLayout=auto");
+    expect(openSpy.mock.calls[1]?.[1]).toBe("_blank");
+    expect(openSpy.mock.calls[1]?.[2]).toBe("noopener,noreferrer");
 
-    expect(poolsideHtml).toContain('data-pdf-variant="poolside"');
-    expect(poolsideHtml).toContain('data-poolside-print-style="ink_saver"');
-    expect(poolsideHtml).toContain('data-poolside-print-layout="landscape"');
-    expect(poolsideHtml).toContain("High elbow catch");
-    expect(poolsideHtml).toContain("Calm exhale");
-    expect(poolsideHtml).toContain(
-      "High elbow catch: Keep the forearm vertical before pressing back."
-    );
-    expect(poolsideHtml).toContain(
-      "Calm exhale: Start the exhale before the head turns to breathe."
-    );
-    expect(poolsideHtml).toContain('class="brand-mark brand-mark-poolside"');
-    expect(poolsideHtml).toContain('class="brand-logo brand-logo-poolside"');
-    expect(poolsideHtml).toContain("lockup-domain-ink.png");
-    expect(poolsideHtml).toContain("Print Preview");
-    expect(poolsideHtml).toContain("Total");
-    expect(poolsideHtml).toContain('data-testid="workout-pdf-total"');
-    expect(poolsideHtml).toContain('<link rel="icon" href="/favicon.ico" sizes="any" />');
-    expect(poolsideHtml).toContain('<link rel="apple-touch-icon" href="/apple-touch-icon.png" />');
-    expect(poolsideHtml).not.toContain("Pool session execution");
-    expect(poolsideHtml).not.toContain("Source: Local draft");
-    expect(poolsideHtml).not.toContain(">Color mode<");
-    expect(poolsideHtml).not.toContain(">Ink saver<");
-    expect(poolsideHtml).not.toContain(">Portrait<");
-    expect(poolsideHtml).not.toContain(">Landscape<");
-    expect(poolsideHtml).not.toContain("~");
-    expect(poolsideHtml).toContain(
-      "<title>freeswimming-local-pdf-workout-poolside-note-draft.pdf - FreeSwimming</title>"
-    );
-    expect(poolsideHtml).toContain("body-landscape-columns");
-    expect(poolsideHtml).toContain("poolside-meta-landscape");
-    expect(poolsideHtml).not.toContain("poolside-side-rail");
-    expect(poolsideHtml).toContain("size: A4;");
-    expect(poolsideHtml).not.toContain("size: A4 landscape");
-    expect(poolsideWindow.document.open).toHaveBeenCalledTimes(1);
-    expect(poolsideWindow.document.close).toHaveBeenCalledTimes(1);
+    const poolsidePreviewUrl = new URL(poolsidePreviewHref, "http://localhost");
+    const previewId = poolsidePreviewUrl.searchParams.get("previewId");
+    expect(previewId).toBeTruthy();
+
+    const storedPreview = readStoredWorkoutPoolsidePreviewDraft(previewId ?? "");
+    expect(storedPreview?.draftState).toBe("local_draft");
+    expect(storedPreview?.draft.title).toBe("Local PDF workout");
+    expect(storedPreview?.draft.steps[0]?.stroke).toBe("reverse_im_order");
+    expect(storedPreview?.focusPoints).toEqual([
+      "High elbow catch: Keep the forearm vertical before pressing back.",
+    ]);
     expect(poolsideWindow.focus).toHaveBeenCalledTimes(1);
-    expect(screen.getByText("Keeps the blue surfaces")).toBeVisible();
-    expect(screen.getByText("Uses white surfaces.")).toBeVisible();
-    expect(screen.getByText("Print options")).toBeVisible();
-    expect(
-      screen.queryByText("Compact lane-side note in one tall column.")
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText("Wider split layout for longer programs and more focus notes.")
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText("Keeps the blue surfaces when your browser prints backgrounds.")
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText("Uses white surfaces and strong outlines for cheaper printing.")
-    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("workout-editor-pdf-notice")).toHaveTextContent(
+      `Opened Print Preview for ${buildWorkoutPdfFileName(
+        {
+          ...buildDraft(),
+          title: "Local PDF workout",
+        },
+        { draftState: "local_draft", variant: "poolside" }
+      )}. Finish layout and print settings in that tab.`
+    );
   }, 30000);
 
   it("collapses the metadata panel by default for saved builder sessions and reopens on demand", async () => {
@@ -2734,8 +2712,10 @@ describe("WorkoutBuilderHub", () => {
     });
 
     vi.useFakeTimers();
-    fireEvent.click(screen.getByTestId("workout-editor-pdf-open"));
-    expect(screen.getByTestId("workout-editor-pdf-notice")).toBeVisible();
+    act(() => {
+      fireEvent.click(screen.getByTestId("workout-editor-pdf-open"));
+    });
+    expect(screen.queryByTestId("workout-editor-pdf-notice")).toBeVisible();
 
     act(() => {
       vi.advanceTimersByTime(WORKOUT_NOTICE_AUTO_DISMISS_MS);
@@ -2832,22 +2812,30 @@ describe("WorkoutBuilderHub", () => {
     fireEvent.click(screen.getByTestId("saved-workouts-poolside-workout-2"));
     expect(screen.getByTestId("saved-workout-poolside-workout-2-panel")).toBeVisible();
     expect(screen.getByText("Swimmer: Stian Vikra")).toBeVisible();
-    expect(screen.getByTestId("saved-workout-poolside-workout-2-notation-auto")).toBeChecked();
-    expect(screen.getByTestId("saved-workout-poolside-workout-2-rest-layout-auto")).toBeChecked();
-    fireEvent.click(screen.getByTestId("saved-workout-poolside-workout-2-notation-abbreviated"));
-    fireEvent.click(screen.getByTestId("saved-workout-poolside-workout-2-rest-layout-below"));
+    expect(screen.queryByText("Print options")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Style, layout, notation, and rest layout stay in Print Preview.")
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("saved-workout-poolside-workout-2-print-preview")).toHaveAttribute(
+      "href",
+      expect.stringContaining("/my-library/workouts/poolside-preview?workoutId=workout-2")
+    );
     expect(screen.getByTestId("saved-workout-poolside-workout-2-print-preview")).toHaveAttribute(
       "href",
       expect.stringContaining("focusMode=custom")
     );
     expect(screen.getByTestId("saved-workout-poolside-workout-2-print-preview")).toHaveAttribute(
       "href",
-      expect.stringContaining("notationMode=abbreviated")
+      expect.stringContaining("notationMode=auto")
     );
     expect(screen.getByTestId("saved-workout-poolside-workout-2-print-preview")).toHaveAttribute(
       "href",
-      expect.stringContaining("restLayout=below_step")
+      expect.stringContaining("restLayout=auto")
     );
+    fireEvent.click(screen.getByTestId("saved-workout-poolside-workout-2-focus-focus-2"));
+    expect(
+      screen.getByTestId("saved-workout-poolside-workout-2-print-preview").getAttribute("href")
+    ).not.toContain("focusId=focus-2");
 
     fireEvent.click(screen.getByTestId("workout-builder-delete-workout-workout-2"));
 

--- a/tests/unit/workout-poolside-preview.test.ts
+++ b/tests/unit/workout-poolside-preview.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildWorkoutPoolsidePreviewHref,
+  buildWorkoutPoolsidePrintFrameHref,
+  readStoredWorkoutPoolsidePreviewDraft,
+  writeStoredWorkoutPoolsidePreviewDraft,
+} from "@/lib/workouts/poolside-preview";
+import type { SessionDraft } from "@/lib/session-generator-v1/shared";
+
+function buildDraft(): SessionDraft {
+  return {
+    version: 1,
+    status: "draft",
+    generatorKind: "rule_engine_v1",
+    createdAt: "2026-04-19T08:00:00.000Z",
+    sourceFingerprint: "fingerprint-1",
+    title: "Poolside preview draft",
+    titleSuggestions: [],
+    description: "",
+    environment: "pool",
+    poolLengthUnit: "m",
+    poolLengthM: 25,
+    sessionType: "threshold_css",
+    effort: "moderate",
+    sizeMode: "distance",
+    targetDistanceM: 1600,
+    targetTimeMin: null,
+    totalDistanceM: 1600,
+    estimatedDurationMin: 35,
+    basePaceSecondsPer100m: 120,
+    usedCssPaceLabel: null,
+    allowedStrokes: ["freestyle"],
+    equipmentAllowlist: [],
+    focusText: "",
+    goalTitle: "",
+    constraintText: "",
+    warnings: [],
+    steps: [
+      {
+        id: "step-1",
+        category: "warmup",
+        name: "Warmup swim",
+        stroke: "freestyle",
+        intensity: "easy",
+        durationMode: "distance",
+        distanceM: 400,
+        timeMin: null,
+        targetSummary: "",
+        notes: "",
+      },
+    ],
+  };
+}
+
+describe("workout poolside preview helpers", () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("builds a preview route href with default print settings and explicit focus selection", () => {
+    const href = buildWorkoutPoolsidePreviewHref(
+      "/my-library/workouts/poolside-preview?workoutId=workout-1",
+      {
+        selectedFocusIds: ["focus-1", "focus-2"],
+      }
+    );
+
+    expect(href).toContain("/my-library/workouts/poolside-preview?workoutId=workout-1");
+    expect(href).toContain("focusMode=custom");
+    expect(href).toContain("focusId=focus-1");
+    expect(href).toContain("focusId=focus-2");
+    expect(href).toContain("printStyle=color");
+    expect(href).toContain("printLayout=portrait");
+    expect(href).toContain("notationMode=auto");
+    expect(href).toContain("restLayout=auto");
+  });
+
+  it("builds an embedded canonical frame href for the preview surface", () => {
+    const href = buildWorkoutPoolsidePrintFrameHref("workout-1", {
+      selectedFocusIds: [],
+      settings: {
+        printStyle: "ink_saver",
+        printLayout: "landscape",
+        notationMode: "abbreviated",
+        restLayout: "below_step",
+      },
+    });
+
+    expect(href).toBe(
+      "/api/my-library/workouts/workout-1/export/pdf?variant=poolside&previewChrome=embedded&printStyle=ink_saver&printLayout=landscape&notationMode=abbreviated&restLayout=below_step&focusMode=custom"
+    );
+  });
+
+  it("stores and reloads local draft previews by preview id", () => {
+    writeStoredWorkoutPoolsidePreviewDraft("preview-1", {
+      draft: buildDraft(),
+      draftState: "local_draft",
+      focusPoints: ["High elbow catch"],
+      swimmerName: "Stian Vikra",
+    });
+
+    expect(readStoredWorkoutPoolsidePreviewDraft("preview-1")).toMatchObject({
+      draftState: "local_draft",
+      focusPoints: ["High elbow catch"],
+      swimmerName: "Stian Vikra",
+    });
+  });
+});

--- a/tests/unit/workouts-shared.test.ts
+++ b/tests/unit/workouts-shared.test.ts
@@ -1059,6 +1059,20 @@ describe("workouts shared readiness", () => {
     expect(html).not.toContain("margin: 12mm;");
   });
 
+  it("can render an embedded poolside preview without the standalone toolbar chrome", () => {
+    const html = buildWorkoutPdfHtmlDocument(buildDraft(), {
+      draftState: "local_draft",
+      variant: "poolside",
+      previewChrome: "embedded",
+    });
+
+    expect(html).toContain('data-pdf-variant="poolside"');
+    expect(html).not.toContain('<div class="toolbar">');
+    expect(html).not.toContain(">Print / Save PDF<");
+    expect(html).not.toContain(">Close<");
+    expect(html).not.toContain("@media (max-width: 900px)");
+  });
+
   it("keeps long poolside focus text inside the chosen compact width", () => {
     const compactHtml = buildWorkoutPdfHtmlDocument(buildDraft(), {
       draftState: "canonical",


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-04-19T21:30:38.222Z for branch `feat/poolside-preview-owned-print-settings` (base ref `origin/main`).
- Latest commit: `29a28f2` - Move poolside print settings into preview.
- User-visible changes: User/admin runtime behavior may change on touched routes/components.
- Technical changes: Updated 14 file(s): `app/api/my-library/workouts/[workoutId]/export/pdf/route.ts`, `app/my-library/workouts/poolside-preview/page.tsx`, `components/my-library/workouts/PoolsideNotePanel.tsx`, `components/my-library/workouts/PoolsidePreviewPageClient.tsx`, `components/my-library/workouts/SavedWorkoutsPanel.tsx`, `... and 9 more file(s)`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-04-19-poolside-note-preview-owned-print-settings-and-builder-simplification-10-10.md`
- Scorecard target outcomes: 10 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (1); tests (4); API handlers (1); runtime UI/routes/components (8).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (14):
  - `app/api/my-library/workouts/[workoutId]/export/pdf/route.ts`
  - `app/my-library/workouts/poolside-preview/page.tsx`
  - `components/my-library/workouts/PoolsideNotePanel.tsx`
  - `components/my-library/workouts/PoolsidePreviewPageClient.tsx`
  - `components/my-library/workouts/SavedWorkoutsPanel.tsx`
  - `components/my-library/workouts/WorkoutBuilderHub.tsx`
  - `components/my-library/workouts/WorkoutEditor.tsx`
  - `docs/task-briefs/in-progress/2026-04-19-poolside-note-preview-owned-print-settings-and-builder-simplification-10-10.md`
  - `... and 6 more file(s)`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `29a28f2` (`git revert 29a28f2`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **PASS** (artifacts/test-runs/20260419-230345, lane: full-public)
- `npm run verify:pre-merge`: **PENDING** for `29a28f2` (last green marker: `a7b50df` at 2026-04-19T18:37:11Z; rerun on current HEAD).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  -   -  434 [desktop-firefox] › tests/e2e/private-access-gate.spec.ts:14:7 › private access gate › redirects public users to preview access and unlocks
  -   -  435 [desktop-firefox] › tests/e2e/private-access-gate.spec.ts:68:7 › private access gate › blocks protected api paths for unauthenticated public request context
  -   -  436 [desktop-firefox] › tests/e2e/private-access-gate.spec.ts:75:7 › private access gate › keeps indexing metadata locked while site is private
  -   ✓  437 [desktop-firefox] › tests/e2e/sitemap.spec.ts:32:5 › sitemap contains canonical public routes (150ms)
  -   ✓  438 [desktop-firefox] › tests/e2e/soft-launch-banner.spec.ts:9:5 › public pages do not render legacy under-construction banner (1.4s)
  -   103 passed (21.2m)
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
