### PR TITLE
feat: clean up my swim profile IA

### DIFF
--- a/app/my-library/page.tsx
+++ b/app/my-library/page.tsx
@@ -108,6 +108,16 @@ export default async function MyLibraryPage() {
   }
   const claimHref = `/claim?${claimQuery.toString()}`;
   const latestProgram = programLibrarySnapshot.recentPrograms[0] ?? null;
+  const mySwimProfileSummary = [
+    athleteProfileSnapshot.profile?.primaryName?.trim() || null,
+    athleteProfileSnapshot.cssMetric
+      ? `CSS ${athleteProfileSnapshot.cssMetric.paceLabel}/100m`
+      : null,
+    athleteProfileSnapshot.preferences?.poolLengthLabel ?? null,
+    athleteProfileSnapshot.preferences?.preferredWeeklySessionCount
+      ? `${athleteProfileSnapshot.preferences.preferredWeeklySessionCount} sessions/week`
+      : null,
+  ].filter((value): value is string => Boolean(value));
 
   return (
     <SiteChrome>
@@ -154,40 +164,22 @@ export default async function MyLibraryPage() {
             <section className="rounded-2xl border border-slate-200 bg-white p-5">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
-                  <h2 className="text-lg font-semibold text-slate-900">
-                    Athlete profile, training setup & records
-                  </h2>
-                  <p className="mt-2 text-sm text-slate-600">
-                    {!athleteProfileSnapshot.profileSchemaReady
-                      ? "This athlete profile foundation is still syncing in this environment."
-                      : athleteProfileSnapshot.profile ||
-                          athleteProfileSnapshot.cssMetric ||
-                          athleteProfileSnapshot.preferences ||
-                          athleteProfileSnapshot.personalRecords.length > 0
-                        ? [
-                            athleteProfileSnapshot.profile?.primaryName ?? "Private swimmer",
-                            athleteProfileSnapshot.profile?.ageBandLabel ?? null,
-                            athleteProfileSnapshot.cssMetric
-                              ? `CSS ${athleteProfileSnapshot.cssMetric.paceLabel}/100m`
-                              : null,
-                            athleteProfileSnapshot.preferences?.poolLengthLabel ?? null,
-                            athleteProfileSnapshot.preferences?.preferredWeeklySessionCount
-                              ? `${athleteProfileSnapshot.preferences.preferredWeeklySessionCount} sessions/week`
-                              : null,
-                            athleteProfileSnapshot.personalRecords.length > 0
-                              ? `${athleteProfileSnapshot.personalRecords.length} record${athleteProfileSnapshot.personalRecords.length === 1 ? "" : "s"}`
-                              : null,
-                          ]
-                            .filter(Boolean)
-                            .join(" · ")
-                        : "Add your private swimmer profile, current CSS, practical preferences, and personal records now so later generator work has a real foundation."}
-                  </p>
+                  <h2 className="text-lg font-semibold text-slate-900">My Swim Profile</h2>
+                  {!athleteProfileSnapshot.profileSchemaReady ? (
+                    <p className="mt-2 text-sm text-slate-600">
+                      This athlete profile foundation is still syncing in this environment.
+                    </p>
+                  ) : mySwimProfileSummary.length > 0 ? (
+                    <p className="mt-2 text-sm text-slate-600">
+                      {mySwimProfileSummary.join(" · ")}
+                    </p>
+                  ) : null}
                 </div>
                 <Link
                   href="/my-library/profile"
                   className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700"
                 >
-                  Open training setup
+                  Open profile
                 </Link>
               </div>
             </section>

--- a/app/my-library/profile/page.tsx
+++ b/app/my-library/profile/page.tsx
@@ -42,66 +42,15 @@ export default async function MyLibraryProfilePage() {
               <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
                 My Library
               </p>
-              <h1 className="mt-2 text-3xl font-bold text-slate-900">
-                Athlete profile, training setup & records
-              </h1>
-              <p className="mt-2 max-w-[64ch] text-sm text-slate-600">
-                Keep a private swimmer profile, trusted CSS, practical training preferences, and
-                current personal records together in one place without mixing them into Goals,
-                Focus, or Notes.
-              </p>
+              <h1 className="mt-2 text-3xl font-bold text-slate-900">My Swim Profile</h1>
             </div>
-            <div className="flex flex-wrap gap-2">
-              <Link
-                href="/my-library/training"
-                className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
-              >
-                Open focus & notes
-              </Link>
+            <div className="flex flex-wrap justify-end gap-2">
               <Link
                 href="/my-library"
                 className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
               >
                 Back to My Library
               </Link>
-            </div>
-          </div>
-
-          <div className="mt-8 rounded-2xl border border-blue-100 bg-blue-50/60 p-5">
-            <h2 className="text-base font-semibold text-slate-900">How this fits</h2>
-            <div className="mt-3 grid gap-3 lg:grid-cols-4">
-              <div className="rounded-2xl border border-white/80 bg-white/80 p-4">
-                <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
-                  Athlete profile
-                </p>
-                <p className="mt-2 text-sm text-slate-700">
-                  Private swimmer context that stays stable between sessions.
-                </p>
-              </div>
-              <div className="rounded-2xl border border-white/80 bg-white/80 p-4">
-                <p className="text-xs font-semibold uppercase tracking-wide text-cyan-700">
-                  Metrics & preferences
-                </p>
-                <p className="mt-2 text-sm text-slate-700">
-                  Trusted CSS and practical defaults that later help shape session generation.
-                </p>
-              </div>
-              <div className="rounded-2xl border border-white/80 bg-white/80 p-4">
-                <p className="text-xs font-semibold uppercase tracking-wide text-emerald-700">
-                  Personal records
-                </p>
-                <p className="mt-2 text-sm text-slate-700">
-                  Private current bests for explicit swim events, ready for later generator use.
-                </p>
-              </div>
-              <div className="rounded-2xl border border-white/80 bg-white/80 p-4">
-                <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">
-                  Goals, Focus & Notes
-                </p>
-                <p className="mt-2 text-sm text-slate-700">
-                  Direction, current work, and reflections still stay separate from training setup.
-                </p>
-              </div>
             </div>
           </div>
 

--- a/components/my-library/profile/AthleteProfileHub.tsx
+++ b/components/my-library/profile/AthleteProfileHub.tsx
@@ -395,7 +395,6 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
   const [actionSuccess, setActionSuccess] = useState("");
   const [isClientReady, setIsClientReady] = useState(false);
   const [isOnline, setIsOnline] = useState(true);
-  const [isRefreshing, setIsRefreshing] = useState(false);
   const [activeStatusSection, setActiveStatusSection] = useState<ProfileSectionKey | null>(null);
   const [sectionOpenState, setSectionOpenState] = useState<SectionDisclosureState>(() =>
     buildDefaultDisclosureState({
@@ -579,12 +578,6 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
     return payload?.error || fallback;
   }
 
-  function setGlobalStatus(message: string, kind: "error" | "success") {
-    setActiveStatusSection(null);
-    setActionError(kind === "error" ? message : "");
-    setActionSuccess(kind === "success" ? message : "");
-  }
-
   function setSectionStatus(
     section: ProfileSectionKey,
     message: string,
@@ -633,65 +626,6 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
     }
 
     return null;
-  }
-
-  async function refreshProfile() {
-    setIsRefreshing(true);
-    setGlobalStatus("", "success");
-
-    try {
-      const response = await fetch("/api/my-library/profile", {
-        method: "GET",
-        cache: "no-store",
-      });
-
-      if (!response.ok) {
-        setGlobalStatus(
-          await parseError(response, "Could not refresh training setup right now."),
-          "error"
-        );
-        return;
-      }
-
-      const payload = (await response.json().catch(() => null)) as ApiError | null;
-      if (!payload?.ok || !payload.snapshot) {
-        setGlobalStatus("Could not refresh training setup right now.", "error");
-        return;
-      }
-
-      setSnapshot(payload.snapshot);
-
-      if (!hasUnsavedProfileChanges) {
-        setProfileDraft(buildProfileDraft(payload.snapshot.profile));
-      }
-
-      if (!hasUnsavedCssChanges) {
-        setCssDraft(buildCssMetricDraft(payload.snapshot.cssMetric));
-      }
-
-      if (!hasUnsavedPreferencesChanges) {
-        setPreferencesDraft(buildPreferencesDraft(payload.snapshot.preferences));
-      }
-
-      if (!hasUnsavedRecordChanges) {
-        setRecordDraft(
-          buildPersonalRecordDraft(
-            findRecordById(payload.snapshot.personalRecords, recordDraft.editingRecordId)
-          )
-        );
-      }
-
-      void sendClientAnalyticsEvent("athlete_profile_refreshed", {
-        hasProfile: Boolean(payload.snapshot.profile),
-        hasCssMetric: Boolean(payload.snapshot.cssMetric),
-        hasPreferences: Boolean(payload.snapshot.preferences),
-        personalRecordCount: payload.snapshot.personalRecords.length,
-      });
-    } catch {
-      setGlobalStatus("Could not refresh training setup right now.", "error");
-    } finally {
-      setIsRefreshing(false);
-    }
   }
 
   async function saveProfile(event: React.FormEvent) {
@@ -1181,17 +1115,6 @@ export default function AthleteProfileHub({ initialSnapshot, userId }: Props) {
           {globalActionSuccess}
         </div>
       ) : null}
-
-      <div className="flex justify-end">
-        <button
-          type="button"
-          onClick={() => void refreshProfile()}
-          disabled={isRefreshing}
-          className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-400"
-        >
-          {isRefreshing ? "Refreshing..." : "Refresh all"}
-        </button>
-      </div>
 
       <section
         data-testid="athlete-profile-section-profile"

--- a/docs/task-briefs/in-progress/2026-04-21-my-swim-profile-page-ia-and-copy-cleanup-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-21-my-swim-profile-page-ia-and-copy-cleanup-10-10.md
@@ -3,10 +3,10 @@
 ## Metadata
 
 - `id`: `2026-04-21-my-swim-profile-page-ia-and-copy-cleanup-10-10`
-- `status`: `planned`
+- `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-04-21`
-- `updated`: `2026-04-22`
+- `updated`: `2026-04-24`
 
 ## Goal
 
@@ -140,3 +140,8 @@ Critical target categories for `10/10` claim:
 ## Checkpoint Log
 
 - `2026-04-21 | planned | created from owner finding that Athlete Profile page is over-explained and should become My Swim Profile | next: implement or defer before maintenance baseline`
+- `2026-04-24 | in-progress | route/page scope patched to My Swim Profile label, entrypoint cleanup, and redundant explainer/refresh action removal | next: run targeted QA, capture screenshots, then full gates`
+- `2026-04-24 | in-progress | desktop/mobile screenshots captured in output/playwright/my-swim-profile-ia and verify:pre-pr passed on rerun after one transient 3100 connection-refused flake in verify-open | next: owner screenshot approval, then commit/push/open PR`
+- `2026-04-24 | in-progress | perf-budget trend recommended tightening one stretch target after two green weekly runs; decision deferred to maintenance baseline because this brief is narrow IA/copy cleanup, not perf-baseline scope | next: record same defer note in PR summary`
+- `2026-04-24 | in-progress | owner approved screenshots, My Swim Profile card fallback summary noise was removed, and support-surface tests were hardened by removing unnecessary full-route settle in account-security plus treating local connection reset/refused as transient goto retries | next: rerun full verify:pre-pr and proceed to PR flow`
+- `2026-04-24 | in-progress | full verify:pre-pr green after support-surface hardening (`106 passed`, `344 skipped`); no new product-surface regressions found in desktop/mobile profile flows | next: commit, push, open PR, then run verify:pre-merge before merge recommendation`

--- a/tests/e2e/account-security-simplification.spec.ts
+++ b/tests/e2e/account-security-simplification.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
-import { gotoWithTransientRetry, waitForRouteToSettle } from "./utils/transient-navigation";
+import { gotoWithTransientRetry } from "./utils/transient-navigation";
 
 const isSiteLockEnabled = process.env.SITE_LOCK_ENABLED === "1";
 
@@ -66,7 +66,7 @@ async function loginToMyLibraryViaDevBypass(page: Page) {
   }
 
   await gotoWithTransientRetry(page, "/my-library");
-  await waitForRouteToSettle(page);
+  await expect(page.getByRole("heading", { name: "My Library" })).toBeVisible();
 }
 
 test.describe("account security simplification", () => {
@@ -79,8 +79,6 @@ test.describe("account security simplification", () => {
 
     await loginToMyLibraryViaDevBypass(page);
     await expectSecurityRouteRedirect(page, "/my-library");
-    await gotoWithTransientRetry(page, "/my-library");
-    await waitForRouteToSettle(page);
     expect(new URL(page.url()).pathname).toBe("/my-library");
     await expect(page.getByRole("heading", { name: "My Library" })).toBeVisible();
     await expect(page.getByText("Account & Security")).toHaveCount(0);

--- a/tests/e2e/my-library-athlete-profile.spec.ts
+++ b/tests/e2e/my-library-athlete-profile.spec.ts
@@ -88,9 +88,9 @@ test.describe("my library athlete profile", () => {
 
     await loginToMyLibraryViaDevBypass(page);
     await expect(page.getByRole("heading", { name: "My Library" })).toBeVisible();
-    await expect(page.getByRole("link", { name: "Open training setup" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Open profile" })).toBeVisible();
 
-    const openProfileLink = page.getByRole("link", { name: "Open training setup" });
+    const openProfileLink = page.getByRole("link", { name: "Open profile" });
     await expect(openProfileLink).toHaveAttribute("href", "/my-library/profile");
     const href = await openProfileLink.getAttribute("href");
     expect(href).toBeTruthy();
@@ -104,7 +104,7 @@ test.describe("my library athlete profile", () => {
     await waitForRouteToSettle(page);
     await expect(
       page.getByRole("heading", {
-        name: "Athlete profile, training setup & records",
+        name: "My Swim Profile",
         level: 1,
       })
     ).toBeVisible();
@@ -131,7 +131,7 @@ test.describe("my library athlete profile", () => {
     await waitForRouteToSettle(page);
     await expect(
       page.getByRole("heading", {
-        name: "Athlete profile, training setup & records",
+        name: "My Swim Profile",
         level: 1,
       })
     ).toBeVisible();
@@ -166,7 +166,7 @@ test.describe("my library athlete profile", () => {
     await waitForRouteToSettle(page);
     await expect(
       page.getByRole("heading", {
-        name: "Athlete profile, training setup & records",
+        name: "My Swim Profile",
         level: 1,
       })
     ).toBeVisible();

--- a/tests/e2e/utils/transient-navigation.ts
+++ b/tests/e2e/utils/transient-navigation.ts
@@ -30,7 +30,9 @@ function currentPageMatchesTarget(page: Page, href: string) {
 
 function isTransientGotoError(error: unknown) {
   const errorMessage = error instanceof Error ? error.message : String(error);
-  return /ERR_ABORTED|frame was detached|page\.goto: Timeout \d+ms exceeded/i.test(errorMessage);
+  return /ERR_ABORTED|ERR_CONNECTION_REFUSED|ERR_CONNECTION_RESET|ECONNRESET|frame was detached|page\.goto: Timeout \d+ms exceeded/i.test(
+    errorMessage
+  );
 }
 
 export async function prewarmRoute(


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-04-24T13:13:08.010Z for branch `feature/my-swim-profile-ia-cleanup-2026-04-24` (base ref `origin/main`).
- Latest commit: `6aa585e` - feat: clean up my swim profile IA.
- User-visible changes: User/admin runtime behavior may change on touched routes/components.
- Technical changes: Updated 7 file(s): `app/my-library/page.tsx`, `app/my-library/profile/page.tsx`, `components/my-library/profile/AthleteProfileHub.tsx`, `docs/task-briefs/in-progress/2026-04-21-my-swim-profile-page-ia-and-copy-cleanup-10-10.md`, `tests/e2e/account-security-simplification.spec.ts`, `... and 2 more file(s)`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-04-21-my-swim-profile-page-ia-and-copy-cleanup-10-10.md`
- Scorecard target outcomes: 12 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (1); tests (3); runtime UI/routes/components (3).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (7):
  - `app/my-library/page.tsx`
  - `app/my-library/profile/page.tsx`
  - `components/my-library/profile/AthleteProfileHub.tsx`
  - `docs/task-briefs/in-progress/2026-04-21-my-swim-profile-page-ia-and-copy-cleanup-10-10.md`
  - `tests/e2e/account-security-simplification.spec.ts`
  - `tests/e2e/my-library-athlete-profile.spec.ts`
  - `tests/e2e/utils/transient-navigation.ts`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `6aa585e` (`git revert 6aa585e`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **PASS** (artifacts/test-runs/20260424-144716, lane: full-public)
- `npm run verify:pre-merge`: **PENDING** for `6aa585e` (last green marker: `2403dfe` at 2026-04-24T08:56:30Z; rerun on current HEAD).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  -   -  446 [desktop-firefox] › tests/e2e/private-access-gate.spec.ts:14:7 › private access gate › redirects public users to preview access and unlocks
  -   -  447 [desktop-firefox] › tests/e2e/private-access-gate.spec.ts:68:7 › private access gate › blocks protected api paths for unauthenticated public request context
  -   -  448 [desktop-firefox] › tests/e2e/private-access-gate.spec.ts:75:7 › private access gate › keeps indexing metadata locked while site is private
  -   ✓  449 [desktop-firefox] › tests/e2e/sitemap.spec.ts:32:5 › sitemap contains canonical public routes (30ms)
  -   ✓  450 [desktop-firefox] › tests/e2e/soft-launch-banner.spec.ts:9:5 › public pages do not render legacy under-construction banner (1.4s)
  -   106 passed (17.9m)
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
