### PR TITLE
billing: enable checkout invoice creation

### DIFF
--- a/app/api/checkout/session/route.ts
+++ b/app/api/checkout/session/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
-import type Stripe from "stripe";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { createAdminSupabaseClient } from "@/lib/supabase/admin";
 import { getAppUrl } from "@/lib/supabase/env";
 import { getCatalogProductById, getCatalogProducts } from "@/lib/commerce/catalog";
+import { buildCheckoutSessionPayload } from "@/lib/commerce/checkout";
 import { upsertCatalogProducts } from "@/lib/commerce/entitlements";
 import { trackAnalyticsEvent } from "@/lib/analytics/events";
 import { createStripeClient } from "@/lib/stripe/server";
@@ -15,18 +15,6 @@ type CheckoutBody = {
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-
-function getSafePath(input: string | undefined, fallback: string) {
-  if (!input) return fallback;
-  if (!input.startsWith("/")) return fallback;
-  if (input.startsWith("//")) return fallback;
-  return input;
-}
-
-function getSuccessUrl(origin: string) {
-  const successUrl = new URL("/checkout/success", origin).toString();
-  return `${successUrl}?session_id={CHECKOUT_SESSION_ID}`;
-}
 
 export async function POST(request: Request) {
   const contentType = request.headers.get("content-type") ?? "";
@@ -79,22 +67,12 @@ export async function POST(request: Request) {
 
     const stripe = createStripeClient();
     const appUrl = getAppUrl();
-    const cancelPath = getSafePath(body.cancelPath, "/programs");
-    const sessionPayload: Stripe.Checkout.SessionCreateParams = {
-      mode: "payment",
-      customer_creation: "always",
-      allow_promotion_codes: true,
-      success_url: getSuccessUrl(appUrl),
-      cancel_url: new URL(cancelPath, appUrl).toString(),
-      line_items: [{ price: product.stripePriceId, quantity: 1 }],
-      metadata: {
-        fs_product_id: product.id,
-        fs_product_slug: product.slug,
-        fs_product_kind: product.kind,
-      },
-      ...(user?.id ? { client_reference_id: user.id } : {}),
-      ...(user?.email ? { customer_email: user.email } : {}),
-    };
+    const sessionPayload = buildCheckoutSessionPayload({
+      appUrl,
+      cancelPath: body.cancelPath,
+      product,
+      user,
+    });
 
     const session = await stripe.checkout.sessions.create(sessionPayload);
     if (!session.url) {

--- a/app/api/portal/route.ts
+++ b/app/api/portal/route.ts
@@ -54,6 +54,24 @@ async function resolveStripeCustomerId(params: {
     return null;
   }
 
+  const { data: ownedEntitlementMissingCustomer, error: missingCustomerError } = await supabase
+    .from("entitlements")
+    .select("id")
+    .eq("user_id", userId)
+    .is("stripe_customer_id", null)
+    .limit(1)
+    .maybeSingle();
+
+  if (missingCustomerError) {
+    throw new Error(
+      `Could not verify owned entitlement before customer fallback: ${missingCustomerError.message}`
+    );
+  }
+
+  if (!ownedEntitlementMissingCustomer) {
+    return null;
+  }
+
   const customers = await stripe.customers.list({
     email: normalizedEmail,
     limit: 10,

--- a/docs/checklists/finance-reporting-baseline.md
+++ b/docs/checklists/finance-reporting-baseline.md
@@ -48,6 +48,7 @@ npm run finance:reconcile -- \
 - Required env: `STRIPE_SECRET_KEY`, `NEXT_PUBLIC_SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`.
 - Date window is UTC and inclusive (`--from..--to`).
 - Command auto-collects Stripe checkout sessions + entitlement rows, writes JSON exports, then runs deterministic mismatch checks.
+- Stripe session exports include customer ID, invoice ID, `invoice_creation.enabled`, `client_reference_id`, and product metadata so missing Billing Portal invoice history can be classified as either pre-invoice-creation legacy behavior or a current checkout bug.
 
 Fallback mode: stage both exports in one folder using filename hints:
 

--- a/docs/runbooks/auth-account-support.md
+++ b/docs/runbooks/auth-account-support.md
@@ -6,7 +6,7 @@ Use this runbook when users ask where account, sign-in, billing, or recovery act
 
 - `My Library` is the account home.
 - The signed-in email is shown on `My Library`.
-- `Manage billing` lives on `My Library` and opens the Stripe Billing Portal.
+- `Manage billing` lives on `My Library` and opens the Stripe Billing Portal for the authenticated user's Stripe customer.
 - `Sign out` lives on `My Library`.
 - `/auth/sign-in` owns one-time email-code sign-in, resend, cooldown, and spam/junk-folder guidance.
 - `/preview-access` owns private preview unlock guidance when site-lock is enabled.
@@ -25,6 +25,12 @@ Use this runbook when users ask where account, sign-in, billing, or recovery act
 - If a user asks which email is signed in: send them to `My Library`.
 - If a user wants to sign out: use `Sign out` on `My Library`.
 - If a user needs billing or invoices: use `Manage billing` on `My Library`.
+- If the Stripe Billing Portal says there is no invoice history after a one-time Checkout purchase:
+  - verify the authenticated app user owns an entitlement row with the same `stripe_customer_id` as the Stripe customer opened in the portal,
+  - do not open a Stripe customer found by email unless the app user already owns an entitlement that needs its missing `stripe_customer_id` repaired,
+  - verify the Checkout Session has `payment_status=paid`,
+  - verify `invoice_creation.enabled=true` and an invoice ID exists for the session,
+  - treat older sandbox purchases made before invoice creation was enabled as receipt/charge-only records; they do not retroactively gain portal invoice history.
 - If a sign-in code does not arrive: ask them to check spam/junk, wait for any cooldown, then request a new code on `/auth/sign-in`.
 - If a code expires or fails: request a new code from `/auth/sign-in`.
 - If preview access is blocked while the site is private: use `/preview-access`; admin sign-in and preview-password behavior stay separate from normal My Library sign-in.

--- a/docs/task-briefs/in-progress/2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10.md
+++ b/docs/task-briefs/in-progress/2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10.md
@@ -3,10 +3,10 @@
 ## Metadata
 
 - `id`: `2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10`
-- `status`: `planned`
+- `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-04-21`
-- `updated`: `2026-04-21`
+- `updated`: `2026-04-26`
 
 ## Goal
 
@@ -138,6 +138,19 @@ Critical target categories for `10/10` claim:
 - Required if the user-facing Manage billing expectation changes.
 - Support notes must include how to diagnose missing invoice history.
 
+## Implementation Notes
+
+- Root cause from code audit and Stripe documentation: the app used one-time Checkout Sessions (`mode=payment`) without `invoice_creation.enabled=true`; Stripe only auto-generates invoices for subscriptions, while one-time Checkout purchases need explicit invoice creation.
+- Read-only Stripe test API evidence on `2026-04-26`: inspected 10 recent Checkout Sessions, all 10 were payment-mode, 5 were paid, 6 had a customer, 0 had an invoice, 0 had invoice creation enabled, and 5 paid sessions had no invoice. No raw secret, email, or full Stripe ID was output.
+- Billing Portal can show invoices for the authenticated user's Stripe customer, but older sandbox one-time purchases created without invoice creation remain receipt/charge-only and do not retroactively gain portal invoice history.
+- `/api/portal` does not accept a customer ID from the browser; it resolves the Stripe customer from the authenticated Supabase user and owned entitlement records, with email only used for best-effort guest-entitlement attachment and repairing an already owned entitlement missing `stripe_customer_id`.
+- App-side `Manage billing` copy does not promise invoice history; support guidance now documents the exact missing-invoice checks.
+- `finance:reconcile -- --collect-live` now includes invoice and invoice-creation fields from Stripe Checkout Sessions so sandbox exports can prove whether invoices are intentionally absent or created.
+
 ## Checkpoint Log
 
 - `2026-04-21 | planned | created from owner finding that Stripe Billing Portal showed no invoice history after sandbox purchase | next: implement or defer before maintenance baseline`
+- `2026-04-26 | in-progress | branch stripe-sandbox-invoice-portal-verification from main ecbc6ba; Stripe docs confirmed one-time Checkout purchases require invoice_creation.enabled=true for paid invoices | next: implement checkout payload, support runbook, targeted tests`
+- `2026-04-26 | in-progress | implemented Checkout invoice_creation payload, owner-scoped portal fallback guard, invoice-aware finance export fields, and support/checklist guidance; targeted Vitest passed for checkout payload, portal route, portal utils, and finance reconciliation | next: run verify:pre-pr, push PR, then pre-merge gate after CI`
+- `2026-04-26 | in-progress | npm run verify:pre-pr PASS (full lane; 838 unit tests, build, perf budgets, 112 E2E passed / 344 skipped; log artifacts/test-runs/20260426-075810/verify.log); Stripe test API summary confirmed 0/10 recent payment sessions had invoice_creation enabled and 5 paid sessions had no invoice | next: commit, push, open PR`
+- `2026-04-26 | in-progress | final pre-PR rerun after docs checkpoint reached E2E and hit one unrelated mobile Chromium client-ready timeout in poolside-save-image-export; targeted rerun of that exact test passed (1/1), matching the earlier full green run | next: commit, push, open PR with flake note`

--- a/docs/task-briefs/planned/2026-04-18-maintenance-baseline-pre-live-10-10.md
+++ b/docs/task-briefs/planned/2026-04-18-maintenance-baseline-pre-live-10-10.md
@@ -6,7 +6,7 @@
 - `status`: `planned`
 - `owner`: `stianvikra`
 - `created`: `2026-04-18`
-- `updated`: `2026-04-25`
+- `updated`: `2026-04-26`
 
 ## Goal
 
@@ -23,9 +23,9 @@ Bring the repo and runtime maintenance baseline to a pre-live 10/10 level: no kn
   - [2026-04-21-my-swim-profile-page-ia-and-copy-cleanup-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-21-my-swim-profile-page-ia-and-copy-cleanup-10-10.md)
   - [2026-04-21-account-security-simplification-and-auth-surface-audit-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-21-account-security-simplification-and-auth-surface-audit-10-10.md)
   - [2026-04-21-course-dashboard-new-content-and-continue-card-cleanup-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-21-course-dashboard-new-content-and-continue-card-cleanup-10-10.md)
+  - [2026-04-21-my-library-my-training-ia-and-builder-entrypoint-reconcile-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-21-my-library-my-training-ia-and-builder-entrypoint-reconcile-10-10.md)
 - Remaining findings-wave brief that currently takes precedence:
-  - [2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/planned/2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10.md)
-  - [2026-04-21-my-library-my-training-ia-and-builder-entrypoint-reconcile-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/planned/2026-04-21-my-library-my-training-ia-and-builder-entrypoint-reconcile-10-10.md)
+  - [2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10.md)
 
 ## Why This Brief Exists
 

--- a/lib/commerce/checkout.ts
+++ b/lib/commerce/checkout.ts
@@ -1,0 +1,65 @@
+import type Stripe from "stripe";
+import type { CatalogProduct } from "@/lib/commerce/catalog";
+
+type CheckoutUser = {
+  id?: string | null;
+  email?: string | null;
+};
+
+type BuildCheckoutSessionPayloadInput = {
+  appUrl: string;
+  cancelPath?: string;
+  product: CatalogProduct;
+  user?: CheckoutUser | null;
+};
+
+export function getSafeCheckoutCancelPath(input: string | undefined, fallback = "/programs") {
+  if (!input) return fallback;
+  if (!input.startsWith("/")) return fallback;
+  if (input.startsWith("//")) return fallback;
+  return input;
+}
+
+export function getCheckoutSuccessUrl(origin: string) {
+  const successUrl = new URL("/checkout/success", origin).toString();
+  return `${successUrl}?session_id={CHECKOUT_SESSION_ID}`;
+}
+
+function buildCheckoutMetadata(
+  product: CatalogProduct,
+  user?: CheckoutUser | null
+): Stripe.MetadataParam {
+  return {
+    fs_product_id: product.id,
+    fs_product_slug: product.slug,
+    fs_product_kind: product.kind,
+    ...(user?.id ? { fs_user_id: user.id } : {}),
+  };
+}
+
+export function buildCheckoutSessionPayload({
+  appUrl,
+  cancelPath,
+  product,
+  user,
+}: BuildCheckoutSessionPayloadInput): Stripe.Checkout.SessionCreateParams {
+  const metadata = buildCheckoutMetadata(product, user);
+
+  return {
+    mode: "payment",
+    customer_creation: "always",
+    allow_promotion_codes: true,
+    success_url: getCheckoutSuccessUrl(appUrl),
+    cancel_url: new URL(getSafeCheckoutCancelPath(cancelPath), appUrl).toString(),
+    line_items: [{ price: product.stripePriceId, quantity: 1 }],
+    metadata,
+    invoice_creation: {
+      enabled: true,
+      invoice_data: {
+        metadata,
+      },
+    },
+    ...(user?.id ? { client_reference_id: user.id } : {}),
+    ...(user?.email ? { customer_email: user.email } : {}),
+  };
+}

--- a/scripts/reconcile-finance-entitlements.mjs
+++ b/scripts/reconcile-finance-entitlements.mjs
@@ -62,6 +62,14 @@ function requireEnv(name) {
   return value;
 }
 
+function serializeStripeReference(value) {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && typeof value.id === "string") {
+    return value.id;
+  }
+  return "";
+}
+
 function parseIsoDateStart(dateValue, flagName) {
   if (!ISO_DATE_PATTERN.test(dateValue)) {
     throw new Error(`${flagName} must use YYYY-MM-DD format.`);
@@ -431,6 +439,10 @@ async function collectStripeRows(window) {
       status: session.status ?? "",
       created: session.created,
       customer: session.customer ?? "",
+      invoice: serializeStripeReference(session.invoice),
+      invoice_creation_enabled: Boolean(session.invoice_creation?.enabled),
+      client_reference_id: session.client_reference_id ?? "",
+      metadata_product_id: session.metadata?.fs_product_id ?? "",
       customer_email: session.customer_details?.email ?? "",
       amount_total: session.amount_total ?? null,
       currency: session.currency ?? "",

--- a/tests/unit/checkout-session-payload.test.ts
+++ b/tests/unit/checkout-session-payload.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { CatalogProduct } from "@/lib/commerce/catalog";
+import { buildCheckoutSessionPayload } from "@/lib/commerce/checkout";
+
+const product: CatalogProduct = {
+  id: "guide_poolside",
+  slug: "poolside-guide",
+  title: "Poolside guide",
+  kind: "course_addon",
+  stripePriceId: "price_test_poolside",
+  active: true,
+};
+
+describe("buildCheckoutSessionPayload", () => {
+  it("enables post-purchase invoice creation for one-time Checkout purchases", () => {
+    const user = {
+      id: "11111111-1111-4111-8111-111111111111",
+      email: "swimmer@example.com",
+    };
+    const payload = buildCheckoutSessionPayload({
+      appUrl: "https://freeswimming.example",
+      cancelPath: "/my-library",
+      product,
+      user,
+    });
+
+    expect(payload).toMatchObject({
+      mode: "payment",
+      customer_creation: "always",
+      allow_promotion_codes: true,
+      success_url: "https://freeswimming.example/checkout/success?session_id={CHECKOUT_SESSION_ID}",
+      cancel_url: "https://freeswimming.example/my-library",
+      line_items: [{ price: "price_test_poolside", quantity: 1 }],
+      client_reference_id: user.id,
+      customer_email: user.email,
+    });
+    expect(payload.metadata).toEqual({
+      fs_product_id: "guide_poolside",
+      fs_product_slug: "poolside-guide",
+      fs_product_kind: "course_addon",
+      fs_user_id: user.id,
+    });
+    expect(payload.invoice_creation).toEqual({
+      enabled: true,
+      invoice_data: {
+        metadata: payload.metadata,
+      },
+    });
+  });
+
+  it("falls back to a local cancel path and omits absent user fields", () => {
+    const payload = buildCheckoutSessionPayload({
+      appUrl: "https://freeswimming.example",
+      cancelPath: "https://evil.example/return",
+      product,
+      user: null,
+    });
+
+    expect(payload.cancel_url).toBe("https://freeswimming.example/programs");
+    expect(payload).not.toHaveProperty("client_reference_id");
+    expect(payload).not.toHaveProperty("customer_email");
+    expect(payload.metadata).toEqual({
+      fs_product_id: "guide_poolside",
+      fs_product_slug: "poolside-guide",
+      fs_product_kind: "course_addon",
+    });
+  });
+});

--- a/tests/unit/portal-route.test.ts
+++ b/tests/unit/portal-route.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  attachGuestEntitlementsByEmailMock,
+  createAdminSupabaseClientMock,
+  createServerSupabaseClientMock,
+  createStripeClientMock,
+  getAppUrlMock,
+} = vi.hoisted(() => ({
+  attachGuestEntitlementsByEmailMock: vi.fn(),
+  createAdminSupabaseClientMock: vi.fn(),
+  createServerSupabaseClientMock: vi.fn(),
+  createStripeClientMock: vi.fn(),
+  getAppUrlMock: vi.fn(),
+}));
+
+vi.mock("@/lib/commerce/entitlements", () => ({
+  attachGuestEntitlementsByEmail: attachGuestEntitlementsByEmailMock,
+  normalizeEmail: (email: string) => email.trim().toLowerCase(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminSupabaseClient: createAdminSupabaseClientMock,
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerSupabaseClient: createServerSupabaseClientMock,
+}));
+
+vi.mock("@/lib/supabase/env", () => ({
+  getAppUrl: getAppUrlMock,
+}));
+
+vi.mock("@/lib/stripe/server", () => ({
+  createStripeClient: createStripeClientMock,
+}));
+
+import { POST } from "@/app/api/portal/route";
+
+type SupabaseResult = {
+  data: Record<string, unknown> | null;
+  error: { message: string } | null;
+};
+
+function buildRequest(body: Record<string, unknown>) {
+  return new Request("https://freeswimming.example/api/portal", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function buildSelectMaybeSingleChain(result: SupabaseResult, shape: "existing" | "missing") {
+  const maybeSingle = vi.fn().mockResolvedValue(result);
+  const limit = vi.fn().mockReturnValue({ maybeSingle });
+
+  if (shape === "existing") {
+    const order = vi.fn().mockReturnValue({ limit });
+    const not = vi.fn().mockReturnValue({ order });
+    const eq = vi.fn().mockReturnValue({ not });
+    return { eq };
+  }
+
+  const is = vi.fn().mockReturnValue({ limit });
+  const eq = vi.fn().mockReturnValue({ is });
+  return { eq };
+}
+
+function buildPortalSupabaseClient(input: {
+  entitlementWithCustomer: SupabaseResult;
+  entitlementMissingCustomer: SupabaseResult;
+}) {
+  const select = vi.fn((columns: string) => {
+    if (columns === "stripe_customer_id") {
+      return buildSelectMaybeSingleChain(input.entitlementWithCustomer, "existing");
+    }
+    if (columns === "id") {
+      return buildSelectMaybeSingleChain(input.entitlementMissingCustomer, "missing");
+    }
+    throw new Error(`Unexpected select columns: ${columns}`);
+  });
+  const from = vi.fn((table: string) => {
+    expect(table).toBe("entitlements");
+    return { select };
+  });
+
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: {
+          user: {
+            id: "11111111-1111-4111-8111-111111111111",
+            email: "Swimmer@Example.com",
+          },
+        },
+      }),
+    },
+    from,
+    select,
+  };
+}
+
+function buildStripeClient() {
+  return {
+    customers: {
+      list: vi.fn().mockResolvedValue({ data: [{ id: "cus_email_match" }] }),
+    },
+    billingPortal: {
+      sessions: {
+        create: vi.fn().mockResolvedValue({
+          url: "https://billing.stripe.com/session/test",
+        }),
+      },
+    },
+  };
+}
+
+describe("/api/portal route", () => {
+  beforeEach(() => {
+    attachGuestEntitlementsByEmailMock.mockResolvedValue(0);
+    createAdminSupabaseClientMock.mockReturnValue({});
+    getAppUrlMock.mockReturnValue("https://freeswimming.example");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates the billing portal for the owned entitlement customer and ignores request customer ids", async () => {
+    const supabase = buildPortalSupabaseClient({
+      entitlementWithCustomer: {
+        data: { stripe_customer_id: "cus_owned" },
+        error: null,
+      },
+      entitlementMissingCustomer: {
+        data: null,
+        error: null,
+      },
+    });
+    const stripe = buildStripeClient();
+    createServerSupabaseClientMock.mockResolvedValue(supabase);
+    createStripeClientMock.mockReturnValue(stripe);
+
+    const response = await POST(
+      buildRequest({
+        returnPath: "/my-library",
+        customer: "cus_attacker",
+      })
+    );
+    const payload = (await response.json()) as { ok?: boolean; url?: string };
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({
+      ok: true,
+      url: "https://billing.stripe.com/session/test",
+    });
+    expect(stripe.customers.list).not.toHaveBeenCalled();
+    expect(stripe.billingPortal.sessions.create).toHaveBeenCalledWith({
+      customer: "cus_owned",
+      return_url: "https://freeswimming.example/my-library",
+    });
+  });
+
+  it("does not open an email-matched Stripe customer without an owned entitlement", async () => {
+    const supabase = buildPortalSupabaseClient({
+      entitlementWithCustomer: {
+        data: null,
+        error: null,
+      },
+      entitlementMissingCustomer: {
+        data: null,
+        error: null,
+      },
+    });
+    const stripe = buildStripeClient();
+    createServerSupabaseClientMock.mockResolvedValue(supabase);
+    createStripeClientMock.mockReturnValue(stripe);
+
+    const response = await POST(buildRequest({ returnPath: "/my-library" }));
+    const payload = (await response.json()) as { ok?: boolean; error?: string };
+
+    expect(response.status).toBe(404);
+    expect(payload).toEqual({
+      ok: false,
+      error: "No Stripe billing account found for this user.",
+    });
+    expect(stripe.customers.list).not.toHaveBeenCalled();
+    expect(stripe.billingPortal.sessions.create).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- User-visible changes: Future one-time Stripe Checkout purchases can produce invoice history in Stripe Billing Portal when Stripe creates the invoice; existing receipt-only sandbox purchases stay non-retroactive.
- Technical changes: Adds a shared Checkout Session payload builder with `invoice_creation.enabled=true`, tightens `/api/portal` customer fallback authz, extends finance reconciliation exports with invoice fields, and adds targeted unit coverage.
- Policy impact: yes - this touches Stripe billing processor behavior, customer/invoice metadata, and support guidance; no new processor or raw payment data handling is introduced.
- Policy version note: No policy version bump; Stripe is already the billing processor, no new payment data category is stored in-app, and support guidance reinforces Stripe-hosted invoice/payment handling.
- Brief link(s): `docs/task-briefs/in-progress/2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10.md`

## Scope

- In scope: Stripe sandbox invoice-history root-cause verification, Checkout invoice creation for future payment-mode purchases, portal customer ownership hardening, finance export fields, runbook/checklist updates, and task-brief lifecycle move to `in-progress`.
- Out of scope: live Stripe data changes, pricing/product model changes, billing UI redesign, Account & Security redesign, and unrelated poolside/export test hardening.

## Risk

- Main risk: Older sandbox purchases still have no invoice history because Stripe does not retroactively create invoices for payment sessions created without invoice creation; support must treat those as receipt/charge-only records.
- Rollback plan: Revert `afd052c` to remove invoice creation, portal fallback hardening, finance export additions, docs updates, and the brief lifecycle move.

## Test Evidence

- Policy-impact checklist: PASS - reviewed `docs/checklists/policy-impact-release-review.md`; Stripe remains the existing payment processor, no card/payment data is stored in-app, no secrets or raw env values are committed, and Stripe test API evidence was summarized without emails or full Stripe IDs.
- `npx vitest run tests/unit/checkout-session-payload.test.ts tests/unit/portal-route.test.ts tests/unit/portal-utils.test.ts tests/unit/finance-reconciliation.test.ts`: **PASS** (18 tests).
- `npm run typecheck`: **PASS**.
- `npm run lint`: **PASS**.
- `npm run verify:pre-pr`: **PASS** (full lane, `artifacts/test-runs/20260426-075810/verify.log`; 838 unit tests, build, perf budgets, 112 E2E passed / 344 skipped).
- `npm run verify:pre-pr`: **FAIL** on later rerun after docs checkpoint due to unrelated `poolside-save-image-export` mobile Chromium client-ready timeout; same test passed in the earlier full green run.
- `PW_PORT=3100 NEXT_DIST_DIR=.next-playwright SITE_LOCK_ENABLED=0 npx playwright test tests/e2e/poolside-save-image-export.spec.ts --project=mobile-chromium`: **PASS** (1/1 targeted rerun).
- Read-only Stripe test API summary, 2026-04-26: inspected 10 recent Checkout Sessions; 10 payment-mode, 5 paid, 6 with customer, 0 with invoice, 0 with invoice creation enabled, 5 paid without invoice; no raw secret, email, or full Stripe ID output.
- `npm run verify:pre-merge`: **PASS** for `afd052caadb140c66e928b993ac4534087b0e782` (full lane, `artifacts/test-runs/20260426-090528/verify.log`; 838 unit tests, build, perf budgets, 113 E2E passed / 343 skipped; private-gate regression skipped because `SITE_LOCK_ENABLED!=1`).

## Checklist

- [x] Brief moved from `planned` to `in-progress`.
- [x] Stripe invoice-history root cause documented.
- [x] Billing Portal access remains owner-scoped and request body cannot choose customer.
- [x] Support/finance guidance updated.
- [x] No screenshots required; this slice changes backend/docs/tests only, not app UI/visual layout.
- [x] `npm run verify:pre-merge` passed after CI green.
