### PR TITLE
feat: add poolside note display options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,9 +122,11 @@ This file defines how coding agents should collaborate in this repository.
   6. run `npm run verify:pre-merge` and summarize merge readiness.
 - For visual work, this screenshot approval stop overrides the normal automation-first flow. Assistant should not continue into `verify:pre-pr`, PR creation, or `verify:pre-merge` until the owner has approved the screenshot handoff or explicitly waived that review.
 - Handoff must include:
+  - an absolute filesystem folder link to the full-resolution screenshot artifacts,
   - `2-4` representative screenshots from the changed surface,
   - one short explanation per screenshot describing what changed and what the owner should verify,
   - explicit note of any known visual caveat or remaining judgment call.
+- Chat-embedded screenshot previews are secondary only; owner review should be possible from the linked artifact folder without relying on compressed chat thumbnails.
 - Screenshot filenames must make the comparison type explicit:
   - use `before-<surface>-<viewport>.*` and `after-<surface>-<viewport>.*` when the same surface is shown before and after,
   - use `after-<changed-surface>-<viewport>.*` and `reference-<comparison-surface>-<viewport>.*` when the handoff is comparing the changed surface to a separate reference surface instead of a true before-state,

--- a/app/api/my-library/workouts/[workoutId]/export/pdf/route.ts
+++ b/app/api/my-library/workouts/[workoutId]/export/pdf/route.ts
@@ -10,6 +10,8 @@ import {
   normalizeWorkoutPoolsidePrintStyle,
   normalizeWorkoutPdfPreviewChrome,
   normalizeWorkoutPoolsideRestLayout,
+  normalizeWorkoutPoolsideSessionNoteMode,
+  normalizeWorkoutPoolsideStepNotesMode,
   selectWorkoutPoolsideFocusPoints,
   type WorkoutPoolsideFocusOption,
 } from "@/lib/workouts/shared";
@@ -63,6 +65,12 @@ export async function GET(request: Request, context: RouteContext) {
   );
   const poolsideRestLayout = normalizeWorkoutPoolsideRestLayout(
     requestUrl.searchParams.get("restLayout")
+  );
+  const poolsideSessionNoteMode = normalizeWorkoutPoolsideSessionNoteMode(
+    requestUrl.searchParams.get("sessionNoteMode")
+  );
+  const poolsideStepNotesMode = normalizeWorkoutPoolsideStepNotesMode(
+    requestUrl.searchParams.get("stepNotesMode")
   );
   const previewChrome = normalizeWorkoutPdfPreviewChrome(
     requestUrl.searchParams.get("previewChrome")
@@ -146,6 +154,8 @@ export async function GET(request: Request, context: RouteContext) {
         poolsidePrintLayout,
         poolsideNotationMode,
         poolsideRestLayout,
+        poolsideSessionNoteMode,
+        poolsideStepNotesMode,
         swimmerName: athleteProfileSnapshot?.profile?.primaryName ?? null,
         logoUrl,
         fontUrl,

--- a/components/my-library/workouts/PoolsidePreviewPageClient.tsx
+++ b/components/my-library/workouts/PoolsidePreviewPageClient.tsx
@@ -38,7 +38,9 @@ function arePreviewSettingsEqual(
     left.printStyle === right.printStyle &&
     left.printLayout === right.printLayout &&
     left.notationMode === right.notationMode &&
-    left.restLayout === right.restLayout
+    left.restLayout === right.restLayout &&
+    left.sessionNoteMode === right.sessionNoteMode &&
+    left.stepNotesMode === right.stepNotesMode
   );
 }
 
@@ -84,6 +86,8 @@ export default function PoolsidePreviewPageClient() {
       printLayout: searchParams.get("printLayout"),
       notationMode: searchParams.get("notationMode"),
       restLayout: searchParams.get("restLayout"),
+      sessionNoteMode: searchParams.get("sessionNoteMode"),
+      stepNotesMode: searchParams.get("stepNotesMode"),
     })
   );
   const [localPreviewDraft, setLocalPreviewDraft] = useState<
@@ -110,6 +114,8 @@ export default function PoolsidePreviewPageClient() {
       printLayout: params.get("printLayout"),
       notationMode: params.get("notationMode"),
       restLayout: params.get("restLayout"),
+      sessionNoteMode: params.get("sessionNoteMode"),
+      stepNotesMode: params.get("stepNotesMode"),
     });
     setSettings((current) =>
       arePreviewSettingsEqual(current, nextSettings) ? current : nextSettings
@@ -193,6 +199,8 @@ export default function PoolsidePreviewPageClient() {
       poolsidePrintLayout: settings.printLayout,
       poolsideNotationMode: settings.notationMode,
       poolsideRestLayout: settings.restLayout,
+      poolsideSessionNoteMode: settings.sessionNoteMode,
+      poolsideStepNotesMode: settings.stepNotesMode,
       swimmerName: localPreviewDraft.swimmerName,
       logoUrl: new URL(
         getWorkoutPdfLogoPath({
@@ -214,6 +222,8 @@ export default function PoolsidePreviewPageClient() {
         settings.printLayout,
         settings.notationMode,
         settings.restLayout,
+        settings.sessionNoteMode,
+        settings.stepNotesMode,
       ].join("|"),
     [localPreviewDraft?.updatedAt, previewFrameHref, settings]
   );
@@ -501,7 +511,7 @@ export default function PoolsidePreviewPageClient() {
               </p>
             ) : null}
 
-            <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            <div className="mt-4 grid gap-3 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
               <label className="grid gap-2" htmlFor="poolside-preview-style">
                 <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
                   Ink usage
@@ -585,6 +595,49 @@ export default function PoolsidePreviewPageClient() {
                   <option value="auto">Auto</option>
                   <option value="inline">All inline</option>
                   <option value="below_step">All separate line</option>
+                </select>
+              </label>
+
+              <label className="grid gap-2" htmlFor="poolside-preview-session-note">
+                <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Session note
+                </span>
+                <select
+                  id="poolside-preview-session-note"
+                  value={settings.sessionNoteMode}
+                  onChange={(event) =>
+                    updateSetting(
+                      "sessionNoteMode",
+                      event.target.value as WorkoutPoolsidePreviewSettings["sessionNoteMode"]
+                    )
+                  }
+                  data-testid="poolside-preview-session-note"
+                  className="h-11 rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-blue-300 focus:ring-2 focus:ring-blue-100"
+                >
+                  <option value="off">Hidden</option>
+                  <option value="include">Shown</option>
+                </select>
+              </label>
+
+              <label className="grid gap-2" htmlFor="poolside-preview-step-notes">
+                <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Step notes
+                </span>
+                <select
+                  id="poolside-preview-step-notes"
+                  value={settings.stepNotesMode}
+                  onChange={(event) =>
+                    updateSetting(
+                      "stepNotesMode",
+                      event.target.value as WorkoutPoolsidePreviewSettings["stepNotesMode"]
+                    )
+                  }
+                  data-testid="poolside-preview-step-notes"
+                  className="h-11 rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-blue-300 focus:ring-2 focus:ring-blue-100"
+                >
+                  <option value="off">Hidden</option>
+                  <option value="drills_only">Drill steps</option>
+                  <option value="all">All notes</option>
                 </select>
               </label>
             </div>

--- a/docs/task-briefs/in-progress/2026-04-21-poolside-note-session-and-step-notes-display-options-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-21-poolside-note-session-and-step-notes-display-options-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-04-21-poolside-note-session-and-step-notes-display-options-10-10`
-- `status`: `planned`
+- `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-04-21`
 - `updated`: `2026-04-21`
@@ -42,9 +42,9 @@ Let poolside note users optionally include the saved session note and relevant s
   - session note, if enabled, renders below Focus as a separate box,
   - step notes, if enabled, render under the step line they belong to,
   - step-note modes should be:
-    - `Off`
-    - `Drills only`
-    - `All step notes`
+    - `Hidden`
+    - `Drill steps`
+    - `All notes`
   - session-note mode should be a simple include/exclude control unless implementation shows a clearer existing pattern,
   - notes must be included in `Print / Save PDF` and `Save image` output when enabled,
   - no new note authoring model or persistence schema is introduced in this brief.
@@ -117,7 +117,7 @@ Critical target categories for `10/10` claim in this brief:
   - saved workout identity and step ordering.
 - Local-only / preview state:
   - include session note on/off,
-  - step-note display mode (`Off`, `Drills only`, `All step notes`),
+  - step-note display mode (`Hidden`, `Drill steps`, `All notes`),
   - rendered preview/export readiness state.
 - Sync policy:
   - toggling note display changes only preview/export presentation,
@@ -141,7 +141,8 @@ Critical target categories for `10/10` claim in this brief:
 - Add poolside preview presentation controls for session note and step notes.
 - Render session note below Focus as a separate box when enabled and populated.
 - Render step notes under their matching step line when enabled and populated.
-- Support `Off`, `Drills only`, and `All step notes` for step notes.
+- Support `Hidden`, `Drill steps`, and `All notes` for step notes.
+- Prefer concrete drill names in the poolside step summary when present, so generic `Drill` is replaced by labels like `Catch drill`.
 - Validate portrait and landscape poolside note layouts.
 - Validate print/PDF and Save image output.
 - Preserve existing note authoring and Garmin/export semantics.
@@ -158,7 +159,7 @@ Critical target categories for `10/10` claim in this brief:
 ## Acceptance Criteria
 
 1. Poolside preview exposes a clear session-note include/exclude control.
-2. Poolside preview exposes `Off`, `Drills only`, and `All step notes` modes for step notes.
+2. Poolside preview exposes `Hidden`, `Drill steps`, and `All notes` modes for step notes.
 3. Default poolside output remains unchanged/noiseless when note options are off.
 4. Session note renders below Focus in its own box only when enabled and populated.
 5. Step notes render directly under the step line they belong to only when enabled by the selected mode.
@@ -242,3 +243,6 @@ Critical target categories for `10/10` claim in this brief:
 ## Checkpoint Log
 
 - `2026-04-21 | planned | created after the poolside mobile preview/save-image reliability closeout; scope is limited to optional session note and step-note display in poolside preview/export, with maintenance baseline still sequenced after this findings-wave follow-up | next: implement end-to-end or explicitly defer before starting maintenance baseline`
+- `2026-04-21 | in-progress | moved to feature branch feat/poolside-session-step-notes-2026-04-21 and started implementation; default note output remains off while preview controls, renderer options, and URL settings are being wired together | next: targeted validation, screenshots, owner review`
+- `2026-04-21 | in-progress | owner review caught wording and readability issues; refined labels to Hidden/Shown and Hidden/Drill steps/All notes, increased note readability, and moved concrete drill identity into the step summary where available | next: refresh targeted tests and screenshot handoff`
+- `2026-04-21 | in-progress | targeted unit validation passed (66 tests) and owner approved the refreshed screenshot handoff in output/playwright/poolside-notes-review | next: run verify:pre-pr, commit, push, and open PR`

--- a/docs/task-briefs/planned/2026-04-18-maintenance-baseline-pre-live-10-10.md
+++ b/docs/task-briefs/planned/2026-04-18-maintenance-baseline-pre-live-10-10.md
@@ -19,7 +19,7 @@ Bring the repo and runtime maintenance baseline to a pre-live 10/10 level: no kn
   - [2026-04-20-swim-session-builder-library-default-entry-action-density-and-workspace-nav-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-20-swim-session-builder-library-default-entry-action-density-and-workspace-nav-10-10.md)
   - [2026-04-20-poolside-note-mobile-preview-and-save-image-reliability-followup-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-20-poolside-note-mobile-preview-and-save-image-reliability-followup-10-10.md)
 - Remaining findings-wave brief that currently takes precedence:
-  - [2026-04-21-poolside-note-session-and-step-notes-display-options-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/planned/2026-04-21-poolside-note-session-and-step-notes-display-options-10-10.md)
+  - [2026-04-21-poolside-note-session-and-step-notes-display-options-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-04-21-poolside-note-session-and-step-notes-display-options-10-10.md)
   - [2026-04-21-poolside-note-save-image-crop-boundary-followup-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/planned/2026-04-21-poolside-note-save-image-crop-boundary-followup-10-10.md)
   - [2026-04-21-my-swim-profile-page-ia-and-copy-cleanup-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/planned/2026-04-21-my-swim-profile-page-ia-and-copy-cleanup-10-10.md)
   - [2026-04-21-account-security-simplification-and-auth-surface-audit-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/planned/2026-04-21-account-security-simplification-and-auth-surface-audit-10-10.md)

--- a/lib/workouts/poolside-preview.ts
+++ b/lib/workouts/poolside-preview.ts
@@ -5,12 +5,16 @@ import type {
   WorkoutPoolsidePrintLayout,
   WorkoutPoolsidePrintStyle,
   WorkoutPoolsideRestLayout,
+  WorkoutPoolsideSessionNoteMode,
+  WorkoutPoolsideStepNotesMode,
 } from "@/lib/workouts/shared";
 import {
   normalizeWorkoutPoolsideNotationMode,
   normalizeWorkoutPoolsidePrintLayout,
   normalizeWorkoutPoolsidePrintStyle,
   normalizeWorkoutPoolsideRestLayout,
+  normalizeWorkoutPoolsideSessionNoteMode,
+  normalizeWorkoutPoolsideStepNotesMode,
 } from "@/lib/workouts/shared";
 
 const WORKOUT_POOLSIDE_PREVIEW_STORAGE_PREFIX = "my-library-workout-poolside-preview-v1:";
@@ -20,6 +24,8 @@ export type WorkoutPoolsidePreviewSettings = {
   printLayout: WorkoutPoolsidePrintLayout;
   notationMode: WorkoutPoolsideNotationMode;
   restLayout: WorkoutPoolsideRestLayout;
+  sessionNoteMode: WorkoutPoolsideSessionNoteMode;
+  stepNotesMode: WorkoutPoolsideStepNotesMode;
 };
 
 export type StoredWorkoutPoolsidePreviewDraft = {
@@ -36,6 +42,8 @@ export const DEFAULT_WORKOUT_POOLSIDE_PREVIEW_SETTINGS: WorkoutPoolsidePreviewSe
   printLayout: "portrait",
   notationMode: "auto",
   restLayout: "auto",
+  sessionNoteMode: "off",
+  stepNotesMode: "off",
 };
 
 function slugifyPoolsideFilePart(value: string) {
@@ -91,12 +99,16 @@ export function normalizeWorkoutPoolsidePreviewSettings(input?: {
   printLayout?: string | null | undefined;
   notationMode?: string | null | undefined;
   restLayout?: string | null | undefined;
+  sessionNoteMode?: string | null | undefined;
+  stepNotesMode?: string | null | undefined;
 }): WorkoutPoolsidePreviewSettings {
   return {
     printStyle: normalizeWorkoutPoolsidePrintStyle(input?.printStyle),
     printLayout: normalizeWorkoutPoolsidePrintLayout(input?.printLayout),
     notationMode: normalizeWorkoutPoolsideNotationMode(input?.notationMode),
     restLayout: normalizeWorkoutPoolsideRestLayout(input?.restLayout),
+    sessionNoteMode: normalizeWorkoutPoolsideSessionNoteMode(input?.sessionNoteMode),
+    stepNotesMode: normalizeWorkoutPoolsideStepNotesMode(input?.stepNotesMode),
   };
 }
 
@@ -109,6 +121,8 @@ export function applyWorkoutPoolsidePreviewSettings(
   searchParams.set("printLayout", normalized.printLayout);
   searchParams.set("notationMode", normalized.notationMode);
   searchParams.set("restLayout", normalized.restLayout);
+  searchParams.set("sessionNoteMode", normalized.sessionNoteMode);
+  searchParams.set("stepNotesMode", normalized.stepNotesMode);
 }
 
 export function buildWorkoutPoolsidePreviewHref(

--- a/lib/workouts/shared.ts
+++ b/lib/workouts/shared.ts
@@ -177,6 +177,8 @@ export const WORKOUT_POOLSIDE_PRINT_STYLES = ["color", "ink_saver"] as const;
 export const WORKOUT_POOLSIDE_PRINT_LAYOUTS = ["portrait", "landscape"] as const;
 export const WORKOUT_POOLSIDE_NOTATION_MODES = ["auto", "full", "abbreviated"] as const;
 export const WORKOUT_POOLSIDE_REST_LAYOUTS = ["auto", "inline", "below_step"] as const;
+export const WORKOUT_POOLSIDE_SESSION_NOTE_MODES = ["off", "include"] as const;
+export const WORKOUT_POOLSIDE_STEP_NOTES_MODES = ["off", "drills_only", "all"] as const;
 
 export const WORKOUT_POOLSIDE_ABBREVIATION_LEGEND = [
   { short: "Free", full: "Freestyle" },
@@ -196,6 +198,8 @@ export type WorkoutPoolsidePrintStyle = (typeof WORKOUT_POOLSIDE_PRINT_STYLES)[n
 export type WorkoutPoolsidePrintLayout = (typeof WORKOUT_POOLSIDE_PRINT_LAYOUTS)[number];
 export type WorkoutPoolsideNotationMode = (typeof WORKOUT_POOLSIDE_NOTATION_MODES)[number];
 export type WorkoutPoolsideRestLayout = (typeof WORKOUT_POOLSIDE_REST_LAYOUTS)[number];
+export type WorkoutPoolsideSessionNoteMode = (typeof WORKOUT_POOLSIDE_SESSION_NOTE_MODES)[number];
+export type WorkoutPoolsideStepNotesMode = (typeof WORKOUT_POOLSIDE_STEP_NOTES_MODES)[number];
 type WorkoutPoolsideLineSecondaryPlacement = Exclude<WorkoutPoolsideRestLayout, "auto">;
 export type WorkoutPoolsideFocusOption = {
   id: string;
@@ -241,6 +245,8 @@ export type WorkoutPdfModel = {
   poolsideNotationMode: WorkoutPoolsideNotationMode;
   poolsideRestLayout: WorkoutPoolsideRestLayout;
   poolsideResolvedRestLayout: WorkoutPoolsideRestLayout;
+  poolsideSessionNoteMode: WorkoutPoolsideSessionNoteMode;
+  poolsideStepNotesMode: WorkoutPoolsideStepNotesMode;
   logoUrl: string | null;
   swimmerName: string | null;
   sourceLabel: string;
@@ -267,6 +273,13 @@ type WorkoutPoolsideLineItem = {
   text: string;
   secondaryText?: string | null;
   secondaryPlacement?: WorkoutPoolsideLineSecondaryPlacement | null;
+  stepNoteCandidates?: WorkoutPoolsideLineItemNote[];
+  stepNotes?: string[];
+};
+
+type WorkoutPoolsideLineItemNote = {
+  text: string;
+  scope: "drill" | "step";
 };
 
 type WorkoutPoolsideContentDriver = "title" | "chip" | "line";
@@ -822,6 +835,8 @@ export function buildWorkoutPdfModel(
     poolsidePrintLayout?: WorkoutPoolsidePrintLayout;
     poolsideNotationMode?: WorkoutPoolsideNotationMode;
     poolsideRestLayout?: WorkoutPoolsideRestLayout;
+    poolsideSessionNoteMode?: WorkoutPoolsideSessionNoteMode;
+    poolsideStepNotesMode?: WorkoutPoolsideStepNotesMode;
     swimmerName?: string | null;
     logoUrl?: string | null;
   }
@@ -838,12 +853,19 @@ export function buildWorkoutPdfModel(
     options?.poolsideRestLayout == null
       ? "below_step"
       : normalizeWorkoutPoolsideRestLayout(options.poolsideRestLayout);
+  const poolsideSessionNoteMode = normalizeWorkoutPoolsideSessionNoteMode(
+    options?.poolsideSessionNoteMode
+  );
+  const poolsideStepNotesMode = normalizeWorkoutPoolsideStepNotesMode(
+    options?.poolsideStepNotesMode
+  );
   const fileName = buildWorkoutPdfFileName(draft, { draftState, variant });
   const sourceLabel = draftState === "canonical" ? "Canonical workout" : "Local draft";
   const focusPoints = buildWorkoutPdfFocusPoints(draft, options?.focusPoints);
   const poolsideFormatting = buildWorkoutPoolsideLineItemsForDraft(draft, {
     notationMode: poolsideNotationMode,
     restLayout: poolsideRestLayout,
+    stepNotesMode: poolsideStepNotesMode,
   });
   const poolsideLineItems = poolsideFormatting.items;
   const poolsideLines = poolsideLineItems.map(formatWorkoutPoolsideLineItemText);
@@ -860,6 +882,8 @@ export function buildWorkoutPdfModel(
       poolsideNotationMode,
       poolsideRestLayout,
       poolsideResolvedRestLayout: poolsideFormatting.resolvedRestLayout,
+      poolsideSessionNoteMode,
+      poolsideStepNotesMode,
       logoUrl: options?.logoUrl ?? null,
       swimmerName,
       sourceLabel,
@@ -963,6 +987,8 @@ export function buildWorkoutPdfModel(
     poolsideNotationMode,
     poolsideRestLayout,
     poolsideResolvedRestLayout: poolsideFormatting.resolvedRestLayout,
+    poolsideSessionNoteMode,
+    poolsideStepNotesMode,
     logoUrl: options?.logoUrl ?? null,
     swimmerName,
     sourceLabel,
@@ -995,6 +1021,8 @@ export function buildWorkoutPdfHtmlDocument(
     poolsidePrintLayout?: WorkoutPoolsidePrintLayout;
     poolsideNotationMode?: WorkoutPoolsideNotationMode;
     poolsideRestLayout?: WorkoutPoolsideRestLayout;
+    poolsideSessionNoteMode?: WorkoutPoolsideSessionNoteMode;
+    poolsideStepNotesMode?: WorkoutPoolsideStepNotesMode;
     swimmerName?: string | null;
     logoUrl?: string | null;
     fontUrl?: string | null;
@@ -1658,6 +1686,15 @@ function buildPoolsideWorkoutPdfHtmlDocument(
         </section>
       `
     : "";
+  const sessionNoteHtml =
+    model.poolsideSessionNoteMode === "include" && model.description
+      ? `
+        <section class="callout">
+          <p class="callout-label">Session note</p>
+          <p class="session-note-text">${escapeHtml(model.description)}</p>
+        </section>
+      `
+      : "";
   const heroTotalHtml = totalDistanceValue
     ? `
         <div class="hero-total-pill" data-testid="workout-pdf-total">
@@ -1691,13 +1728,21 @@ function buildPoolsideWorkoutPdfHtmlDocument(
     ? `
         <div class="body body-landscape-columns">
           ${stepsHtml}
-          ${hasFocusPoints ? `<div class="poolside-meta poolside-meta-landscape">${focusPointsHtml}</div>` : ""}
+          ${
+            hasFocusPoints || sessionNoteHtml
+              ? `<div class="poolside-meta poolside-meta-landscape">${focusPointsHtml}${sessionNoteHtml}</div>`
+              : ""
+          }
         </div>
       `
     : `
         <div class="body body-single-column">
           ${stepsHtml}
-          ${hasFocusPoints ? `<div class="poolside-meta">${focusPointsHtml}</div>` : ""}
+          ${
+            hasFocusPoints || sessionNoteHtml
+              ? `<div class="poolside-meta">${focusPointsHtml}${sessionNoteHtml}</div>`
+              : ""
+          }
         </div>
       `;
   const heroHtml = isLandscape
@@ -2126,6 +2171,13 @@ function buildPoolsideWorkoutPdfHtmlDocument(
         line-height: 1.3;
       }
 
+      .session-note-text {
+        margin: 4px 0 0;
+        font-size: 11.4px;
+        line-height: 1.34;
+        color: var(--ink);
+      }
+
       .section-title {
         margin: 2px 0 0;
         font-size: 15px;
@@ -2233,6 +2285,17 @@ function buildPoolsideWorkoutPdfHtmlDocument(
 
       .poolside-line-secondary-inline .poolside-line-secondary-text {
         display: inline;
+      }
+
+      .poolside-line-note-list {
+        margin: 4px 0 0;
+        padding-left: 15px;
+        display: grid;
+        gap: 2px;
+        font-size: 11.1px;
+        line-height: 1.32;
+        font-weight: 560;
+        color: var(--muted);
       }
 
       .poolside-line-recovery {
@@ -2348,6 +2411,8 @@ function buildPoolsideWorkoutPdfHtmlDocument(
         data-poolside-notation-mode="${escapeHtml(model.poolsideNotationMode)}"
         data-poolside-rest-layout="${escapeHtml(model.poolsideRestLayout)}"
         data-poolside-resolved-rest-layout="${escapeHtml(model.poolsideResolvedRestLayout)}"
+        data-poolside-session-note-mode="${escapeHtml(model.poolsideSessionNoteMode)}"
+        data-poolside-step-notes-mode="${escapeHtml(model.poolsideStepNotesMode)}"
         data-poolside-width-profile="${escapeHtml(sizingProfile.widthProfile)}"
         data-poolside-content-driver="${escapeHtml(sizingProfile.contentDriver)}"
         data-poolside-page-width-mm="${escapeHtml(String(sizingProfile.pageWidthMm))}"
@@ -3104,6 +3169,14 @@ function renderWorkoutPoolsideLineHtml(line: WorkoutPoolsideLineItem) {
           : ""
       }<span class="poolside-line-secondary-text">${escapeHtml(line.secondaryText)}</span></span>`
     : "";
+  const stepNotesHtml =
+    line.stepNotes && line.stepNotes.length > 0
+      ? `
+        <ul class="poolside-line-note-list">
+          ${line.stepNotes.map((note) => `<li>${escapeHtml(note)}</li>`).join("")}
+        </ul>
+      `
+      : "";
 
   return `
     <li class="poolside-line ${line.kind === "recovery" ? "poolside-line-recovery" : ""}">
@@ -3111,6 +3184,7 @@ function renderWorkoutPoolsideLineHtml(line: WorkoutPoolsideLineItem) {
         <span class="poolside-line-primary">${escapeHtml(line.text)}</span>
         ${secondaryHtml}
       </span>
+      ${stepNotesHtml}
     </li>
   `;
 }
@@ -3141,17 +3215,23 @@ function estimatePoolsideWrappedLineCount(text: string, charactersPerLine: numbe
 }
 
 function estimateWorkoutPoolsideLineRows(line: WorkoutPoolsideLineItem) {
+  const noteRows = (line.stepNotes ?? []).reduce(
+    (rows, note) => rows + estimatePoolsideWrappedLineCount(note, 38),
+    0
+  );
+
   if (!line.secondaryText) {
-    return estimatePoolsideWrappedLineCount(line.text, 34);
+    return estimatePoolsideWrappedLineCount(line.text, 34) + noteRows;
   }
 
   if (line.secondaryPlacement === "inline") {
-    return estimatePoolsideWrappedLineCount(`${line.text} · ${line.secondaryText}`, 34);
+    return estimatePoolsideWrappedLineCount(`${line.text} · ${line.secondaryText}`, 34) + noteRows;
   }
 
   return (
     estimatePoolsideWrappedLineCount(line.text, 34) +
-    estimatePoolsideWrappedLineCount(line.secondaryText, 28)
+    estimatePoolsideWrappedLineCount(line.secondaryText, 28) +
+    noteRows
   );
 }
 
@@ -3188,15 +3268,16 @@ function splitWorkoutPoolsideLandscapeLineItems(items: WorkoutPoolsideLineItem[]
 
 function buildWorkoutPoolsideSizingLines(items: WorkoutPoolsideLineItem[]) {
   return items.flatMap((item) => {
+    const noteLines = item.stepNotes ?? [];
     if (!item.secondaryText) {
-      return [item.text];
+      return [item.text, ...noteLines];
     }
 
     if (item.secondaryPlacement === "inline") {
-      return [`${item.text} · ${item.secondaryText}`];
+      return [`${item.text} · ${item.secondaryText}`, ...noteLines];
     }
 
-    return [item.text, item.secondaryText];
+    return [item.text, item.secondaryText, ...noteLines];
   });
 }
 
@@ -3461,6 +3542,22 @@ export function normalizeWorkoutPoolsideRestLayout(
   return "auto";
 }
 
+export function normalizeWorkoutPoolsideSessionNoteMode(
+  value: string | null | undefined
+): WorkoutPoolsideSessionNoteMode {
+  return value === "include" ? "include" : "off";
+}
+
+export function normalizeWorkoutPoolsideStepNotesMode(
+  value: string | null | undefined
+): WorkoutPoolsideStepNotesMode {
+  if (value === "drills_only" || value === "all") {
+    return value;
+  }
+
+  return "off";
+}
+
 export function normalizeWorkoutPdfPreviewChrome(
   value: string | null | undefined
 ): WorkoutPdfPreviewChrome {
@@ -3582,11 +3679,39 @@ function shouldInlineWorkoutPoolsideSecondary(
   );
 }
 
+function selectWorkoutPoolsideLineItemStepNotes(
+  candidates: WorkoutPoolsideLineItemNote[] | null | undefined,
+  mode: WorkoutPoolsideStepNotesMode
+) {
+  if (mode === "off" || !candidates || candidates.length === 0) {
+    return [];
+  }
+
+  const selectedCandidates =
+    mode === "drills_only"
+      ? candidates.filter((candidate) => candidate.scope === "drill")
+      : candidates;
+  const seen = new Set<string>();
+  const selectedNotes: string[] = [];
+
+  for (const candidate of selectedCandidates) {
+    const normalized = normalizeNullableText(candidate.text, 260);
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+    selectedNotes.push(normalized);
+    seen.add(normalized);
+  }
+
+  return selectedNotes;
+}
+
 function formatWorkoutPoolsideLineItem(
   item: WorkoutPoolsideLineItem,
   options: {
     notationMode: WorkoutPoolsideNotationMode;
     requestedRestLayout: WorkoutPoolsideRestLayout;
+    stepNotesMode: WorkoutPoolsideStepNotesMode;
   }
 ) {
   const { primaryText, secondaryText } = formatWorkoutPoolsideLineTexts(item, {
@@ -3607,6 +3732,10 @@ function formatWorkoutPoolsideLineItem(
     text: primaryText,
     secondaryText,
     secondaryPlacement,
+    stepNotes: selectWorkoutPoolsideLineItemStepNotes(
+      item.stepNoteCandidates,
+      options.stepNotesMode
+    ),
   };
 }
 
@@ -3616,12 +3745,14 @@ function formatWorkoutPoolsideLineItems(
 ) {
   const notationMode = normalizeWorkoutPoolsideNotationMode(options?.notationMode);
   const requestedRestLayout = normalizeWorkoutPoolsideRestLayout(options?.restLayout);
+  const stepNotesMode = normalizeWorkoutPoolsideStepNotesMode(options?.stepNotesMode);
 
   return {
     items: items.map((item) =>
       formatWorkoutPoolsideLineItem(item, {
         notationMode,
         requestedRestLayout,
+        stepNotesMode,
       })
     ),
     resolvedRestLayout: requestedRestLayout,
@@ -3735,6 +3866,7 @@ function buildWorkoutPoolsideLines(draft: SessionDraft | null | undefined) {
 type WorkoutPoolsideFormattingOptions = {
   notationMode?: WorkoutPoolsideNotationMode;
   restLayout?: WorkoutPoolsideRestLayout;
+  stepNotesMode?: WorkoutPoolsideStepNotesMode;
 };
 
 type WorkoutPoolsideFormattingResult = {
@@ -3895,6 +4027,7 @@ function buildWorkoutPoolsideSingleGroupLineItems(
         entry.step,
         null,
         trailingRecoveryText,
+        inlineRecoverySteps,
         basePaceSecondsPer100m,
         environment,
         poolLengthUnit
@@ -3956,6 +4089,7 @@ function buildWorkoutPoolsideRepeatGroupLineItems(
         step,
         repeatCount,
         trailingRecoveryText,
+        trailingRecoverySteps,
         basePaceSecondsPer100m,
         environment,
         poolLengthUnit
@@ -4009,11 +4143,16 @@ function buildWorkoutPoolsideRepeatGroupLineItems(
         secondaryText: [lastInterval.secondaryText, trailingPostSetRestText]
           .filter(Boolean)
           .join(" · "),
+        stepNoteCandidates: [
+          ...(lastInterval.stepNoteCandidates ?? []),
+          ...buildWorkoutPoolsideStepNoteCandidates(trailingPostSetRestSteps),
+        ],
       };
     } else {
       lineItems.push({
         kind: "recovery",
         text: trailingPostSetRestText,
+        stepNoteCandidates: buildWorkoutPoolsideStepNoteCandidates(trailingPostSetRestSteps),
       });
     }
   }
@@ -4028,6 +4167,7 @@ function buildWorkoutPoolsideIntervalLineItem(
   step: SessionDraftStep,
   repeatCount: number | null,
   trailingRecoveryText: string | null,
+  trailingRecoverySteps: SessionDraftStep[],
   basePaceSecondsPer100m: number,
   environment: SessionGeneratorEnvironment,
   poolLengthUnit: SessionDraftPoolLengthUnit
@@ -4044,7 +4184,28 @@ function buildWorkoutPoolsideIntervalLineItem(
     kind: "interval" as const,
     text,
     secondaryText: trailingRecoveryText,
+    stepNoteCandidates: buildWorkoutPoolsideStepNoteCandidates([step, ...trailingRecoverySteps]),
   };
+}
+
+function isWorkoutPoolsideDrillNoteStep(step: SessionDraftStep) {
+  return step.category === "drill" || Boolean(step.drillType);
+}
+
+function buildWorkoutPoolsideStepNoteCandidates(steps: SessionDraftStep[]) {
+  return steps
+    .map((step) => {
+      const text = normalizeNullableText(step.notes, 260);
+      if (!text) {
+        return null;
+      }
+
+      return {
+        text,
+        scope: isWorkoutPoolsideDrillNoteStep(step) ? "drill" : "step",
+      } satisfies WorkoutPoolsideLineItemNote;
+    })
+    .filter((candidate): candidate is WorkoutPoolsideLineItemNote => candidate !== null);
 }
 
 function buildWorkoutPoolsideRecoverySummary(
@@ -4114,6 +4275,7 @@ function buildWorkoutPoolsideStandaloneRecoveryLineItem(
       poolLengthUnit,
       "standalone"
     ),
+    stepNoteCandidates: buildWorkoutPoolsideStepNoteCandidates([step]),
   };
 }
 
@@ -4215,17 +4377,18 @@ function buildWorkoutPoolsideDescriptor(
   primaryTargetLabel: string | null
 ) {
   const parts: string[] = [];
+  const isDrillStep = step.category === "drill" || step.stroke === "drill";
 
   if (step.category === "kick") {
     if (step.stroke && step.stroke !== "choice" && step.stroke !== "drill") {
       parts.push(getSessionStepStrokeLabel(step.stroke));
     }
     parts.push("Kick");
-  } else if (step.category === "drill" || step.stroke === "drill") {
-    if (step.drillType && step.drillType !== "none") {
-      parts.push(getSessionStepDrillTypeLabel(step.drillType));
+  } else if (isDrillStep) {
+    if (step.stroke && step.stroke !== "choice" && step.stroke !== "drill") {
+      parts.push(getSessionStepStrokeLabel(step.stroke));
     }
-    parts.push("Drill");
+    parts.push(resolveWorkoutPoolsideDrillLabel(step, durationLabel, primaryTargetLabel));
   } else if (step.stroke === "choice") {
     parts.push("Choice");
   } else if (step.stroke) {
@@ -4235,6 +4398,7 @@ function buildWorkoutPoolsideDescriptor(
   if (
     step.drillType &&
     step.drillType !== "none" &&
+    !isDrillStep &&
     !parts.includes(getSessionStepDrillTypeLabel(step.drillType))
   ) {
     parts.push(getSessionStepDrillTypeLabel(step.drillType));
@@ -4261,6 +4425,36 @@ function buildWorkoutPoolsideDescriptor(
   ].filter(Boolean) as string[];
 
   return duplicateLabels.some((label) => normalizedName === label.toLowerCase()) ? null : name;
+}
+
+function resolveWorkoutPoolsideDrillLabel(
+  step: SessionDraftStep,
+  durationLabel: string,
+  primaryTargetLabel: string | null
+) {
+  const name = typeof step.name === "string" ? step.name.trim() : "";
+  const normalizedName = name.toLowerCase();
+  const genericNames = new Set(["drill", "drill step", "swim drill", "pool drill"]);
+  const duplicateLabels = [
+    durationLabel,
+    primaryTargetLabel,
+    getSessionStepIntensityLabel(step.intensity),
+  ].filter(Boolean) as string[];
+
+  if (
+    name &&
+    !name.includes("·") &&
+    !genericNames.has(normalizedName) &&
+    !duplicateLabels.some((label) => normalizedName === label.toLowerCase())
+  ) {
+    return name;
+  }
+
+  if (step.drillType && step.drillType !== "none") {
+    return getSessionStepDrillTypeLabel(step.drillType);
+  }
+
+  return "Drill";
 }
 
 function buildWorkoutPoolsideTargetLabel(

--- a/tests/unit/poolside-preview-page-client.test.tsx
+++ b/tests/unit/poolside-preview-page-client.test.tsx
@@ -148,6 +148,7 @@ describe("PoolsidePreviewPageClient", () => {
   );
 
   beforeEach(() => {
+    navigationState.searchParams = new URLSearchParams("previewId=preview-1");
     writeStoredWorkoutPoolsidePreviewDraft("preview-1", {
       draft: buildDraft(),
       draftState: "local_draft",
@@ -307,5 +308,24 @@ describe("PoolsidePreviewPageClient", () => {
 
     await markEmbeddedPreviewReady();
     expect(screen.getByTestId("poolside-preview-save-image")).not.toBeDisabled();
+  });
+
+  it("keeps note controls off by default and syncs selected note modes into the URL", async () => {
+    render(<PoolsidePreviewPageClient />);
+
+    expect(screen.getByTestId("poolside-preview-session-note")).toHaveValue("off");
+    expect(screen.getByTestId("poolside-preview-step-notes")).toHaveValue("off");
+
+    fireEvent.change(screen.getByTestId("poolside-preview-session-note"), {
+      target: { value: "include" },
+    });
+    fireEvent.change(screen.getByTestId("poolside-preview-step-notes"), {
+      target: { value: "drills_only" },
+    });
+
+    await waitFor(() => {
+      expect(window.location.search).toContain("sessionNoteMode=include");
+      expect(window.location.search).toContain("stepNotesMode=drills_only");
+    });
   });
 });

--- a/tests/unit/workout-poolside-preview.test.ts
+++ b/tests/unit/workout-poolside-preview.test.ts
@@ -74,6 +74,8 @@ describe("workout poolside preview helpers", () => {
     expect(href).toContain("printLayout=portrait");
     expect(href).toContain("notationMode=auto");
     expect(href).toContain("restLayout=auto");
+    expect(href).toContain("sessionNoteMode=off");
+    expect(href).toContain("stepNotesMode=off");
   });
 
   it("builds an embedded canonical frame href for the preview surface", () => {
@@ -84,11 +86,13 @@ describe("workout poolside preview helpers", () => {
         printLayout: "landscape",
         notationMode: "abbreviated",
         restLayout: "below_step",
+        sessionNoteMode: "include",
+        stepNotesMode: "drills_only",
       },
     });
 
     expect(href).toBe(
-      "/api/my-library/workouts/workout-1/export/pdf?variant=poolside&previewChrome=embedded&printStyle=ink_saver&printLayout=landscape&notationMode=abbreviated&restLayout=below_step&focusMode=custom"
+      "/api/my-library/workouts/workout-1/export/pdf?variant=poolside&previewChrome=embedded&printStyle=ink_saver&printLayout=landscape&notationMode=abbreviated&restLayout=below_step&sessionNoteMode=include&stepNotesMode=drills_only&focusMode=custom"
     );
   });
 

--- a/tests/unit/workouts-routes.test.ts
+++ b/tests/unit/workouts-routes.test.ts
@@ -506,6 +506,8 @@ describe("workouts routes", () => {
     expect(body).toContain('data-poolside-print-style="ink_saver"');
     expect(body).toContain('data-poolside-notation-mode="abbreviated"');
     expect(body).toContain('data-poolside-rest-layout="inline"');
+    expect(body).toContain('data-poolside-session-note-mode="off"');
+    expect(body).toContain('data-poolside-step-notes-mode="off"');
     expect(body).toContain('data-testid="workout-pdf-total"');
     expect(body).toContain("Calm exhale: Start the exhale before the head turns to breathe.");
     expect(body).not.toContain("High elbow catch");

--- a/tests/unit/workouts-shared.test.ts
+++ b/tests/unit/workouts-shared.test.ts
@@ -1021,6 +1021,8 @@ describe("workouts shared readiness", () => {
     ).toBe("freeswimming-garmin-readiness-draft-poolside-note.pdf");
     expect(html).toContain('data-pdf-variant="poolside"');
     expect(html).toContain('data-poolside-print-style="ink_saver"');
+    expect(html).toContain('data-poolside-session-note-mode="off"');
+    expect(html).toContain('data-poolside-step-notes-mode="off"');
     expect(html).toContain("High elbow catch");
     expect(html).toContain("Calm exhale");
     expect(html).toContain("400m");
@@ -1041,6 +1043,7 @@ describe("workouts shared readiness", () => {
     expect(html).not.toContain(">Portrait<");
     expect(html).not.toContain(">Landscape<");
     expect(html).not.toContain("Compact lane-side note");
+    expect(html).not.toContain("Start smooth.");
     expect(html).not.toContain("~10 min");
     expect(html).toContain("400m · Freestyle · Easy");
     expect(html).not.toContain("P:");
@@ -1057,6 +1060,64 @@ describe("workouts shared readiness", () => {
     expect(html).toContain("margin: 8mm;");
     expect(html).not.toContain("width: min(100%, 144mm)");
     expect(html).not.toContain("margin: 12mm;");
+  });
+
+  it("adds poolside session and selected step notes only when preview controls ask for them", () => {
+    const draft: SessionDraft = {
+      ...buildDraft(),
+      description: "Bring the snorkel and keep the main set calm.",
+      steps: [
+        {
+          ...buildDraft().steps[0],
+          notes: "Settle into long strokes.",
+        },
+        {
+          id: "step-2",
+          category: "drill",
+          name: "Catch drill",
+          stroke: "freestyle",
+          drillType: "drill",
+          intensity: "easy",
+          durationMode: "distance",
+          distanceM: 50,
+          timeMin: null,
+          targetSummary: "",
+          notes: "Single-arm catch with the non-working arm forward.",
+        },
+      ],
+    };
+    const defaultHtml = buildWorkoutPdfHtmlDocument(draft, {
+      draftState: "canonical",
+      variant: "poolside",
+      focusPoints: ["High elbow catch"],
+    });
+    const drillNotesHtml = buildWorkoutPdfHtmlDocument(draft, {
+      draftState: "canonical",
+      variant: "poolside",
+      focusPoints: ["High elbow catch"],
+      poolsideSessionNoteMode: "include",
+      poolsideStepNotesMode: "drills_only",
+    });
+    const allNotesHtml = buildWorkoutPdfHtmlDocument(draft, {
+      draftState: "canonical",
+      variant: "poolside",
+      poolsideStepNotesMode: "all",
+    });
+
+    expect(defaultHtml).toContain('data-poolside-session-note-mode="off"');
+    expect(defaultHtml).toContain('data-poolside-step-notes-mode="off"');
+    expect(defaultHtml).not.toContain("Bring the snorkel");
+    expect(defaultHtml).not.toContain("Single-arm catch");
+    expect(drillNotesHtml).toContain('data-poolside-session-note-mode="include"');
+    expect(drillNotesHtml).toContain('data-poolside-step-notes-mode="drills_only"');
+    expect(drillNotesHtml).toContain("Session note");
+    expect(drillNotesHtml).toContain("Bring the snorkel and keep the main set calm.");
+    expect(drillNotesHtml).toContain("50m · Freestyle · Catch drill · Easy");
+    expect(drillNotesHtml).not.toContain("50m · Freestyle · Drill · Catch drill · Easy");
+    expect(drillNotesHtml).toContain("Single-arm catch with the non-working arm forward.");
+    expect(drillNotesHtml).not.toContain("Settle into long strokes.");
+    expect(allNotesHtml).toContain("Single-arm catch with the non-working arm forward.");
+    expect(allNotesHtml).toContain("Settle into long strokes.");
   });
 
   it("can render an embedded poolside preview without the standalone toolbar chrome", () => {


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-04-21T20:06:26.654Z for branch `feat/poolside-session-step-notes-2026-04-21` (base ref `origin/main`).
- Latest commit: `b16db26` - feat: add poolside note display options.
- User-visible changes: User/admin runtime behavior may change on touched routes/components.
- Technical changes: Updated 11 file(s): `AGENTS.md`, `app/api/my-library/workouts/[workoutId]/export/pdf/route.ts`, `components/my-library/workouts/PoolsidePreviewPageClient.tsx`, `docs/task-briefs/in-progress/2026-04-21-poolside-note-session-and-step-notes-display-options-10-10.md`, `docs/task-briefs/planned/2026-04-18-maintenance-baseline-pre-live-10-10.md`, `... and 6 more file(s)`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-04-21-poolside-note-session-and-step-notes-display-options-10-10.md`
- Scorecard target outcomes: 11 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (2); tests (4); API handlers (1); runtime UI/routes/components (3); other files (1).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (11):
  - `AGENTS.md`
  - `app/api/my-library/workouts/[workoutId]/export/pdf/route.ts`
  - `components/my-library/workouts/PoolsidePreviewPageClient.tsx`
  - `docs/task-briefs/in-progress/2026-04-21-poolside-note-session-and-step-notes-display-options-10-10.md`
  - `docs/task-briefs/planned/2026-04-18-maintenance-baseline-pre-live-10-10.md`
  - `lib/workouts/poolside-preview.ts`
  - `lib/workouts/shared.ts`
  - `tests/unit/poolside-preview-page-client.test.tsx`
  - `... and 3 more file(s)`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `b16db26` (`git revert b16db26`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **PASS** (artifacts/test-runs/20260421-210008, lane: full-public)
- `npm run verify:pre-merge`: **PASS** for `b16db26` (2026-04-21T19:48:22Z, lane: full, mode: skipped).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  -   -  440 [desktop-firefox] › tests/e2e/private-access-gate.spec.ts:14:7 › private access gate › redirects public users to preview access and unlocks
  -   -  441 [desktop-firefox] › tests/e2e/private-access-gate.spec.ts:68:7 › private access gate › blocks protected api paths for unauthenticated public request context
  -   -  442 [desktop-firefox] › tests/e2e/private-access-gate.spec.ts:75:7 › private access gate › keeps indexing metadata locked while site is private
  -   ✓  443 [desktop-firefox] › tests/e2e/sitemap.spec.ts:32:5 › sitemap contains canonical public routes (24ms)
  -   ✓  444 [desktop-firefox] › tests/e2e/soft-launch-banner.spec.ts:9:5 › public pages do not render legacy under-construction banner (1.4s)
  -   104 passed (16.7m)
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
