### PR TITLE
docs: plan travel findings brief wave

### DIFF
--- a/docs/task-briefs/planned/2026-04-18-maintenance-baseline-pre-live-10-10.md
+++ b/docs/task-briefs/planned/2026-04-18-maintenance-baseline-pre-live-10-10.md
@@ -20,6 +20,12 @@ Bring the repo and runtime maintenance baseline to a pre-live 10/10 level: no kn
   - [2026-04-20-poolside-note-mobile-preview-and-save-image-reliability-followup-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-20-poolside-note-mobile-preview-and-save-image-reliability-followup-10-10.md)
 - Remaining findings-wave brief that currently takes precedence:
   - [2026-04-21-poolside-note-session-and-step-notes-display-options-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/planned/2026-04-21-poolside-note-session-and-step-notes-display-options-10-10.md)
+  - [2026-04-21-poolside-note-save-image-crop-boundary-followup-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/planned/2026-04-21-poolside-note-save-image-crop-boundary-followup-10-10.md)
+  - [2026-04-21-my-swim-profile-page-ia-and-copy-cleanup-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/planned/2026-04-21-my-swim-profile-page-ia-and-copy-cleanup-10-10.md)
+  - [2026-04-21-account-security-simplification-and-auth-surface-audit-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/planned/2026-04-21-account-security-simplification-and-auth-surface-audit-10-10.md)
+  - [2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/planned/2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10.md)
+  - [2026-04-21-course-dashboard-new-content-and-continue-card-cleanup-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/planned/2026-04-21-course-dashboard-new-content-and-continue-card-cleanup-10-10.md)
+  - [2026-04-21-my-library-my-training-ia-and-builder-entrypoint-reconcile-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/planned/2026-04-21-my-library-my-training-ia-and-builder-entrypoint-reconcile-10-10.md)
 
 ## Why This Brief Exists
 

--- a/docs/task-briefs/planned/2026-04-21-account-security-simplification-and-auth-surface-audit-10-10.md
+++ b/docs/task-briefs/planned/2026-04-21-account-security-simplification-and-auth-surface-audit-10-10.md
@@ -1,0 +1,149 @@
+# Task Brief: Account Security Simplification And Auth Surface Audit (10/10)
+
+## Metadata
+
+- `id`: `2026-04-21-account-security-simplification-and-auth-surface-audit-10-10`
+- `status`: `planned`
+- `owner`: `stianvikra`
+- `created`: `2026-04-21`
+- `updated`: `2026-04-21`
+
+## Goal
+
+Audit whether the current Account & Security surface provides necessary user value, then simplify or remove it without weakening auth, privacy, logout, email identity, or recovery behavior.
+
+## Sequencing Lock
+
+- Run before removing Account & Security entrypoints from My Swim Profile.
+- Run before maintenance baseline unless explicitly deferred.
+- Treat this as security/auth-adjacent work, not visual cleanup.
+
+## Why This Brief Exists
+
+- The current Account & Security page may not give enough value to justify a dedicated surface.
+- Email identity might belong in My Swim Profile or a minimal account area instead.
+- One-time-code login guidance may belong in sign-in/help copy rather than a permanent account page.
+- Future Face ID/passkey work is out of scope until auth architecture supports it cleanly.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim:
+
+- `Business logic correctness and data integrity`
+- `Reliability and failure handling`
+- `Security and authz`
+- `Privacy and compliance`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                     | Evidence                               | Expected Closeout Score |
+| --------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | Account/security entrypoints either map to real user jobs or are removed/moved with a documented replacement.                      | route audit and IA decision log        | `5/5`                   |
+| UX flow clarity                               | `target`     | Users can still understand login identity, logout/recovery path, and one-time-code behavior without dead-end account UI.           | manual QA and Help/Guide review        | `5/5`                   |
+| Visual design quality                         | `target`     | Any remaining account UI matches current My Library/builder form and action hierarchy without extra explanatory clutter.           | screenshots                            | `5/5`                   |
+| Business logic correctness and data integrity | `target`     | Session state, logged-in email, logout, protected route access, and profile links behave exactly as intended after simplification. | auth tests and protected route QA      | `5/5`                   |
+| Admin editor ergonomics                       | `N/A`        | N/A because this affects owner account/auth surfaces, not admin editing or publishing flows.                                       | explicit scope rationale               | `N/A`                   |
+| Accessibility (a11y)                          | `target`     | Remaining auth/account actions have clear labels, focus states, keyboard access, and no icon-only ambiguity.                       | semantic review                        | `5/5`                   |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: simplification should not add auth client weight or slow protected route transitions.                             | build and route QA                     | `4/5`                   |
+| Data placement and sync boundaries            | `target`     | Email/session identity remains auth-provider/server-canonical; no sensitive account data is moved to unsafe local storage.         | code review                            | `5/5`                   |
+| Caching and invalidation strategy             | `target`     | Auth/session changes cannot show stale user identity or stale logged-in/logged-out state.                                          | auth transition QA                     | `5/5`                   |
+| Reliability and failure handling              | `target`     | Missing session, expired one-time code, logout, and protected redirect states fail closed with clear user recovery.                | negative-path tests                    | `5/5`                   |
+| Security and authz                            | `target`     | No protected path becomes public, logout remains available if currently supported, and auth checks fail closed.                    | negative auth tests and route review   | `5/5`                   |
+| Privacy and compliance                        | `target`     | Email identity and account details are minimized and shown only to the authenticated owner; no PII appears in logs/errors.         | privacy review                         | `5/5`                   |
+| Content governance                            | `target`     | One-time-code/spam/junk guidance has a single source of truth in sign-in/help copy if page copy is removed.                        | Help/Guide/content review              | `5/5`                   |
+| Admin workflow and editability                | `N/A`        | N/A because no admin CRUD/status/publish workflow changes.                                                                         | explicit scope rationale               | `N/A`                   |
+| SEO and crawlability                          | `N/A`        | N/A because account/security routes are authenticated/private and should not be indexed.                                           | explicit scope rationale               | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because no public AI-discoverable content surface changes.                                                                     | explicit scope rationale               | `N/A`                   |
+| Analytics and KPI observability               | `supporting` | Supporting only: if auth/account events exist, removed route/action names must not break event assumptions.                        | event diff review                      | `4/5`                   |
+| Commerce and revenue ops                      | `supporting` | Supporting only: simplification must not remove billing-management access if it is routed through account UI.                      | billing link audit                     | `4/5`                   |
+| Incident response and support operations      | `target`     | Support can still tell a user where to find login email, logout, and one-time-code recovery guidance after simplification.         | support/help note                      | `5/5`                   |
+| Finance and reporting operations              | `N/A`        | N/A because this brief changes auth/account surface only and does not modify billing, invoices, payouts, or reporting data.        | explicit scope rationale tied to scope | `N/A`                   |
+| i18n operational readiness                    | `target`     | Remaining auth/account copy uses stable labels suitable for later translation and avoids duplicate wording across routes.          | copy inventory review                  | `5/5`                   |
+| Stack-fit and dependency discipline           | `target`     | Use existing auth/session APIs and UI components; add no auth dependency or passkey/Face ID integration in this slice.             | dependency diff and code review        | `5/5`                   |
+| Testing and QA automation                     | `target`     | Authenticated, unauthenticated, logout, expired/missing session, and protected route paths have targeted coverage.                 | unit/e2e tests and verify gates        | `5/5`                   |
+| Scalability and cost efficiency               | `supporting` | Supporting only: fewer low-value account surfaces reduce support and maintenance overhead.                                         | IA review                              | `4/5`                   |
+| DevOps and rollback readiness                 | `target`     | Any removed route/entrypoint has a clear rollback and no schema/migration dependency.                                              | PR plan and rollback notes             | `5/5`                   |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - auth session,
+  - account email identity,
+  - entitlement/billing links if present.
+- Local-only:
+  - transient UI state only.
+- Sync policy:
+  - auth state must refresh after login/logout and route transitions.
+- Retention and sensitivity:
+  - do not store raw auth secrets or one-time codes.
+- Cache/invalidation:
+  - protected routes must not render stale authenticated data after logout.
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - auth provider user ID / server-side user ID, as currently implemented.
+- Human-readable identifier:
+  - email address is display identity, not a mutable route identifier.
+- Rename policy:
+  - email change is out of scope unless existing auth provider support is already implemented and tested.
+- Compatibility:
+  - existing account/profile routes must redirect or be removed deliberately with tests.
+
+## Scope
+
+- Audit Account & Security route, buttons, links, tests, and user jobs.
+- Decide whether to remove, hide, or reduce Account & Security.
+- Preserve necessary logout, email identity, billing access, and recovery guidance.
+- Move one-time-code/spam/junk guidance to sign-in/help copy if needed.
+
+## Out Of Scope
+
+- Face ID/passkeys.
+- Change-email implementation.
+- New auth provider integration.
+- Billing portal verification.
+- Profile data schema changes.
+
+## Acceptance Criteria
+
+1. Account & Security either has a clear retained purpose or is removed/reduced with documented replacements.
+2. User can still identify logged-in email if that is currently supported and useful.
+3. User can still log out if logout exists today.
+4. One-time-code recovery guidance remains available in the correct sign-in/help context.
+5. Protected routes still fail closed.
+6. No private account data leaks into public UI, logs, or errors.
+
+## Validation
+
+- `npm run lint:briefs`
+- auth/account route tests
+- protected route negative-path tests
+- mobile/desktop screenshot handoff for changed surfaces
+- owner approval before PR gate
+- `npm run verify:pre-pr`
+- `npm run verify:pre-merge`
+
+## Manual QA Environments
+
+- Local and Vercel preview.
+- Logged-in owner.
+- Logged-out user.
+- Expired/missing session where practical.
+- Mobile and desktop.
+
+## Design Constraints
+
+- Follow current My Library/swim builder action hierarchy.
+- No icon-only security actions unless labels remain accessible.
+- Keep security copy plain and actionable.
+
+## Help/Guide Impact
+
+- Required if Account & Security copy is removed.
+- Help/Guide must cover one-time-code email, spam/junk reminder, and recovery path if those are no longer visible in-page.
+
+## Checkpoint Log
+
+- `2026-04-21 | planned | created from owner finding that Account & Security may be low-value and needs a 10/10 auth/security audit before removal | next: implement or defer before maintenance baseline`

--- a/docs/task-briefs/planned/2026-04-21-course-dashboard-new-content-and-continue-card-cleanup-10-10.md
+++ b/docs/task-briefs/planned/2026-04-21-course-dashboard-new-content-and-continue-card-cleanup-10-10.md
@@ -1,0 +1,139 @@
+# Task Brief: Course Dashboard New Content And Continue Card Cleanup (10/10)
+
+## Metadata
+
+- `id`: `2026-04-21-course-dashboard-new-content-and-continue-card-cleanup-10-10`
+- `status`: `planned`
+- `owner`: `stianvikra`
+- `created`: `2026-04-21`
+- `updated`: `2026-04-21`
+
+## Goal
+
+Make the course dashboard notification and continue-card surfaces more compact by removing redundant explanatory copy and low-value actions.
+
+## Sequencing Lock
+
+- Run before maintenance baseline unless explicitly deferred.
+- Keep this as dashboard UI/copy cleanup, not a course progress model redesign.
+
+## Why This Brief Exists
+
+- New lesson notification currently repeats itself with `New content`, count, heading, paragraph, and a first-lesson button.
+- Owner decision: remove `Open first new lesson`.
+- Continue card copy `We saved your latest lesson on this device...` is redundant.
+- Course dashboard should follow the cleaner UI principles used in swim session builder, preview page controls, and contact/test-user form surfaces.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim:
+
+- `Product goals and IA`
+- `UX flow clarity`
+- `Visual design quality`
+- `Business logic correctness and data integrity`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                             | Evidence                               | Expected Closeout Score |
+| --------------------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | New-content and continue-course cards each expose one clear job with minimal repeated copy.                                | screenshot and route review            | `5/5`                   |
+| UX flow clarity                               | `target`     | Users can see new lesson count, reveal/hide list, open a lesson link, and continue course without duplicate CTAs.          | manual QA and targeted e2e             | `5/5`                   |
+| Visual design quality                         | `target`     | Cards are compact, right-sized, and visually consistent across mobile/desktop with current polished app surfaces.          | before/after screenshots               | `5/5`                   |
+| Business logic correctness and data integrity | `target`     | Removing copy/buttons does not break lesson list, continue route, latest lesson state, or progress persistence.            | unit/e2e tests                         | `5/5`                   |
+| Admin editor ergonomics                       | `N/A`        | N/A because this changes learner dashboard surfaces, not admin editor workflows.                                           | explicit scope rationale               | `N/A`                   |
+| Accessibility (a11y)                          | `target`     | Toggle and continue actions have labels, focus, keyboard support, and screen-reader understandable state.                  | semantic review                        | `5/5`                   |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: cleanup should reduce or preserve client work and not regress `/course` budgets.                          | build/perf budget output               | `4/5`                   |
+| Data placement and sync boundaries            | `target`     | Latest lesson state remains in the current local/server ownership model; UI cleanup does not change persistence semantics. | code review                            | `5/5`                   |
+| Caching and invalidation strategy             | `target`     | New lesson list and continue state do not show stale or contradictory counts after hide/show or route transitions.         | route QA                               | `5/5`                   |
+| Reliability and failure handling              | `target`     | Empty, no-new-lessons, saved-latest-lesson missing, and route-load failure states stay clear after copy removal.           | targeted QA                            | `5/5`                   |
+| Security and authz                            | `supporting` | Supporting only: dashboard continues to respect existing access/private-gate boundaries.                                   | route auth review                      | `4/5`                   |
+| Privacy and compliance                        | `supporting` | Supporting only: latest-lesson device copy removal must not expose new personal progress data.                             | privacy review                         | `4/5`                   |
+| Content governance                            | `target`     | Removed explanatory copy has no duplicate surviving variant; labels are canonical and concise.                             | copy review                            | `5/5`                   |
+| Admin workflow and editability                | `N/A`        | N/A because no admin course authoring or publish workflow changes.                                                         | explicit scope rationale               | `N/A`                   |
+| SEO and crawlability                          | `supporting` | Supporting only: public/private course dashboard metadata and crawl controls remain unchanged.                             | route metadata review                  | `4/5`                   |
+| AI discoverability                            | `supporting` | Supporting only: public course semantic structure remains stable if any public course surface is touched.                  | route semantic review                  | `4/5`                   |
+| Analytics and KPI observability               | `target`     | Removing `Open first new lesson` does not break or mislabel tracked lesson-open/continue events if they exist.             | event diff review                      | `5/5`                   |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, checkout, entitlement, or billing workflow changes.                                                | explicit scope rationale               | `N/A`                   |
+| Incident response and support operations      | `N/A`        | N/A because this dashboard copy cleanup introduces no new support workflow or incident runbook path.                       | explicit scope rationale tied to scope | `N/A`                   |
+| Finance and reporting operations              | `N/A`        | N/A because no finance, payout, invoice, or reporting path changes.                                                        | explicit scope rationale tied to scope | `N/A`                   |
+| i18n operational readiness                    | `target`     | New labels are concise, canonical, and avoid mixed-language/duplicated translation debt.                                   | copy inventory review                  | `5/5`                   |
+| Stack-fit and dependency discipline           | `target`     | Use existing course dashboard components and no new dependency.                                                            | dependency diff                        | `5/5`                   |
+| Testing and QA automation                     | `target`     | Tests cover new-content toggle, lesson links, continue action, and removed first-lesson button.                            | targeted tests and verify gates        | `5/5`                   |
+| Scalability and cost efficiency               | `supporting` | Supporting only: smaller surfaces reduce future content maintenance.                                                       | diff review                            | `4/5`                   |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: narrow UI/copy diff with no schema or migration.                                                          | PR review                              | `4/5`                   |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - course/lesson publication and access state.
+- Local or existing state:
+  - latest lesson device state as currently implemented.
+- Sync policy:
+  - no change to progress or latest-lesson persistence.
+- Retention and sensitivity:
+  - no new personal data surface.
+- Cache/invalidation:
+  - new lesson count/list and continue target should stay coherent after route changes.
+
+## Identity And Rename Contract
+
+- `N/A`
+- Rationale: no course, lesson, slug, or route identifier is renamed.
+
+## Scope
+
+- Simplify new-content notification.
+- Remove `Open first new lesson`.
+- Keep a clear show/hide lesson list control.
+- Remove redundant continue-card helper copy.
+- Make `Continue course` compact and visually aligned to save vertical space.
+
+## Out Of Scope
+
+- Course progress storage changes.
+- Lesson publishing/admin workflow changes.
+- New notification system.
+- Commerce/access model changes.
+
+## Acceptance Criteria
+
+1. New-content card keeps `New content` and count.
+2. `Open first new lesson` is removed.
+3. Lesson list remains directly usable when shown.
+4. `Show lesson list`/`Hide lesson list` is right-aligned or otherwise compact.
+5. Continue card no longer shows the redundant saved-device sentence.
+6. Continue action still routes correctly.
+7. Mobile and desktop preserve the same visual language.
+
+## Validation
+
+- `npm run lint:briefs`
+- targeted course dashboard tests
+- targeted mobile/desktop screenshots
+- owner screenshot approval before PR gate
+- `npm run verify:pre-pr`
+- `npm run verify:pre-merge`
+
+## Manual QA Environments
+
+- Local and Vercel preview.
+- Course dashboard with one new lesson.
+- Course dashboard with no new lessons.
+- Latest lesson present and absent.
+- Mobile and desktop.
+
+## Design Constraints
+
+- Use current app button/card rhythm.
+- No explanatory copy unless it changes a user decision.
+- Keep labels short and product-facing.
+
+## Help/Guide Impact
+
+- `N/A` unless implementation removes a documented course recovery behavior.
+
+## Checkpoint Log
+
+- `2026-04-21 | planned | created from owner findings about over-explained new lesson notification and continue-card copy | next: implement or defer before maintenance baseline`

--- a/docs/task-briefs/planned/2026-04-21-my-library-my-training-ia-and-builder-entrypoint-reconcile-10-10.md
+++ b/docs/task-briefs/planned/2026-04-21-my-library-my-training-ia-and-builder-entrypoint-reconcile-10-10.md
@@ -1,0 +1,159 @@
+# Task Brief: My Library My Training IA And Builder Entrypoint Reconcile (10/10)
+
+## Metadata
+
+- `id`: `2026-04-21-my-library-my-training-ia-and-builder-entrypoint-reconcile-10-10`
+- `status`: `planned`
+- `owner`: `stianvikra`
+- `created`: `2026-04-21`
+- `updated`: `2026-04-21`
+
+## Goal
+
+Clarify the broader My Library/My Training information architecture so swim sessions, dryland builder, program builder preview, profile, and account surfaces are named and placed consistently.
+
+## Sequencing Lock
+
+- Run after the narrower My Swim Profile and Account & Security briefs unless this brief is used first as a discovery-only IA pass.
+- Run before maintenance baseline unless explicitly deferred.
+- Do not use this brief to implement all child cleanups in one large PR.
+
+## Why This Brief Exists
+
+- Owner raised possible IA changes:
+  - add `My Profile`,
+  - place Account/Security inside profile if kept,
+  - change `Athlete Profile` to `Swimmer Profile`,
+  - put goals/focus/notes inside profile,
+  - consider `Overview -> My Training`,
+  - reconcile Swim session builder, Dryland builder, and Program builder preview.
+- These decisions are broader than one page cleanup and should be planned before maintenance work resumes.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim:
+
+- `Product goals and IA`
+- `UX flow clarity`
+- `Business logic correctness and data integrity`
+- `Accessibility (a11y)`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                              | Evidence                               | Expected Closeout Score |
+| --------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | My Library/My Training route map has clear jobs, labels, hierarchy, and builder entrypoints without duplicated concepts.    | IA map and route review                | `5/5`                   |
+| UX flow clarity                               | `target`     | Users can find profile, saved sessions, builders, and training areas with fewer ambiguous labels and no dead-end paths.     | manual QA and screenshots              | `5/5`                   |
+| Visual design quality                         | `target`     | Navigation and entrypoint surfaces follow the current clean builder/profile/card style across mobile and desktop.           | screenshot review                      | `5/5`                   |
+| Business logic correctness and data integrity | `target`     | IA changes do not break saved sessions, profile data, program/dryland access, route params, or existing user data.          | route tests and data audit             | `5/5`                   |
+| Admin editor ergonomics                       | `N/A`        | N/A because this changes owner-facing navigation/IA, not admin editing or publishing workflows.                             | explicit scope rationale               | `N/A`                   |
+| Accessibility (a11y)                          | `target`     | Navigation labels, tab order, current-page state, and focus behavior remain clear across changed route entrypoints.         | semantic review                        | `5/5`                   |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: IA changes must not add route-level payload bloat or slow `/my-library`.                                   | build/perf review                      | `4/5`                   |
+| Data placement and sync boundaries            | `target`     | Moving entrypoints does not move data ownership; server/local boundaries are documented for each touched domain.            | data-boundary review                   | `5/5`                   |
+| Caching and invalidation strategy             | `supporting` | Supporting only: route/link changes must not create stale lists or broken back navigation.                                  | route QA                               | `4/5`                   |
+| Reliability and failure handling              | `target`     | Empty/loading/error states remain reachable and clear for profile, sessions, builders, and training overview paths.         | targeted QA                            | `5/5`                   |
+| Security and authz                            | `target`     | Protected My Library/My Training routes remain authenticated and no account/profile data is exposed through new links.      | auth route tests                       | `5/5`                   |
+| Privacy and compliance                        | `target`     | Personal profile, records, focus, notes, and account data remain private and minimized.                                     | privacy review                         | `5/5`                   |
+| Content governance                            | `target`     | Route labels such as `My Swim Profile`, `My Training`, and builder names have one canonical naming contract.                | label inventory                        | `5/5`                   |
+| Admin workflow and editability                | `N/A`        | N/A because no admin CRUD/status workflow changes.                                                                          | explicit scope rationale               | `N/A`                   |
+| SEO and crawlability                          | `N/A`        | N/A because this is authenticated My Library/My Training IA with no public crawl contract.                                  | explicit scope rationale               | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because no public AI-discoverable content surface or structured data changes.                                           | explicit scope rationale               | `N/A`                   |
+| Analytics and KPI observability               | `target`     | Existing navigation/action events are preserved or renamed deliberately with migration notes.                               | event taxonomy review                  | `5/5`                   |
+| Commerce and revenue ops                      | `supporting` | Supporting only: IA must not hide entitlement/billing paths if they remain required for paid access.                        | commerce link audit                    | `4/5`                   |
+| Incident response and support operations      | `target`     | Support can describe where users find profile, sessions, builders, account/billing, and training overview after IA changes. | support/help note                      | `5/5`                   |
+| Finance and reporting operations              | `N/A`        | N/A because this IA brief does not modify invoice, payout, reconciliation, or financial reporting logic.                    | explicit scope rationale tied to scope | `N/A`                   |
+| i18n operational readiness                    | `target`     | Canonical labels avoid mixed terminology and can be translated later without duplicate concepts.                            | copy inventory review                  | `5/5`                   |
+| Stack-fit and dependency discipline           | `target`     | Reuse existing routing, tabs, cards, and nav components; add no dependency.                                                 | dependency diff                        | `5/5`                   |
+| Testing and QA automation                     | `target`     | Tests cover changed navigation, back links, protected routes, and mobile/desktop entrypoints.                               | targeted tests and verify gates        | `5/5`                   |
+| Scalability and cost efficiency               | `target`     | IA creates a stable place for future swim/dryland/program surfaces without one-off navigation sprawl.                       | IA review                              | `5/5`                   |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: changes should be split into reversible child PRs with no schema migration unless separately briefed.      | PR slicing plan                        | `4/5`                   |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - user identity,
+  - saved sessions,
+  - profile/preferences/records,
+  - training focus/goals/notes where server-backed,
+  - entitlements if referenced.
+- Local-only:
+  - transient navigation state only.
+- Sync policy:
+  - IA changes must not change persistence or sync semantics.
+- Retention and sensitivity:
+  - no new exposure of personal training/account data.
+- Cache/invalidation:
+  - route transitions/back links should not show stale builder/profile state.
+
+## Identity And Rename Contract
+
+- Canonical stable IDs:
+  - existing user/session/program/profile IDs remain unchanged.
+- Human-readable labels:
+  - label candidates include `My Swim Profile`, `My Training`, `Swim session builder`, `Dryland builder`, and `Program builder`.
+- Mutability:
+  - route labels may change, stable data IDs must not.
+- Compatibility:
+  - route redirects/aliases are required if paths change.
+
+## Scope
+
+- Map current My Library/My Training route and entrypoint structure.
+- Decide canonical labels and ownership for:
+  - profile,
+  - goals/focus/notes,
+  - account/security,
+  - saved sessions,
+  - swim session builder,
+  - dryland builder,
+  - program builder preview.
+- Produce narrow implementation slices if more than one route changes.
+
+## Out Of Scope
+
+- Implementing all child IA changes in one PR.
+- New builder features.
+- Account/Security auth changes unless coordinated with its dedicated brief.
+- Billing verification.
+
+## Acceptance Criteria
+
+1. A route/IA map exists for My Library/My Training.
+2. Canonical labels are documented and applied to changed surfaces.
+3. Builder entrypoints are findable and not duplicated confusingly.
+4. Profile/account/training concepts are separated or grouped deliberately.
+5. Mobile and desktop navigation remain consistent.
+6. Any route path changes have redirects or compatibility coverage.
+
+## Validation
+
+- `npm run lint:briefs`
+- targeted route/navigation tests
+- protected route tests
+- screenshot handoff for changed IA surfaces
+- owner approval before PR gate
+- `npm run verify:pre-pr`
+- `npm run verify:pre-merge`
+
+## Manual QA Environments
+
+- Local and Vercel preview.
+- My Library.
+- My Swim Sessions.
+- Profile/training/account surfaces.
+- Mobile and desktop.
+
+## Design Constraints
+
+- Follow the cleaner My Swim Sessions and builder action-density work.
+- Avoid adding another floating menu.
+- Use concise labels over explanatory paragraphs.
+
+## Help/Guide Impact
+
+- Required if route names, user workflow names, or account/profile locations change.
+
+## Checkpoint Log
+
+- `2026-04-21 | planned | created from owner IA findings around My Profile, My Training, builder entrypoints, and account/profile grouping | next: implement discovery/IA pass or defer before maintenance baseline`

--- a/docs/task-briefs/planned/2026-04-21-my-swim-profile-page-ia-and-copy-cleanup-10-10.md
+++ b/docs/task-briefs/planned/2026-04-21-my-swim-profile-page-ia-and-copy-cleanup-10-10.md
@@ -1,0 +1,142 @@
+# Task Brief: My Swim Profile Page IA And Copy Cleanup (10/10)
+
+## Metadata
+
+- `id`: `2026-04-21-my-swim-profile-page-ia-and-copy-cleanup-10-10`
+- `status`: `planned`
+- `owner`: `stianvikra`
+- `created`: `2026-04-21`
+- `updated`: `2026-04-21`
+
+## Goal
+
+Turn the current athlete profile/training setup/records page into a cleaner `My Swim Profile` surface with less explanatory copy and clearer navigation back to My Library.
+
+## Sequencing Lock
+
+- Run before maintenance baseline unless explicitly deferred.
+- Coordinate with the separate Account & Security audit brief before removing account/security entrypoints permanently.
+- Keep this as page IA/copy cleanup, not a profile-data schema redesign.
+
+## Why This Brief Exists
+
+- The current title and copy over-explain the page.
+- `Athlete profile, training setup & records` should become the simpler product-facing label `My Swim Profile`.
+- The page should feel consistent with the cleaner surfaces already established in:
+  - Swim session builder action hierarchy,
+  - poolside preview settings,
+  - early-access/test-user contact form visual polish.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim:
+
+- `Product goals and IA`
+- `UX flow clarity`
+- `Visual design quality`
+- `Business logic correctness and data integrity`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                      | Evidence                               | Expected Closeout Score |
+| --------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | Page title, hierarchy, and back navigation clearly communicate `My Swim Profile` without redundant explanatory sections.            | route review and screenshots           | `5/5`                   |
+| UX flow clarity                               | `target`     | Primary page jobs are obvious and users are not distracted by low-value helper copy or redundant nav buttons.                       | manual QA                              | `5/5`                   |
+| Visual design quality                         | `target`     | Layout matches the current clean My Library/swim builder card rhythm and avoids floating explanatory blocks.                        | before/after screenshot review         | `5/5`                   |
+| Business logic correctness and data integrity | `target`     | Removing or moving copy/nav does not remove profile data, records, training preferences, or saved state.                            | targeted tests and code review         | `5/5`                   |
+| Admin editor ergonomics                       | `N/A`        | N/A because this changes owner-facing My Library profile UI, not admin editor workflows.                                            | explicit scope rationale               | `N/A`                   |
+| Accessibility (a11y)                          | `target`     | Heading hierarchy, focus order, link/button labels, and keyboard navigation remain clear after IA cleanup.                          | semantic review and targeted QA        | `5/5`                   |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: copy/layout removal should not add JS or payload and must not regress `/my-library`.                               | build output and route QA              | `4/5`                   |
+| Data placement and sync boundaries            | `target`     | Profile data remains server-canonical or existing local-state ownership as currently implemented; cleanup changes no data boundary. | code review                            | `5/5`                   |
+| Caching and invalidation strategy             | `supporting` | Supporting only: no cache or invalidation behavior changes unless discovered and explicitly documented.                             | route diff review                      | `4/5`                   |
+| Reliability and failure handling              | `target`     | Empty/loading/error states for profile sections remain reachable and understandable after removing explanatory copy.                | targeted QA                            | `5/5`                   |
+| Security and authz                            | `supporting` | Supporting only: protected profile route stays inside existing auth boundary and exposes no new account data.                       | auth boundary review                   | `4/5`                   |
+| Privacy and compliance                        | `target`     | No private profile, preferences, or records are newly exposed or made more prominent outside the authenticated owner context.       | privacy review                         | `5/5`                   |
+| Content governance                            | `target`     | Product labels are canonicalized to `My Swim Profile`; removed explanatory copy is either deleted or moved to Help only if needed.  | copy review                            | `5/5`                   |
+| Admin workflow and editability                | `N/A`        | N/A because no admin workflow, role-gated content mutation, or publishing state changes.                                            | explicit scope rationale               | `N/A`                   |
+| SEO and crawlability                          | `N/A`        | N/A because this is an authenticated My Library surface with no public crawl contract.                                              | explicit scope rationale               | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because no public content semantics or structured data change.                                                                  | explicit scope rationale               | `N/A`                   |
+| Analytics and KPI observability               | `supporting` | Supporting only: if existing page-view/action events exist, labels should not create broken analytics names.                        | event diff review                      | `4/5`                   |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, checkout, entitlement, or billing path changes.                                                             | explicit scope rationale               | `N/A`                   |
+| Incident response and support operations      | `N/A`        | N/A because this IA cleanup introduces no new support operation or incident runbook path.                                           | explicit scope rationale tied to scope | `N/A`                   |
+| Finance and reporting operations              | `N/A`        | N/A because no finance, billing, payout, or reconciliation behavior changes.                                                        | explicit scope rationale tied to scope | `N/A`                   |
+| i18n operational readiness                    | `target`     | New canonical labels avoid hard-coded inconsistent terminology and are easy to translate later.                                     | copy inventory review                  | `5/5`                   |
+| Stack-fit and dependency discipline           | `target`     | Cleanup reuses existing components and design tokens with no new dependency.                                                        | dependency diff                        | `5/5`                   |
+| Testing and QA automation                     | `target`     | Targeted tests and screenshot handoff cover desktop/mobile profile page and preserved section behavior.                             | targeted tests and screenshots         | `5/5`                   |
+| Scalability and cost efficiency               | `supporting` | Supporting only: simpler IA reduces future support/content maintenance burden.                                                      | scope review                           | `4/5`                   |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: narrow UI/copy diff with no schema or migration keeps rollback straightforward.                                    | PR review                              | `4/5`                   |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - existing profile, training preferences, records, goals/focus/notes data as currently implemented.
+- Local-only:
+  - transient UI state only.
+- Sync policy:
+  - no changed write semantics.
+- Retention and sensitivity:
+  - no new retention or disclosure path.
+- Cache/invalidation:
+  - no cache changes planned.
+
+## Identity And Rename Contract
+
+- Human-readable page label changes to `My Swim Profile`.
+- No persisted entity rename is planned.
+- Existing route identifiers should remain compatible unless a follow-up IA brief explicitly changes routing.
+
+## Scope
+
+- Rename visible page title to `My Swim Profile`.
+- Remove the long intro paragraph under the title.
+- Remove `How this fits` if it remains low-value explanatory content.
+- Right-align or preserve `Back to My Library` as the useful top-level navigation action.
+- Audit whether `Refresh all` has a clear job; remove if it is redundant or confusing.
+
+## Out Of Scope
+
+- Account & Security deletion or auth policy changes.
+- Profile schema changes.
+- New goals/focus/notes authoring work.
+- Commerce or billing changes.
+
+## Acceptance Criteria
+
+1. Page title reads `My Swim Profile`.
+2. Redundant explanatory paragraph is gone.
+3. `How this fits` is removed unless implementation discovers a measurable user job it uniquely serves.
+4. `Back to My Library` remains clear and visually aligned with the header.
+5. No profile data or edit capability is lost.
+6. Desktop and mobile remain visually consistent with current My Library/builder design.
+
+## Validation
+
+- `npm run lint:briefs`
+- targeted unit/component tests if route content is covered
+- targeted Playwright or visual QA for desktop/mobile
+- screenshot handoff before `verify:pre-pr`
+- owner screenshot approval before PR gate
+- `npm run verify:pre-pr`
+- `npm run verify:pre-merge`
+
+## Manual QA Environments
+
+- Local and Vercel preview.
+- Mobile and desktop My Swim Profile route.
+- Authenticated owner context with existing profile data and empty-state profile data.
+
+## Design Constraints
+
+- Follow the cleaner swim session builder and poolside preview action hierarchy.
+- Avoid explanatory cards inside cards.
+- Keep copy product-facing and short.
+
+## Help/Guide Impact
+
+- Move only genuinely useful explanation to Help/Guide.
+- Do not keep permanent page copy just to document architecture.
+
+## Checkpoint Log
+
+- `2026-04-21 | planned | created from owner finding that Athlete Profile page is over-explained and should become My Swim Profile | next: implement or defer before maintenance baseline`

--- a/docs/task-briefs/planned/2026-04-21-poolside-note-save-image-crop-boundary-followup-10-10.md
+++ b/docs/task-briefs/planned/2026-04-21-poolside-note-save-image-crop-boundary-followup-10-10.md
@@ -1,0 +1,138 @@
+# Task Brief: Poolside Note Save Image Crop Boundary Followup (10/10)
+
+## Metadata
+
+- `id`: `2026-04-21-poolside-note-save-image-crop-boundary-followup-10-10`
+- `status`: `planned`
+- `owner`: `stianvikra`
+- `created`: `2026-04-21`
+- `updated`: `2026-04-21`
+
+## Goal
+
+Ensure Save image exports only the poolside note surface, with no extra white or blue margin on the left or around the exported note.
+
+## Sequencing Lock
+
+- Run this before maintenance baseline unless explicitly deferred.
+- Keep this as a narrow poolside export boundary fix, not a new print preview redesign.
+- Depends on the shipped save-image baseline:
+  - [2026-04-20-poolside-note-save-as-image-export-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-20-poolside-note-save-as-image-export-10-10.md)
+  - [2026-04-20-poolside-note-mobile-preview-and-save-image-reliability-followup-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-20-poolside-note-mobile-preview-and-save-image-reliability-followup-10-10.md)
+
+## Why This Brief Exists
+
+- Current saved PNG can still include an unwanted left-side white margin.
+- Poolside Save image should behave like a precise export of the note itself, not the surrounding preview container.
+- The fix must preserve the current poolside visual language, including the print preview page and the compact poolside note card design already shipped.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim:
+
+- `UX flow clarity`
+- `Visual design quality`
+- `Business logic correctness and data integrity`
+- `Reliability and failure handling`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                     | Evidence                               | Expected Closeout Score |
+| --------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | Save image remains a direct poolside note export action and does not imply the surrounding preview UI is part of the asset.        | screenshot and PNG artifact review     | `5/5`                   |
+| UX flow clarity                               | `target`     | Users can save once or repeatedly and get a clean note image without extra margins or stale crop state.                            | manual QA and targeted e2e             | `5/5`                   |
+| Visual design quality                         | `target`     | Exported portrait and landscape PNGs crop tightly to the note boundary and match the current poolside note design system.          | before/after PNG comparison            | `5/5`                   |
+| Business logic correctness and data integrity | `target`     | Export crop uses the intended note element and current preview settings without mutating workout data or presentation settings.    | unit/e2e coverage and code review      | `5/5`                   |
+| Admin editor ergonomics                       | `N/A`        | N/A because this changes owner-facing poolside export behavior, not admin editing or publishing flows.                             | explicit scope rationale               | `N/A`                   |
+| Accessibility (a11y)                          | `supporting` | Supporting only: Save image controls keep labels, focus, and disabled/busy state semantics.                                        | semantic review                        | `4/5`                   |
+| Performance (CWV + payloads)                  | `target`     | Cropping/export fix adds no heavy dependency and does not make image export noticeably slower on mobile preview.                   | dependency diff and mobile export QA   | `5/5`                   |
+| Data placement and sync boundaries            | `target`     | Saved image remains a local browser-generated artifact; no new server persistence or sync path is introduced.                      | code review                            | `5/5`                   |
+| Caching and invalidation strategy             | `target`     | Changing preview settings before save always exports the current rendered note and crop boundary.                                  | e2e export comparison                  | `5/5`                   |
+| Reliability and failure handling              | `target`     | Missing readiness, repeated save, mobile Safari-like viewport, and landscape/portrait states never create blank or clipped images. | targeted Playwright coverage           | `5/5`                   |
+| Security and authz                            | `supporting` | Supporting only: export remains inside existing authenticated owner preview routes with no new public asset endpoint.              | auth boundary review                   | `4/5`                   |
+| Privacy and compliance                        | `target`     | Exported PNG contains only intentionally visible poolside note content, not surrounding private UI or browser chrome.              | artifact inspection                    | `5/5`                   |
+| Content governance                            | `supporting` | Supporting only: exported image uses the current poolside note content source of truth and does not create alternate copy.         | artifact comparison                    | `4/5`                   |
+| Admin workflow and editability                | `N/A`        | N/A because no role-gated admin mutation workflow changes.                                                                         | explicit scope rationale               | `N/A`                   |
+| SEO and crawlability                          | `N/A`        | N/A because authenticated export behavior changes no public route metadata, sitemap, robots, or crawlable content.                 | explicit scope rationale               | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because no public AI-discoverable content or structured data changes.                                                          | explicit scope rationale               | `N/A`                   |
+| Analytics and KPI observability               | `N/A`        | N/A because success is verified through deterministic export artifacts, not product analytics.                                     | explicit scope rationale               | `N/A`                   |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, entitlement, checkout, or revenue path changes.                                                            | explicit scope rationale               | `N/A`                   |
+| Incident response and support operations      | `N/A`        | N/A because this is a narrow owner-facing export crop fix and introduces no new support workflow.                                  | explicit scope rationale tied to scope | `N/A`                   |
+| Finance and reporting operations              | `N/A`        | N/A because no finance, reconciliation, payout, or reporting path changes.                                                         | explicit scope rationale tied to scope | `N/A`                   |
+| i18n operational readiness                    | `N/A`        | N/A because no locale routing, translation model, or public copy architecture changes.                                             | explicit scope rationale tied to scope | `N/A`                   |
+| Stack-fit and dependency discipline           | `target`     | Fix uses existing browser/export stack and adds no new rendering or image dependency unless unavoidable and explicitly justified.  | dependency diff and code review        | `5/5`                   |
+| Testing and QA automation                     | `target`     | Tests and screenshot artifacts cover before/after crop for portrait and landscape and repeated Save image.                         | Playwright artifacts and verify gates  | `5/5`                   |
+| Scalability and cost efficiency               | `supporting` | Supporting only: no server-side export cost or background processing is introduced.                                                | architecture review                    | `4/5`                   |
+| DevOps and rollback readiness                 | `supporting` | Supporting only: change stays a narrow reversible UI/export diff with no schema or migration.                                      | PR diff review                         | `4/5`                   |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - saved workout content and poolside note data stay unchanged.
+- Local-only:
+  - generated PNG blob/download state.
+- Sync policy:
+  - Save image reads the current rendered note surface only.
+  - No export action writes back to workout data.
+- Retention and sensitivity:
+  - exported PNG is owner-triggered and local to the browser/device.
+- Cache/invalidation:
+  - preview setting changes must invalidate the rendered export target before save.
+
+## Identity And Rename Contract
+
+- `N/A`
+- Rationale: no persisted entities, route params, slugs, titles, or aliases are introduced or renamed.
+
+## Scope
+
+- Fix Save image crop boundary for poolside note.
+- Validate portrait and landscape.
+- Validate preview surface versus actual downloaded PNG.
+- Preserve current poolside print preview controls and design rhythm.
+
+## Out Of Scope
+
+- Session/step note display options.
+- New image formats beyond the current PNG path.
+- Server-side rendering/export service.
+- Print/PDF redesign.
+
+## Acceptance Criteria
+
+1. Saved PNG has no extra left white margin.
+2. Saved PNG has no excess preview-container background beyond the note boundary.
+3. Portrait and landscape exports both crop to the intended note surface.
+4. Repeated Save image attempts work without stale or blank exports.
+5. Exported image still includes the full visible poolside note content.
+
+## Validation
+
+- `npm run lint:briefs`
+- targeted unit/e2e coverage for export target selection and repeated save
+- targeted screenshot handoff before `verify:pre-pr`
+- owner screenshot/artifact approval before PR gate
+- `npm run verify:pre-pr`
+- `npm run verify:pre-merge`
+
+## Manual QA Environments
+
+- Local and Vercel preview.
+- Mobile portrait viewport.
+- Desktop landscape viewport.
+- Actual downloaded PNG inspected in addition to in-browser preview.
+
+## Design Constraints
+
+- Match current poolside preview page design.
+- Preserve the cleaner exported note surface from the latest save-image work.
+- Screenshot names must explicitly mark `before-` and `after-` crop artifacts.
+
+## Help/Guide Impact
+
+- `N/A` unless implementation changes the user-facing Save image workflow text.
+
+## Checkpoint Log
+
+- `2026-04-21 | planned | created from owner finding that Save image still leaves left-side white margin | next: implement or defer before maintenance baseline`

--- a/docs/task-briefs/planned/2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10.md
+++ b/docs/task-briefs/planned/2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10.md
@@ -1,0 +1,143 @@
+# Task Brief: Stripe Sandbox Invoice History And Billing Portal Verification (10/10)
+
+## Metadata
+
+- `id`: `2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10`
+- `status`: `planned`
+- `owner`: `stianvikra`
+- `created`: `2026-04-21`
+- `updated`: `2026-04-21`
+
+## Goal
+
+Verify why Stripe Billing Portal shows no invoice history after a sandbox purchase and make the app, Stripe setup, and support expectations consistent before live billing trust is needed.
+
+## Sequencing Lock
+
+- Run before pre-live maintenance baseline if billing confidence is required before launch.
+- Keep this as billing verification and contract hardening, not broad commerce redesign.
+- Coordinate with Account & Security only if billing access currently depends on that page.
+
+## Why This Brief Exists
+
+- Owner observed `No invoice history` in Stripe Billing Portal after a previous sandbox purchase.
+- The cause may be valid sandbox behavior, incomplete payment/subscription state, portal configuration, customer mismatch, or webhook/app-state drift.
+- Billing flows must be 10/10 in finance/reporting/support categories before launch.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim:
+
+- `Business logic correctness and data integrity`
+- `Security and authz`
+- `Commerce and revenue ops`
+- `Finance and reporting operations`
+- `Testing and QA automation`
+
+| Category                                      | Mapping      | Target Threshold (if `target`)                                                                                                      | Evidence                               | Expected Closeout Score |
+| --------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | Billing entrypoints and portal expectations clearly match what sandbox/live users can actually see.                                 | billing flow audit and screenshots     | `5/5`                   |
+| UX flow clarity                               | `target`     | User can understand Manage billing outcomes and is not promised invoice history when Stripe cannot show one.                        | portal QA and copy review              | `5/5`                   |
+| Visual design quality                         | `supporting` | Supporting only: any app-side billing copy/link changes match current My Library action style.                                      | screenshot review                      | `4/5`                   |
+| Business logic correctness and data integrity | `target`     | Stripe customer, checkout/session, subscription/payment, invoice, entitlement, and portal records reconcile for the tested user.    | Stripe API/dashboard reconciliation    | `5/5`                   |
+| Admin editor ergonomics                       | `N/A`        | N/A because this does not change admin content editing or publishing flows.                                                         | explicit scope rationale               | `N/A`                   |
+| Accessibility (a11y)                          | `supporting` | Supporting only: app-side billing links/buttons keep clear labels and focus states.                                                 | semantic review                        | `4/5`                   |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: billing link verification should not add client payload or slow My Library.                                        | route diff review                      | `4/5`                   |
+| Data placement and sync boundaries            | `target`     | Stripe remains source of truth for billing/customer/invoice data; app entitlement mirror rules are documented.                      | data contract review                   | `5/5`                   |
+| Caching and invalidation strategy             | `target`     | Billing/entitlement state cannot stay stale after checkout, portal return, webhook, or manual refresh.                              | webhook/route QA                       | `5/5`                   |
+| Reliability and failure handling              | `target`     | Missing invoice, incomplete checkout, customer mismatch, and portal errors produce diagnosable outcomes, not silent confusion.      | negative-path QA and logs              | `5/5`                   |
+| Security and authz                            | `target`     | Billing portal access is owner-scoped and cannot expose another user's Stripe customer or invoice data.                             | authz tests and code review            | `5/5`                   |
+| Privacy and compliance                        | `target`     | Billing PII is minimized in app logs/UI and Stripe-hosted pages are the source for sensitive payment method data.                   | privacy review                         | `5/5`                   |
+| Content governance                            | `supporting` | Supporting only: billing copy and support guidance have one source of truth.                                                        | help/runbook review                    | `4/5`                   |
+| Admin workflow and editability                | `N/A`        | N/A because no admin CRUD/status workflow changes.                                                                                  | explicit scope rationale               | `N/A`                   |
+| SEO and crawlability                          | `N/A`        | N/A because billing portal and My Library billing routes are authenticated/private and not crawlable.                               | explicit scope rationale               | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because no public AI-discoverable content changes.                                                                              | explicit scope rationale               | `N/A`                   |
+| Analytics and KPI observability               | `target`     | Checkout/portal/invoice state has enough safe logging or events to support reconciliation without PII leakage.                      | event/log review                       | `5/5`                   |
+| Commerce and revenue ops                      | `target`     | Checkout, customer portal, invoice history expectations, and entitlements reconcile for sandbox test purchase.                      | Stripe dashboard/API evidence          | `5/5`                   |
+| Incident response and support operations      | `target`     | Support can diagnose `No invoice history`, missing payment method, incomplete purchase, and customer mismatch.                      | support runbook/checklist              | `5/5`                   |
+| Finance and reporting operations              | `target`     | Sandbox purchase/invoice/payment records are reconcilable, or documented as intentionally absent with exact Stripe reason.          | finance reconciliation notes           | `5/5`                   |
+| i18n operational readiness                    | `N/A`        | N/A because this brief does not change locale architecture; billing copy remains current-language only for this verification slice. | explicit scope rationale tied to scope | `N/A`                   |
+| Stack-fit and dependency discipline           | `target`     | Use existing Stripe SDK/routes/configuration; add no billing dependency unless required and justified.                              | dependency diff                        | `5/5`                   |
+| Testing and QA automation                     | `target`     | Tests cover portal/customer ownership and webhook/checkout state where repo supports deterministic test coverage.                   | targeted tests and verify gates        | `5/5`                   |
+| Scalability and cost efficiency               | `supporting` | Supporting only: reconciliation approach should support future billing growth without manual guessing.                              | ops review                             | `4/5`                   |
+| DevOps and rollback readiness                 | `target`     | Config or code changes have rollback notes and do not require destructive Stripe data changes.                                      | PR/runbook notes                       | `5/5`                   |
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - Stripe customer, checkout, subscription/payment, invoice, payment method.
+- App-canonical/mirror:
+  - entitlement state only if existing app logic mirrors Stripe state.
+- Local-only:
+  - transient portal redirect state.
+- Sync policy:
+  - webhook and portal-return behavior must be documented and tested where possible.
+- Retention and sensitivity:
+  - no raw card/payment data in the app.
+- Cache/invalidation:
+  - post-checkout and post-portal state must refresh or be explicitly manually refreshed.
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - app user ID mapped to Stripe customer ID.
+- Human-readable identifier:
+  - email is display/contact identity, not a billing authorization key by itself.
+- Compatibility:
+  - detect and document orphaned or duplicate sandbox customers if found.
+
+## Scope
+
+- Audit Stripe sandbox purchase history for the test user.
+- Verify portal invoice history behavior.
+- Verify Stripe customer mapping and app billing route.
+- Verify webhook/entitlement state where implemented.
+- Update support/runbook/help copy if the current behavior is expected.
+
+## Out Of Scope
+
+- New pricing model.
+- Payment method redesign.
+- Live-mode billing migration.
+- Account & Security redesign except billing-link dependency audit.
+
+## Acceptance Criteria
+
+1. We know exactly why portal shows no invoice history.
+2. The tested user maps to the expected Stripe customer.
+3. Checkout/payment/subscription/invoice state is reconciled or documented as intentionally absent.
+4. App copy does not overpromise invoice visibility.
+5. Billing portal access is owner-scoped.
+6. Support has a deterministic troubleshooting path.
+
+## Validation
+
+- `npm run lint:briefs`
+- Stripe sandbox dashboard/API evidence captured in PR summary without secrets
+- targeted billing route/auth tests where applicable
+- targeted webhook/entitlement tests where applicable
+- `npm run verify:pre-pr`
+- `npm run verify:pre-merge`
+
+## Manual QA Environments
+
+- Local where Stripe sandbox env is available.
+- Vercel preview if sandbox env is available.
+- Stripe test dashboard and customer portal.
+
+## Constraints
+
+- Never commit Stripe secrets or raw env values.
+- Do not use email alone as an authorization boundary.
+- Do not change live billing data.
+
+## Help/Guide Impact
+
+- Required if the user-facing Manage billing expectation changes.
+- Support notes must include how to diagnose missing invoice history.
+
+## Checkpoint Log
+
+- `2026-04-21 | planned | created from owner finding that Stripe Billing Portal showed no invoice history after sandbox purchase | next: implement or defer before maintenance baseline`


### PR DESCRIPTION
## Summary

- User-visible changes: Adds six planned 10/10 task briefs so the travel-period findings are ready to execute without owner re-triage.
- Technical changes: Adds planned brief files for poolside image crop, My Swim Profile cleanup, Account & Security audit, Stripe billing verification, course dashboard cleanup, and My Library/My Training IA; updates maintenance baseline sequencing.
- Policy impact: yes - docs-only planning touches future auth/account, Stripe billing, support, finance, and i18n readiness scope; no runtime policy enforcement changes in this PR.
- Policy version note: Docs-only planning update; no deployed policy version changes. Future implementation briefs must run their own policy-impact review.

Brief link(s):

- docs/task-briefs/planned/2026-04-21-poolside-note-save-image-crop-boundary-followup-10-10.md
- docs/task-briefs/planned/2026-04-21-my-swim-profile-page-ia-and-copy-cleanup-10-10.md
- docs/task-briefs/planned/2026-04-21-account-security-simplification-and-auth-surface-audit-10-10.md
- docs/task-briefs/planned/2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10.md
- docs/task-briefs/planned/2026-04-21-course-dashboard-new-content-and-continue-card-cleanup-10-10.md
- docs/task-briefs/planned/2026-04-21-my-library-my-training-ia-and-builder-entrypoint-reconcile-10-10.md

Policy review reference:

- docs/checklists/policy-impact-release-review.md

## Scope

- In scope: Planned 10/10 briefs for captured findings and maintenance-baseline sequencing updates.
- Out of scope: Product runtime changes, auth/billing implementation, UI implementation, schema changes, and merge of any child brief.

## Risk

- Main risk: Over-scoping the findings wave or treating security/billing findings as cosmetic cleanup later.
- Rollback plan: Revert this docs-only commit or edit/remove individual planned briefs before implementation starts.

## Test Evidence

- Policy-impact checklist: PASS - docs-only planning reviewed against docs/checklists/policy-impact-release-review.md; runtime policy enforcement is unchanged.
- `npm run lint:briefs:all`: PASS - all scorecard-mapped briefs passed locally.
- `npm run verify:pre-pr`: PASS - docs-only lane passed locally on branch head fabd8ff.
- `npm run verify:pre-merge`: PASS - docs-only lane passed locally on branch head fabd8ff.

## Checklist

- [x] Brief link(s) included.
- [x] Scorecard mapping included for all new planned briefs.
- [x] Maintenance baseline sequencing updated.
- [x] `npm run verify:pre-pr` passed.
- [x] `npm run verify:pre-merge` passed before merge.
