### PR TITLE
docs: keep post-merge closeout in same chat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,7 @@ This file defines how coding agents should collaborate in this repository.
 - Start a new chat or provide a carry-forward prompt when it is the best way to preserve momentum and reduce risk, not only when context is already heavy.
 - Mandatory chat-handoff gate:
   - After every merge + local sync, and before creating a new implementation branch or starting a new active brief, assistant must explicitly assess whether to continue in the current chat or start a new chat.
+  - If `npm run post-merge:preflight` surfaces a repo-managed docs-only closeout for the just-merged workstream, complete that closeout PR in the same chat before making the chat-handoff assessment. Treat the closeout as part of the same workstream, not as a new implementation slice.
   - The post-merge handoff must include exactly one of:
     - `Chat: continue here` with a short rationale, or
     - `Chat: start new chat` with a ready-to-use carry-forward prompt.

--- a/docs/runbooks/pr-flow-and-chat-handoff.md
+++ b/docs/runbooks/pr-flow-and-chat-handoff.md
@@ -17,7 +17,8 @@ Use this as the canonical repo path for PR sync, merge readiness, and baton pass
    - `git checkout main`
    - `git pull --ff-only origin main`
    - `npm run post-merge:preflight`
-9. Before creating a new implementation branch or starting a new active brief, complete the mandatory chat-handoff gate below.
+9. If post-merge preflight reports a repo-managed docs-only closeout for the just-merged workstream, complete that closeout PR in the same chat before handoff assessment.
+10. Before creating a new implementation branch or starting a new active brief, complete the mandatory chat-handoff gate below.
 
 Use raw `gh pr create`, raw `gh pr edit`, or manual PR-body editing only when the repo entrypoint is blocked by credentials or sandbox limits.
 
@@ -35,6 +36,8 @@ Start a new chat or provide a carry-forward prompt when that is the best way to 
 ## Mandatory Handoff Gate After Merge / Before New Implementation
 
 This gate is required after each merge + local sync and before any new implementation branch, new active brief, or major workstream pivot.
+
+If `npm run post-merge:preflight` surfaces a repo-managed docs-only closeout for the just-merged workstream, do that closeout in the same chat first. It is part of the current workstream's closeout, not a reason to start a new chat.
 
 Assessment:
 


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-05-01T20:22:49.545Z for branch `docs/post-merge-closeout-before-chat-handoff-2026-05-01` (base ref `origin/main`).
- Latest commit: `2158b50` - docs: keep post-merge closeout in same chat.
- User-visible changes: No direct user-visible behavior change expected from the touched file areas.
- Technical changes: Updated 2 file(s): `AGENTS.md`, `docs/runbooks/pr-flow-and-chat-handoff.md`.
- Policy impact: no (no auth/analytics/user-data-rights/third-party processor paths detected).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link(s): `docs/task-briefs/in-progress/2026-05-01-ai-swim-coach-roadmap-alignment-10-10.md`
- Scorecard target outcomes: 7 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (1); other files (1).
- Out of scope: Application runtime behavior, DB schema, and content payloads remain unchanged.
- Changed files (2):
  - `AGENTS.md`
  - `docs/runbooks/pr-flow-and-chat-handoff.md`

## Risk

- Main risk: Operational/docs drift if generated scope/evidence text does not match final merged changes.
- Rollback plan: Revert `2158b50` (`git revert 2158b50`) to restore previous behavior.

## Test Evidence

- `npm run verify:docs-only`: **PASS** (artifacts/test-runs/20260501-222243)
- `npm run verify:pre-pr`: **PASS** (artifacts/test-runs/20260501-222243, lane: docs-only)
- `npm run verify:pre-merge`: **PASS** for `2158b50` (2026-05-01T20:22:44Z, lane: docs-only, mode: skipped-docs-only).
- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  - [brief-lint] PASS docs/task-briefs/planned/2026-05-01-platform-architecture-stack-practice-audit-10-10.md
  - [brief-lint] PASS docs/task-briefs/planned/2026-05-01-session-step-reference-surface-architecture-hardening-10-10.md
  - [brief-lint] All 220 changed brief file(s) passed.
  - [admin-audit-lint] PASS docs/checklists/admin-full-audit-gate-checklist.md + docs/checklists/admin-full-audit-findings-log.md (7 checklist workflow row(s), 9 evidence reference(s), 7 score row(s), 4 finding row(s)).
  - [env-parity-lint] PASS docs/task-briefs/done/2026-02-19-environment-config-and-secret-parity-audit.md + docs/runbooks/environment-config-and-secret-parity.md + docs/checklists/admin-access-and-secret-rotation.md (closeout enforced)
  - [pr-body-generated-lint] PASS
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs:all`
- [ ] `npm run lint:admin-audit`
- [ ] `npm run lint:env-parity`
- [ ] `npm run lint:pr-body:generated`
- [x] `npm run verify:docs-only`
- [x] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Runtime gates N/A for this pure docs/governance diff, or rationale documented if full lane was forced intentionally
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
