### PR TITLE
Refine course dashboard cards

### DIFF
--- a/components/my-library/ContinueCourseCard.tsx
+++ b/components/my-library/ContinueCourseCard.tsx
@@ -30,17 +30,12 @@ export default function ContinueCourseCard() {
 
   return (
     <section className="rounded-2xl border border-blue-100 bg-blue-50/40 p-5">
-      <h2 className="text-lg font-semibold text-slate-900">Continue Free Course</h2>
-      <p className="mt-2 text-sm text-slate-600">
-        {hasSavedProgress
-          ? "We saved your latest lesson on this device. Continue where you left off."
-          : "Start the free course and your lesson progress will be saved on this device."}
-      </p>
-      <div className="mt-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h2 className="text-lg font-semibold text-slate-900">Continue Free Course</h2>
         <Link
           href={continueHref}
           onClick={onResumeClick}
-          className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-medium text-white transition hover:bg-blue-500 active:bg-blue-700"
+          className="inline-flex h-10 items-center justify-center self-start rounded-xl bg-blue-600 px-4 text-sm font-medium text-white transition hover:bg-blue-500 active:bg-blue-700"
         >
           {hasSavedProgress ? "Continue course" : "Start free course"}
         </Link>

--- a/components/my-library/MyLibraryNewContentNotice.tsx
+++ b/components/my-library/MyLibraryNewContentNotice.tsx
@@ -121,13 +121,13 @@ export default function MyLibraryNewContentNotice({ userId }: Props) {
   }, [currentSignal, newLessonCount, visible]);
 
   const trackOpen = useCallback(
-    (source: "open_first" | "open_list_item", lessonId: string | null) => {
+    (lessonId: string | null) => {
       if (!currentSignal) return;
       void sendClientAnalyticsEvent("library_new_content_notice_opened", {
         lessonCount: currentSignal.lessonCount,
         newLessonCount,
         signature: currentSignal.signature,
-        source,
+        source: "open_list_item",
         lessonId,
       });
     },
@@ -206,45 +206,28 @@ export default function MyLibraryNewContentNotice({ userId }: Props) {
               {newLessonCount} new lesson{newLessonCount === 1 ? "" : "s"}
             </p>
           </div>
-          <p className="mt-2 text-base font-semibold text-slate-900">
-            +{newLessonCount} nye leksjoner i Free Course
-          </p>
-          <p className="mt-1 max-w-[54ch] text-sm text-slate-600">
-            Freshly published lessons are waiting. Open the first one now, or expand the list when
-            you want the full overview.
-          </p>
-          <div className="mt-4 flex flex-wrap items-center gap-2">
-            <Link
-              data-testid="my-library-new-content-open"
-              href={buildLessonHref(newLessons[0]?.lessonId ?? currentSignal.firstLessonId)}
-              onClick={() =>
-                trackOpen("open_first", newLessons[0]?.lessonId ?? currentSignal.firstLessonId)
-              }
-              className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500"
-            >
-              Open first new lesson
-            </Link>
-            <button
-              data-testid="my-library-new-content-toggle"
-              type="button"
-              onClick={() => setDetailsExpanded((current) => !current)}
-              aria-expanded={detailsExpanded}
-              aria-controls="my-library-new-content-details"
-              className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-4 text-sm font-medium text-blue-800 transition hover:bg-blue-50"
-            >
-              {detailsExpanded ? "Hide lesson list" : "Show lesson list"}
-            </button>
-          </div>
         </div>
-        <button
-          data-testid="my-library-new-content-dismiss"
-          type="button"
-          onClick={handleDismiss}
-          aria-label="Dismiss new lesson notice"
-          className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-blue-200 bg-white text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
-        >
-          X
-        </button>
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <button
+            data-testid="my-library-new-content-toggle"
+            type="button"
+            onClick={() => setDetailsExpanded((current) => !current)}
+            aria-expanded={detailsExpanded}
+            aria-controls="my-library-new-content-details"
+            className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-4 text-sm font-medium text-blue-800 transition hover:bg-blue-50"
+          >
+            {detailsExpanded ? "Hide lesson list" : "Show lesson list"}
+          </button>
+          <button
+            data-testid="my-library-new-content-dismiss"
+            type="button"
+            onClick={handleDismiss}
+            aria-label="Dismiss new lesson notice"
+            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-blue-200 bg-white text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+          >
+            X
+          </button>
+        </div>
       </div>
 
       {detailsExpanded ? (
@@ -261,7 +244,7 @@ export default function MyLibraryNewContentNotice({ userId }: Props) {
                 <Link
                   data-testid={`my-library-new-content-item-${lesson.lessonId}`}
                   href={buildLessonHref(lesson.lessonId)}
-                  onClick={() => trackOpen("open_list_item", lesson.lessonId)}
+                  onClick={() => trackOpen(lesson.lessonId)}
                   className="inline-flex flex-wrap items-center gap-1 text-sm font-medium text-blue-800 hover:text-blue-700 hover:underline"
                 >
                   <span>{lesson.lessonTitle}</span>

--- a/docs/task-briefs/in-progress/2026-04-21-course-dashboard-new-content-and-continue-card-cleanup-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-21-course-dashboard-new-content-and-continue-card-cleanup-10-10.md
@@ -3,10 +3,10 @@
 ## Metadata
 
 - `id`: `2026-04-21-course-dashboard-new-content-and-continue-card-cleanup-10-10`
-- `status`: `planned`
+- `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-04-21`
-- `updated`: `2026-04-21`
+- `updated`: `2026-04-24`
 
 ## Goal
 
@@ -137,3 +137,5 @@ Critical target categories for `10/10` claim:
 ## Checkpoint Log
 
 - `2026-04-21 | planned | created from owner findings about over-explained new lesson notification and continue-card copy | next: implement or defer before maintenance baseline`
+- `2026-04-24 | in-progress | branch feat/course-dashboard-card-cleanup-2026-04-24; compacted continue card, removed first-lesson CTA, and updated unit/e2e contracts to use lesson-list opens only | next: capture desktop/mobile screenshots for owner approval`
+- `2026-04-24 | in-progress | owner approved screenshots; verify:pre-pr passed on full lane (106 passed, 344 skipped); perf trend again recommended tightening one stretch target, deferred to maintenance-baseline decision rather than this product slice | next: commit, push, open PR, and run verify:pre-merge`

--- a/tests/e2e/my-library-new-content-notice.spec.ts
+++ b/tests/e2e/my-library-new-content-notice.spec.ts
@@ -64,10 +64,10 @@ async function refreshDevSessionForCurrentRoute(page: Page) {
   await waitForRouteToSettle(page);
 }
 
-async function openFirstNewLessonFromNotice(page: Page) {
+async function openExpandedNewLessonFromNotice(page: Page, lessonId: string) {
   const openLink = page
     .getByTestId("my-library-new-content-notice")
-    .getByTestId("my-library-new-content-open");
+    .getByTestId(`my-library-new-content-item-${lessonId}`);
   await expect(openLink).toBeVisible();
   await expect(openLink).toHaveAttribute("href", /\/course\?lesson=/);
   const href = await openLink.getAttribute("href");
@@ -156,7 +156,9 @@ test.describe("my library new content notice", () => {
 
     const banner = page.getByTestId("my-library-new-content-notice");
     await expect(banner).toBeVisible();
-    await expect(banner).toContainText(/\+\d+ nye leksjoner i Free Course/);
+    await expect(banner).toContainText("New content");
+    await expect(banner).toContainText("1 new lesson");
+    await expect(page.getByTestId("my-library-new-content-open")).toHaveCount(0);
     await expect(page.getByTestId("my-library-new-content-toggle")).toHaveAttribute(
       "aria-expanded",
       "false"
@@ -170,7 +172,7 @@ test.describe("my library new content notice", () => {
     );
     await expect(page.getByTestId("my-library-new-content-list")).toBeVisible();
 
-    await openFirstNewLessonFromNotice(page);
+    await openExpandedNewLessonFromNotice(page, "mod1-l1");
 
     await gotoWithTransientRetry(page, "/my-library");
     await waitForRouteToSettle(page);
@@ -208,7 +210,7 @@ test.describe("my library new content notice", () => {
     await expect(page.getByTestId("my-library-new-content-notice")).toBeVisible();
     await page.getByTestId("my-library-new-content-toggle").click();
     await expect(page.getByTestId("my-library-new-content-item-mod1-l1")).toBeVisible();
-    await openFirstNewLessonFromNotice(page);
+    await openExpandedNewLessonFromNotice(page, "mod1-l1");
   });
 
   test("keeps page usable and shows retry state when notice signal fetch fails", async ({

--- a/tests/unit/continue-course-card.test.tsx
+++ b/tests/unit/continue-course-card.test.tsx
@@ -39,10 +39,10 @@ describe("ContinueCourseCard", () => {
     render(<ContinueCourseCard />);
 
     expect(
-      screen.getByText(
+      screen.queryByText(
         "Start the free course and your lesson progress will be saved on this device."
       )
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
 
     const link = screen.getByRole("link", { name: "Start free course" });
     expect(link).toHaveAttribute("href", "/course");
@@ -65,8 +65,8 @@ describe("ContinueCourseCard", () => {
     });
 
     expect(
-      screen.getByText("We saved your latest lesson on this device. Continue where you left off.")
-    ).toBeInTheDocument();
+      screen.queryByText("We saved your latest lesson on this device. Continue where you left off.")
+    ).not.toBeInTheDocument();
 
     const link = screen.getByRole("link", { name: "Continue course" });
     expect(link).toHaveAttribute("href", "/course?lesson=mod1-l2");

--- a/tests/unit/my-library-new-content-notice-component.test.tsx
+++ b/tests/unit/my-library-new-content-notice-component.test.tsx
@@ -85,7 +85,8 @@ describe("MyLibraryNewContentNotice", () => {
     await waitFor(() => {
       expect(screen.getByTestId("my-library-new-content-notice")).toBeInTheDocument();
     });
-    expect(screen.getByText("+2 nye leksjoner i Free Course")).toBeInTheDocument();
+    expect(screen.getByText("2 new lessons")).toBeInTheDocument();
+    expect(screen.queryByText("+2 nye leksjoner i Free Course")).not.toBeInTheDocument();
     expect(screen.queryByTestId("my-library-new-content-list")).not.toBeInTheDocument();
     expect(screen.getByTestId("my-library-new-content-toggle")).toHaveAttribute(
       "aria-expanded",
@@ -158,15 +159,18 @@ describe("MyLibraryNewContentNotice", () => {
     await waitFor(() => {
       expect(screen.getByTestId("my-library-new-content-notice")).toBeInTheDocument();
     });
-    expect(screen.getByText("+2 nye leksjoner i Free Course")).toBeInTheDocument();
+    expect(screen.getByText("2 new lessons")).toBeInTheDocument();
+    expect(screen.queryByTestId("my-library-new-content-open")).not.toBeInTheDocument();
     expect(screen.queryByTestId("my-library-new-content-item-mod1-l2")).not.toBeInTheDocument();
     expect(screen.queryByTestId("my-library-new-content-item-mod1-l3")).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByTestId("my-library-new-content-open"));
+    fireEvent.click(screen.getByTestId("my-library-new-content-toggle"));
 
     await waitFor(() => {
-      expect(screen.getByTestId("my-library-new-content-notice")).toBeInTheDocument();
+      expect(screen.getByTestId("my-library-new-content-item-mod1-l2")).toBeInTheDocument();
     });
+
+    fireEvent.click(screen.getByTestId("my-library-new-content-item-mod1-l2"));
     const storedRaw = localStorage.getItem(buildMyLibrarySeenStorageKey("user-1"));
     expect(storedRaw).toContain(previousSignal.signature);
     expect(storedRaw).not.toContain(signal.signature);
@@ -175,13 +179,8 @@ describe("MyLibraryNewContentNotice", () => {
       lessonCount: signal.lessonCount,
       newLessonCount: 2,
       signature: signal.signature,
-      source: "open_first",
+      source: "open_list_item",
       lessonId: "mod1-l2",
-    });
-
-    fireEvent.click(screen.getByTestId("my-library-new-content-toggle"));
-    await waitFor(() => {
-      expect(screen.getByTestId("my-library-new-content-item-mod1-l3")).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByTestId("my-library-new-content-item-mod1-l3"));


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-04-24T15:48:21.522Z for branch `feat/course-dashboard-card-cleanup-2026-04-24` (base ref `origin/main`).
- Latest commit: `c51f894` - Refine course dashboard cards.
- User-visible changes: User/admin runtime behavior may change on touched routes/components.
- Technical changes: Updated 6 file(s): `components/my-library/ContinueCourseCard.tsx`, `components/my-library/MyLibraryNewContentNotice.tsx`, `docs/task-briefs/in-progress/2026-04-21-course-dashboard-new-content-and-continue-card-cleanup-10-10.md`, `tests/e2e/my-library-new-content-notice.spec.ts`, `tests/unit/continue-course-card.test.tsx`, `... and 1 more file(s)`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-04-21-course-dashboard-new-content-and-continue-card-cleanup-10-10.md`
- Scorecard target outcomes: 13 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (1); tests (3); runtime UI/routes/components (2).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (6):
  - `components/my-library/ContinueCourseCard.tsx`
  - `components/my-library/MyLibraryNewContentNotice.tsx`
  - `docs/task-briefs/in-progress/2026-04-21-course-dashboard-new-content-and-continue-card-cleanup-10-10.md`
  - `tests/e2e/my-library-new-content-notice.spec.ts`
  - `tests/unit/continue-course-card.test.tsx`
  - `tests/unit/my-library-new-content-notice-component.test.tsx`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `c51f894` (`git revert c51f894`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **PASS** (artifacts/test-runs/20260424-172152, lane: full-public)
- `npm run verify:pre-merge`: **PENDING** for `c51f894` (last green marker: `106e77c` at 2026-04-24T14:19:35Z; rerun on current HEAD).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  -   -  446 [desktop-firefox] › tests/e2e/private-access-gate.spec.ts:14:7 › private access gate › redirects public users to preview access and unlocks
  -   -  447 [desktop-firefox] › tests/e2e/private-access-gate.spec.ts:68:7 › private access gate › blocks protected api paths for unauthenticated public request context
  -   -  448 [desktop-firefox] › tests/e2e/private-access-gate.spec.ts:75:7 › private access gate › keeps indexing metadata locked while site is private
  -   ✓  449 [desktop-firefox] › tests/e2e/sitemap.spec.ts:32:5 › sitemap contains canonical public routes (38ms)
  -   ✓  450 [desktop-firefox] › tests/e2e/soft-launch-banner.spec.ts:9:5 › public pages do not render legacy under-construction banner (1.5s)
  -   106 passed (18.3m)
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
