### PR TITLE
docs: close out my swim sessions ergonomics brief

### DIFF
--- a/docs/task-briefs/done/2026-04-20-my-swim-sessions-selection-and-action-label-ergonomics-10-10.md
+++ b/docs/task-briefs/done/2026-04-20-my-swim-sessions-selection-and-action-label-ergonomics-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-04-20-my-swim-sessions-selection-and-action-label-ergonomics-10-10`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-04-20`
 - `updated`: `2026-04-20`
@@ -201,6 +201,7 @@ Critical target categories for `10/10` claim in this brief:
 
 ## Checkpoint Log
 
+- `2026-04-20 | closeout on main | PR #488 was merged to main as \`bdf5d2b8d6ad6c60fd9e885eee73cc21e56b4db6\`; this closeout sweep moved the brief to \`done\` and cleaned the main-worktree-generated artifacts used during merge/review work | next: none`
 - `2026-04-20 | verify:pre-pr passed | full public verification lane passed after syncing the local dependency/runtime environment for this clean worktree; screenshot review was approved before gates, and the branch is ready for commit/push/PR handoff | next: commit, push, open/update PR, then run \`verify:pre-merge\` and monitor CI`
 - `2026-04-20 | implementation checkpoint | shipped the saved-sessions ergonomics diff on the feature branch: row action text now reads \`Open\`, selection mode uses a larger left-side hit area with full-row selected state, default cleanup helper copy is removed, and targeted unit + Playwright coverage passed; after screenshots are ready for owner review before \`verify:pre-pr\` | next: owner screenshot approval or correction pass, then run \`npm run verify:pre-pr\``
 - `2026-04-20 | implementation start | added the brief directly on the feature branch because it was not yet present on \`main\`, and started the narrow saved-sessions ergonomics slice scoped to label truthfulness, larger selection hit area, and helper-copy cleanup | next: implement the panel contract, update targeted unit/e2e coverage, and generate after screenshots for owner approval before \`verify:pre-pr\``


### PR DESCRIPTION
## Summary

- What changed and why? Close out the merged my-swim-sessions ergonomics brief on `main` by moving it from `in-progress` to `done` and recording the post-merge checkpoint in the brief.
- User-visible changes: No user-visible product behavior changes; this is a docs-only lifecycle closeout after PR #488.
- Technical changes: Move `docs/task-briefs/in-progress/2026-04-20-my-swim-sessions-selection-and-action-label-ergonomics-10-10.md` to `docs/task-briefs/done/...` and add a closeout checkpoint entry tied to merge commit `bdf5d2b8d6ad6c60fd9e885eee73cc21e56b4db6`.
- Policy impact: no (docs-only brief lifecycle closeout; no auth, content-policy, or runtime contract changed)
- Policy version note: N/A (docs-only closeout; no policy document changed)
- Brief link(s): `docs/task-briefs/done/2026-04-20-my-swim-sessions-selection-and-action-label-ergonomics-10-10.md`

## Scope

- In scope: Clean the generated main-worktree leftovers used during merge review and move the merged ergonomics brief to `done` with a final checkpoint entry.
- Out of scope: Any repo-root cleanup, runtime changes, test contract changes, or reopening the already merged ergonomics implementation.

## Risk

- Main risk: Low; the only meaningful risk is incorrect brief lifecycle bookkeeping if the file move or checkpoint entry is wrong.
- Rollback plan: Revert commit `fb73bdc` or move the brief back to `in-progress` if the closeout metadata is incorrect.

## Test Evidence

- Policy-impact checklist: N/A (docs-only brief closeout with no policy-triggering file paths or runtime behavior changes)
- `npm run verify:docs-only`: **PASS** local docs-only lane executed through `npm run verify:pre-pr`
- `npm run lint:briefs:all`: **PASS** local docs-only lane
- `npm run lint:admin-audit`: **PASS** local docs-only lane
- `npm run lint:env-parity`: **PASS** local docs-only lane
- `npm run lint:pr-body:generated`: **PASS** local docs-only lane
- `npm run verify:pre-pr`: **PASS** local docs-only lane on closeout branch `docs/my-swim-sessions-selection-and-action-label-ergonomics-closeout`
- `npm run verify:pre-merge`: **NOT RUN** pending owner approval and final merge-readiness pass for PR #489
- [ ] `npm run verify:docs-only` (pure docs/governance diffs only)
- [ ] `npm run lint:briefs:all` (required for docs-only lane)
- [ ] `npm run lint:admin-audit` (required for docs-only lane)
- [ ] `npm run lint:env-parity` (required for docs-only lane)
- [ ] `npm run lint:pr-body:generated` (required for docs-only lane)
- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [ ] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be `PASS` on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## Checklist

- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [x] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [x] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added
