### PR TITLE
docs: close out stripe sandbox billing brief

### DIFF
--- a/docs/task-briefs/done/2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10.md
+++ b/docs/task-briefs/done/2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-04-21`
 - `updated`: `2026-04-26`
@@ -147,6 +147,28 @@ Critical target categories for `10/10` claim:
 - App-side `Manage billing` copy does not promise invoice history; support guidance now documents the exact missing-invoice checks.
 - `finance:reconcile -- --collect-live` now includes invoice and invoice-creation fields from Stripe Checkout Sessions so sandbox exports can prove whether invoices are intentionally absent or created.
 
+## Closeout Summary
+
+- Shipped via PR #517 and merged to `main` as `bd3a9e5`.
+- Scope completed:
+  - one-time Stripe Checkout Sessions now request invoice creation for future sandbox/live payment-mode purchases,
+  - `/api/portal` remains owner-scoped and no browser request can choose a Stripe customer,
+  - support and finance guidance now explain why older sandbox purchases can show no invoice history,
+  - finance reconciliation exports now include invoice and invoice-creation fields.
+- Known limitation: older sandbox one-time purchases created before `invoice_creation.enabled=true` remain receipt/charge-only and will not retroactively gain invoices in Stripe Billing Portal.
+- Carry-forward verification: create a new sandbox purchase after `bd3a9e5` and confirm the resulting invoice appears in Stripe/customer portal evidence before live billing confidence is claimed.
+- Carry-forward maintenance item: `npm run test:perf:budgets` again recommended tightening one stretch target after two consecutive weekly green runs; budget ratchet decision remains deferred to the maintenance baseline brief.
+- No screenshot handoff was required because this slice changed backend, tests, and docs only, not app UI/layout.
+
+## Closeout Validation
+
+- Targeted tests: `npx vitest run tests/unit/checkout-session-payload.test.ts tests/unit/portal-route.test.ts tests/unit/portal-utils.test.ts tests/unit/finance-reconciliation.test.ts` PASS, 18 tests.
+- `npm run verify:pre-pr`: PASS on implementation branch, full lane, 838 unit tests, build, perf budgets, 112 E2E passed / 344 skipped, log `artifacts/test-runs/20260426-075810/verify.log`.
+- Later `npm run verify:pre-pr` rerun hit an unrelated `poolside-save-image-export` mobile Chromium client-ready timeout; targeted rerun of that exact test passed 1/1 and the same test passed in final pre-merge.
+- GitHub CI for PR #517: PASS for `verify`, `e2e-smoke`, `site-lock-smoke`, `CodeQL`, `size-check`, `deploy-preview`, and Vercel.
+- `npm run verify:pre-merge`: PASS on `afd052caadb140c66e928b993ac4534087b0e782`, full lane, 838 unit tests, build, perf budgets, 113 E2E passed / 343 skipped, marker `artifacts/verify-pre-merge/20260426-072711.json`.
+- Merge: PR #517 squashed into `bd3a9e5` on `2026-04-26`.
+
 ## Checkpoint Log
 
 - `2026-04-21 | planned | created from owner finding that Stripe Billing Portal showed no invoice history after sandbox purchase | next: implement or defer before maintenance baseline`
@@ -154,3 +176,4 @@ Critical target categories for `10/10` claim:
 - `2026-04-26 | in-progress | implemented Checkout invoice_creation payload, owner-scoped portal fallback guard, invoice-aware finance export fields, and support/checklist guidance; targeted Vitest passed for checkout payload, portal route, portal utils, and finance reconciliation | next: run verify:pre-pr, push PR, then pre-merge gate after CI`
 - `2026-04-26 | in-progress | npm run verify:pre-pr PASS (full lane; 838 unit tests, build, perf budgets, 112 E2E passed / 344 skipped; log artifacts/test-runs/20260426-075810/verify.log); Stripe test API summary confirmed 0/10 recent payment sessions had invoice_creation enabled and 5 paid sessions had no invoice | next: commit, push, open PR`
 - `2026-04-26 | in-progress | final pre-PR rerun after docs checkpoint reached E2E and hit one unrelated mobile Chromium client-ready timeout in poolside-save-image-export; targeted rerun of that exact test passed (1/1), matching the earlier full green run | next: commit, push, open PR with flake note`
+- `2026-04-26 | done | PR #517 merged as bd3a9e5 after green CI and local verify:pre-merge; brief moved to done in docs-only closeout | next: continue to maintenance baseline with sandbox re-test and perf-budget ratchet decision carried forward`

--- a/docs/task-briefs/planned/2026-04-18-maintenance-baseline-pre-live-10-10.md
+++ b/docs/task-briefs/planned/2026-04-18-maintenance-baseline-pre-live-10-10.md
@@ -24,8 +24,9 @@ Bring the repo and runtime maintenance baseline to a pre-live 10/10 level: no kn
   - [2026-04-21-account-security-simplification-and-auth-surface-audit-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-21-account-security-simplification-and-auth-surface-audit-10-10.md)
   - [2026-04-21-course-dashboard-new-content-and-continue-card-cleanup-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-21-course-dashboard-new-content-and-continue-card-cleanup-10-10.md)
   - [2026-04-21-my-library-my-training-ia-and-builder-entrypoint-reconcile-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-21-my-library-my-training-ia-and-builder-entrypoint-reconcile-10-10.md)
-- Remaining findings-wave brief that currently takes precedence:
-  - [2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/in-progress/2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10.md)
+  - [2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10.md](/Users/stianvikra/freeswimming/docs/task-briefs/done/2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10.md)
+- Remaining findings-wave briefs that currently take precedence:
+  - none; maintenance baseline can start after this docs-only closeout merges.
 
 ## Why This Brief Exists
 
@@ -51,8 +52,13 @@ Bring the repo and runtime maintenance baseline to a pre-live 10/10 level: no kn
   - PR #507 reconfirmed that recommendation on `2026-04-24` with `35.6%` worst margin (`artifacts/test-runs/20260424-094822/verify.log`),
   - PR #509 carried the same recommendation forward while keeping the `My Swim Profile` IA/copy slice narrow,
   - PR #512 reconfirmed that recommendation on `2026-04-25` with `35.6%` worst margin (`artifacts/test-runs/20260425-152253/verify.log`),
+  - PR #517 reconfirmed that recommendation on `2026-04-26` with `35.6%` worst margin (`artifacts/test-runs/20260426-090528/verify.log`),
   - these product slices intentionally deferred the ratchet decision out of feature work,
   - this maintenance baseline must review `artifacts/perf-budgets/trend-log.ndjson`, decide `tighten` / `hold` / `revert`, and record the decision in the active brief and PR summary.
+- Carry-forward Stripe sandbox verification:
+  - PR #517 fixed invoice creation for future one-time Checkout purchases,
+  - older sandbox payment-mode purchases do not retroactively gain invoices,
+  - the first maintenance/billing follow-up should create a fresh sandbox purchase after `bd3a9e5` and confirm invoice visibility in Stripe/customer portal evidence before claiming live billing confidence.
 
 ## Recommended Execution Order
 
@@ -79,7 +85,7 @@ Do not batch all three into one PR unless validation shows the diff is still eas
 - Remove all known `high` or `critical` production dependency findings on current `main`.
 - Lock the runtime contract explicitly in repo files, not only in CI workflow YAML.
 - Define the maintenance cadence that should happen weekly, monthly, and quarterly.
-- Resolve the carried-forward perf-budget stretch-target recommendation from PRs #496, #507, #509, and #512 with a documented `tighten` / `hold` / `revert` decision.
+- Resolve the carried-forward perf-budget stretch-target recommendation from PRs #496, #507, #509, #512, and #517 with a documented `tighten` / `hold` / `revert` decision.
 - Keep major migrations explicitly deferred into separate planned briefs or backlog items.
 
 ## Before Live
@@ -184,7 +190,8 @@ Critical target categories for a `10/10` claim in this brief:
 3. One canonical maintenance runbook/checklist exists and defines weekly, monthly, and quarterly cadence.
 4. Major dependency migrations remain explicitly deferred into separate planned work, not silently bundled into the baseline pass.
 5. All baseline child PRs are narrow enough that root cause remains debuggable.
-6. The carried-forward perf-budget stretch-target recommendation from PRs `#496`, `#507`, `#509`, and `#512` is reviewed against current trend evidence, and the baseline PR records `tighten`, `hold`, or `revert` with rationale.
+6. The carried-forward perf-budget stretch-target recommendation from PRs `#496`, `#507`, `#509`, `#512`, and `#517` is reviewed against current trend evidence, and the baseline PR records `tighten`, `hold`, or `revert` with rationale.
+7. A fresh post-`bd3a9e5` Stripe sandbox purchase confirms invoice visibility, or the baseline records why that verification is deferred before live billing confidence is claimed.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- User-visible changes: No runtime UI/app behavior change; this is a docs-only lifecycle closeout.
- Technical changes: Moves the Stripe sandbox invoice/billing portal brief from `in-progress` to `done` and updates the maintenance baseline carry-forward list.
- Policy impact: yes - the docs mention Stripe processor behavior, invoice evidence, and support/finance expectations; no payment processor, runtime policy, or raw payment data handling changes in this PR.
- Policy version note: No policy version bump; PR is docs-only and records the already-merged Stripe behavior from PR #517.
- Brief link(s): `docs/task-briefs/done/2026-04-21-stripe-sandbox-invoice-history-and-billing-portal-verification-10-10.md`
- Scorecard target outcomes: Stripe closeout target categories are recorded as `5/5` except testing QA carries the documented out-of-scope flake note from PR #517; maintenance baseline target scoring remains planned.

## Scope

- In scope: Stripe brief lifecycle move to `done`, closeout summary/validation, known old-sandbox-purchase limitation, post-`bd3a9e5` sandbox re-test carry-forward, and maintenance baseline perf-budget carry-forward update.
- Out of scope: runtime code, Stripe config/data changes, UI, screenshots, pricing, billing portal configuration, and performance budget changes.

## Risk

- Main risk: Documentation drift if maintenance baseline does not later perform the fresh sandbox purchase verification or perf-budget ratchet decision.
- Rollback plan: Revert `dad8dc0` to restore the previous brief lifecycle state.

## Test Evidence

- Policy-impact checklist: PASS - reviewed `docs/checklists/policy-impact-release-review.md`; docs-only Stripe processor/support wording reviewed; no secrets, raw env values, card data, or runtime policy changes added.
- `npm run lint:briefs`: PASS/skip for changed-brief detector before commit; `npm run lint:briefs:all`: PASS for all 194 briefs.
- `npm run verify:pre-pr`: PASS on `dad8dc0`, docs-only lane, log `artifacts/test-runs/20260426-094612/verify.log`.
- `npm run verify:pre-merge`: PASS on `dad8dc042f208ca4d079e12f50c8d570053930ac`, docs-only lane, marker `artifacts/verify-pre-merge/20260426-075006.json`.
- CI: PASS for PR #518 after rerunning `verify` with the corrected policy-impact checklist reference.

## Checklist

- [x] Stripe brief moved from `in-progress` to `done`.
- [x] Closeout records PR #517 merge commit `bd3a9e5` and validation evidence.
- [x] Old sandbox purchases documented as non-retroactive invoice limitation.
- [x] Fresh sandbox purchase verification carried forward to maintenance/billing follow-up.
- [x] Perf-budget tighten recommendation carried forward to maintenance baseline.
- [x] No screenshots required; docs-only lifecycle/governance diff.
- [x] `npm run verify:pre-merge` passed after CI green.
