### PR TITLE
my-library: reconcile training IA labels

### DIFF
--- a/app/my-library/dryland/[sessionId]/page.tsx
+++ b/app/my-library/dryland/[sessionId]/page.tsx
@@ -55,7 +55,7 @@ export default async function DrylandBuilderPage({ params }: Props) {
                 href="/my-library/dryland"
                 className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
               >
-                View dryland sessions
+                Dryland Sessions
               </Link>
               <Link
                 href="/my-library"

--- a/app/my-library/dryland/page.tsx
+++ b/app/my-library/dryland/page.tsx
@@ -28,7 +28,7 @@ export default async function DrylandSessionsPage() {
               <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
                 My Library
               </p>
-              <h1 className="mt-2 text-3xl font-bold text-slate-900">View dryland sessions</h1>
+              <h1 className="mt-2 text-3xl font-bold text-slate-900">Dryland Sessions</h1>
               <p className="mt-2 max-w-[68ch] text-sm text-slate-600">
                 Browse saved strength and stretching sessions first, then open one focused session
                 at a time when you want to edit, execute, or finish it.

--- a/app/my-library/page.tsx
+++ b/app/my-library/page.tsx
@@ -118,7 +118,7 @@ export default async function MyLibraryPage() {
       ? `${athleteProfileSnapshot.preferences.preferredWeeklySessionCount} sessions/week`
       : null,
   ].filter((value): value is string => Boolean(value));
-  const focusAndNotesSummary = !trainingContextSnapshot.schemaReady
+  const myTrainingSummary = !trainingContextSnapshot.schemaReady
     ? "This training context is still syncing in this environment."
     : trainingContextSnapshot.focusNeedsPrimarySelection
       ? `You have ${trainingContextSnapshot.openFocuses.length} open focuses and need to choose one primary cue before other My Library surfaces use a single focus.`
@@ -211,9 +211,9 @@ export default async function MyLibraryPage() {
             <section className="rounded-2xl border border-slate-200 bg-white p-5">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
-                  <h2 className="text-lg font-semibold text-slate-900">Focus & Notes</h2>
-                  {focusAndNotesSummary ? (
-                    <p className="mt-2 text-sm text-slate-600">{focusAndNotesSummary}</p>
+                  <h2 className="text-lg font-semibold text-slate-900">My Training</h2>
+                  {myTrainingSummary ? (
+                    <p className="mt-2 text-sm text-slate-600">{myTrainingSummary}</p>
                   ) : null}
                 </div>
                 <Link
@@ -227,7 +227,7 @@ export default async function MyLibraryPage() {
             <section className="rounded-2xl border border-slate-200 bg-white p-5">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
-                  <h2 className="text-lg font-semibold text-slate-900">Swim Sessions</h2>
+                  <h2 className="text-lg font-semibold text-slate-900">My Swim Sessions</h2>
                   {!workoutLibrarySnapshot.schemaReady ? (
                     <p className="mt-2 text-sm text-slate-600">
                       This canonical swim-session layer is still syncing in this environment.
@@ -266,7 +266,7 @@ export default async function MyLibraryPage() {
                     href="/my-library/generator"
                     className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
                   >
-                    AI-generated session
+                    AI session generator
                   </Link>
                 </div>
               </div>
@@ -275,7 +275,7 @@ export default async function MyLibraryPage() {
             <section className="rounded-2xl border border-slate-200 bg-white p-5">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
-                  <h2 className="text-lg font-semibold text-slate-900">Dryland builder</h2>
+                  <h2 className="text-lg font-semibold text-slate-900">Dryland Sessions</h2>
                   {!drylandLibrarySnapshot.schemaReady ? (
                     <p className="mt-2 text-sm text-slate-600">
                       This dryland foundation is still syncing in this environment.
@@ -288,7 +288,7 @@ export default async function MyLibraryPage() {
                       href="/my-library/dryland"
                       className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
                     >
-                      View dryland sessions
+                      Dryland Sessions
                     </Link>
                   ) : null}
                   {drylandLibrarySnapshot.schemaReady ? (
@@ -324,7 +324,7 @@ export default async function MyLibraryPage() {
                   </div>
                   <p className="mt-2 text-sm text-slate-600">
                     {!programLibrarySnapshot.schemaReady
-                      ? "Program planning tools are still syncing in this environment."
+                      ? "Program builder preview is still syncing in this environment."
                       : latestProgram
                         ? [
                             latestProgram.title,

--- a/app/my-library/programs/[programId]/page.tsx
+++ b/app/my-library/programs/[programId]/page.tsx
@@ -44,9 +44,9 @@ export default async function ProgramBuilderPage({ params }: Props) {
               <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
                 My Library
               </p>
-              <h1 className="mt-2 text-3xl font-bold text-slate-900">Program planning</h1>
+              <h1 className="mt-2 text-3xl font-bold text-slate-900">Program builder preview</h1>
               <p className="mt-2 max-w-[68ch] text-sm text-slate-600">
-                Open one saved program in its own route, place accepted workouts into week/day
+                Preview one saved program in its own route, place accepted workouts into week/day
                 slots, and export the saved canonical program without forking planner identity.
               </p>
             </div>

--- a/app/my-library/training/page.tsx
+++ b/app/my-library/training/page.tsx
@@ -67,10 +67,10 @@ export default async function MyLibraryTrainingPage({ searchParams }: Props) {
               <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
                 My Library
               </p>
-              <h1 className="mt-2 text-3xl font-bold text-slate-900">Focus & Notes</h1>
+              <h1 className="mt-2 text-3xl font-bold text-slate-900">My Training</h1>
               <p className="mt-2 max-w-[64ch] text-sm text-slate-600">
-                Keep today&apos;s cue clear, keep supporting focuses nearby, and save quick notes
-                from the pool without turning this page into a wall of setup text.
+                Keep goals, today&apos;s cue, supporting focuses, and poolside notes in one training
+                workspace without turning this page into a wall of setup text.
               </p>
             </div>
             <div className="flex flex-wrap gap-2">

--- a/components/my-library/dryland/DrylandBuilderHub.tsx
+++ b/components/my-library/dryland/DrylandBuilderHub.tsx
@@ -168,7 +168,7 @@ export default function DrylandBuilderHub({ drylandLibrary, browseOnly = false }
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <h2 className="text-lg font-semibold text-slate-900">
-            {browseOnly ? "View dryland sessions" : "Dryland builder"}
+            {browseOnly ? "Dryland Sessions" : "Dryland builder"}
           </h2>
           <p className="mt-2 max-w-[68ch] text-sm text-slate-600">
             {browseOnly
@@ -184,7 +184,7 @@ export default function DrylandBuilderHub({ drylandLibrary, browseOnly = false }
               href="/my-library/dryland"
               className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
             >
-              View dryland sessions
+              Dryland Sessions
             </Link>
           ) : null}
           {drylandLibrary.schemaReady ? (
@@ -388,7 +388,7 @@ export default function DrylandBuilderHub({ drylandLibrary, browseOnly = false }
                   href="/my-library/dryland"
                   className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
                 >
-                  View dryland sessions
+                  Dryland Sessions
                 </Link>
               ) : null}
             </div>

--- a/components/my-library/goals/GoalsHub.tsx
+++ b/components/my-library/goals/GoalsHub.tsx
@@ -528,15 +528,15 @@ export default function GoalsHub({ initialGoals, templates, activeLimit }: Props
               Turn goals into next-session work
             </h2>
             <p className="mt-2 max-w-[64ch] text-sm text-slate-600">
-              Goals stay long-term. Use Focus & Notes to turn one goal into the next training
-              priority or a poolside observation without re-entering the same context.
+              Goals stay long-term. Use My Training to turn one goal into the next training priority
+              or a poolside observation without re-entering the same context.
             </p>
           </div>
           <Link
             href="/my-library/training"
             className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700"
           >
-            Open focus & notes
+            Open My Training
           </Link>
         </div>
       </section>

--- a/components/my-library/programs/ProgramBuilderHub.tsx
+++ b/components/my-library/programs/ProgramBuilderHub.tsx
@@ -461,7 +461,7 @@ export default function ProgramBuilderHub({ programLibrary }: Props) {
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h2 className="text-lg font-semibold text-slate-900">Program planning</h2>
+          <h2 className="text-lg font-semibold text-slate-900">Program builder preview</h2>
           <p className="mt-2 max-w-[66ch] text-sm text-slate-600">
             Save a canonical program, place accepted workouts into week/day slots, and keep one
             shared planning surface ready for later planner and export work.

--- a/components/my-library/training/TrainingContextHub.tsx
+++ b/components/my-library/training/TrainingContextHub.tsx
@@ -268,7 +268,8 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
   const [pendingNoteSaveId, setPendingNoteSaveId] = useState<string | null>(null);
   const [showFocusComposer, setShowFocusComposer] = useState(true);
   const [showNoteComposer, setShowNoteComposer] = useState(true);
-  const [noteListFilters, setNoteListFilters] = useState<NoteListFilters>(DEFAULT_NOTE_LIST_FILTERS);
+  const [noteListFilters, setNoteListFilters] =
+    useState<NoteListFilters>(DEFAULT_NOTE_LIST_FILTERS);
 
   useEffect(() => {
     setIsOnline(readNavigatorOnlineState());
@@ -1038,7 +1039,7 @@ export default function TrainingContextHub({ initialSnapshot, initialGoalPrefill
     >
       {!snapshot.schemaReady ? (
         <section className="rounded-2xl border border-amber-200 bg-amber-50/70 p-5">
-          <h2 className="text-lg font-semibold text-slate-900">Focus & Notes are syncing</h2>
+          <h2 className="text-lg font-semibold text-slate-900">My Training is syncing</h2>
           <p className="mt-2 text-sm text-slate-700">
             The new training-context tables are not ready in this environment yet. Refresh after the
             migration has finished.

--- a/components/my-library/workouts/WorkoutBuilderHub.tsx
+++ b/components/my-library/workouts/WorkoutBuilderHub.tsx
@@ -439,7 +439,7 @@ export default function WorkoutBuilderHub({
               href="/my-library/generator"
               className="inline-flex h-10 items-center justify-center rounded-xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100"
             >
-              AI-generated session
+              AI session generator
             </Link>
           </div>
           {recentWorkouts.length > 0 ? (
@@ -670,7 +670,7 @@ export default function WorkoutBuilderHub({
                   href="/my-library/generator"
                   className="inline-flex h-10 items-center justify-center rounded-xl border border-amber-200 bg-white px-4 text-sm font-medium text-amber-900 transition hover:bg-amber-50 active:bg-amber-100"
                 >
-                  AI-generated session
+                  AI session generator
                 </Link>
                 <Link
                   href="/my-library/workouts"

--- a/docs/runbooks/auth-account-support.md
+++ b/docs/runbooks/auth-account-support.md
@@ -12,6 +12,14 @@ Use this runbook when users ask where account, sign-in, billing, or recovery act
 - `/preview-access` owns private preview unlock guidance when site-lock is enabled.
 - `/my-library/security` is a legacy protected route that redirects signed-in users to `My Library`.
 
+## My Library IA
+
+- `My Swim Profile` holds swimmer identity, CSS, preferences, and personal records.
+- `My Training` (`/my-library/training`) holds goals-to-focus workflow, focus cues, and poolside notes.
+- `My Swim Sessions` (`/my-library/workouts`) is the saved swim-session list and swim builder entrypoint.
+- `Dryland Sessions` (`/my-library/dryland`) is the saved strength/stretching list and dryland builder entrypoint.
+- `Program builder preview` is optional and only for placing saved swim sessions into week/day slots.
+
 ## Support Answers
 
 - If a user asks which email is signed in: send them to `My Library`.

--- a/docs/runbooks/core-flow-incident-response.md
+++ b/docs/runbooks/core-flow-incident-response.md
@@ -45,7 +45,7 @@ Provide a deterministic first-response flow for production incidents on core rou
 
 Additional `My Library` sub-route checks:
 
-- `/my-library/goals` -> `/my-library/training`
+- `/my-library/goals` -> `/my-library/training` (`My Training`)
   - confirm `Use as focus` and `Add note` links include a canonical `goalId` query param,
   - confirm opening the linked training route preselects the intended goal without mutating the goal row,
   - confirm existing local focus/note draft text is preserved when goal-prefill is applied.
@@ -56,7 +56,7 @@ Additional `My Library` sub-route checks:
   - confirm `/api/my-library/generator/session-draft` returns owner-scoped `200` for session target, `401` for unauthenticated reads, and explicit `422` when program target is chosen in this slice,
   - confirm `/api/my-library/workouts` and `/api/my-library/workouts/[workoutId]` return owner-scoped `200`, fail-closed `401`, and `404` for missing canonical workout ids,
   - confirm `/api/my-library/workouts/[workoutId]/export/pdf` returns owner-scoped printable `200`, fail-closed `401`, `404` for missing canonical workout ids, and `503` when the canonical workouts schema is not ready,
-  - confirm `/my-library/workouts` stays a list-first browse surface with `My Swim Sessions`, `Build pool session`, `Build open water session`, and `AI-generated session` exposed as the primary actions and no hidden editor mutation happening in the background,
+  - confirm `/my-library/workouts` stays a list-first browse surface with `My Swim Sessions`, `Build pool session`, `Build open water session`, and `AI session generator` exposed as the primary actions and no hidden editor mutation happening in the background,
   - confirm `Build pool session` creates a fresh canonical workout row directly and lands on the pool detail route with `Session details` expanded on first load,
   - confirm `Build open water session` creates a fresh canonical workout row directly and lands on the open-water detail route with the environment locked to open water,
   - confirm existing saved-session edits still start from `My Swim Sessions` rather than a chooser tied to the most recently saved session,

--- a/docs/task-briefs/in-progress/2026-04-21-my-library-my-training-ia-and-builder-entrypoint-reconcile-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-21-my-library-my-training-ia-and-builder-entrypoint-reconcile-10-10.md
@@ -3,10 +3,10 @@
 ## Metadata
 
 - `id`: `2026-04-21-my-library-my-training-ia-and-builder-entrypoint-reconcile-10-10`
-- `status`: `planned`
+- `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-04-21`
-- `updated`: `2026-04-21`
+- `updated`: `2026-04-26`
 
 ## Goal
 
@@ -110,6 +110,38 @@ Critical target categories for `10/10` claim:
   - program builder preview.
 - Produce narrow implementation slices if more than one route changes.
 
+## Implementation Slice
+
+This PR is the first executable reconcile slice:
+
+- no route path changes,
+- no persistence, auth, entitlement, or sync-boundary changes,
+- canonical visible labels are applied to existing entrypoints,
+- route/IA map and support guidance are documented,
+- larger profile/account grouping decisions remain deferred unless a later brief names them.
+
+## Route/IA Map
+
+| Route                       | Canonical label           | Job                                                                 |
+| --------------------------- | ------------------------- | ------------------------------------------------------------------- |
+| `/my-library`               | `My Library`              | account home and top-level owner dashboard                          |
+| `/my-library/profile`       | `My Swim Profile`         | swimmer identity, CSS, preferences, and personal records            |
+| `/my-library/goals`         | `Goals`                   | long-term targets and result/progress tracking                      |
+| `/my-library/training`      | `My Training`             | goal-to-focus workflow, focus cues, and poolside notes              |
+| `/my-library/workouts`      | `My Swim Sessions`        | saved swim sessions plus pool/open-water builder entrypoints        |
+| `/my-library/generator`     | `AI session generator`    | AI-assisted session drafting that saves into `My Swim Sessions`     |
+| `/my-library/dryland`       | `Dryland Sessions`        | saved strength/stretching sessions plus dryland builder entrypoints |
+| `/my-library/programs/<id>` | `Program builder preview` | optional week/day planning from saved swim sessions                 |
+| `/my-library/security`      | legacy account redirect   | redirects signed-in users to `My Library`; no live account surface  |
+
+## Route, Label, And Support Sweep
+
+- Searched identifiers: `Focus & Notes`, `My Training`, `Swim Sessions`, `My Swim Sessions`, `Dryland builder`, `View dryland sessions`, `Dryland Sessions`, `Program planning`, `Program builder preview`, `AI-generated session`, `AI session generator`.
+- Checked surfaces: `app/`, `components/`, `tests/`, `docs/runbooks/`, `docs/user-flow-map.md`, active task briefs, and targeted Help/Admin assertions.
+- Intentional leftovers:
+  - historical `done/` task briefs retain the labels that were true when those PRs shipped,
+  - API/schema error strings using `Dryland builder` remain because this slice does not rename backend contracts.
+
 ## Out Of Scope
 
 - Implementing all child IA changes in one PR.
@@ -157,3 +189,6 @@ Critical target categories for `10/10` claim:
 ## Checkpoint Log
 
 - `2026-04-21 | planned | created from owner IA findings around My Profile, My Training, builder entrypoints, and account/profile grouping | next: implement discovery/IA pass or defer before maintenance baseline`
+- `2026-04-26 | in-progress | started first executable IA reconcile slice from main after PR #514; scoped to canonical labels, route/IA documentation, support guidance, and targeted tests with no route/data movement | next: run targeted validation and screenshot handoff before PR gates`
+- `2026-04-26 | validation checkpoint | typecheck, targeted unit tests, targeted desktop Playwright, and all-brief lint passed; screenshot handoff captured in output/playwright/my-library-training-ia-reconcile-2026-04-26 | next: wait for owner visual approval before verify:pre-pr and PR update`
+- `2026-04-26 | pre-pr checkpoint | owner approved screenshot handoff; npm run verify:pre-pr passed with 113 passed and 343 skipped after full lint/typecheck/unit/build/perf/e2e lane; perf trend recommended tightening a stretch target, held outside this IA slice for a separate budget decision | next: commit, push, open PR, monitor CI, then run verify:pre-merge`

--- a/docs/user-flow-map.md
+++ b/docs/user-flow-map.md
@@ -56,3 +56,13 @@ flowchart LR
 - `Mark as done` -> `Done`
 - `Lessons` (for course drawer)
 - `Menu` (for main drawer)
+
+## My Library Authenticated IA
+
+- `/my-library`: account home and top-level owner dashboard.
+- `/my-library/profile`: `My Swim Profile` for swimmer identity, CSS, preferences, and personal records.
+- `/my-library/goals`: `Goals` for long-term targets and progress.
+- `/my-library/training`: `My Training` for turning goals into focus cues and notes.
+- `/my-library/workouts`: `My Swim Sessions` for saved swim sessions plus `Build pool session`, `Build open water session`, and `AI session generator`.
+- `/my-library/dryland`: `Dryland Sessions` for saved strength/stretching work and dryland creation.
+- `/my-library/programs/<id>`: `Program builder preview` for optional week/day planning from saved swim sessions.

--- a/tests/e2e/my-library-dryland-builder.spec.ts
+++ b/tests/e2e/my-library-dryland-builder.spec.ts
@@ -43,7 +43,7 @@ test.describe("my library dryland builder", () => {
     testInfo.setTimeout(240_000);
 
     await loginToMyLibraryViaDevBypass(page);
-    await expect(page.getByRole("heading", { name: "Dryland builder" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Dryland Sessions" })).toBeVisible();
 
     const createButton = page.getByTestId("my-library-create-strength-session");
     const schemaReady = await createButton.isVisible().catch(() => false);

--- a/tests/e2e/my-library-generator-intake.spec.ts
+++ b/tests/e2e/my-library-generator-intake.spec.ts
@@ -192,7 +192,7 @@ async function waitForWorkoutLibraryBrowseReady(page: Page) {
 }
 
 async function openGeneratorFromMyLibrary(page: Page) {
-  const openGeneratorLink = page.getByRole("link", { name: "AI-generated session" });
+  const openGeneratorLink = page.getByRole("link", { name: "AI session generator" });
   await expect(openGeneratorLink).toBeVisible({ timeout: 15_000 });
   await expect(openGeneratorLink).toHaveAttribute("href", "/my-library/generator");
   const href = (await openGeneratorLink.getAttribute("href")) ?? "";

--- a/tests/e2e/my-library-landing-entrypoints.spec.ts
+++ b/tests/e2e/my-library-landing-entrypoints.spec.ts
@@ -48,8 +48,9 @@ test.describe("my library landing entrypoints", () => {
     await expect(page.getByRole("heading", { name: "Free Course" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "My Swim Profile" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Goals" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Focus & Notes" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Swim Sessions" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "My Training" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "My Swim Sessions" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Dryland Sessions" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Swim session builder" })).toHaveCount(0);
     await expect(page.getByRole("heading", { name: "Continue Free Course" })).toHaveCount(0);
 
@@ -62,7 +63,7 @@ test.describe("my library landing entrypoints", () => {
     await expect(page.getByRole("link", { name: "Start free course" })).toHaveCount(0);
     await expect(page.getByRole("link", { name: "Open profile" })).toHaveCount(0);
     await expect(page.getByRole("link", { name: "Open goals" })).toHaveCount(0);
-    await expect(page.getByRole("link", { name: "Open focus & notes" })).toHaveCount(0);
+    await expect(page.getByRole("link", { name: "Open My Training" })).toHaveCount(0);
 
     const freeCourseCard = page
       .getByRole("heading", { name: "Free Course" })
@@ -80,7 +81,7 @@ test.describe("my library landing entrypoints", () => {
     await expect(goalsCard.getByRole("link", { name: "Open" })).toBeVisible();
 
     const focusCard = page
-      .getByRole("heading", { name: "Focus & Notes" })
+      .getByRole("heading", { name: "My Training" })
       .locator("xpath=ancestor::section[1]");
     await expect(focusCard.getByRole("link", { name: "Open" })).toBeVisible();
 

--- a/tests/e2e/my-library-program-export.spec.ts
+++ b/tests/e2e/my-library-program-export.spec.ts
@@ -251,7 +251,7 @@ async function waitForProgramExportPreviewReady(page: Page) {
 
 async function ensureProgramSchemaReady(page: Page) {
   const schemaWarning = page.getByText(
-    /This canonical program layer is still syncing in this environment\.|Program planning tools are still syncing in this environment\./
+    /This canonical program layer is still syncing in this environment\.|Program builder preview is still syncing in this environment\./
   );
 
   if ((await schemaWarning.count()) > 0 && (await schemaWarning.first().isVisible())) {

--- a/tests/e2e/my-library-training-context.spec.ts
+++ b/tests/e2e/my-library-training-context.spec.ts
@@ -131,7 +131,7 @@ test.describe("my library training context", () => {
 
     await loginToMyLibraryViaDevBypass(page);
     await gotoWithTransientRetry(page, "/my-library/training", 60_000);
-    await expect(page.getByRole("heading", { name: "Focus & Notes", level: 1 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "My Training", level: 1 })).toBeVisible();
     await waitForTrainingContextClientReady(page);
 
     await page.getByTestId("training-overview-card-goals").click();
@@ -166,7 +166,7 @@ test.describe("my library training context", () => {
 
     await expect(
       page.getByRole("heading", {
-        name: "Focus & Notes",
+        name: "My Training",
         level: 1,
       })
     ).toBeVisible();
@@ -210,7 +210,7 @@ test.describe("my library training context", () => {
 
     await expect(
       page.getByRole("heading", {
-        name: "Focus & Notes",
+        name: "My Training",
         level: 1,
       })
     ).toBeVisible();
@@ -242,7 +242,7 @@ test.describe("my library training context", () => {
 
     await loginToMyLibraryViaDevBypass(page);
     await gotoWithTransientRetry(page, "/my-library/training", 60_000);
-    await expect(page.getByRole("heading", { name: "Focus & Notes", level: 1 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "My Training", level: 1 })).toBeVisible();
     await waitForTrainingContextClientReady(page);
 
     if (

--- a/tests/unit/goals-hub.test.tsx
+++ b/tests/unit/goals-hub.test.tsx
@@ -57,13 +57,13 @@ describe("GoalsHub", () => {
     vi.unstubAllGlobals();
   });
 
-  it("shows explicit bridge actions into Focus & Notes for active goals", () => {
+  it("shows explicit bridge actions into My Training for active goals", () => {
     render(<GoalsHub initialGoals={[buildGoal()]} templates={[]} activeLimit={3} />);
 
     expect(
       screen.getByRole("heading", { name: "Turn goals into next-session work" })
     ).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Open focus & notes" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "Open My Training" })).toHaveAttribute(
       "href",
       "/my-library/training"
     );

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -2807,7 +2807,7 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.getByTestId("workout-builder-empty-create-pool")).toBeVisible();
     expect(screen.getByTestId("workout-builder-empty-create-open-water")).toBeVisible();
     expect(screen.queryByTestId("saved-workout-card-workout-1")).not.toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "AI-generated session" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "AI session generator" })).toHaveAttribute(
       "href",
       "/my-library/generator"
     );
@@ -3061,7 +3061,7 @@ describe("WorkoutBuilderHub", () => {
 
     expect(screen.getByRole("button", { name: "Build pool session" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Build open water session" })).toBeVisible();
-    expect(screen.getByRole("link", { name: "AI-generated session" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "AI session generator" })).toHaveAttribute(
       "href",
       "/my-library/generator"
     );


### PR DESCRIPTION
## Summary

- User-visible changes: `Focus & Notes` is now presented as `My Training`, saved swim sessions as `My Swim Sessions`, the AI entrypoint as `AI session generator`, dryland browse surfaces as `Dryland Sessions`, and program detail copy as `Program builder preview`.
- Technical changes: Updated My Library route/component labels, aligned e2e/unit expectations, moved the active brief to `in-progress`, and updated route/IA support docs with no route path, schema, auth, billing, entitlement, persistence, or sync-boundary changes.
- Policy impact: no - this PR does not touch policy-impacting auth/session/account routes, analytics/consent, user data rights, or third-party processor contracts.
- Policy version note: N/A - no terms, privacy, processor, consent, or user-data-rights policy language changes.
- Brief link(s): `docs/task-briefs/in-progress/2026-04-21-my-library-my-training-ia-and-builder-entrypoint-reconcile-10-10.md`

## Scope

- In scope: Canonical visible labels for My Library/My Training entrypoints, route/IA map documentation, support/runbook copy, targeted tests, and owner-approved screenshot handoff for changed UI surfaces.
- Out of scope: Route path changes, profile/account regrouping, auth/security behavior, billing verification, analytics taxonomy changes, database/schema changes, and builder feature changes.

## Risk

- Main risk: A stale label could remain in a user/support surface and keep the My Library IA inconsistent.
- Rollback plan: Revert `cc84f0e` to restore the previous labels/docs/tests.
- Mitigation: Route/label/support sweep plus updated My Library e2e/unit coverage.

## Test Evidence

- Policy-impact checklist: N/A - no policy-impacting scope or changed policy-impact files.
- `npm run typecheck`: **PASS**
- `npx vitest run tests/unit/goals-hub.test.tsx tests/unit/workout-builder-hub.test.tsx tests/unit/dryland-builder-hub.test.tsx tests/unit/program-builder-hub.test.tsx`: **PASS**
- `PW_PORT=3100 NEXT_DIST_DIR=.next-playwright SITE_LOCK_ENABLED=0 npx playwright test tests/e2e/my-library-landing-entrypoints.spec.ts tests/e2e/my-library-training-context.spec.ts tests/e2e/my-library-generator-intake.spec.ts tests/e2e/my-library-dryland-builder.spec.ts --project=desktop-chromium`: **PASS**
- `npm run lint:briefs:all`: **PASS**
- `git diff --check`: **PASS**
- `npm run verify:pre-pr`: **PASS** on `cc84f0e`, `113 passed`, `343 skipped`, artifacts at `artifacts/test-runs/20260426-053930`
- `npm run verify:pre-merge`: **PASS** on `cc84f0e`, `112 passed`, `344 skipped`, marker at `artifacts/verify-pre-merge/20260426-044742.json`
- Screenshot handoff: owner-approved after-only artifacts in `/Users/stianvikra/freeswimming/output/playwright/my-library-training-ia-reconcile-2026-04-26`
- Representative screenshots: `after-my-library-desktop.png`, `after-my-library-mobile.png`, `after-my-training-desktop.png`, `after-dryland-sessions-desktop.png`
- Vercel preview: pending/manual QA not claimed in this body.

- [x] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge`
- [ ] Local manual QA done on dev URL
- [ ] Vercel preview manual QA done

## Checklist

- [x] Acceptance criteria are met for the scoped label-only IA slice.
- [x] Docs/runbooks updated for changed support-facing terminology.
- [x] Changed task brief includes scorecard mapping, route/IA map, checkpoint log, and validation evidence.
- [x] Owner approved screenshot handoff before PR gate.
- [x] No secrets or sensitive data added.
- [x] Required CI checks are green.
- [x] `npm run verify:pre-merge` passes on current PR HEAD before merge readiness.

## UI Evidence

- Owner-approved screenshot folder: `/Users/stianvikra/freeswimming/output/playwright/my-library-training-ia-reconcile-2026-04-26`
- Handoff type: after-only screenshots, because this slice compares the changed surfaces against the agreed IA labels rather than a before/after visual redesign.
- Known visual caveat: none from the approved handoff.

## Scorecard Closeout

- Critical target categories for 10/10 claim: `Product goals and IA`, `UX flow clarity`, `Business logic correctness and data integrity`, `Accessibility (a11y)`, `Testing and QA automation`.
- Achieved target categories: all scoped target categories are `5/5` for this label-only IA slice.
- Remaining gaps: profile/account grouping and any route-path consolidation remain intentionally deferred to later named briefs.
- Performance trend note: pre-PR perf trend recommends tightening a stretch target after two green weekly runs; held outside this IA PR for a separate budget decision.

## Merge Gate

- CI checks must be green.
- `npm run verify:pre-merge` passed on current PR HEAD `cc84f0e`.
- Do not merge until the owner explicitly approves merge.
