### PR TITLE
docs: close out poolside save image export brief

### DIFF
--- a/docs/task-briefs/done/2026-04-20-poolside-note-save-as-image-export-10-10.md
+++ b/docs/task-briefs/done/2026-04-20-poolside-note-save-as-image-export-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-04-20-poolside-note-save-as-image-export-10-10`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-04-20`
 - `updated`: `2026-04-20`
@@ -240,6 +240,7 @@ Critical target categories for `10/10` claim in this brief:
 
 ## Checkpoint Log
 
+- `2026-04-20 | merged + closeout | PR #485 merged to \`main\` as squash commit \`2069336\`; poolside note preview now exports PNG images from the current preview state across saved-workout and local-draft entry paths, local \`npm run verify:pre-merge\` passed, required GitHub checks were green, and this docs-only follow-up moved the brief from \`in-progress\` to \`done\` so lifecycle state matches shipped reality | next: none`
 - `2026-04-20 | pre-pr gate green | owner approved the save-image screenshots/export artifacts, embedded canonical preview assets were normalized to relative paths for image-capture parity, targeted unit + Playwright coverage passed, and \`npm run verify:pre-pr\` finished green after confirming two unrelated desktop-chromium flakes as environment/backend noise rather than save-image regressions | next: stage only the scoped source/test/brief files, commit, push, open/update the PR, monitor CI, and run \`npm run verify:pre-merge\` before merge recommendation`
 - `2026-04-20 | implementation + artifact checkpoint | wired preview-owned PNG export into the poolside preview, added focused unit coverage for filename/export state, added a desktop Playwright export path, and generated local approval artifacts in \`output/playwright/poolside-save-image-export/\`; targeted \`vitest\` and \`typecheck\` passed, while the dedicated Playwright spec currently skips its auth/schema branch in this local environment and is documented as an environment-limited signal rather than a product failure | next: owner review of the generated screenshots/export artifact, then \`npm run lint:briefs\` + \`npm run verify:pre-pr\` before PR update`
 - `2026-04-20 | implementation start | created a clean implementation worktree from \`origin/main\`, moved the save-as-image export brief into \`in-progress\`, and started the narrow poolside PNG-export slice scoped to the existing preview renderer plus transient client-side export state | next: wire the export path, add focused coverage, and produce before/after/export artifacts for owner approval before \`verify:pre-pr\``


### PR DESCRIPTION
## Summary
- User-visible changes: No runtime change; this PR only closes out the shipped poolside save-image brief so docs lifecycle matches what is already live on `main` from PR #485.
- Technical changes: Moves `docs/task-briefs/in-progress/2026-04-20-poolside-note-save-as-image-export-10-10.md` to `docs/task-briefs/done/2026-04-20-poolside-note-save-as-image-export-10-10.md`, flips brief status to `done`, and adds the merged + closeout checkpoint referencing PR #485 and commit `2069336`.
- Policy impact: no - docs-only lifecycle closeout with no auth, privacy, payments, content-governance policy, or runtime contract change.
- Policy version note: N/A (docs-only lifecycle closeout; no policy artifact changed)
- Brief link(s): `docs/task-briefs/done/2026-04-20-poolside-note-save-as-image-export-10-10.md`

## Scope
- In scope: Move the merged save-image brief from `in-progress` to `done` and record final closeout metadata after PR #485 shipped.
- Out of scope: Any runtime/code change, additional poolside note behavior, or maintenance-baseline work.

## Risk
- Main risk: Lifecycle drift if the closeout brief does not accurately reflect the already-merged implementation history.
- Rollback plan: Revert this docs-only PR if the brief should remain `in-progress` or if the closeout checkpoint text needs to be rewritten.

## Test Evidence
- Policy-impact checklist: N/A (docs-only lifecycle closeout; no policy-governed behavior changed, so `docs/checklists/policy-impact-release-review.md` does not apply)
- `npm run verify:pre-pr`: **PASS** (docs-only lane on closeout branch)
- `npm run verify:pre-merge`: **PASS** (docs-only lane on HEAD `9582d3b`)
- `npm run lint:briefs:all`: **PASS** (via docs-only lane)
- `npm run lint:admin-audit`: **PASS** (via docs-only lane)
- `npm run lint:env-parity`: **PASS** (via docs-only lane)
- `npm run lint:pr-body:generated`: **PASS** (via docs-only lane)
- `npm run verify:docs-only`: **PASS**
- Local manual QA done on dev URL (list URL + browser/device in PR description): **N/A** (docs-only PR)
- Vercel preview manual QA done (paste preview URL + browser/device in PR description): **N/A** (docs-only PR)
- QA covered relevant matrix for this change (mobile, tablet, desktop browsers): **N/A** (docs-only PR)

## Checklist
- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [x] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [x] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added
