### PR TITLE
docs: close out tailwind dependency brief

### DIFF
--- a/docs/checklists/monthly-maintenance-pass.md
+++ b/docs/checklists/monthly-maintenance-pass.md
@@ -24,6 +24,12 @@ Use this checklist for the monthly issue created by `.github/workflows/monthly-m
 - [ ] Confirm GitHub Actions still use `node-version-file: .nvmrc`.
 - [ ] Document any required runtime/tooling change as its own PR.
 
+## Continuous Improvement Capture
+
+- [ ] Review recent PRs, CI failures, screenshot handoffs, and release-gate notes for repeatable lessons.
+- [ ] Place each lesson in the narrowest durable home: active brief/PR evidence, maintenance runbook, domain runbook, architecture/testing docs, or a planned brief.
+- [ ] Record owner and next checkpoint for any lesson intentionally deferred out of the current maintenance pass.
+
 ## Performance Budget Ratchet
 
 - [ ] Run `npm run test:perf:trend`.

--- a/docs/runbooks/maintenance-cadence.md
+++ b/docs/runbooks/maintenance-cadence.md
@@ -21,6 +21,17 @@ Keep dependency hygiene, runtime pinning, performance budgets, and release-gate 
 5. Record each PR, decision, and validation result in the monthly issue.
 6. Close the issue only after deferrals have owners or planned briefs.
 
+## Continuous Learning Loop
+
+Maintenance is also where repo lessons become durable process improvements. When a PR, CI run, screenshot handoff, support incident, or release gate exposes a repeatable pattern, record it in the narrowest durable place instead of relying on chat memory:
+
+- update the active brief checkpoint or PR body for one-off evidence and explicit `tighten` / `hold` / `revert` decisions,
+- update this runbook or the monthly checklist for recurring maintenance workflow changes,
+- update testing, architecture, security, billing, or UI-debug runbooks when the lesson belongs to a specific operating surface,
+- open a planned brief when the lesson requires product, architecture, or toolchain work that should not be bundled into the current PR.
+
+Keep the change small and place it where the next operator will naturally look before repeating the same work.
+
 ## Triage Rules
 
 - Patch/minor dependency PRs: merge when CI and local release gates are green.
@@ -85,8 +96,8 @@ Before merge:
 npm run verify:pre-merge
 ```
 
-For local Playwright-heavy gates, use the repo's normal Node runtime from `.nvmrc`. If Next dev-server memory restarts cause `ERR_EMPTY_RESPONSE` flakes, rerun with:
+For local Playwright-heavy gates, use the repo's normal Node runtime from `.nvmrc`. Playwright's managed Next devserver defaults to `8192` MB through `playwright.config.ts` after the Tailwind 4 migration. If a local machine needs a different ceiling, override it with:
 
 ```bash
-NODE_OPTIONS=--max-old-space-size=4096 npm run verify:pre-merge
+PW_NEXT_DEV_MAX_OLD_SPACE_SIZE_MB=8192 npm run verify:pre-merge
 ```

--- a/docs/task-briefs/done/2026-04-28-tailwind-v4-dependency-maintenance-10-10.md
+++ b/docs/task-briefs/done/2026-04-28-tailwind-v4-dependency-maintenance-10-10.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - `id`: `2026-04-28-tailwind-v4-dependency-maintenance-10-10`
-- `status`: `in-progress`
+- `status`: `done`
 - `owner`: `stianvikra`
 - `created`: `2026-04-28`
 - `updated`: `2026-04-28`
@@ -202,3 +202,4 @@ Critical target categories for `10/10` claim:
 - `2026-04-28 | in-progress | targeted heavy E2E passed after the first heap patch; full pre-PR still hit the same Next restart later in desktop my-library, so the Playwright-only heap ceiling was raised to 8192 MB | next: rerun targeted heavy E2E, then full verify:pre-pr`
 - `2026-04-28 | in-progress | targeted heavy E2E passed with the final 8192 MB Playwright devserver heap ceiling | next: rerun full verify:pre-pr`
 - `2026-04-28 | in-progress | final verify:pre-pr passed after the 8192 MB Playwright devserver heap ceiling; full E2E passed without Next memory-threshold restart | next: commit, push, update PR #366 handoff, monitor CI, then run verify:pre-merge`
+- `2026-04-28 | done | PR #366 merged to main as cffcbcd after owner-approved screenshot handoff, green CI, local verify:pre-pr, and local verify:pre-merge; carry-forward learnings are captured for maintenance baseline: keep perf-budget tightening out of dependency closeouts, align maintenance docs with the 8192 MB Playwright devserver heap default, and track recurring workout-builder hydration warnings as diagnostics rather than a Tailwind blocker | next: close out this brief via docs-only lifecycle PR, then run the maintenance-baseline audit`


### PR DESCRIPTION
## Summary

- User-visible changes: No direct end-user/admin runtime behavior change; this is a docs-only lifecycle and maintenance-system calibration PR.
- Technical changes: Moves the Tailwind 4 dependency brief from `in-progress` to `done`, records the #366 merge closeout, adds a continuous learning loop to the maintenance cadence, adds continuous-improvement capture to the monthly maintenance checklist, and aligns the Playwright-heavy gate guidance with the 8192 MB devserver heap default from the Tailwind 4 migration.
- Policy impact: no - no auth, privacy, terms, consent, analytics, data-rights, payment, or customer policy behavior changes.
- Policy version note: N/A - no policy surface or legal/compliance text changed.

## Scope

- In scope: Docs-only Tailwind brief lifecycle closeout, maintenance cadence calibration, monthly maintenance checklist improvement, and final validation evidence for PR #544.
- Out of scope: Runtime code, dependency versions, app UI, DB/schema, CI workflow logic, branch protection, performance-budget threshold changes, and product behavior.
- Changed files:
  - `docs/checklists/monthly-maintenance-pass.md`
  - `docs/runbooks/maintenance-cadence.md`
  - `docs/task-briefs/done/2026-04-28-tailwind-v4-dependency-maintenance-10-10.md`

## Risk

- Main risk: Docs/process drift if the closeout or maintenance guidance does not match the actual Tailwind 4 merge evidence.
- Rollback plan: Revert `5d70b33` to restore the prior docs state; no runtime rollback, data repair, or secret rotation is required.

## Test Evidence

- Brief link(s): `docs/task-briefs/done/2026-04-28-tailwind-v4-dependency-maintenance-10-10.md`
- Policy-impact checklist: N/A - docs-only maintenance/lifecycle change with no policy-impacting scope.
- `npm run verify:pre-pr`: **PASS** on head `5d70b33`; docs-only lane; artifact `artifacts/test-runs/20260428-225155/verify.log`.
- `npm run verify:pre-merge`: **PASS** on head `5d70b33`; docs-only lane; marker `artifacts/verify-pre-merge/20260428-205503.json`; reused current-head docs-only PASS artifact `artifacts/test-runs/20260428-225155/verify.log`.
- GitHub required checks: **PASS** on PR #544 (`verify`, `size-check`, `Analyze (javascript-typescript)`, `CodeQL`, Vercel/deploy-preview, `e2e-smoke`, and `site-lock-smoke`).
- Runtime gates: N/A because verification selected the docs-only lane for a pure docs/governance diff.
- Local manual QA: N/A because no UI/runtime behavior changed.
- Vercel preview manual QA: N/A because no UI/runtime behavior changed; Vercel deployment check passed.

## UI Evidence

- [x] Screenshot(s) N/A: docs-only lifecycle/process update, no visible UI changed.
- [x] Mobile behavior N/A: docs-only lifecycle/process update, no visible UI changed.

## Checklist

- [x] Checked boxes in this PR have supporting evidence or explicit `N/A` rationale
- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [x] Every `target` scorecard row has measurable threshold + evidence source
- [x] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [x] PR is <= 500 changed lines, or intentionally split/explained
- [x] No secrets or sensitive data added

## Notes

- Continuous improvement is now explicitly captured in the maintenance cadence and monthly checklist so repeatable lessons from PRs, CI, screenshot handoffs, and release gates get placed in the right durable docs or planned briefs.
- Perf-budget tightening remains a carry-forward for the maintenance/perf baseline, not this Tailwind closeout.

## Owner Merge Step

- Direct URL: `https://github.com/stianvikra/freeswimming/pull/544`
- [x] Required checks are green
- [x] Local QA + Vercel preview QA are completed or explicitly N/A
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d docs/tailwind-v4-closeout-continuous-learning-2026-04-28`
- [ ] Optional: `git fetch --prune`
