### PR TITLE
feat: extract session step surface renderer

### DIFF
--- a/components/my-library/workouts/SessionStepSurfaceRenderer.tsx
+++ b/components/my-library/workouts/SessionStepSurfaceRenderer.tsx
@@ -1,0 +1,995 @@
+"use client";
+
+import { ArrowDown, ArrowUp, ChevronDown, ChevronUp, Ellipsis } from "lucide-react";
+import type { ReactNode } from "react";
+import {
+  getManualPoolCategoryLabelClass,
+  getManualPoolViewSectionHeaderClass,
+  getManualPoolViewSectionToneClass,
+  type SessionStepViewSection,
+} from "@/components/my-library/workouts/sessionStepSurfaceContract";
+import type { SessionDraftStep } from "@/lib/session-generator-v1/shared";
+
+/**
+ * Shared renderer for the workout session-step surface.
+ *
+ * Owns mode chrome, collapsed summary cards, view sections, mobile action shells, and rearrange
+ * controls. It intentionally does not own canonical draft mutation, persistence, export/PDF
+ * behavior, or the editable form fields that still live in `WorkoutEditor`.
+ */
+
+export const SESSION_STEP_SURFACE_MODES = ["edit", "rearrange", "view"] as const;
+
+export type SessionStepSurfaceMode = (typeof SESSION_STEP_SURFACE_MODES)[number];
+
+const SESSION_STEP_SURFACE_MODE_LABELS: Record<SessionStepSurfaceMode, string> = {
+  edit: "Edit",
+  rearrange: "Rearrange",
+  view: "View",
+};
+
+const mobileSummaryToggleClass =
+  "w-full rounded-2xl text-left outline-none transition focus-visible:ring-2 focus-visible:ring-blue-200";
+const mobileIconButtonBaseClass =
+  "inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border transition";
+const mobileActionToggleClass = `${mobileIconButtonBaseClass} border-slate-200 bg-white text-slate-700 hover:bg-slate-50 active:bg-slate-100`;
+const mobileActionPanelClass = "mt-3 rounded-2xl border border-slate-200 bg-slate-50/90 p-2.5";
+const mobileSecondaryActionClass =
+  "inline-flex min-h-10 w-full items-center justify-start rounded-xl border px-3 py-2 text-sm font-medium transition";
+const rearrangeMoveButtonClass =
+  "inline-flex h-10 w-12 items-center justify-center rounded-xl border border-slate-200 bg-white text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 sm:h-9 sm:w-10";
+const recentlyMovedBlockClass = "bg-teal-50/80 shadow-sm ring-2 ring-inset ring-teal-300";
+const desktopHeaderStackClass = "flex items-start justify-between gap-3";
+const desktopSummaryBlockClass = "min-w-0 flex-1";
+
+function getMobileExpandToggleClass(expanded: boolean) {
+  return `${mobileIconButtonBaseClass} ${
+    expanded
+      ? "border-blue-200 bg-blue-50 text-blue-800 hover:bg-blue-100 active:bg-blue-100"
+      : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50 active:bg-slate-100"
+  }`;
+}
+
+export type SessionStepSummaryContentModel = {
+  label: string;
+  title: string;
+  labelClassName: string;
+  categoryLabel?: string | null;
+  description?: string | null;
+  targetSummary?: string | null;
+  notes?: string | null;
+  pendingDelete?: boolean;
+};
+
+/**
+ * Presentation-only model for the step surface. Callbacks are controlled by `WorkoutEditor`; IDs
+ * are canonical draft identifiers and must not be derived from display labels.
+ */
+export type SessionStepSurfaceRendererProps = {
+  mode: SessionStepSurfaceMode;
+  title: string;
+  showModeTabs: boolean;
+  showAddActions: boolean;
+  hasSteps: boolean;
+  rearrangeLiveMessage: string;
+  lastRemovedLabel: string | null;
+  children: ReactNode;
+  viewSections?: readonly SessionStepViewSection[];
+  onModeChange: (mode: SessionStepSurfaceMode) => void;
+  onAddStep: () => void;
+  onAddRepeat: () => void;
+  onUndoLastRemoval: () => void;
+  onDismissLastRemoval: () => void;
+  onOpenViewStep: (stepId: string) => void;
+  onOpenViewRepeat: (repeatGroupId: string) => void;
+};
+
+export function SessionStepSurfaceRenderer({
+  mode,
+  title,
+  showModeTabs,
+  showAddActions,
+  hasSteps,
+  rearrangeLiveMessage,
+  lastRemovedLabel,
+  children,
+  viewSections = [],
+  onModeChange,
+  onAddStep,
+  onAddRepeat,
+  onUndoLastRemoval,
+  onDismissLastRemoval,
+  onOpenViewStep,
+  onOpenViewRepeat,
+}: SessionStepSurfaceRendererProps) {
+  const isViewMode = mode === "view";
+
+  return (
+    <div
+      data-testid="workout-editor-session-steps-surface"
+      className="rounded-2xl border border-slate-200 bg-white p-3 sm:p-4"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h3 className="text-base font-semibold text-slate-900">{title}</h3>
+        <div className="flex flex-wrap items-center gap-3">
+          {showModeTabs ? (
+            <div
+              role="group"
+              aria-label="Builder mode"
+              className="inline-flex rounded-xl border border-blue-100 bg-blue-50/60 p-1"
+            >
+              {SESSION_STEP_SURFACE_MODES.map((nextMode) => {
+                const isSelected = mode === nextMode;
+
+                return (
+                  <button
+                    key={nextMode}
+                    type="button"
+                    onClick={() => onModeChange(nextMode)}
+                    aria-pressed={isSelected}
+                    data-testid={`workout-editor-builder-mode-${nextMode}`}
+                    className={`inline-flex h-8 items-center justify-center rounded-lg px-3 text-sm font-semibold transition ${
+                      isSelected
+                        ? "border border-blue-200 bg-blue-600 text-white shadow-sm"
+                        : "text-blue-900/70 hover:text-blue-900"
+                    }`}
+                  >
+                    {SESSION_STEP_SURFACE_MODE_LABELS[nextMode]}
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
+          {showAddActions ? (
+            <div className="flex flex-wrap items-center gap-2 border-l border-slate-200 pl-3">
+              <button
+                type="button"
+                onClick={onAddStep}
+                data-testid="session-draft-add-step"
+                className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100 sm:h-10 sm:px-4"
+              >
+                Add step
+              </button>
+              <button
+                type="button"
+                onClick={onAddRepeat}
+                data-testid="session-draft-add-repeat"
+                className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-blue-50 px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-100 active:bg-blue-200 sm:h-10 sm:px-4"
+              >
+                Add repeat
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="mt-4 space-y-4">
+        <p data-testid="workout-editor-rearrange-live" className="sr-only" aria-live="polite">
+          {rearrangeLiveMessage}
+        </p>
+
+        {!hasSteps ? (
+          <div
+            data-testid="session-draft-empty-steps"
+            className="rounded-2xl border border-dashed border-slate-300 bg-slate-50/80 p-3 sm:p-4"
+          >
+            <p className="text-sm font-medium text-slate-900">Start from a clean empty session.</p>
+            <p className="mt-1 text-sm text-slate-600">
+              Add your first step or repeat block below when you are ready to build from scratch.
+            </p>
+          </div>
+        ) : null}
+
+        {lastRemovedLabel ? (
+          <div
+            data-testid="workout-editor-removal-undo"
+            className="rounded-2xl border border-blue-200 bg-blue-50/90 p-3 sm:p-4"
+          >
+            <p className="text-sm font-medium text-blue-950">
+              Deleted <span className="font-semibold">{lastRemovedLabel}</span>.
+            </p>
+            <p className="mt-1 text-sm text-blue-900">
+              Undo restores it to the same local spot before you save this workout.
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={onUndoLastRemoval}
+                data-testid="workout-editor-removal-undo-button"
+                className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700"
+              >
+                Undo delete
+              </button>
+              <button
+                type="button"
+                onClick={onDismissLastRemoval}
+                data-testid="workout-editor-removal-dismiss-button"
+                className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-4 text-sm font-medium text-blue-900 transition hover:bg-blue-100 active:bg-blue-200"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        {isViewMode && viewSections.length > 0 ? (
+          <SessionStepViewSections
+            sections={viewSections}
+            onOpenStep={onOpenViewStep}
+            onOpenRepeat={onOpenViewRepeat}
+          />
+        ) : (
+          children
+        )}
+      </div>
+    </div>
+  );
+}
+
+type SessionStepViewSectionsProps = {
+  sections: readonly SessionStepViewSection[];
+  onOpenStep: (stepId: string) => void;
+  onOpenRepeat: (repeatGroupId: string) => void;
+};
+
+function SessionStepViewSections({
+  sections,
+  onOpenStep,
+  onOpenRepeat,
+}: SessionStepViewSectionsProps) {
+  return (
+    <>
+      {sections.map((section) => (
+        <section
+          key={section.key}
+          data-testid={`workout-editor-view-section-${section.key}`}
+          data-view-category={section.category}
+          className={`overflow-hidden rounded-2xl border bg-white ${getManualPoolViewSectionToneClass(
+            section.category
+          )}`}
+        >
+          <div className={`px-4 py-3 ${getManualPoolViewSectionHeaderClass(section.category)}`}>
+            <p
+              className={`text-xs font-semibold tracking-wide uppercase ${getManualPoolCategoryLabelClass(
+                section.category
+              )}`}
+            >
+              {section.title}
+            </p>
+          </div>
+          <div className="divide-y divide-slate-200/80">
+            {section.lines.map((line) => {
+              const lineTarget = line.target;
+              const lineContent = (
+                <div className="space-y-2">
+                  <p className="text-base leading-6 text-slate-900">{line.primaryText}</p>
+                  {line.secondaryText ? (
+                    <p className="text-sm font-semibold text-blue-800">{line.secondaryText}</p>
+                  ) : null}
+                  {line.detailText ? (
+                    <p className="text-sm leading-5 text-slate-500">{line.detailText}</p>
+                  ) : null}
+                </div>
+              );
+
+              if (lineTarget?.kind === "repeat") {
+                return (
+                  <button
+                    key={line.key}
+                    type="button"
+                    data-testid={`workout-editor-view-repeat-${lineTarget.repeatGroupId}`}
+                    onClick={() => onOpenRepeat(lineTarget.repeatGroupId)}
+                    className="block w-full px-4 py-3 text-left transition hover:bg-slate-50 focus-visible:ring-2 focus-visible:ring-blue-300 focus-visible:outline-none"
+                  >
+                    {lineContent}
+                  </button>
+                );
+              }
+
+              if (lineTarget?.kind === "step") {
+                return (
+                  <button
+                    key={line.key}
+                    type="button"
+                    data-testid={`workout-editor-view-line-${section.key}-${line.key}`}
+                    onClick={() => onOpenStep(lineTarget.stepId)}
+                    className="block w-full px-4 py-3 text-left transition hover:bg-slate-50 focus-visible:ring-2 focus-visible:ring-blue-300 focus-visible:outline-none"
+                  >
+                    {lineContent}
+                  </button>
+                );
+              }
+
+              return (
+                <div key={line.key} className="px-4 py-3">
+                  {lineContent}
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      ))}
+    </>
+  );
+}
+
+export type SessionStepSummaryCardProps = {
+  stepId: string;
+  index: number;
+  panelId: string;
+  dataManualPoolCategory?: SessionDraftStep["category"];
+  canUseDesktopCardOpen: boolean;
+  cardStateClass: string;
+  categoryRailClass: string;
+  isEditMode: boolean;
+  isSummaryOnlyMode: boolean;
+  isOpen: boolean;
+  mobileActionsOpen: boolean;
+  pendingDelete: boolean;
+  removalLabel: string | null;
+  showRearrangeControls: boolean;
+  showMobilePrimaryAddAfter: boolean;
+  showMobilePrimaryAddRepeatAfter: boolean;
+  canAddRepeatAfter: boolean;
+  isLinkedPostSetRest: boolean;
+  moveUpDisabled: boolean;
+  moveDownDisabled: boolean;
+  wasRecentlyMoved: boolean;
+  summary: SessionStepSummaryContentModel;
+  editPanel: ReactNode;
+  onOpen: () => void;
+  onToggle: () => void;
+  onToggleMobileActions: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onAddStepAfter: () => void;
+  onAddRepeatAfter: () => void;
+  onDuplicate: () => void;
+  onRequestRemove: () => void;
+  onConfirmRemoval: () => void;
+  onCancelRemoval: () => void;
+};
+
+export function SessionStepSummaryCard({
+  stepId,
+  index,
+  panelId,
+  dataManualPoolCategory,
+  canUseDesktopCardOpen,
+  cardStateClass,
+  categoryRailClass,
+  isEditMode,
+  isSummaryOnlyMode,
+  isOpen,
+  mobileActionsOpen,
+  pendingDelete,
+  removalLabel,
+  showRearrangeControls,
+  showMobilePrimaryAddAfter,
+  showMobilePrimaryAddRepeatAfter,
+  canAddRepeatAfter,
+  isLinkedPostSetRest,
+  moveUpDisabled,
+  moveDownDisabled,
+  wasRecentlyMoved,
+  summary,
+  editPanel,
+  onOpen,
+  onToggle,
+  onToggleMobileActions,
+  onMoveUp,
+  onMoveDown,
+  onAddStepAfter,
+  onAddRepeatAfter,
+  onDuplicate,
+  onRequestRemove,
+  onConfirmRemoval,
+  onCancelRemoval,
+}: SessionStepSummaryCardProps) {
+  return (
+    <article
+      key={stepId}
+      data-mobile-actions="progressive"
+      data-manual-pool-category={dataManualPoolCategory}
+      data-desktop-card-clickable={canUseDesktopCardOpen ? "true" : "false"}
+      onClick={
+        canUseDesktopCardOpen
+          ? (event) => {
+              if (shouldIgnoreCardEditClick(event.target)) {
+                return;
+              }
+
+              onOpen();
+            }
+          : undefined
+      }
+      className={`rounded-2xl border p-3 transition sm:p-4 ${cardStateClass} ${categoryRailClass} ${
+        wasRecentlyMoved ? recentlyMovedBlockClass : ""
+      } ${
+        canUseDesktopCardOpen && !pendingDelete
+          ? "cursor-pointer hover:border-blue-200 hover:bg-white hover:shadow-sm"
+          : ""
+      }`}
+    >
+      <div className={desktopHeaderStackClass}>
+        <div className={desktopSummaryBlockClass}>
+          {isSummaryOnlyMode || showRearrangeControls ? (
+            <div data-testid={`session-draft-step-mobile-summary-${index}`} className="sm:hidden">
+              <SessionStepSummaryContent summary={summary} />
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={onToggle}
+              aria-expanded={isOpen}
+              aria-controls={panelId}
+              data-testid={`session-draft-step-mobile-summary-${index}`}
+              className={`${mobileSummaryToggleClass} sm:hidden`}
+            >
+              <SessionStepSummaryContent summary={summary} />
+            </button>
+          )}
+          <div data-testid={`session-draft-step-summary-${index}`} className="hidden sm:block">
+            <SessionStepSummaryContent summary={summary} />
+          </div>
+        </div>
+        {isEditMode ? (
+          <div className="hidden shrink-0 sm:flex">
+            <button
+              type="button"
+              onClick={onToggle}
+              aria-expanded={isOpen}
+              aria-controls={panelId}
+              data-testid={`session-draft-step-toggle-${index}`}
+              className={`inline-flex h-9 items-center justify-center rounded-xl border px-3 text-sm transition ${
+                isOpen
+                  ? "border-blue-200 bg-blue-50 text-blue-800 hover:bg-blue-100"
+                  : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
+              }`}
+            >
+              {isOpen ? "Done" : "Edit"}
+            </button>
+          </div>
+        ) : null}
+        {showRearrangeControls ? (
+          <div
+            data-testid={`session-draft-step-rearrange-controls-${index}`}
+            className="flex shrink-0 flex-col gap-2 sm:flex-row sm:flex-wrap"
+          >
+            <MoveButton
+              testId={`session-draft-step-rearrange-move-up-${index}`}
+              disabled={moveUpDisabled}
+              onClick={onMoveUp}
+              direction="up"
+            />
+            <MoveButton
+              testId={`session-draft-step-rearrange-move-down-${index}`}
+              disabled={moveDownDisabled}
+              onClick={onMoveDown}
+              direction="down"
+            />
+          </div>
+        ) : isEditMode ? (
+          <div className="flex shrink-0 items-start gap-2 sm:hidden">
+            <button
+              type="button"
+              onClick={onToggle}
+              aria-expanded={isOpen}
+              aria-controls={panelId}
+              aria-label={isOpen ? "Hide step details" : "Show step details"}
+              data-testid={`session-draft-step-mobile-toggle-${index}`}
+              className={getMobileExpandToggleClass(isOpen)}
+            >
+              {isOpen ? (
+                <ChevronUp aria-hidden="true" className="size-4" />
+              ) : (
+                <ChevronDown aria-hidden="true" className="size-4" />
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={onToggleMobileActions}
+              aria-expanded={mobileActionsOpen}
+              aria-controls={`session-draft-step-mobile-actions-panel-${stepId}`}
+              data-testid={`session-draft-step-mobile-actions-toggle-${index}`}
+              className={mobileActionToggleClass}
+            >
+              <Ellipsis className="size-5" />
+              <span className="sr-only">
+                {mobileActionsOpen ? "Hide step actions" : "Show step actions"}
+              </span>
+            </button>
+          </div>
+        ) : null}
+      </div>
+
+      {isEditMode && mobileActionsOpen ? (
+        <div
+          id={`session-draft-step-mobile-actions-panel-${stepId}`}
+          data-testid={`session-draft-step-mobile-actions-panel-${index}`}
+          className={`${mobileActionPanelClass} sm:hidden`}
+        >
+          <div className="mt-2 grid gap-2">
+            {!showMobilePrimaryAddAfter && !isLinkedPostSetRest ? (
+              <MobileActionButton
+                testId={`session-draft-step-mobile-add-after-${index}`}
+                tone="blue"
+                onClick={onAddStepAfter}
+              >
+                Add step after
+              </MobileActionButton>
+            ) : null}
+            {canAddRepeatAfter && !showMobilePrimaryAddRepeatAfter && !isLinkedPostSetRest ? (
+              <MobileActionButton
+                testId={`session-draft-step-mobile-add-repeat-after-${index}`}
+                tone="blue"
+                onClick={onAddRepeatAfter}
+              >
+                Add repeat after
+              </MobileActionButton>
+            ) : null}
+            {isLinkedPostSetRest ? null : (
+              <MobileActionButton
+                testId={`session-draft-step-mobile-duplicate-${index}`}
+                tone="slate"
+                onClick={onDuplicate}
+              >
+                Duplicate
+              </MobileActionButton>
+            )}
+            {isLinkedPostSetRest ? null : (
+              <MobileActionButton
+                testId={`session-draft-step-mobile-remove-${index}`}
+                tone="rose"
+                onClick={onRequestRemove}
+              >
+                Delete
+              </MobileActionButton>
+            )}
+          </div>
+        </div>
+      ) : null}
+
+      {isEditMode && showMobilePrimaryAddAfter ? (
+        <div className="mt-3 flex flex-wrap gap-2 sm:hidden">
+          <button
+            type="button"
+            onClick={onAddStepAfter}
+            data-testid={`session-draft-step-mobile-primary-add-after-${index}`}
+            className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-50"
+          >
+            Add after
+          </button>
+          {showMobilePrimaryAddRepeatAfter ? (
+            <button
+              type="button"
+              onClick={onAddRepeatAfter}
+              data-testid={`session-draft-step-mobile-primary-add-repeat-after-${index}`}
+              className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-blue-50 px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-100"
+            >
+              Repeat after
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+
+      {pendingDelete ? (
+        <RemovalConfirm
+          className="mt-3"
+          label={removalLabel}
+          fallbackLabel="this step"
+          onConfirm={onConfirmRemoval}
+          onCancel={onCancelRemoval}
+        />
+      ) : null}
+
+      {editPanel}
+    </article>
+  );
+}
+
+export type SessionStepRepeatSummaryCardProps = {
+  repeatGroupId: string;
+  groupIndex: number;
+  dataManualPoolCategory?: SessionDraftStep["category"];
+  categoryRailClass?: string;
+  dataDesktopCardClickable: boolean;
+  pendingDelete: boolean;
+  isEditMode: boolean;
+  isRearrangeMode: boolean;
+  isOpen: boolean;
+  isManualPoolMode: boolean;
+  mobileActionsOpen: boolean;
+  moveUpDisabled: boolean;
+  moveDownDisabled: boolean;
+  wasRecentlyMoved: boolean;
+  summary: SessionStepSummaryContentModel & {
+    showRepeatBlockBadge: boolean;
+  };
+  editPanel: ReactNode;
+  onOpen: () => void;
+  onToggle: () => void;
+  onToggleMobileActions: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onAddStepAfter: () => void;
+  onAddRepeatAfter: () => void;
+  onDuplicate: () => void;
+  onRequestRemove: () => void;
+};
+
+export function SessionStepRepeatSummaryCard({
+  repeatGroupId,
+  groupIndex,
+  dataManualPoolCategory,
+  categoryRailClass = "",
+  dataDesktopCardClickable,
+  pendingDelete,
+  isEditMode,
+  isRearrangeMode,
+  isOpen,
+  isManualPoolMode,
+  mobileActionsOpen,
+  moveUpDisabled,
+  moveDownDisabled,
+  wasRecentlyMoved,
+  summary,
+  editPanel,
+  onOpen,
+  onToggle,
+  onToggleMobileActions,
+  onMoveUp,
+  onMoveDown,
+  onAddStepAfter,
+  onAddRepeatAfter,
+  onDuplicate,
+  onRequestRemove,
+}: SessionStepRepeatSummaryCardProps) {
+  return (
+    <section
+      key={repeatGroupId}
+      data-testid={`workout-editor-repeat-group-${groupIndex}`}
+      data-containment-style="calm"
+      data-manual-pool-category={dataManualPoolCategory}
+      data-desktop-card-clickable={dataDesktopCardClickable ? "true" : "false"}
+      onClick={
+        dataDesktopCardClickable
+          ? (event) => {
+              if (shouldIgnoreCardEditClick(event.target)) {
+                return;
+              }
+
+              onOpen();
+            }
+          : undefined
+      }
+      className={`rounded-2xl border p-3 sm:p-4 ${
+        pendingDelete
+          ? "border-dashed border-rose-300 bg-rose-50/70 ring-1 ring-rose-100 ring-inset"
+          : `border-blue-100 bg-gradient-to-b from-blue-50/70 to-white ring-1 ring-blue-100 ring-inset ${categoryRailClass}`
+      } ${wasRecentlyMoved ? recentlyMovedBlockClass : ""} ${
+        dataDesktopCardClickable && !pendingDelete ? "cursor-pointer hover:shadow-sm" : ""
+      }`}
+    >
+      <div className="space-y-3">
+        <div className={desktopHeaderStackClass}>
+          <div className={desktopSummaryBlockClass}>
+            {isRearrangeMode ? (
+              <div
+                data-testid={`session-draft-repeat-mobile-summary-${groupIndex}`}
+                className="sm:hidden"
+              >
+                <RepeatSummaryContent summary={summary} isManualPoolMode={isManualPoolMode} />
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={onToggle}
+                aria-expanded={isOpen}
+                data-testid={`session-draft-repeat-mobile-summary-${groupIndex}`}
+                className={`${mobileSummaryToggleClass} sm:hidden`}
+              >
+                <RepeatSummaryContent summary={summary} isManualPoolMode={isManualPoolMode} />
+              </button>
+            )}
+            <div
+              data-testid={`session-draft-repeat-summary-${groupIndex}`}
+              className="hidden sm:block"
+            >
+              <RepeatSummaryContent summary={summary} isManualPoolMode={isManualPoolMode} />
+            </div>
+          </div>
+          {isEditMode ? (
+            <div className="hidden shrink-0 sm:flex">
+              <button
+                type="button"
+                onClick={onToggle}
+                aria-expanded={isOpen}
+                data-testid={`session-draft-repeat-toggle-${groupIndex}`}
+                className={`inline-flex h-9 items-center justify-center rounded-xl border px-3 text-sm transition ${
+                  isOpen
+                    ? "border-blue-200 bg-blue-50 text-blue-800 hover:bg-blue-100"
+                    : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
+                }`}
+              >
+                {isOpen ? "Done" : "Edit"}
+              </button>
+            </div>
+          ) : null}
+          {isRearrangeMode ? (
+            <div
+              data-testid={`session-draft-repeat-rearrange-controls-${groupIndex}`}
+              className="flex shrink-0 flex-col gap-2 sm:flex-row sm:flex-wrap"
+            >
+              <MoveButton
+                testId={`session-draft-repeat-rearrange-move-up-${groupIndex}`}
+                disabled={moveUpDisabled}
+                onClick={onMoveUp}
+                direction="up"
+              />
+              <MoveButton
+                testId={`session-draft-repeat-rearrange-move-down-${groupIndex}`}
+                disabled={moveDownDisabled}
+                onClick={onMoveDown}
+                direction="down"
+              />
+            </div>
+          ) : isEditMode ? (
+            <div className="flex shrink-0 items-start gap-2 sm:hidden">
+              <button
+                type="button"
+                onClick={onToggle}
+                aria-expanded={isOpen}
+                aria-label={isOpen ? "Hide repeat details" : "Show repeat details"}
+                data-testid={`session-draft-repeat-mobile-toggle-${groupIndex}`}
+                className={getMobileExpandToggleClass(isOpen)}
+              >
+                {isOpen ? (
+                  <ChevronUp aria-hidden="true" className="size-4" />
+                ) : (
+                  <ChevronDown aria-hidden="true" className="size-4" />
+                )}
+              </button>
+              {isOpen ? (
+                <button
+                  type="button"
+                  onClick={onToggleMobileActions}
+                  aria-expanded={mobileActionsOpen}
+                  aria-controls={`session-draft-repeat-mobile-actions-panel-${repeatGroupId}`}
+                  data-testid={`session-draft-repeat-mobile-actions-toggle-${groupIndex}`}
+                  className={mobileActionToggleClass}
+                >
+                  <Ellipsis className="size-5" />
+                  <span className="sr-only">
+                    {mobileActionsOpen ? "Hide repeat actions" : "Show repeat actions"}
+                  </span>
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+
+        {isEditMode && isOpen ? (
+          <div className="sm:hidden">
+            <button
+              type="button"
+              onClick={onAddStepAfter}
+              data-testid={`session-draft-repeat-mobile-primary-add-step-after-${groupIndex}`}
+              className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-50"
+            >
+              Add step after
+            </button>
+          </div>
+        ) : null}
+
+        {isEditMode && isOpen && mobileActionsOpen ? (
+          <div
+            id={`session-draft-repeat-mobile-actions-panel-${repeatGroupId}`}
+            data-testid={`session-draft-repeat-mobile-actions-panel-${groupIndex}`}
+            className={`${mobileActionPanelClass} sm:hidden`}
+          >
+            <div className="mt-2 grid gap-2">
+              <MobileActionButton
+                testId={`session-draft-repeat-mobile-add-repeat-after-${groupIndex}`}
+                tone="blue"
+                onClick={onAddRepeatAfter}
+              >
+                Add repeat after
+              </MobileActionButton>
+              <MobileActionButton
+                testId={`session-draft-repeat-mobile-duplicate-${groupIndex}`}
+                tone="slate"
+                onClick={onDuplicate}
+              >
+                Duplicate repeat
+              </MobileActionButton>
+              <MobileActionButton
+                testId={`session-draft-repeat-mobile-remove-${groupIndex}`}
+                tone="rose"
+                onClick={onRequestRemove}
+              >
+                Delete repeat
+              </MobileActionButton>
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      {editPanel}
+    </section>
+  );
+}
+
+export function SessionStepSummaryContent({
+  summary,
+}: {
+  summary: SessionStepSummaryContentModel;
+}) {
+  return (
+    <>
+      <p className={`text-xs font-semibold tracking-wide uppercase ${summary.labelClassName}`}>
+        {summary.label}
+      </p>
+      <p className="mt-1 text-sm font-medium text-slate-900">{summary.title}</p>
+      {summary.categoryLabel ? (
+        <p className="mt-1 text-xs font-medium text-slate-600">{summary.categoryLabel}</p>
+      ) : null}
+      {summary.description ? (
+        <p className="mt-2 text-xs text-slate-500">{summary.description}</p>
+      ) : null}
+      {summary.targetSummary ? (
+        <p className="mt-1 text-xs text-slate-500">{summary.targetSummary}</p>
+      ) : null}
+      {summary.pendingDelete ? (
+        <p className="mt-2 text-[11px] font-semibold tracking-wide text-rose-700 uppercase">
+          Will be removed
+        </p>
+      ) : null}
+      {summary.notes ? <p className="mt-1 text-xs text-slate-400">{summary.notes}</p> : null}
+    </>
+  );
+}
+
+function RepeatSummaryContent({
+  summary,
+  isManualPoolMode,
+}: {
+  summary: SessionStepSummaryContentModel & { showRepeatBlockBadge: boolean };
+  isManualPoolMode: boolean;
+}) {
+  return (
+    <>
+      <p className={`text-xs font-semibold tracking-wide uppercase ${summary.labelClassName}`}>
+        {summary.label}
+      </p>
+      {isManualPoolMode && summary.showRepeatBlockBadge ? (
+        <p className="mt-2">
+          <span className="inline-flex rounded-full border border-blue-200 bg-white px-3 py-1 text-[11px] font-semibold tracking-wide text-blue-700 uppercase">
+            Repeat block
+          </span>
+        </p>
+      ) : null}
+      <p className="mt-2 text-sm font-medium text-slate-900">{summary.title}</p>
+      {summary.pendingDelete ? (
+        <p className="mt-2 text-[11px] font-semibold tracking-wide text-rose-700 uppercase">
+          Will be removed
+        </p>
+      ) : null}
+    </>
+  );
+}
+
+function MoveButton({
+  testId,
+  disabled,
+  onClick,
+  direction,
+}: {
+  testId: string;
+  disabled: boolean;
+  onClick: () => void;
+  direction: "up" | "down";
+}) {
+  const Icon = direction === "up" ? ArrowUp : ArrowDown;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={`Move ${direction}`}
+      title={`Move ${direction}`}
+      data-testid={testId}
+      className={rearrangeMoveButtonClass}
+    >
+      <Icon aria-hidden="true" className="size-4" />
+    </button>
+  );
+}
+
+function MobileActionButton({
+  testId,
+  tone,
+  onClick,
+  children,
+}: {
+  testId: string;
+  tone: "blue" | "slate" | "rose";
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  const toneClass =
+    tone === "blue"
+      ? "border-blue-200 bg-white text-blue-800 hover:bg-blue-50"
+      : tone === "rose"
+        ? "border-rose-200 bg-white text-rose-700 hover:bg-rose-50"
+        : "border-slate-200 bg-white text-slate-700 hover:bg-slate-100";
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid={testId}
+      className={`${mobileSecondaryActionClass} ${toneClass}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function RemovalConfirm({
+  className = "",
+  label,
+  fallbackLabel,
+  onConfirm,
+  onCancel,
+}: {
+  className?: string;
+  label: string | null;
+  fallbackLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div
+      data-testid="workout-editor-removal-confirm"
+      className={`${className} rounded-2xl border border-rose-200 bg-rose-50/90 p-3`}
+    >
+      <p className="text-sm font-medium text-rose-950">
+        Delete <span className="font-semibold">{label ?? fallbackLabel}</span>?
+      </p>
+      <p className="mt-1 text-sm text-rose-900">
+        This builder change stays local until you save, and you can still undo it right after
+        deletion.
+      </p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={onConfirm}
+          data-testid="workout-editor-removal-confirm-button"
+          className="inline-flex h-10 items-center justify-center rounded-xl bg-rose-600 px-4 text-sm font-semibold text-white transition hover:bg-rose-500 active:bg-rose-700"
+        >
+          Delete now
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          data-testid="workout-editor-removal-cancel-button"
+          className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-900 transition hover:bg-rose-100 active:bg-rose-200"
+        >
+          Keep it
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function shouldIgnoreCardEditClick(target: EventTarget | null) {
+  if (!(target instanceof Element)) return false;
+
+  return Boolean(
+    target.closest(
+      'button, a, input, select, textarea, [role="button"], [data-card-click-ignore="true"]'
+    )
+  );
+}

--- a/components/my-library/workouts/WorkoutEditor.tsx
+++ b/components/my-library/workouts/WorkoutEditor.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowDown, ArrowUp, ChevronDown, ChevronUp, Ellipsis } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -11,6 +10,13 @@ import {
   type TextareaHTMLAttributes,
 } from "react";
 import PoolsideNotePanel from "@/components/my-library/workouts/PoolsideNotePanel";
+import {
+  RemovalConfirm,
+  SessionStepRepeatSummaryCard,
+  SessionStepSummaryCard,
+  SessionStepSurfaceRenderer,
+  type SessionStepSurfaceMode,
+} from "@/components/my-library/workouts/SessionStepSurfaceRenderer";
 import {
   MANUAL_POOL_REST_DURATION_MODES,
   applyRecommendedStepFocus,
@@ -34,8 +40,6 @@ import {
   getManualPoolCategoryRailClass,
   getManualPoolDrillNameInputValue,
   getManualPoolDurationModesForCategory,
-  getManualPoolViewSectionHeaderClass,
-  getManualPoolViewSectionToneClass,
   getRecommendedStepFocus,
   getStepDurationModeEditorLabel,
   getStepTargetModeEditorLabel,
@@ -201,13 +205,6 @@ const MANUAL_POOL_VISIBLE_STEP_INTENSITY_PRESETS = [
   "ascending",
   "descending",
 ] as const satisfies readonly SessionDraftStepIntensityPreset[];
-const WORKOUT_VIEW_MODES = ["edit", "rearrange", "view"] as const;
-const WORKOUT_VIEW_MODE_LABELS: Record<(typeof WORKOUT_VIEW_MODES)[number], string> = {
-  edit: "Edit",
-  rearrange: "Rearrange",
-  view: "View",
-};
-
 type LastRemovedBlock = {
   kind: "step" | "repeat";
   label: string;
@@ -227,15 +224,9 @@ type SupportSectionKey = "readiness" | "garminExport" | "handoff";
 const CUSTOM_DISTANCE_VALUE = "custom";
 const EMPTY_WORKOUT_POOLSIDE_FOCUS_OPTIONS: WorkoutPoolsideFocusOption[] = [];
 const DESKTOP_CARD_EDIT_MEDIA_QUERY = "(hover: hover) and (pointer: fine)";
-const CARD_EDIT_IGNORE_SELECTOR =
-  "button, a, input, select, textarea, summary, [role='button'], [role='link'], [data-card-edit-ignore='true']";
 
 function getPoolBuilderAutoTitle(environment: SessionGeneratorEnvironment | null | undefined) {
   return environment === "pool" ? "Untitled pool session" : null;
-}
-
-function shouldIgnoreCardEditClick(target: EventTarget | null) {
-  return target instanceof Element && Boolean(target.closest(CARD_EDIT_IGNORE_SELECTOR));
 }
 
 function syncAutoGrowingTextareaHeight(node: HTMLTextAreaElement, minRows: number) {
@@ -794,8 +785,7 @@ export default function WorkoutEditor({
       forceMetadataOpenOnLoad ||
       (copyVariant !== "generator" && !(savedWorkout && copyVariant === "default"))
   );
-  const [builderViewMode, setBuilderViewMode] =
-    useState<(typeof WORKOUT_VIEW_MODES)[number]>("edit");
+  const [builderViewMode, setBuilderViewMode] = useState<SessionStepSurfaceMode>("edit");
   const [selectedPoolsideFocusIds, setSelectedPoolsideFocusIds] = useState<string[]>(() =>
     getDefaultWorkoutPoolsideFocusIds(trainingFocusOptions)
   );
@@ -992,25 +982,6 @@ export default function WorkoutEditor({
   const supportPreviewShellClass =
     "mt-4 overflow-hidden rounded-2xl border border-slate-200 bg-slate-950";
   const supportSummaryItemClass = "rounded-xl bg-slate-100/80 p-3 sm:p-4";
-  const mobileSummaryToggleClass =
-    "w-full rounded-2xl text-left outline-none transition focus-visible:ring-2 focus-visible:ring-blue-200";
-  const mobileIconButtonBaseClass =
-    "inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border transition";
-  const mobileActionToggleClass = `${mobileIconButtonBaseClass} border-slate-200 bg-white text-slate-700 hover:bg-slate-50 active:bg-slate-100`;
-  const getMobileExpandToggleClass = (expanded: boolean) =>
-    `${mobileIconButtonBaseClass} ${
-      expanded
-        ? "border-blue-200 bg-blue-50 text-blue-800 hover:bg-blue-100 active:bg-blue-100"
-        : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50 active:bg-slate-100"
-    }`;
-  const mobileActionPanelClass = "mt-3 rounded-2xl border border-slate-200 bg-slate-50/90 p-2.5";
-  const mobileSecondaryActionClass =
-    "inline-flex min-h-10 w-full items-center justify-start rounded-xl border px-3 py-2 text-sm font-medium transition";
-  const rearrangeMoveButtonClass =
-    "inline-flex h-10 w-12 items-center justify-center rounded-xl border border-slate-200 bg-white text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 sm:h-9 sm:w-10";
-  const recentlyMovedBlockClass = "bg-teal-50/80 shadow-sm ring-2 ring-inset ring-teal-300";
-  const desktopHeaderStackClass = "flex items-start justify-between gap-3";
-  const desktopSummaryBlockClass = "min-w-0 flex-1";
   const desktopRepeatControlRowClass = "grid gap-3";
   const isEditMode = builderViewMode === "edit";
   const isRearrangeMode = builderViewMode === "rearrange";
@@ -2374,7 +2345,6 @@ export default function WorkoutEditor({
     const insideRepeatGroup = options?.insideRepeatGroup ?? false;
     const isLinkedPostSetRest = options?.isLinkedPostSetRest ?? false;
     const isOpen = isEditMode && openStepId === step.id;
-    const toggleLabel = isOpen ? "Done" : "Edit";
     const panelId = `session-draft-step-panel-${step.id}`;
     const normalizedStep = isManualPoolMode ? normalizeManualPoolStepForEditor(step) : step;
     const isGeneratorSummaryCard = copyVariant === "generator";
@@ -2488,45 +2458,23 @@ export default function WorkoutEditor({
     const showManualPoolDrillNameField =
       isManualPoolMode && !isMinimalRestEditor && isManualPoolDrillNameRelevantStep(normalizedStep);
     const manualPoolDrillNameHelpId = `session-draft-step-drill-name-help-${step.id}`;
-    const stepSummaryContent = (
-      <>
-        <p
-          className={`text-xs font-semibold tracking-wide uppercase ${topLevelCategoryLabelClass}`}
-        >
-          {stepLabel}
-        </p>
-        <p className="mt-1 text-sm font-medium text-slate-900">{stepTitle}</p>
-        {!isManualPoolMode && !isGeneratorSummaryCard ? (
-          <p className="mt-1 text-xs font-medium text-slate-600">
-            {getSessionStepCategoryLabel(step.category)}
-          </p>
-        ) : null}
-        {!isManualPoolMode && !isGeneratorSummaryCard ? (
-          <p className="mt-2 text-xs text-slate-600">
-            {buildStepSummary(
-              step,
-              draft.basePaceSecondsPer100m,
-              draft.environment,
-              poolLengthUnit
-            )}
-          </p>
-        ) : null}
-        {options?.descriptionOverride ? (
-          <p className="mt-2 text-xs text-slate-500">{options.descriptionOverride}</p>
-        ) : null}
-        {!isManualPoolMode && !isGeneratorSummaryCard && step.targetSummary ? (
-          <p className="mt-1 text-xs text-slate-500">{step.targetSummary}</p>
-        ) : null}
-        {pendingDelete ? (
-          <p className="mt-2 text-[11px] font-semibold tracking-wide text-rose-700 uppercase">
-            Will be removed
-          </p>
-        ) : null}
-        {!isGeneratorSummaryCard && stepNotes ? (
-          <p className="mt-1 text-xs text-slate-400">{stepNotes}</p>
-        ) : null}
-      </>
-    );
+    const stepSummary = {
+      label: stepLabel,
+      title: stepTitle,
+      labelClassName: topLevelCategoryLabelClass,
+      categoryLabel:
+        !isManualPoolMode && !isGeneratorSummaryCard
+          ? getSessionStepCategoryLabel(step.category)
+          : null,
+      description:
+        options?.descriptionOverride ??
+        (!isManualPoolMode && !isGeneratorSummaryCard
+          ? buildStepSummary(step, draft.basePaceSecondsPer100m, draft.environment, poolLengthUnit)
+          : null),
+      targetSummary: !isManualPoolMode && !isGeneratorSummaryCard ? step.targetSummary : null,
+      pendingDelete,
+      notes: !isGeneratorSummaryCard ? stepNotes : null,
+    };
     const isTerminalSessionStepBlock =
       isTopLevelSessionStepBlock && sessionStepBlockIndex === sessionStepEditBlocks.length - 1;
     const moveUpDisabled = isTopLevelSessionStepBlock
@@ -2756,888 +2704,1004 @@ export default function WorkoutEditor({
         setOpenRepeatGroupId(normalizedStep.repeatGroupId);
       }
     };
-
-    return (
-      <article
-        key={step.id}
-        data-mobile-actions="progressive"
-        data-manual-pool-category={
-          isTopLevelSessionStepBlock && !pendingDelete ? normalizedStep.category : undefined
-        }
-        data-desktop-card-clickable={canUseDesktopCardOpen ? "true" : "false"}
-        onClick={
-          canUseDesktopCardOpen
-            ? (event) => {
-                if (shouldIgnoreCardEditClick(event.target)) {
-                  return;
-                }
-
-                openStepCard();
+    const toggleMobileStepActions = () =>
+      setOpenMobileActionKey((current) => (current === mobileActionKey ? null : mobileActionKey));
+    const requestRemoveStep = () => {
+      requestStepRemoval(step.id);
+      setOpenMobileActionKey(null);
+    };
+    const editPanel = isOpen ? (
+      <div id={panelId} className="mt-4 grid gap-4 md:grid-cols-2">
+        {isManualPoolMode ? null : (
+          <label className="text-sm text-slate-700">
+            Step name
+            <input
+              type="text"
+              value={step.name}
+              onChange={(event) =>
+                updateDraftStep(step.id, (current) => ({
+                  ...current,
+                  name: event.target.value,
+                }))
               }
-            : undefined
-        }
-        className={`rounded-2xl border p-3 transition sm:p-4 ${cardStateClass} ${topLevelCategoryRailClass} ${
-          stepWasRecentlyMoved ? recentlyMovedBlockClass : ""
-        } ${
-          canUseDesktopCardOpen && !pendingDelete
-            ? "cursor-pointer hover:border-blue-200 hover:bg-white hover:shadow-sm"
-            : ""
-        }`}
-      >
-        <div className={desktopHeaderStackClass}>
-          <div className={desktopSummaryBlockClass}>
-            {isSummaryOnlyMode || showRearrangeControls ? (
-              <div data-testid={`session-draft-step-mobile-summary-${index}`} className="sm:hidden">
-                {stepSummaryContent}
-              </div>
-            ) : (
-              <button
-                type="button"
-                onClick={toggleStepCard}
-                aria-expanded={isOpen}
-                aria-controls={panelId}
-                data-testid={`session-draft-step-mobile-summary-${index}`}
-                className={`${mobileSummaryToggleClass} sm:hidden`}
+              data-testid={`session-draft-step-name-${index}`}
+              className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+            />
+          </label>
+        )}
+
+        <label className="text-sm text-slate-700">
+          {isManualPoolMode ? "Step Type" : "Category"}
+          <select
+            value={stepCategoryValue}
+            disabled={isLinkedPostSetRest}
+            onChange={(event) =>
+              updateDraftStep(step.id, (current) =>
+                applyRecommendedStepFocus(current, {
+                  category: event.target.value as SessionDraftStepCategory,
+                })
+              )
+            }
+            className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+          >
+            {(isLinkedPostSetRest
+              ? (["rest"] as const)
+              : isManualPoolMode
+                ? MANUAL_POOL_VISIBLE_STEP_CATEGORIES
+                : SESSION_DRAFT_STEP_CATEGORIES
+            ).map((value) => (
+              <option key={value} value={value}>
+                {getSessionStepCategoryLabel(value)}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {isMinimalRestEditor ? null : (
+          <label className="text-sm text-slate-700">
+            {isManualPoolMode ? "Stroke Type" : "Stroke pattern"}
+            <select
+              value={stepStrokeValue}
+              onChange={(event) => {
+                const nextStroke = event.target.value as SessionDraftStep["stroke"];
+
+                updateDraftStep(step.id, (current) =>
+                  applyRecommendedStepFocus(current, {
+                    stroke: nextStroke,
+                  })
+                );
+              }}
+              data-testid={`session-draft-step-stroke-${index}`}
+              className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+            >
+              {(isManualPoolMode
+                ? MANUAL_POOL_VISIBLE_STEP_STROKES
+                : SESSION_DRAFT_STEP_STROKES
+              ).map((value) => (
+                <option key={value} value={value}>
+                  {getSessionStepStrokeLabel(value)}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        {isMinimalRestEditor ? null : (
+          <label className="text-sm text-slate-700">
+            {isManualPoolMode ? "Drill Type" : "Focus tag"}
+            <select
+              value={stepDrillTypeValue}
+              onChange={(event) =>
+                updateDraftStep(step.id, (current) => ({
+                  ...current,
+                  drillType: event.target.value as NonNullable<SessionDraftStep["drillType"]>,
+                }))
+              }
+              data-testid={`session-draft-step-drill-type-${index}`}
+              className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+            >
+              {SESSION_DRAFT_STEP_DRILL_TYPES.map((value) => (
+                <option key={value} value={value}>
+                  {getSessionStepDrillTypeLabel(value)}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        {showManualPoolDrillNameField ? (
+          <div className="text-sm text-slate-700">
+            <label htmlFor={`session-draft-step-drill-name-${step.id}`}>Drill name</label>
+            <input
+              id={`session-draft-step-drill-name-${step.id}`}
+              type="text"
+              value={getManualPoolDrillNameInputValue(normalizedStep)}
+              onChange={(event) =>
+                updateDraftStep(step.id, (current) => ({
+                  ...current,
+                  name: event.target.value,
+                }))
+              }
+              aria-describedby={manualPoolDrillNameHelpId}
+              placeholder="Catch drill"
+              data-testid={`session-draft-step-drill-name-${index}`}
+              className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+            />
+            <p id={manualPoolDrillNameHelpId} className="mt-2 text-sm text-slate-500">
+              Names the drill. Use Notes for execution cues.
+            </p>
+          </div>
+        ) : null}
+
+        {isManualPoolMode || isMinimalRestEditor ? null : (
+          <>
+            <p className="text-sm text-slate-500 md:col-span-2">
+              {buildStepStrokeGuidance(step, isManualPoolMode)}
+            </p>
+            <p className="text-sm text-slate-500 md:col-span-2">
+              {buildStepFocusGuidance(step, isManualPoolMode)}
+            </p>
+          </>
+        )}
+
+        {isMinimalRestEditor ? null : (
+          <label className="text-sm text-slate-700">
+            Equipment
+            <select
+              value={stepEquipmentValue}
+              onChange={(event) =>
+                updateDraftStep(step.id, (current) => ({
+                  ...current,
+                  equipment: event.target.value as NonNullable<SessionDraftStep["equipment"]>,
+                }))
+              }
+              data-testid={`session-draft-step-equipment-${index}`}
+              className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+            >
+              {SESSION_DRAFT_STEP_EQUIPMENT.map((value) => (
+                <option key={value} value={value}>
+                  {getSessionStepEquipmentLabel(value)}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        {isManualPoolMode || isMinimalRestEditor ? null : (
+          <label className="text-sm text-slate-700">
+            Effort
+            <select
+              value={stepIntensityValue}
+              onChange={(event) =>
+                updateDraftStep(step.id, (current) => ({
+                  ...current,
+                  intensity: event.target.value as SessionDraftStepIntensityPreset,
+                }))
+              }
+              className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+            >
+              {(isManualPoolMode
+                ? MANUAL_POOL_VISIBLE_STEP_INTENSITY_PRESETS
+                : SESSION_DRAFT_STEP_INTENSITY_PRESETS
+              ).map((value) => (
+                <option key={value} value={value}>
+                  {getSessionStepIntensityLabel(value)}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        <label className="text-sm text-slate-700">
+          {isManualPoolMode ? "Duration" : "Duration mode"}
+          <select
+            value={stepDurationModeValue}
+            onChange={(event) =>
+              updateStepDurationMode(step.id, event.target.value as SessionDraftStepDurationMode)
+            }
+            data-testid={`session-draft-step-duration-mode-${index}`}
+            className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+          >
+            {(isManualPoolMode
+              ? getManualPoolDurationModesForCategory(stepCategoryValue)
+              : SESSION_DRAFT_STEP_DURATION_MODES
+            ).map((value) => (
+              <option key={value} value={value}>
+                {getStepDurationModeEditorLabel(value, isManualPoolMode)}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {step.durationMode === "distance" ? (
+          <div className="grid gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-3 sm:p-4 md:col-span-2 md:grid-cols-2">
+            <label className="text-sm text-slate-700">
+              Distance
+              <select
+                value={
+                  selectedDistancePreset ? String(selectedDistancePreset) : CUSTOM_DISTANCE_VALUE
+                }
+                onChange={(event) =>
+                  updateStepDistanceSelection(step.id, event.target.value, stepDistanceUnit)
+                }
+                data-testid={`session-draft-step-distance-${index}`}
+                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
               >
-                {stepSummaryContent}
-              </button>
-            )}
-            <div data-testid={`session-draft-step-summary-${index}`} className="hidden sm:block">
-              {stepSummaryContent}
+                {SESSION_DRAFT_STEP_DISTANCE_PRESETS.map((value) => (
+                  <option key={value} value={String(value)}>
+                    {stepDistanceUnit === "yd" ? `${value}yd` : formatDistanceMetersLabel(value)}
+                  </option>
+                ))}
+                <option value={CUSTOM_DISTANCE_VALUE}>Custom distance</option>
+              </select>
+            </label>
+            {!selectedDistancePreset ? (
+              <label className="text-sm text-slate-700">
+                {`Custom distance (${stepDistanceUnit})`}
+                <input
+                  ref={(node) => {
+                    customDistanceInputRefs.current[step.id] = node;
+                  }}
+                  type="text"
+                  inputMode="decimal"
+                  value={formatEditableDistance(step.distanceM, stepDistanceUnit)}
+                  onChange={(event) =>
+                    updateDraftStep(step.id, (current) => ({
+                      ...current,
+                      distanceM: parseDistanceInput(event.target.value, stepDistanceUnit),
+                    }))
+                  }
+                  data-testid={`session-draft-step-distance-custom-${index}`}
+                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                />
+              </label>
+            ) : null}
+          </div>
+        ) : step.durationMode === "fixed_rest" && isManualPoolMode ? (
+          <label className="text-sm text-slate-700">
+            Rest time
+            <input
+              type="text"
+              inputMode="numeric"
+              placeholder="MM:SS"
+              value={timeDurationInputs[step.id] ?? ""}
+              onFocus={() => {
+                timeDurationInputFocusRef.current[step.id] = true;
+              }}
+              onBlur={() => {
+                commitTimeDurationInput(step.id);
+              }}
+              onChange={(event) => handleTimeDurationInputChange(step.id, event.target.value)}
+              data-testid={`session-draft-step-rest-time-${index}`}
+              className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+            />
+          </label>
+        ) : step.durationMode === "fixed_rest" ? (
+          <div className="grid gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-3 sm:p-4 md:col-span-2 md:grid-cols-[1fr_1fr_auto]">
+            <label className="text-sm text-slate-700">
+              Minutes
+              <input
+                type="text"
+                inputMode="numeric"
+                value={getDurationMinutes(step.timeMin)}
+                onChange={(event) =>
+                  updateStepDurationClock(step.id, "minutes", event.target.value)
+                }
+                data-testid={`session-draft-step-rest-minutes-${index}`}
+                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+              />
+            </label>
+            <label className="text-sm text-slate-700">
+              Seconds
+              <input
+                type="text"
+                inputMode="numeric"
+                value={getDurationSeconds(step.timeMin)}
+                onChange={(event) =>
+                  updateStepDurationClock(step.id, "seconds", event.target.value)
+                }
+                data-testid={`session-draft-step-rest-seconds-${index}`}
+                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+              />
+            </label>
+            <div className="self-end text-sm text-slate-500">
+              {step.timeMin
+                ? `Fixed Rest Time ${formatClockDurationLabel(step.timeMin)}`
+                : "Set Fixed Rest Time"}
             </div>
           </div>
-          {isEditMode ? (
-            <div className="hidden shrink-0 sm:flex">
-              <button
-                type="button"
-                onClick={toggleStepCard}
-                aria-expanded={isOpen}
-                aria-controls={panelId}
-                data-testid={`session-draft-step-toggle-${index}`}
-                className={`inline-flex h-9 items-center justify-center rounded-xl border px-3 text-sm transition ${
-                  isOpen
-                    ? "border-blue-200 bg-blue-50 text-blue-800 hover:bg-blue-100"
-                    : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
-                }`}
-              >
-                {toggleLabel}
-              </button>
-            </div>
-          ) : null}
-          {showRearrangeControls ? (
-            <div
-              data-testid={`session-draft-step-rearrange-controls-${index}`}
-              className="flex shrink-0 flex-col gap-2 sm:flex-row sm:flex-wrap"
-            >
-              <button
-                type="button"
-                onClick={handleMoveUp}
-                disabled={moveUpDisabled}
-                aria-label="Move up"
-                title="Move up"
-                data-testid={`session-draft-step-rearrange-move-up-${index}`}
-                className={rearrangeMoveButtonClass}
-              >
-                <ArrowUp aria-hidden="true" className="size-4" />
-              </button>
-              <button
-                type="button"
-                onClick={handleMoveDown}
-                disabled={moveDownDisabled}
-                aria-label="Move down"
-                title="Move down"
-                data-testid={`session-draft-step-rearrange-move-down-${index}`}
-                className={rearrangeMoveButtonClass}
-              >
-                <ArrowDown aria-hidden="true" className="size-4" />
-              </button>
-            </div>
-          ) : isEditMode ? (
-            <div className="flex shrink-0 items-start gap-2 sm:hidden">
-              <button
-                type="button"
-                onClick={toggleStepCard}
-                aria-expanded={isOpen}
-                aria-controls={panelId}
-                aria-label={isOpen ? "Hide step details" : "Show step details"}
-                data-testid={`session-draft-step-mobile-toggle-${index}`}
-                className={getMobileExpandToggleClass(isOpen)}
-              >
-                {isOpen ? (
-                  <ChevronUp aria-hidden="true" className="size-4" />
-                ) : (
-                  <ChevronDown aria-hidden="true" className="size-4" />
-                )}
-              </button>
-              <button
-                type="button"
-                onClick={() =>
-                  setOpenMobileActionKey((current) =>
-                    current === mobileActionKey ? null : mobileActionKey
-                  )
+        ) : step.durationMode === "time" ? (
+          <label className="text-sm text-slate-700">
+            {isManualPoolMode ? "Time" : "Time (min)"}
+            <input
+              type="text"
+              inputMode="numeric"
+              placeholder={isManualPoolMode ? "MM:SS" : undefined}
+              value={isManualPoolMode ? (timeDurationInputs[step.id] ?? "") : (step.timeMin ?? "")}
+              onFocus={() => {
+                if (!isManualPoolMode) return;
+                timeDurationInputFocusRef.current[step.id] = true;
+              }}
+              onBlur={() => {
+                if (!isManualPoolMode) return;
+                commitTimeDurationInput(step.id);
+              }}
+              onChange={(event) =>
+                isManualPoolMode
+                  ? handleTimeDurationInputChange(step.id, event.target.value)
+                  : updateDraftStep(step.id, (current) => ({
+                      ...current,
+                      timeMin: parsePositiveNumber(event.target.value),
+                    }))
+              }
+              data-testid={`session-draft-step-time-${index}`}
+              className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+            />
+          </label>
+        ) : step.durationMode === "send_off" && isManualPoolMode ? (
+          <label className="text-sm text-slate-700">
+            Send-off time
+            <input
+              type="text"
+              inputMode="numeric"
+              placeholder="MM:SS"
+              value={timeDurationInputs[step.id] ?? ""}
+              onFocus={() => {
+                timeDurationInputFocusRef.current[step.id] = true;
+              }}
+              onBlur={() => {
+                commitTimeDurationInput(step.id);
+              }}
+              onChange={(event) => handleTimeDurationInputChange(step.id, event.target.value)}
+              data-testid={`session-draft-step-sendoff-time-${index}`}
+              className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+            />
+          </label>
+        ) : step.durationMode === "send_off" ? (
+          <div className="grid gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-3 sm:p-4 md:col-span-2 md:grid-cols-[1fr_1fr_auto]">
+            <label className="text-sm text-slate-700">
+              Minutes
+              <input
+                type="text"
+                inputMode="numeric"
+                value={getDurationMinutes(step.timeMin)}
+                onChange={(event) =>
+                  updateStepDurationClock(step.id, "minutes", event.target.value)
                 }
-                aria-expanded={mobileActionsOpen}
-                aria-controls={`session-draft-step-mobile-actions-panel-${step.id}`}
-                data-testid={`session-draft-step-mobile-actions-toggle-${index}`}
-                className={mobileActionToggleClass}
-              >
-                <Ellipsis className="size-5" />
-                <span className="sr-only">
-                  {mobileActionsOpen ? "Hide step actions" : "Show step actions"}
-                </span>
-              </button>
+                data-testid={`session-draft-step-sendoff-minutes-${index}`}
+                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+              />
+            </label>
+            <label className="text-sm text-slate-700">
+              Seconds
+              <input
+                type="text"
+                inputMode="numeric"
+                value={getDurationSeconds(step.timeMin)}
+                onChange={(event) =>
+                  updateStepDurationClock(step.id, "seconds", event.target.value)
+                }
+                data-testid={`session-draft-step-sendoff-seconds-${index}`}
+                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+              />
+            </label>
+            <div className="self-end text-sm text-slate-500">
+              {step.timeMin
+                ? `Send-Off Time ${formatClockDurationLabel(step.timeMin)}`
+                : "Set Send-Off Time"}
             </div>
-          ) : null}
-        </div>
+          </div>
+        ) : step.durationMode === "css_send_off" ? (
+          <label className="text-sm text-slate-700 md:col-span-2">
+            CSS-Based Send-Off Time
+            <select
+              value={String(step.cssSendOffOffsetSeconds ?? 0)}
+              onChange={(event) =>
+                updateDraftStep(step.id, (current) => ({
+                  ...current,
+                  cssSendOffOffsetSeconds: Number.parseInt(event.target.value, 10),
+                }))
+              }
+              data-testid={`session-draft-step-css-sendoff-offset-${index}`}
+              className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+            >
+              {SESSION_DRAFT_STEP_CSS_TARGET_OFFSETS.map((value) => {
+                const sign = value > 0 ? "+" : "";
+                return (
+                  <option key={value} value={String(value)}>
+                    {`CSS ${sign}${value}s (${formatClockDurationLabelFromSeconds(
+                      draft.basePaceSecondsPer100m + value
+                    )})`}
+                  </option>
+                );
+              })}
+            </select>
+          </label>
+        ) : null}
 
-        {isEditMode && mobileActionsOpen ? (
-          <div
-            id={`session-draft-step-mobile-actions-panel-${step.id}`}
-            data-testid={`session-draft-step-mobile-actions-panel-${index}`}
-            className={`${mobileActionPanelClass} sm:hidden`}
-          >
-            <div className="mt-2 grid gap-2">
-              {!showMobilePrimaryAddAfter && !isLinkedPostSetRest ? (
-                <button
-                  type="button"
-                  onClick={handleAddStepAfter}
-                  data-testid={`session-draft-step-mobile-add-after-${index}`}
-                  className={`${mobileSecondaryActionClass} border-blue-200 bg-white text-blue-800 hover:bg-blue-50`}
-                >
-                  Add step after
-                </button>
-              ) : null}
-              {!showMobilePrimaryAddRepeatAfter && !insideRepeatGroup && !isLinkedPostSetRest ? (
-                <button
-                  type="button"
-                  onClick={handleAddRepeatAfter}
-                  data-testid={`session-draft-step-mobile-add-repeat-after-${index}`}
-                  className={`${mobileSecondaryActionClass} border-blue-200 bg-white text-blue-800 hover:bg-blue-50`}
-                >
-                  Add repeat after
-                </button>
-              ) : null}
-              {isLinkedPostSetRest ? null : (
-                <button
-                  type="button"
-                  onClick={handleDuplicate}
-                  data-testid={`session-draft-step-mobile-duplicate-${index}`}
-                  className={`${mobileSecondaryActionClass} border-slate-200 bg-white text-slate-700 hover:bg-slate-100`}
-                >
-                  Duplicate
-                </button>
-              )}
-              {isLinkedPostSetRest ? null : (
-                <button
-                  type="button"
-                  onClick={() => {
-                    requestStepRemoval(step.id);
-                    setOpenMobileActionKey(null);
-                  }}
-                  data-testid={`session-draft-step-mobile-remove-${index}`}
-                  className={`${mobileSecondaryActionClass} border-rose-200 bg-white text-rose-700 hover:bg-rose-50`}
-                >
-                  Delete
-                </button>
-              )}
+        {isMinimalRestEditor ? null : (
+          <label className="text-sm text-slate-700">
+            {isManualPoolMode ? "Target" : "Target mode"}
+            <select
+              value={stepTargetModeValue}
+              onChange={(event) =>
+                updateDraftStep(step.id, (current) => ({
+                  ...current,
+                  targetMode: event.target.value as NonNullable<SessionDraftStep["targetMode"]>,
+                  effortTarget:
+                    event.target.value === "effort"
+                      ? (current.effortTarget ?? current.intensity)
+                      : null,
+                  targetPaceSecondsPer100m:
+                    event.target.value === "target_pace" ? current.targetPaceSecondsPer100m : null,
+                  cssTargetOffsetSeconds:
+                    event.target.value === "css_target_pace"
+                      ? (current.cssTargetOffsetSeconds ?? 0)
+                      : null,
+                }))
+              }
+              data-testid={`session-draft-step-target-mode-${index}`}
+              className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+            >
+              {SESSION_DRAFT_STEP_TARGET_MODES.map((value) => (
+                <option key={value} value={value}>
+                  {getStepTargetModeEditorLabel(value, isManualPoolMode)}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        {!isMinimalRestEditor && stepTargetModeValue === "effort" ? (
+          <label className="text-sm text-slate-700">
+            {isManualPoolMode ? "Effort" : "Target effort"}
+            <select
+              value={stepEffortTargetValue}
+              onChange={(event) =>
+                updateDraftStep(step.id, (current) => ({
+                  ...current,
+                  effortTarget: event.target.value as SessionDraftStepIntensityPreset,
+                }))
+              }
+              data-testid={`session-draft-step-target-effort-${index}`}
+              className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+            >
+              {(isManualPoolMode
+                ? MANUAL_POOL_VISIBLE_STEP_INTENSITY_PRESETS
+                : SESSION_DRAFT_STEP_INTENSITY_PRESETS
+              ).map((value) => (
+                <option key={value} value={value}>
+                  {getSessionStepIntensityLabel(value)}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
+
+        {!isMinimalRestEditor && stepTargetModeValue === "target_pace" ? (
+          <div className="grid gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-3 sm:p-4 md:col-span-2 md:grid-cols-[1fr_1fr_auto]">
+            <label className="text-sm text-slate-700">
+              Pace minutes
+              <input
+                type="text"
+                inputMode="numeric"
+                value={getPaceMinutes(step.targetPaceSecondsPer100m)}
+                onChange={(event) => updateStepTargetPace(step.id, "minutes", event.target.value)}
+                data-testid={`session-draft-step-target-pace-minutes-${index}`}
+                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+              />
+            </label>
+            <label className="text-sm text-slate-700">
+              Pace seconds
+              <input
+                type="text"
+                inputMode="numeric"
+                value={getPaceSeconds(step.targetPaceSecondsPer100m)}
+                onChange={(event) => updateStepTargetPace(step.id, "seconds", event.target.value)}
+                data-testid={`session-draft-step-target-pace-seconds-${index}`}
+                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+              />
+            </label>
+            <div className="self-end text-sm text-slate-500">
+              {step.targetPaceSecondsPer100m
+                ? formatPaceSecondsPer100m(step.targetPaceSecondsPer100m, poolLengthUnit)
+                : "Set pace"}
             </div>
           </div>
         ) : null}
 
-        {isEditMode && showMobilePrimaryAddAfter ? (
-          <div className="mt-3 flex flex-wrap gap-2 sm:hidden">
-            <button
-              type="button"
-              onClick={handleAddStepAfter}
-              data-testid={`session-draft-step-mobile-primary-add-after-${index}`}
-              className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-50"
+        {!isMinimalRestEditor && stepTargetModeValue === "css_target_pace" ? (
+          <label className="text-sm text-slate-700 md:col-span-2">
+            CSS pace offset
+            <select
+              value={String(step.cssTargetOffsetSeconds ?? 0)}
+              onChange={(event) =>
+                updateDraftStep(step.id, (current) => ({
+                  ...current,
+                  cssTargetOffsetSeconds: Number.parseInt(event.target.value, 10),
+                }))
+              }
+              data-testid={`session-draft-step-css-offset-${index}`}
+              className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
             >
-              Add after
-            </button>
-            {showMobilePrimaryAddRepeatAfter ? (
+              {SESSION_DRAFT_STEP_CSS_TARGET_OFFSETS.map((value) => {
+                const sign = value > 0 ? "+" : "";
+                return (
+                  <option key={value} value={String(value)}>
+                    {`CSS ${sign}${value}s (${formatPaceSecondsPer100m(
+                      draft.basePaceSecondsPer100m + value,
+                      poolLengthUnit
+                    )})`}
+                  </option>
+                );
+              })}
+            </select>
+          </label>
+        ) : null}
+
+        {isManualPoolMode || isMinimalRestEditor ? null : (
+          <label className="text-sm text-slate-700 md:col-span-2">
+            Target notes
+            <input
+              type="text"
+              value={step.targetSummary}
+              onChange={(event) =>
+                updateDraftStep(step.id, (current) => ({
+                  ...current,
+                  targetSummary: event.target.value,
+                }))
+              }
+              className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+            />
+          </label>
+        )}
+
+        <label className="text-sm text-slate-700 md:col-span-2">
+          {isManualPoolMode ? "Notes" : "Notes"}
+          <AutoGrowingTextarea
+            aria-label={isManualPoolMode ? "Notes" : "Notes"}
+            value={step.notes}
+            onChange={(event) =>
+              updateDraftStep(step.id, (current) => ({
+                ...current,
+                notes: event.target.value,
+              }))
+            }
+            minRows={isManualPoolMode ? 1 : 3}
+            className="mt-2 block w-full resize-y rounded-xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+          />
+        </label>
+
+        {attachedRestEditor}
+
+        {isEditMode ? (
+          <div
+            data-testid={`session-draft-step-desktop-actions-${index}`}
+            data-desktop-layout="bottom"
+            className="hidden flex-wrap items-center gap-2 border-t border-slate-200 pt-3 sm:flex md:col-span-2"
+          >
+            {isLinkedPostSetRest ? null : (
+              <button
+                type="button"
+                onClick={handleAddStepAfter}
+                data-testid={`session-draft-step-add-after-${index}`}
+                className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm text-blue-800 transition hover:bg-blue-50"
+              >
+                Add step after
+              </button>
+            )}
+            {!insideRepeatGroup && !isLinkedPostSetRest ? (
               <button
                 type="button"
                 onClick={handleAddRepeatAfter}
-                data-testid={`session-draft-step-mobile-primary-add-repeat-after-${index}`}
-                className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-blue-50 px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-100"
+                data-testid={`session-draft-step-add-repeat-after-${index}`}
+                className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm text-blue-800 transition hover:bg-blue-50"
               >
-                Repeat after
+                Add repeat after
               </button>
             ) : null}
-          </div>
-        ) : null}
-
-        {pendingDelete ? (
-          <div
-            data-testid="workout-editor-removal-confirm"
-            className="mt-3 rounded-2xl border border-rose-200 bg-rose-50/90 p-3"
-          >
-            <p className="text-sm font-medium text-rose-950">
-              Delete <span className="font-semibold">{pendingRemoval?.label ?? "this step"}</span>?
-            </p>
-            <p className="mt-1 text-sm text-rose-900">
-              This builder change stays local until you save, and you can still undo it right after
-              deletion.
-            </p>
-            <div className="mt-3 flex flex-wrap gap-2">
+            {isLinkedPostSetRest ? null : (
               <button
                 type="button"
-                onClick={confirmPendingRemoval}
-                data-testid="workout-editor-removal-confirm-button"
-                className="inline-flex h-10 items-center justify-center rounded-xl bg-rose-600 px-4 text-sm font-semibold text-white transition hover:bg-rose-500 active:bg-rose-700"
+                onClick={handleDuplicate}
+                data-testid={`session-draft-step-duplicate-${index}`}
+                className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50"
               >
-                Delete now
+                Duplicate
               </button>
+            )}
+            {isLinkedPostSetRest ? null : (
               <button
                 type="button"
-                onClick={cancelPendingRemoval}
-                data-testid="workout-editor-removal-cancel-button"
-                className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-900 transition hover:bg-rose-100 active:bg-rose-200"
+                onClick={() => requestStepRemoval(step.id)}
+                data-testid={`session-draft-step-remove-${index}`}
+                className="inline-flex h-9 items-center justify-center rounded-xl border border-rose-200 bg-white px-3 text-sm text-rose-700 transition hover:bg-rose-50"
               >
-                Keep it
+                Delete
               </button>
-            </div>
+            )}
+            <button
+              type="button"
+              onClick={() => setOpenStepId(null)}
+              data-testid={`session-draft-step-done-bottom-${index}`}
+              className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-blue-50 px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-100 sm:ml-auto"
+            >
+              Done
+            </button>
           </div>
         ) : null}
+      </div>
+    ) : null;
 
-        {isOpen ? (
-          <div id={panelId} className="mt-4 grid gap-4 md:grid-cols-2">
-            {isManualPoolMode ? null : (
+    return (
+      <SessionStepSummaryCard
+        key={step.id}
+        stepId={step.id}
+        index={index}
+        panelId={panelId}
+        dataManualPoolCategory={
+          isTopLevelSessionStepBlock && !pendingDelete ? normalizedStep.category : undefined
+        }
+        canUseDesktopCardOpen={canUseDesktopCardOpen}
+        cardStateClass={cardStateClass}
+        categoryRailClass={topLevelCategoryRailClass}
+        isEditMode={isEditMode}
+        isSummaryOnlyMode={isSummaryOnlyMode}
+        isOpen={isOpen}
+        mobileActionsOpen={mobileActionsOpen}
+        pendingDelete={pendingDelete}
+        removalLabel={pendingRemoval?.label ?? null}
+        showRearrangeControls={showRearrangeControls}
+        showMobilePrimaryAddAfter={showMobilePrimaryAddAfter}
+        showMobilePrimaryAddRepeatAfter={showMobilePrimaryAddRepeatAfter}
+        canAddRepeatAfter={!insideRepeatGroup && !isLinkedPostSetRest}
+        isLinkedPostSetRest={isLinkedPostSetRest}
+        moveUpDisabled={moveUpDisabled}
+        moveDownDisabled={moveDownDisabled}
+        wasRecentlyMoved={stepWasRecentlyMoved}
+        summary={stepSummary}
+        editPanel={editPanel}
+        onOpen={openStepCard}
+        onToggle={toggleStepCard}
+        onToggleMobileActions={toggleMobileStepActions}
+        onMoveUp={handleMoveUp}
+        onMoveDown={handleMoveDown}
+        onAddStepAfter={handleAddStepAfter}
+        onAddRepeatAfter={handleAddRepeatAfter}
+        onDuplicate={handleDuplicate}
+        onRequestRemove={requestRemoveStep}
+        onConfirmRemoval={confirmPendingRemoval}
+        onCancelRemoval={cancelPendingRemoval}
+      />
+    );
+  }
+
+  function renderRepeatSummaryCard(
+    group: Extract<StepRenderGroup, { kind: "repeat" }>,
+    groupIndex: number
+  ) {
+    const pendingRepeatDelete =
+      pendingRemoval?.kind === "repeat" && pendingRemoval.repeatGroupId === group.repeatGroupId;
+    const repeatSummary = buildRepeatSummary(
+      group.entries,
+      group.repeatCount,
+      draft.basePaceSecondsPer100m,
+      group.repeatEndingRestMode,
+      poolLengthUnit,
+      group.postSetRestEntry?.step ?? null
+    );
+    const repeatDescriptor = useManualLikeStepSummaries
+      ? (manualPoolTopLevelSectionDescriptors[groupIndex] ?? null)
+      : null;
+    const repeatCategory = useManualLikeStepSummaries
+      ? getWorkoutEditorTopLevelCategory(group, {
+          normalizeForManualPool: isManualPoolMode,
+        })
+      : "main";
+    const repeatLabelToneClass =
+      useManualLikeStepSummaries && !pendingRepeatDelete
+        ? getManualPoolCategoryLabelClass(repeatCategory)
+        : "text-blue-700";
+    const repeatLabel = useManualLikeStepSummaries
+      ? (repeatDescriptor?.label ?? "Repeat")
+      : "Repeat set";
+    const isRepeatOpen = isEditMode && openRepeatGroupId === group.repeatGroupId;
+    const hasEditableRepeatEndingRest = Boolean(
+      draft.environment === "pool" &&
+      (() => {
+        const lastEntry = group.entries[group.entries.length - 1];
+        return lastEntry && isSessionDraftRepeatEndingRestStep(lastEntry.step);
+      })()
+    );
+    const repeatMobileActionKey = `repeat:${group.repeatGroupId}`;
+    const repeatMobileActionsOpen = openMobileActionKey === repeatMobileActionKey;
+    const hasRepeatRestConflict = Boolean(
+      hasEditableRepeatEndingRest &&
+      group.postSetRestEntry?.step &&
+      group.repeatEndingRestMode === "use_last_rest"
+    );
+    const repeatConflictKeptBoth = repeatConflictKeepBoth[group.repeatGroupId] === true;
+    const showRepeatRestConflict = hasRepeatRestConflict && !repeatConflictKeptBoth;
+    const showRepeatRestReplacementConfirm =
+      repeatConflictPendingReplacement === group.repeatGroupId;
+    const repeatCanUseDesktopCardOpen =
+      desktopCardEditEnabled && isEditMode && openRepeatGroupId !== group.repeatGroupId;
+    const repeatCategoryRailClass =
+      useManualLikeStepSummaries && !pendingRepeatDelete
+        ? `border-l-4 ${getManualPoolCategoryRailClass(repeatCategory)}`
+        : "";
+
+    const openRepeatCard = () => {
+      setOpenMobileActionKey(null);
+      setOpenStepId(null);
+      setOpenRepeatGroupId(group.repeatGroupId);
+    };
+    const toggleRepeatMobileActions = () =>
+      setOpenMobileActionKey((current) =>
+        current === repeatMobileActionKey ? null : repeatMobileActionKey
+      );
+    const addStepAfterRepeat = () => {
+      insertStepAfterGroup(groupIndex);
+      setOpenMobileActionKey(null);
+    };
+    const addRepeatAfterRepeat = () => {
+      insertRepeatAfterGroup(groupIndex);
+      setOpenMobileActionKey(null);
+    };
+    const duplicateRepeat = () => {
+      duplicateRepeatGroup(group.repeatGroupId);
+      setOpenMobileActionKey(null);
+    };
+    const requestRemoveRepeat = () => {
+      requestRepeatGroupRemoval(group.repeatGroupId);
+      setOpenMobileActionKey(null);
+    };
+
+    const repeatEditPanel =
+      isEditMode && isRepeatOpen ? (
+        <div className="mt-4 space-y-3">
+          <div className={desktopRepeatControlRowClass}>
+            <div className="grid gap-3 sm:flex sm:flex-wrap sm:items-end sm:gap-2">
               <label className="text-sm text-slate-700">
-                Step name
+                Repeat count
                 <input
                   type="text"
-                  value={step.name}
+                  inputMode="numeric"
+                  value={group.repeatCount ?? ""}
                   onChange={(event) =>
-                    updateDraftStep(step.id, (current) => ({
-                      ...current,
-                      name: event.target.value,
-                    }))
+                    updateRepeatGroupCount(group.repeatGroupId, event.target.value)
                   }
-                  data-testid={`session-draft-step-name-${index}`}
-                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                  min={SESSION_DRAFT_REPEAT_MIN}
+                  max={SESSION_DRAFT_REPEAT_MAX}
+                  data-testid={`session-draft-repeat-count-${groupIndex}`}
+                  className="mt-2 block h-11 w-full rounded-xl border border-blue-200 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200 sm:w-28"
                 />
               </label>
-            )}
-
-            <label className="text-sm text-slate-700">
-              {isManualPoolMode ? "Step Type" : "Category"}
-              <select
-                value={stepCategoryValue}
-                disabled={isLinkedPostSetRest}
-                onChange={(event) =>
-                  updateDraftStep(step.id, (current) =>
-                    applyRecommendedStepFocus(current, {
-                      category: event.target.value as SessionDraftStepCategory,
-                    })
-                  )
-                }
-                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-              >
-                {(isLinkedPostSetRest
-                  ? (["rest"] as const)
-                  : isManualPoolMode
-                    ? MANUAL_POOL_VISIBLE_STEP_CATEGORIES
-                    : SESSION_DRAFT_STEP_CATEGORIES
-                ).map((value) => (
-                  <option key={value} value={value}>
-                    {getSessionStepCategoryLabel(value)}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            {isMinimalRestEditor ? null : (
-              <label className="text-sm text-slate-700">
-                {isManualPoolMode ? "Stroke Type" : "Stroke pattern"}
-                <select
-                  value={stepStrokeValue}
-                  onChange={(event) => {
-                    const nextStroke = event.target.value as SessionDraftStep["stroke"];
-
-                    updateDraftStep(step.id, (current) =>
-                      applyRecommendedStepFocus(current, {
-                        stroke: nextStroke,
-                      })
-                    );
-                  }}
-                  data-testid={`session-draft-step-stroke-${index}`}
-                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                >
-                  {(isManualPoolMode
-                    ? MANUAL_POOL_VISIBLE_STEP_STROKES
-                    : SESSION_DRAFT_STEP_STROKES
-                  ).map((value) => (
-                    <option key={value} value={value}>
-                      {getSessionStepStrokeLabel(value)}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            )}
-
-            {isMinimalRestEditor ? null : (
-              <label className="text-sm text-slate-700">
-                {isManualPoolMode ? "Drill Type" : "Focus tag"}
-                <select
-                  value={stepDrillTypeValue}
-                  onChange={(event) =>
-                    updateDraftStep(step.id, (current) => ({
-                      ...current,
-                      drillType: event.target.value as NonNullable<SessionDraftStep["drillType"]>,
-                    }))
-                  }
-                  data-testid={`session-draft-step-drill-type-${index}`}
-                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                >
-                  {SESSION_DRAFT_STEP_DRILL_TYPES.map((value) => (
-                    <option key={value} value={value}>
-                      {getSessionStepDrillTypeLabel(value)}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            )}
-
-            {showManualPoolDrillNameField ? (
-              <div className="text-sm text-slate-700">
-                <label htmlFor={`session-draft-step-drill-name-${step.id}`}>Drill name</label>
-                <input
-                  id={`session-draft-step-drill-name-${step.id}`}
-                  type="text"
-                  value={getManualPoolDrillNameInputValue(normalizedStep)}
-                  onChange={(event) =>
-                    updateDraftStep(step.id, (current) => ({
-                      ...current,
-                      name: event.target.value,
-                    }))
-                  }
-                  aria-describedby={manualPoolDrillNameHelpId}
-                  placeholder="Catch drill"
-                  data-testid={`session-draft-step-drill-name-${index}`}
-                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                />
-                <p id={manualPoolDrillNameHelpId} className="mt-2 text-sm text-slate-500">
-                  Names the drill. Use Notes for execution cues.
-                </p>
-              </div>
-            ) : null}
-
-            {isManualPoolMode || isMinimalRestEditor ? null : (
-              <>
-                <p className="text-sm text-slate-500 md:col-span-2">
-                  {buildStepStrokeGuidance(step, isManualPoolMode)}
-                </p>
-                <p className="text-sm text-slate-500 md:col-span-2">
-                  {buildStepFocusGuidance(step, isManualPoolMode)}
-                </p>
-              </>
-            )}
-
-            {isMinimalRestEditor ? null : (
-              <label className="text-sm text-slate-700">
-                Equipment
-                <select
-                  value={stepEquipmentValue}
-                  onChange={(event) =>
-                    updateDraftStep(step.id, (current) => ({
-                      ...current,
-                      equipment: event.target.value as NonNullable<SessionDraftStep["equipment"]>,
-                    }))
-                  }
-                  data-testid={`session-draft-step-equipment-${index}`}
-                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                >
-                  {SESSION_DRAFT_STEP_EQUIPMENT.map((value) => (
-                    <option key={value} value={value}>
-                      {getSessionStepEquipmentLabel(value)}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            )}
-
-            {isManualPoolMode || isMinimalRestEditor ? null : (
-              <label className="text-sm text-slate-700">
-                Effort
-                <select
-                  value={stepIntensityValue}
-                  onChange={(event) =>
-                    updateDraftStep(step.id, (current) => ({
-                      ...current,
-                      intensity: event.target.value as SessionDraftStepIntensityPreset,
-                    }))
-                  }
-                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                >
-                  {(isManualPoolMode
-                    ? MANUAL_POOL_VISIBLE_STEP_INTENSITY_PRESETS
-                    : SESSION_DRAFT_STEP_INTENSITY_PRESETS
-                  ).map((value) => (
-                    <option key={value} value={value}>
-                      {getSessionStepIntensityLabel(value)}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            )}
-
-            <label className="text-sm text-slate-700">
-              {isManualPoolMode ? "Duration" : "Duration mode"}
-              <select
-                value={stepDurationModeValue}
-                onChange={(event) =>
-                  updateStepDurationMode(
-                    step.id,
-                    event.target.value as SessionDraftStepDurationMode
-                  )
-                }
-                data-testid={`session-draft-step-duration-mode-${index}`}
-                className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-              >
-                {(isManualPoolMode
-                  ? getManualPoolDurationModesForCategory(stepCategoryValue)
-                  : SESSION_DRAFT_STEP_DURATION_MODES
-                ).map((value) => (
-                  <option key={value} value={value}>
-                    {getStepDurationModeEditorLabel(value, isManualPoolMode)}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            {step.durationMode === "distance" ? (
-              <div className="grid gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-3 sm:p-4 md:col-span-2 md:grid-cols-2">
+              {hasEditableRepeatEndingRest ? (
                 <label className="text-sm text-slate-700">
-                  Distance
+                  Rest after last repeat
                   <select
-                    value={
-                      selectedDistancePreset
-                        ? String(selectedDistancePreset)
-                        : CUSTOM_DISTANCE_VALUE
-                    }
+                    value={group.repeatEndingRestMode}
                     onChange={(event) =>
-                      updateStepDistanceSelection(step.id, event.target.value, stepDistanceUnit)
+                      updateRepeatGroupEndingRestMode(
+                        group.repeatGroupId,
+                        event.target.value as SessionDraftRepeatEndingRestMode
+                      )
                     }
-                    data-testid={`session-draft-step-distance-${index}`}
-                    className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                    data-testid={`session-draft-repeat-ending-rest-mode-${groupIndex}`}
+                    className="mt-2 block h-11 w-full rounded-xl border border-blue-200 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200 sm:min-w-[15rem]"
                   >
-                    {SESSION_DRAFT_STEP_DISTANCE_PRESETS.map((value) => (
-                      <option key={value} value={String(value)}>
-                        {stepDistanceUnit === "yd"
-                          ? `${value}yd`
-                          : formatDistanceMetersLabel(value)}
+                    {SESSION_DRAFT_REPEAT_ENDING_REST_MODES.map((mode) => (
+                      <option key={mode} value={mode}>
+                        {getSessionDraftRepeatEndingRestModeLabel(mode)}
                       </option>
                     ))}
-                    <option value={CUSTOM_DISTANCE_VALUE}>Custom distance</option>
                   </select>
                 </label>
-                {!selectedDistancePreset ? (
-                  <label className="text-sm text-slate-700">
-                    {`Custom distance (${stepDistanceUnit})`}
-                    <input
-                      ref={(node) => {
-                        customDistanceInputRefs.current[step.id] = node;
-                      }}
-                      type="text"
-                      inputMode="decimal"
-                      value={formatEditableDistance(step.distanceM, stepDistanceUnit)}
-                      onChange={(event) =>
-                        updateDraftStep(step.id, (current) => ({
-                          ...current,
-                          distanceM: parseDistanceInput(event.target.value, stepDistanceUnit),
-                        }))
-                      }
-                      data-testid={`session-draft-step-distance-custom-${index}`}
-                      className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                    />
-                  </label>
+              ) : null}
+            </div>
+            {showRepeatRestConflict ? (
+              <div className="rounded-xl border border-amber-200 bg-amber-50/90 p-3">
+                <p className="text-sm font-medium text-amber-950">
+                  This creates two rests in a row.
+                </p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() =>
+                      updateRepeatGroupEndingRestMode(group.repeatGroupId, "skip_last_rest")
+                    }
+                    className="inline-flex h-9 items-center justify-center rounded-xl border border-amber-200 bg-white px-3 text-sm font-medium text-amber-900 transition hover:bg-amber-100"
+                  >
+                    Use separate rest step
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setRepeatConflictPendingReplacement(group.repeatGroupId)}
+                    className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-50"
+                  >
+                    Use repeat rest time
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setRepeatConflictKeepBoth((current) => ({
+                        ...current,
+                        [group.repeatGroupId]: true,
+                      }));
+                      setRepeatConflictPendingReplacement((current) =>
+                        current === group.repeatGroupId ? null : current
+                      );
+                    }}
+                    className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+                  >
+                    Keep both
+                  </button>
+                </div>
+                {showRepeatRestReplacementConfirm ? (
+                  <div className="mt-3 rounded-xl border border-rose-200 bg-white p-3">
+                    <p className="text-sm font-medium text-rose-950">
+                      Delete the separate rest step and use repeat rest time?
+                    </p>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => removeRepeatPostSetRestStep(group.repeatGroupId)}
+                        className="inline-flex h-9 items-center justify-center rounded-xl bg-rose-600 px-3 text-sm font-semibold text-white transition hover:bg-rose-500"
+                      >
+                        Delete rest step
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setRepeatConflictPendingReplacement((current) =>
+                            current === group.repeatGroupId ? null : current
+                          )
+                        }
+                        className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
                 ) : null}
-              </div>
-            ) : step.durationMode === "fixed_rest" && isManualPoolMode ? (
-              <label className="text-sm text-slate-700">
-                Rest time
-                <input
-                  type="text"
-                  inputMode="numeric"
-                  placeholder="MM:SS"
-                  value={timeDurationInputs[step.id] ?? ""}
-                  onFocus={() => {
-                    timeDurationInputFocusRef.current[step.id] = true;
-                  }}
-                  onBlur={() => {
-                    commitTimeDurationInput(step.id);
-                  }}
-                  onChange={(event) => handleTimeDurationInputChange(step.id, event.target.value)}
-                  data-testid={`session-draft-step-rest-time-${index}`}
-                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                />
-              </label>
-            ) : step.durationMode === "fixed_rest" ? (
-              <div className="grid gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-3 sm:p-4 md:col-span-2 md:grid-cols-[1fr_1fr_auto]">
-                <label className="text-sm text-slate-700">
-                  Minutes
-                  <input
-                    type="text"
-                    inputMode="numeric"
-                    value={getDurationMinutes(step.timeMin)}
-                    onChange={(event) =>
-                      updateStepDurationClock(step.id, "minutes", event.target.value)
-                    }
-                    data-testid={`session-draft-step-rest-minutes-${index}`}
-                    className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                  />
-                </label>
-                <label className="text-sm text-slate-700">
-                  Seconds
-                  <input
-                    type="text"
-                    inputMode="numeric"
-                    value={getDurationSeconds(step.timeMin)}
-                    onChange={(event) =>
-                      updateStepDurationClock(step.id, "seconds", event.target.value)
-                    }
-                    data-testid={`session-draft-step-rest-seconds-${index}`}
-                    className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                  />
-                </label>
-                <div className="self-end text-sm text-slate-500">
-                  {step.timeMin
-                    ? `Fixed Rest Time ${formatClockDurationLabel(step.timeMin)}`
-                    : "Set Fixed Rest Time"}
-                </div>
-              </div>
-            ) : step.durationMode === "time" ? (
-              <label className="text-sm text-slate-700">
-                {isManualPoolMode ? "Time" : "Time (min)"}
-                <input
-                  type="text"
-                  inputMode="numeric"
-                  placeholder={isManualPoolMode ? "MM:SS" : undefined}
-                  value={
-                    isManualPoolMode ? (timeDurationInputs[step.id] ?? "") : (step.timeMin ?? "")
-                  }
-                  onFocus={() => {
-                    if (!isManualPoolMode) return;
-                    timeDurationInputFocusRef.current[step.id] = true;
-                  }}
-                  onBlur={() => {
-                    if (!isManualPoolMode) return;
-                    commitTimeDurationInput(step.id);
-                  }}
-                  onChange={(event) =>
-                    isManualPoolMode
-                      ? handleTimeDurationInputChange(step.id, event.target.value)
-                      : updateDraftStep(step.id, (current) => ({
-                          ...current,
-                          timeMin: parsePositiveNumber(event.target.value),
-                        }))
-                  }
-                  data-testid={`session-draft-step-time-${index}`}
-                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                />
-              </label>
-            ) : step.durationMode === "send_off" && isManualPoolMode ? (
-              <label className="text-sm text-slate-700">
-                Send-off time
-                <input
-                  type="text"
-                  inputMode="numeric"
-                  placeholder="MM:SS"
-                  value={timeDurationInputs[step.id] ?? ""}
-                  onFocus={() => {
-                    timeDurationInputFocusRef.current[step.id] = true;
-                  }}
-                  onBlur={() => {
-                    commitTimeDurationInput(step.id);
-                  }}
-                  onChange={(event) => handleTimeDurationInputChange(step.id, event.target.value)}
-                  data-testid={`session-draft-step-sendoff-time-${index}`}
-                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                />
-              </label>
-            ) : step.durationMode === "send_off" ? (
-              <div className="grid gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-3 sm:p-4 md:col-span-2 md:grid-cols-[1fr_1fr_auto]">
-                <label className="text-sm text-slate-700">
-                  Minutes
-                  <input
-                    type="text"
-                    inputMode="numeric"
-                    value={getDurationMinutes(step.timeMin)}
-                    onChange={(event) =>
-                      updateStepDurationClock(step.id, "minutes", event.target.value)
-                    }
-                    data-testid={`session-draft-step-sendoff-minutes-${index}`}
-                    className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                  />
-                </label>
-                <label className="text-sm text-slate-700">
-                  Seconds
-                  <input
-                    type="text"
-                    inputMode="numeric"
-                    value={getDurationSeconds(step.timeMin)}
-                    onChange={(event) =>
-                      updateStepDurationClock(step.id, "seconds", event.target.value)
-                    }
-                    data-testid={`session-draft-step-sendoff-seconds-${index}`}
-                    className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                  />
-                </label>
-                <div className="self-end text-sm text-slate-500">
-                  {step.timeMin
-                    ? `Send-Off Time ${formatClockDurationLabel(step.timeMin)}`
-                    : "Set Send-Off Time"}
-                </div>
-              </div>
-            ) : step.durationMode === "css_send_off" ? (
-              <label className="text-sm text-slate-700 md:col-span-2">
-                CSS-Based Send-Off Time
-                <select
-                  value={String(step.cssSendOffOffsetSeconds ?? 0)}
-                  onChange={(event) =>
-                    updateDraftStep(step.id, (current) => ({
-                      ...current,
-                      cssSendOffOffsetSeconds: Number.parseInt(event.target.value, 10),
-                    }))
-                  }
-                  data-testid={`session-draft-step-css-sendoff-offset-${index}`}
-                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                >
-                  {SESSION_DRAFT_STEP_CSS_TARGET_OFFSETS.map((value) => {
-                    const sign = value > 0 ? "+" : "";
-                    return (
-                      <option key={value} value={String(value)}>
-                        {`CSS ${sign}${value}s (${formatClockDurationLabelFromSeconds(
-                          draft.basePaceSecondsPer100m + value
-                        )})`}
-                      </option>
-                    );
-                  })}
-                </select>
-              </label>
-            ) : null}
-
-            {isMinimalRestEditor ? null : (
-              <label className="text-sm text-slate-700">
-                {isManualPoolMode ? "Target" : "Target mode"}
-                <select
-                  value={stepTargetModeValue}
-                  onChange={(event) =>
-                    updateDraftStep(step.id, (current) => ({
-                      ...current,
-                      targetMode: event.target.value as NonNullable<SessionDraftStep["targetMode"]>,
-                      effortTarget:
-                        event.target.value === "effort"
-                          ? (current.effortTarget ?? current.intensity)
-                          : null,
-                      targetPaceSecondsPer100m:
-                        event.target.value === "target_pace"
-                          ? current.targetPaceSecondsPer100m
-                          : null,
-                      cssTargetOffsetSeconds:
-                        event.target.value === "css_target_pace"
-                          ? (current.cssTargetOffsetSeconds ?? 0)
-                          : null,
-                    }))
-                  }
-                  data-testid={`session-draft-step-target-mode-${index}`}
-                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                >
-                  {SESSION_DRAFT_STEP_TARGET_MODES.map((value) => (
-                    <option key={value} value={value}>
-                      {getStepTargetModeEditorLabel(value, isManualPoolMode)}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            )}
-
-            {!isMinimalRestEditor && stepTargetModeValue === "effort" ? (
-              <label className="text-sm text-slate-700">
-                {isManualPoolMode ? "Effort" : "Target effort"}
-                <select
-                  value={stepEffortTargetValue}
-                  onChange={(event) =>
-                    updateDraftStep(step.id, (current) => ({
-                      ...current,
-                      effortTarget: event.target.value as SessionDraftStepIntensityPreset,
-                    }))
-                  }
-                  data-testid={`session-draft-step-target-effort-${index}`}
-                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                >
-                  {(isManualPoolMode
-                    ? MANUAL_POOL_VISIBLE_STEP_INTENSITY_PRESETS
-                    : SESSION_DRAFT_STEP_INTENSITY_PRESETS
-                  ).map((value) => (
-                    <option key={value} value={value}>
-                      {getSessionStepIntensityLabel(value)}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            ) : null}
-
-            {!isMinimalRestEditor && stepTargetModeValue === "target_pace" ? (
-              <div className="grid gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-3 sm:p-4 md:col-span-2 md:grid-cols-[1fr_1fr_auto]">
-                <label className="text-sm text-slate-700">
-                  Pace minutes
-                  <input
-                    type="text"
-                    inputMode="numeric"
-                    value={getPaceMinutes(step.targetPaceSecondsPer100m)}
-                    onChange={(event) =>
-                      updateStepTargetPace(step.id, "minutes", event.target.value)
-                    }
-                    data-testid={`session-draft-step-target-pace-minutes-${index}`}
-                    className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                  />
-                </label>
-                <label className="text-sm text-slate-700">
-                  Pace seconds
-                  <input
-                    type="text"
-                    inputMode="numeric"
-                    value={getPaceSeconds(step.targetPaceSecondsPer100m)}
-                    onChange={(event) =>
-                      updateStepTargetPace(step.id, "seconds", event.target.value)
-                    }
-                    data-testid={`session-draft-step-target-pace-seconds-${index}`}
-                    className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                  />
-                </label>
-                <div className="self-end text-sm text-slate-500">
-                  {step.targetPaceSecondsPer100m
-                    ? formatPaceSecondsPer100m(step.targetPaceSecondsPer100m, poolLengthUnit)
-                    : "Set pace"}
-                </div>
-              </div>
-            ) : null}
-
-            {!isMinimalRestEditor && stepTargetModeValue === "css_target_pace" ? (
-              <label className="text-sm text-slate-700 md:col-span-2">
-                CSS pace offset
-                <select
-                  value={String(step.cssTargetOffsetSeconds ?? 0)}
-                  onChange={(event) =>
-                    updateDraftStep(step.id, (current) => ({
-                      ...current,
-                      cssTargetOffsetSeconds: Number.parseInt(event.target.value, 10),
-                    }))
-                  }
-                  data-testid={`session-draft-step-css-offset-${index}`}
-                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                >
-                  {SESSION_DRAFT_STEP_CSS_TARGET_OFFSETS.map((value) => {
-                    const sign = value > 0 ? "+" : "";
-                    return (
-                      <option key={value} value={String(value)}>
-                        {`CSS ${sign}${value}s (${formatPaceSecondsPer100m(
-                          draft.basePaceSecondsPer100m + value,
-                          poolLengthUnit
-                        )})`}
-                      </option>
-                    );
-                  })}
-                </select>
-              </label>
-            ) : null}
-
-            {isManualPoolMode || isMinimalRestEditor ? null : (
-              <label className="text-sm text-slate-700 md:col-span-2">
-                Target notes
-                <input
-                  type="text"
-                  value={step.targetSummary}
-                  onChange={(event) =>
-                    updateDraftStep(step.id, (current) => ({
-                      ...current,
-                      targetSummary: event.target.value,
-                    }))
-                  }
-                  className="mt-2 block h-11 w-full rounded-xl border border-slate-300 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-                />
-              </label>
-            )}
-
-            <label className="text-sm text-slate-700 md:col-span-2">
-              {isManualPoolMode ? "Notes" : "Notes"}
-              <AutoGrowingTextarea
-                aria-label={isManualPoolMode ? "Notes" : "Notes"}
-                value={step.notes}
-                onChange={(event) =>
-                  updateDraftStep(step.id, (current) => ({
-                    ...current,
-                    notes: event.target.value,
-                  }))
-                }
-                minRows={isManualPoolMode ? 1 : 3}
-                className="mt-2 block w-full resize-y rounded-xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-              />
-            </label>
-
-            {attachedRestEditor}
-
-            {isEditMode ? (
-              <div
-                data-testid={`session-draft-step-desktop-actions-${index}`}
-                data-desktop-layout="bottom"
-                className="hidden flex-wrap items-center gap-2 border-t border-slate-200 pt-3 sm:flex md:col-span-2"
-              >
-                {isLinkedPostSetRest ? null : (
-                  <button
-                    type="button"
-                    onClick={handleAddStepAfter}
-                    data-testid={`session-draft-step-add-after-${index}`}
-                    className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm text-blue-800 transition hover:bg-blue-50"
-                  >
-                    Add step after
-                  </button>
-                )}
-                {!insideRepeatGroup && !isLinkedPostSetRest ? (
-                  <button
-                    type="button"
-                    onClick={handleAddRepeatAfter}
-                    data-testid={`session-draft-step-add-repeat-after-${index}`}
-                    className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm text-blue-800 transition hover:bg-blue-50"
-                  >
-                    Add repeat after
-                  </button>
-                ) : null}
-                {isLinkedPostSetRest ? null : (
-                  <button
-                    type="button"
-                    onClick={handleDuplicate}
-                    data-testid={`session-draft-step-duplicate-${index}`}
-                    className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 transition hover:bg-slate-50"
-                  >
-                    Duplicate
-                  </button>
-                )}
-                {isLinkedPostSetRest ? null : (
-                  <button
-                    type="button"
-                    onClick={() => requestStepRemoval(step.id)}
-                    data-testid={`session-draft-step-remove-${index}`}
-                    className="inline-flex h-9 items-center justify-center rounded-xl border border-rose-200 bg-white px-3 text-sm text-rose-700 transition hover:bg-rose-50"
-                  >
-                    Delete
-                  </button>
-                )}
-                <button
-                  type="button"
-                  onClick={() => setOpenStepId(null)}
-                  data-testid={`session-draft-step-done-bottom-${index}`}
-                  className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-blue-50 px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-100 sm:ml-auto"
-                >
-                  Done
-                </button>
               </div>
             ) : null}
           </div>
-        ) : null}
-      </article>
+
+          {group.entries.map((entry, repeatIndex) =>
+            renderStepEditorCard(entry.step, entry.index, groupIndex, {
+              insideRepeatGroup: true,
+              repeatStepNumber: repeatIndex + 1,
+              labelOverride:
+                repeatIndex === 0
+                  ? isManualPoolMode
+                    ? (manualPoolTopLevelSectionDescriptors[groupIndex]?.label ?? "Repeat")
+                    : "Work interval"
+                  : entry.step.category === "rest"
+                    ? isManualPoolMode
+                      ? buildLinkedRestLabel(
+                          manualPoolTopLevelSectionDescriptors[groupIndex]?.label ?? "Repeat",
+                          "interval"
+                        )
+                      : "Between-interval recovery"
+                    : undefined,
+              descriptionOverride:
+                entry.step.category === "rest" && isManualPoolMode ? null : undefined,
+            })
+          )}
+          {group.postSetRestEntry
+            ? renderStepEditorCard(
+                group.postSetRestEntry.step,
+                group.postSetRestEntry.index,
+                groupIndex,
+                {
+                  labelOverride: isManualPoolMode
+                    ? buildLinkedRestLabel(
+                        manualPoolTopLevelSectionDescriptors[groupIndex]?.label ?? "Repeat",
+                        "set"
+                      )
+                    : "Post-set rest",
+                  descriptionOverride: null,
+                  isLinkedPostSetRest: true,
+                  pendingInlineDelete: repeatConflictPendingReplacement === group.repeatGroupId,
+                }
+              )
+            : null}
+          {pendingRepeatDelete ? (
+            <RemovalConfirm
+              label={pendingRemoval?.label ?? null}
+              fallbackLabel="this repeat block"
+              onConfirm={confirmPendingRemoval}
+              onCancel={cancelPendingRemoval}
+            />
+          ) : null}
+          <div
+            data-testid={`session-draft-repeat-desktop-actions-${groupIndex}`}
+            data-desktop-layout="bottom"
+            className="hidden flex-wrap items-end gap-2 border-t border-blue-100 pt-3 sm:flex"
+          >
+            <button
+              type="button"
+              onClick={addStepAfterRepeat}
+              data-testid={`session-draft-repeat-add-step-after-${groupIndex}`}
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm text-blue-800 transition hover:bg-blue-100"
+            >
+              Add step after
+            </button>
+            <button
+              type="button"
+              onClick={addRepeatAfterRepeat}
+              data-testid={`session-draft-repeat-add-repeat-after-${groupIndex}`}
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm text-blue-800 transition hover:bg-blue-100"
+            >
+              Add repeat after
+            </button>
+            <button
+              type="button"
+              onClick={duplicateRepeat}
+              data-testid={`session-draft-repeat-duplicate-${groupIndex}`}
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm text-blue-800 transition hover:bg-blue-100"
+            >
+              Duplicate repeat
+            </button>
+            <button
+              type="button"
+              onClick={requestRemoveRepeat}
+              data-testid={`session-draft-repeat-remove-${groupIndex}`}
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-3 text-sm text-rose-700 transition hover:bg-rose-50"
+            >
+              Delete repeat
+            </button>
+            <button
+              type="button"
+              onClick={() => toggleRepeatEditor(group.repeatGroupId)}
+              data-testid={`session-draft-repeat-done-bottom-${groupIndex}`}
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-blue-50 px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-100 sm:ml-auto"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      ) : null;
+
+    return (
+      <SessionStepRepeatSummaryCard
+        key={group.repeatGroupId}
+        repeatGroupId={group.repeatGroupId}
+        groupIndex={groupIndex}
+        dataManualPoolCategory={
+          useManualLikeStepSummaries && !pendingRepeatDelete ? repeatCategory : undefined
+        }
+        categoryRailClass={repeatCategoryRailClass}
+        dataDesktopCardClickable={repeatCanUseDesktopCardOpen}
+        pendingDelete={pendingRepeatDelete}
+        isEditMode={isEditMode}
+        isRearrangeMode={isRearrangeMode}
+        isOpen={isRepeatOpen}
+        isManualPoolMode={isManualPoolMode}
+        mobileActionsOpen={repeatMobileActionsOpen}
+        moveUpDisabled={groupIndex === 0}
+        moveDownDisabled={groupIndex === stepGroups.length - 1}
+        wasRecentlyMoved={recentlyMovedBlockKey === `repeat:${group.repeatGroupId}`}
+        summary={{
+          label: repeatLabel,
+          title: repeatSummary,
+          labelClassName: repeatLabelToneClass,
+          pendingDelete: pendingRepeatDelete,
+          showRepeatBlockBadge: isRepeatOpen,
+        }}
+        editPanel={repeatEditPanel}
+        onOpen={openRepeatCard}
+        onToggle={() => toggleRepeatEditor(group.repeatGroupId)}
+        onToggleMobileActions={toggleRepeatMobileActions}
+        onMoveUp={() => moveDraftGroup(groupIndex, -1, repeatLabel)}
+        onMoveDown={() => moveDraftGroup(groupIndex, 1, repeatLabel)}
+        onAddStepAfter={addStepAfterRepeat}
+        onAddRepeatAfter={addRepeatAfterRepeat}
+        onDuplicate={duplicateRepeat}
+        onRequestRemove={requestRemoveRepeat}
+      />
     );
   }
 
@@ -4548,810 +4612,59 @@ export default function WorkoutEditor({
         metadataFields
       )}
 
-      <div
-        data-testid="workout-editor-session-steps-surface"
-        className="rounded-2xl border border-slate-200 bg-white p-3 sm:p-4"
+      <SessionStepSurfaceRenderer
+        mode={builderViewMode}
+        title={
+          isManualPoolMode || copyVariant === "generator" ? "Session steps" : "Editable draft steps"
+        }
+        showModeTabs={showCalmBuilderLayout}
+        showAddActions={isEditMode}
+        hasSteps={stepGroups.length > 0}
+        rearrangeLiveMessage={rearrangeLiveMessage}
+        lastRemovedLabel={lastRemovedBlock?.label ?? null}
+        viewSections={calmViewSections}
+        onModeChange={setBuilderViewMode}
+        onAddStep={addStep}
+        onAddRepeat={addRepeat}
+        onUndoLastRemoval={undoLastRemoval}
+        onDismissLastRemoval={() => setLastRemovedBlock(null)}
+        onOpenViewStep={openTargetedStepEditor}
+        onOpenViewRepeat={openTargetedRepeatEditor}
       >
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <h3 className="text-base font-semibold text-slate-900">
-            {isManualPoolMode || copyVariant === "generator"
-              ? "Session steps"
-              : "Editable draft steps"}
-          </h3>
-          <div className="flex flex-wrap items-center gap-3">
-            {showCalmBuilderLayout ? (
-              <div
-                role="group"
-                aria-label="Builder mode"
-                className="inline-flex rounded-xl border border-blue-100 bg-blue-50/60 p-1"
-              >
-                {WORKOUT_VIEW_MODES.map((mode) => {
-                  const isSelected = builderViewMode === mode;
-
-                  return (
-                    <button
-                      key={mode}
-                      type="button"
-                      onClick={() => setBuilderViewMode(mode)}
-                      aria-pressed={isSelected}
-                      data-testid={`workout-editor-builder-mode-${mode}`}
-                      className={`inline-flex h-8 items-center justify-center rounded-lg px-3 text-sm font-semibold transition ${
-                        isSelected
-                          ? "border border-blue-200 bg-blue-600 text-white shadow-sm"
-                          : "text-blue-900/70 hover:text-blue-900"
-                      }`}
-                    >
-                      {WORKOUT_VIEW_MODE_LABELS[mode]}
-                    </button>
+        {stepGroups.map((group, groupIndex) =>
+          group.kind === "single"
+            ? (() => {
+                if (!useManualLikeStepSummaries || isViewMode) {
+                  return renderStepEditorCard(
+                    group.entries[0].step,
+                    group.entries[0].index,
+                    groupIndex
                   );
-                })}
-              </div>
-            ) : null}
-            {isEditMode ? (
-              <div className="flex flex-wrap items-center gap-2 border-l border-slate-200 pl-3">
-                <button
-                  type="button"
-                  onClick={addStep}
-                  data-testid="session-draft-add-step"
-                  className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50 active:bg-slate-100 sm:h-10 sm:px-4"
-                >
-                  Add step
-                </button>
-                <button
-                  type="button"
-                  onClick={addRepeat}
-                  data-testid="session-draft-add-repeat"
-                  className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-blue-50 px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-100 active:bg-blue-200 sm:h-10 sm:px-4"
-                >
-                  Add repeat
-                </button>
-              </div>
-            ) : null}
-          </div>
-        </div>
+                }
 
-        <div className="mt-4 space-y-4">
-          <p data-testid="workout-editor-rearrange-live" className="sr-only" aria-live="polite">
-            {rearrangeLiveMessage}
-          </p>
-
-          {stepGroups.length === 0 ? (
-            <div
-              data-testid="session-draft-empty-steps"
-              className="rounded-2xl border border-dashed border-slate-300 bg-slate-50/80 p-3 sm:p-4"
-            >
-              <p className="text-sm font-medium text-slate-900">
-                Start from a clean empty session.
-              </p>
-              <p className="mt-1 text-sm text-slate-600">
-                Add your first step or repeat block below when you are ready to build from scratch.
-              </p>
-            </div>
-          ) : null}
-
-          {lastRemovedBlock ? (
-            <div
-              data-testid="workout-editor-removal-undo"
-              className="rounded-2xl border border-blue-200 bg-blue-50/90 p-3 sm:p-4"
-            >
-              <p className="text-sm font-medium text-blue-950">
-                Deleted <span className="font-semibold">{lastRemovedBlock.label}</span>.
-              </p>
-              <p className="mt-1 text-sm text-blue-900">
-                Undo restores it to the same local spot before you save this workout.
-              </p>
-              <div className="mt-3 flex flex-wrap gap-2">
-                <button
-                  type="button"
-                  onClick={undoLastRemoval}
-                  data-testid="workout-editor-removal-undo-button"
-                  className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700"
-                >
-                  Undo delete
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setLastRemovedBlock(null)}
-                  data-testid="workout-editor-removal-dismiss-button"
-                  className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-4 text-sm font-medium text-blue-900 transition hover:bg-blue-100 active:bg-blue-200"
-                >
-                  Dismiss
-                </button>
-              </div>
-            </div>
-          ) : null}
-
-          {isViewMode && calmViewSections.length > 0
-            ? calmViewSections.map((section) => {
-                return (
-                  <section
-                    key={section.key}
-                    data-testid={`workout-editor-view-section-${section.key}`}
-                    data-view-category={section.category}
-                    className={`overflow-hidden rounded-2xl border bg-white ${getManualPoolViewSectionToneClass(
-                      section.category
-                    )}`}
-                  >
-                    <div
-                      className={`px-4 py-3 ${getManualPoolViewSectionHeaderClass(
-                        section.category
-                      )}`}
-                    >
-                      <p
-                        className={`text-xs font-semibold tracking-wide uppercase ${getManualPoolCategoryLabelClass(
-                          section.category
-                        )}`}
-                      >
-                        {section.title}
-                      </p>
-                    </div>
-                    <div className="divide-y divide-slate-200/80">
-                      {section.lines.map((line) => {
-                        const lineTarget = line.target;
-                        const lineContent = (
-                          <div className="space-y-2">
-                            <p className="text-base leading-6 text-slate-900">{line.primaryText}</p>
-                            {line.secondaryText ? (
-                              <p className="text-sm font-semibold text-blue-800">
-                                {line.secondaryText}
-                              </p>
-                            ) : null}
-                            {line.detailText ? (
-                              <p className="text-sm leading-5 text-slate-500">{line.detailText}</p>
-                            ) : null}
-                          </div>
-                        );
-
-                        if (lineTarget?.kind === "repeat") {
-                          return (
-                            <button
-                              key={line.key}
-                              type="button"
-                              data-testid={`workout-editor-view-repeat-${lineTarget.repeatGroupId}`}
-                              onClick={() => openTargetedRepeatEditor(lineTarget.repeatGroupId)}
-                              className="block w-full px-4 py-3 text-left transition hover:bg-slate-50 focus-visible:ring-2 focus-visible:ring-blue-300 focus-visible:outline-none"
-                            >
-                              {lineContent}
-                            </button>
-                          );
-                        }
-
-                        if (lineTarget?.kind === "step") {
-                          return (
-                            <button
-                              key={line.key}
-                              type="button"
-                              data-testid={`workout-editor-view-line-${section.key}-${line.key}`}
-                              onClick={() => openTargetedStepEditor(lineTarget.stepId)}
-                              className="block w-full px-4 py-3 text-left transition hover:bg-slate-50 focus-visible:ring-2 focus-visible:ring-blue-300 focus-visible:outline-none"
-                            >
-                              {lineContent}
-                            </button>
-                          );
-                        }
-
-                        return (
-                          <div key={line.key} className="px-4 py-3">
-                            {lineContent}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </section>
+                const sessionStepBlock = sessionStepEditBlocks.find(
+                  (block) =>
+                    block.kind === "single" &&
+                    block.groupIndex === groupIndex &&
+                    block.entry.step.id === group.entries[0].step.id
                 );
-              })
-            : stepGroups.map((group, groupIndex) =>
-                group.kind === "single" ? (
-                  (() => {
-                    if (!useManualLikeStepSummaries || isViewMode) {
-                      return renderStepEditorCard(
-                        group.entries[0].step,
-                        group.entries[0].index,
-                        groupIndex
-                      );
-                    }
 
-                    const sessionStepBlock = sessionStepEditBlocks.find(
-                      (block) =>
-                        block.kind === "single" &&
-                        block.groupIndex === groupIndex &&
-                        block.entry.step.id === group.entries[0].step.id
-                    );
+                if (!sessionStepBlock || sessionStepBlock.kind !== "single") {
+                  return null;
+                }
 
-                    if (!sessionStepBlock || sessionStepBlock.kind !== "single") {
-                      return null;
-                    }
-
-                    return renderStepEditorCard(
-                      sessionStepBlock.entry.step,
-                      sessionStepBlock.entry.index,
-                      groupIndex,
-                      {
-                        linkedTopLevelRestEntry: sessionStepBlock.linkedRestEntry,
-                      }
-                    );
-                  })()
-                ) : (
-                  <section
-                    key={group.repeatGroupId}
-                    data-testid={`workout-editor-repeat-group-${groupIndex}`}
-                    data-containment-style="calm"
-                    data-manual-pool-category={
-                      useManualLikeStepSummaries &&
-                      !(
-                        pendingRemoval?.kind === "repeat" &&
-                        pendingRemoval.repeatGroupId === group.repeatGroupId
-                      )
-                        ? getWorkoutEditorTopLevelCategory(group, {
-                            normalizeForManualPool: isManualPoolMode,
-                          })
-                        : undefined
-                    }
-                    data-desktop-card-clickable={
-                      desktopCardEditEnabled &&
-                      isEditMode &&
-                      openRepeatGroupId !== group.repeatGroupId
-                        ? "true"
-                        : "false"
-                    }
-                    onClick={
-                      desktopCardEditEnabled &&
-                      isEditMode &&
-                      openRepeatGroupId !== group.repeatGroupId
-                        ? (event) => {
-                            if (shouldIgnoreCardEditClick(event.target)) {
-                              return;
-                            }
-
-                            setOpenMobileActionKey(null);
-                            setOpenStepId(null);
-                            setOpenRepeatGroupId(group.repeatGroupId);
-                          }
-                        : undefined
-                    }
-                    className={`rounded-2xl border p-3 sm:p-4 ${
-                      pendingRemoval?.kind === "repeat" &&
-                      pendingRemoval.repeatGroupId === group.repeatGroupId
-                        ? "border-dashed border-rose-300 bg-rose-50/70 ring-1 ring-rose-100 ring-inset"
-                        : `border-blue-100 bg-gradient-to-b from-blue-50/70 to-white ring-1 ring-blue-100 ring-inset ${
-                            useManualLikeStepSummaries
-                              ? `border-l-4 ${getManualPoolCategoryRailClass(
-                                  getWorkoutEditorTopLevelCategory(group, {
-                                    normalizeForManualPool: isManualPoolMode,
-                                  })
-                                )}`
-                              : ""
-                          }`
-                    } ${
-                      recentlyMovedBlockKey === `repeat:${group.repeatGroupId}`
-                        ? recentlyMovedBlockClass
-                        : ""
-                    } ${
-                      desktopCardEditEnabled &&
-                      isEditMode &&
-                      openRepeatGroupId !== group.repeatGroupId &&
-                      !(
-                        pendingRemoval?.kind === "repeat" &&
-                        pendingRemoval.repeatGroupId === group.repeatGroupId
-                      )
-                        ? "cursor-pointer hover:shadow-sm"
-                        : ""
-                    }`}
-                  >
-                    {(() => {
-                      const repeatSummary = buildRepeatSummary(
-                        group.entries,
-                        group.repeatCount,
-                        draft.basePaceSecondsPer100m,
-                        group.repeatEndingRestMode,
-                        poolLengthUnit,
-                        group.postSetRestEntry?.step ?? null
-                      );
-                      const repeatDescriptor = useManualLikeStepSummaries
-                        ? (manualPoolTopLevelSectionDescriptors[groupIndex] ?? null)
-                        : null;
-                      const repeatCategory = useManualLikeStepSummaries
-                        ? getWorkoutEditorTopLevelCategory(group, {
-                            normalizeForManualPool: isManualPoolMode,
-                          })
-                        : "main";
-                      const repeatLabelToneClass =
-                        useManualLikeStepSummaries &&
-                        !(
-                          pendingRemoval?.kind === "repeat" &&
-                          pendingRemoval.repeatGroupId === group.repeatGroupId
-                        )
-                          ? getManualPoolCategoryLabelClass(repeatCategory)
-                          : "text-blue-700";
-                      const repeatLabel = useManualLikeStepSummaries
-                        ? (repeatDescriptor?.label ?? "Repeat")
-                        : "Repeat set";
-                      const isRepeatOpen = isEditMode && openRepeatGroupId === group.repeatGroupId;
-                      const repeatToggleLabel = isRepeatOpen ? "Done" : "Edit";
-                      const hasEditableRepeatEndingRest = Boolean(
-                        draft.environment === "pool" &&
-                        (() => {
-                          const lastEntry = group.entries[group.entries.length - 1];
-                          return lastEntry && isSessionDraftRepeatEndingRestStep(lastEntry.step);
-                        })()
-                      );
-                      const repeatMobileActionKey = `repeat:${group.repeatGroupId}`;
-                      const repeatMobileActionsOpen = openMobileActionKey === repeatMobileActionKey;
-                      const hasRepeatRestConflict = Boolean(
-                        hasEditableRepeatEndingRest &&
-                        group.postSetRestEntry?.step &&
-                        group.repeatEndingRestMode === "use_last_rest"
-                      );
-                      const repeatConflictKeptBoth =
-                        repeatConflictKeepBoth[group.repeatGroupId] === true;
-                      const showRepeatRestConflict =
-                        hasRepeatRestConflict && !repeatConflictKeptBoth;
-                      const showRepeatRestReplacementConfirm =
-                        repeatConflictPendingReplacement === group.repeatGroupId;
-                      const repeatMoveUpDisabled = groupIndex === 0;
-                      const repeatMoveDownDisabled = groupIndex === stepGroups.length - 1;
-                      const repeatSummaryContent = (
-                        <>
-                          <p
-                            className={`text-xs font-semibold tracking-wide uppercase ${repeatLabelToneClass}`}
-                          >
-                            {repeatLabel}
-                          </p>
-                          {isManualPoolMode && isRepeatOpen ? (
-                            <p className="mt-2">
-                              <span className="inline-flex rounded-full border border-blue-200 bg-white px-3 py-1 text-[11px] font-semibold tracking-wide text-blue-700 uppercase">
-                                Repeat block
-                              </span>
-                            </p>
-                          ) : null}
-                          <p className="mt-2 text-sm font-medium text-slate-900">{repeatSummary}</p>
-                          {pendingRemoval?.kind === "repeat" &&
-                          pendingRemoval.repeatGroupId === group.repeatGroupId ? (
-                            <p className="mt-2 text-[11px] font-semibold tracking-wide text-rose-700 uppercase">
-                              Will be removed
-                            </p>
-                          ) : null}
-                        </>
-                      );
-
-                      return (
-                        <div className="space-y-3">
-                          <div className={desktopHeaderStackClass}>
-                            <div className={desktopSummaryBlockClass}>
-                              {isRearrangeMode ? (
-                                <div
-                                  data-testid={`session-draft-repeat-mobile-summary-${groupIndex}`}
-                                  className="sm:hidden"
-                                >
-                                  {repeatSummaryContent}
-                                </div>
-                              ) : (
-                                <button
-                                  type="button"
-                                  onClick={() => toggleRepeatEditor(group.repeatGroupId)}
-                                  aria-expanded={isRepeatOpen}
-                                  data-testid={`session-draft-repeat-mobile-summary-${groupIndex}`}
-                                  className={`${mobileSummaryToggleClass} sm:hidden`}
-                                >
-                                  {repeatSummaryContent}
-                                </button>
-                              )}
-                              <div
-                                data-testid={`session-draft-repeat-summary-${groupIndex}`}
-                                className="hidden sm:block"
-                              >
-                                {repeatSummaryContent}
-                              </div>
-                            </div>
-                            {isEditMode ? (
-                              <div className="hidden shrink-0 sm:flex">
-                                <button
-                                  type="button"
-                                  onClick={() => toggleRepeatEditor(group.repeatGroupId)}
-                                  aria-expanded={isRepeatOpen}
-                                  data-testid={`session-draft-repeat-toggle-${groupIndex}`}
-                                  className={`inline-flex h-9 items-center justify-center rounded-xl border px-3 text-sm transition ${
-                                    isRepeatOpen
-                                      ? "border-blue-200 bg-blue-50 text-blue-800 hover:bg-blue-100"
-                                      : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
-                                  }`}
-                                >
-                                  {repeatToggleLabel}
-                                </button>
-                              </div>
-                            ) : null}
-                            {isRearrangeMode ? (
-                              <div
-                                data-testid={`session-draft-repeat-rearrange-controls-${groupIndex}`}
-                                className="flex shrink-0 flex-col gap-2 sm:flex-row sm:flex-wrap"
-                              >
-                                <button
-                                  type="button"
-                                  onClick={() => moveDraftGroup(groupIndex, -1, repeatLabel)}
-                                  disabled={repeatMoveUpDisabled}
-                                  aria-label="Move up"
-                                  title="Move up"
-                                  data-testid={`session-draft-repeat-rearrange-move-up-${groupIndex}`}
-                                  className={rearrangeMoveButtonClass}
-                                >
-                                  <ArrowUp aria-hidden="true" className="size-4" />
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={() => moveDraftGroup(groupIndex, 1, repeatLabel)}
-                                  disabled={repeatMoveDownDisabled}
-                                  aria-label="Move down"
-                                  title="Move down"
-                                  data-testid={`session-draft-repeat-rearrange-move-down-${groupIndex}`}
-                                  className={rearrangeMoveButtonClass}
-                                >
-                                  <ArrowDown aria-hidden="true" className="size-4" />
-                                </button>
-                              </div>
-                            ) : isEditMode ? (
-                              <div className="flex shrink-0 items-start gap-2 sm:hidden">
-                                <button
-                                  type="button"
-                                  onClick={() => toggleRepeatEditor(group.repeatGroupId)}
-                                  aria-expanded={isRepeatOpen}
-                                  aria-label={
-                                    isRepeatOpen ? "Hide repeat details" : "Show repeat details"
-                                  }
-                                  data-testid={`session-draft-repeat-mobile-toggle-${groupIndex}`}
-                                  className={getMobileExpandToggleClass(isRepeatOpen)}
-                                >
-                                  {isRepeatOpen ? (
-                                    <ChevronUp aria-hidden="true" className="size-4" />
-                                  ) : (
-                                    <ChevronDown aria-hidden="true" className="size-4" />
-                                  )}
-                                </button>
-                                {isRepeatOpen ? (
-                                  <button
-                                    type="button"
-                                    onClick={() =>
-                                      setOpenMobileActionKey((current) =>
-                                        current === repeatMobileActionKey
-                                          ? null
-                                          : repeatMobileActionKey
-                                      )
-                                    }
-                                    aria-expanded={repeatMobileActionsOpen}
-                                    aria-controls={`session-draft-repeat-mobile-actions-panel-${group.repeatGroupId}`}
-                                    data-testid={`session-draft-repeat-mobile-actions-toggle-${groupIndex}`}
-                                    className={mobileActionToggleClass}
-                                  >
-                                    <Ellipsis className="size-5" />
-                                    <span className="sr-only">
-                                      {repeatMobileActionsOpen
-                                        ? "Hide repeat actions"
-                                        : "Show repeat actions"}
-                                    </span>
-                                  </button>
-                                ) : null}
-                              </div>
-                            ) : null}
-                          </div>
-
-                          {isEditMode && isRepeatOpen ? (
-                            <div className={desktopRepeatControlRowClass}>
-                              <div className="grid gap-3 sm:flex sm:flex-wrap sm:items-end sm:gap-2">
-                                <label className="text-sm text-slate-700">
-                                  Repeat count
-                                  <input
-                                    type="text"
-                                    inputMode="numeric"
-                                    value={group.repeatCount ?? ""}
-                                    onChange={(event) =>
-                                      updateRepeatGroupCount(
-                                        group.repeatGroupId,
-                                        event.target.value
-                                      )
-                                    }
-                                    min={SESSION_DRAFT_REPEAT_MIN}
-                                    max={SESSION_DRAFT_REPEAT_MAX}
-                                    data-testid={`session-draft-repeat-count-${groupIndex}`}
-                                    className="mt-2 block h-11 w-full rounded-xl border border-blue-200 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200 sm:w-28"
-                                  />
-                                </label>
-                                {hasEditableRepeatEndingRest ? (
-                                  <label className="text-sm text-slate-700">
-                                    Rest after last repeat
-                                    <select
-                                      value={group.repeatEndingRestMode}
-                                      onChange={(event) =>
-                                        updateRepeatGroupEndingRestMode(
-                                          group.repeatGroupId,
-                                          event.target.value as SessionDraftRepeatEndingRestMode
-                                        )
-                                      }
-                                      data-testid={`session-draft-repeat-ending-rest-mode-${groupIndex}`}
-                                      className="mt-2 block h-11 w-full rounded-xl border border-blue-200 bg-white px-3 text-base text-slate-900 shadow-sm transition outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200 sm:min-w-[15rem]"
-                                    >
-                                      {SESSION_DRAFT_REPEAT_ENDING_REST_MODES.map((mode) => (
-                                        <option key={mode} value={mode}>
-                                          {getSessionDraftRepeatEndingRestModeLabel(mode)}
-                                        </option>
-                                      ))}
-                                    </select>
-                                  </label>
-                                ) : null}
-                              </div>
-                              {showRepeatRestConflict ? (
-                                <div className="rounded-xl border border-amber-200 bg-amber-50/90 p-3">
-                                  <p className="text-sm font-medium text-amber-950">
-                                    This creates two rests in a row.
-                                  </p>
-                                  <div className="mt-3 flex flex-wrap gap-2">
-                                    <button
-                                      type="button"
-                                      onClick={() =>
-                                        updateRepeatGroupEndingRestMode(
-                                          group.repeatGroupId,
-                                          "skip_last_rest"
-                                        )
-                                      }
-                                      className="inline-flex h-9 items-center justify-center rounded-xl border border-amber-200 bg-white px-3 text-sm font-medium text-amber-900 transition hover:bg-amber-100"
-                                    >
-                                      Use separate rest step
-                                    </button>
-                                    <button
-                                      type="button"
-                                      onClick={() =>
-                                        setRepeatConflictPendingReplacement(group.repeatGroupId)
-                                      }
-                                      className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-50"
-                                    >
-                                      Use repeat rest time
-                                    </button>
-                                    <button
-                                      type="button"
-                                      onClick={() => {
-                                        setRepeatConflictKeepBoth((current) => ({
-                                          ...current,
-                                          [group.repeatGroupId]: true,
-                                        }));
-                                        setRepeatConflictPendingReplacement((current) =>
-                                          current === group.repeatGroupId ? null : current
-                                        );
-                                      }}
-                                      className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
-                                    >
-                                      Keep both
-                                    </button>
-                                  </div>
-                                  {showRepeatRestReplacementConfirm ? (
-                                    <div className="mt-3 rounded-xl border border-rose-200 bg-white p-3">
-                                      <p className="text-sm font-medium text-rose-950">
-                                        Delete the separate rest step and use repeat rest time?
-                                      </p>
-                                      <div className="mt-3 flex flex-wrap gap-2">
-                                        <button
-                                          type="button"
-                                          onClick={() =>
-                                            removeRepeatPostSetRestStep(group.repeatGroupId)
-                                          }
-                                          className="inline-flex h-9 items-center justify-center rounded-xl bg-rose-600 px-3 text-sm font-semibold text-white transition hover:bg-rose-500"
-                                        >
-                                          Delete rest step
-                                        </button>
-                                        <button
-                                          type="button"
-                                          onClick={() =>
-                                            setRepeatConflictPendingReplacement((current) =>
-                                              current === group.repeatGroupId ? null : current
-                                            )
-                                          }
-                                          className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
-                                        >
-                                          Cancel
-                                        </button>
-                                      </div>
-                                    </div>
-                                  ) : null}
-                                </div>
-                              ) : null}
-                            </div>
-                          ) : null}
-
-                          {isEditMode && isRepeatOpen ? (
-                            <div className="sm:hidden">
-                              <button
-                                type="button"
-                                onClick={() => {
-                                  insertStepAfterGroup(groupIndex);
-                                  setOpenMobileActionKey(null);
-                                }}
-                                data-testid={`session-draft-repeat-mobile-primary-add-step-after-${groupIndex}`}
-                                className="inline-flex h-9 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-50"
-                              >
-                                Add step after
-                              </button>
-                            </div>
-                          ) : null}
-
-                          {isEditMode && isRepeatOpen && repeatMobileActionsOpen ? (
-                            <div
-                              id={`session-draft-repeat-mobile-actions-panel-${group.repeatGroupId}`}
-                              data-testid={`session-draft-repeat-mobile-actions-panel-${groupIndex}`}
-                              className={`${mobileActionPanelClass} sm:hidden`}
-                            >
-                              <div className="mt-2 grid gap-2">
-                                <button
-                                  type="button"
-                                  onClick={() => {
-                                    insertRepeatAfterGroup(groupIndex);
-                                    setOpenMobileActionKey(null);
-                                  }}
-                                  data-testid={`session-draft-repeat-mobile-add-repeat-after-${groupIndex}`}
-                                  className={`${mobileSecondaryActionClass} border-blue-200 bg-white text-blue-800 hover:bg-blue-50`}
-                                >
-                                  Add repeat after
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={() => {
-                                    duplicateRepeatGroup(group.repeatGroupId);
-                                    setOpenMobileActionKey(null);
-                                  }}
-                                  data-testid={`session-draft-repeat-mobile-duplicate-${groupIndex}`}
-                                  className={`${mobileSecondaryActionClass} border-slate-200 bg-white text-slate-700 hover:bg-slate-100`}
-                                >
-                                  Duplicate repeat
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={() => {
-                                    requestRepeatGroupRemoval(group.repeatGroupId);
-                                    setOpenMobileActionKey(null);
-                                  }}
-                                  data-testid={`session-draft-repeat-mobile-remove-${groupIndex}`}
-                                  className={`${mobileSecondaryActionClass} border-rose-200 bg-white text-rose-700 hover:bg-rose-50`}
-                                >
-                                  Delete repeat
-                                </button>
-                              </div>
-                            </div>
-                          ) : null}
-                        </div>
-                      );
-                    })()}
-
-                    {isEditMode && openRepeatGroupId === group.repeatGroupId ? (
-                      <div className="mt-4 space-y-3">
-                        {group.entries.map((entry, repeatIndex) =>
-                          renderStepEditorCard(entry.step, entry.index, groupIndex, {
-                            insideRepeatGroup: true,
-                            repeatStepNumber: repeatIndex + 1,
-                            labelOverride:
-                              repeatIndex === 0
-                                ? isManualPoolMode
-                                  ? (manualPoolTopLevelSectionDescriptors[groupIndex]?.label ??
-                                    "Repeat")
-                                  : "Work interval"
-                                : entry.step.category === "rest"
-                                  ? isManualPoolMode
-                                    ? buildLinkedRestLabel(
-                                        manualPoolTopLevelSectionDescriptors[groupIndex]?.label ??
-                                          "Repeat",
-                                        "interval"
-                                      )
-                                    : "Between-interval recovery"
-                                  : undefined,
-                            descriptionOverride:
-                              entry.step.category === "rest" && isManualPoolMode ? null : undefined,
-                          })
-                        )}
-                        {group.postSetRestEntry
-                          ? renderStepEditorCard(
-                              group.postSetRestEntry.step,
-                              group.postSetRestEntry.index,
-                              groupIndex,
-                              {
-                                labelOverride: isManualPoolMode
-                                  ? buildLinkedRestLabel(
-                                      manualPoolTopLevelSectionDescriptors[groupIndex]?.label ??
-                                        "Repeat",
-                                      "set"
-                                    )
-                                  : "Post-set rest",
-                                descriptionOverride: null,
-                                isLinkedPostSetRest: true,
-                                pendingInlineDelete:
-                                  repeatConflictPendingReplacement === group.repeatGroupId,
-                              }
-                            )
-                          : null}
-                        {pendingRemoval?.kind === "repeat" &&
-                        pendingRemoval.repeatGroupId === group.repeatGroupId ? (
-                          <div
-                            data-testid="workout-editor-removal-confirm"
-                            className="rounded-2xl border border-rose-200 bg-rose-50/90 p-3"
-                          >
-                            <p className="text-sm font-medium text-rose-950">
-                              Delete{" "}
-                              <span className="font-semibold">
-                                {pendingRemoval?.label ?? "this repeat block"}
-                              </span>
-                              ?
-                            </p>
-                            <p className="mt-1 text-sm text-rose-900">
-                              This builder change stays local until you save, and you can still undo
-                              it right after deletion.
-                            </p>
-                            <div className="mt-3 flex flex-wrap gap-2">
-                              <button
-                                type="button"
-                                onClick={confirmPendingRemoval}
-                                data-testid="workout-editor-removal-confirm-button"
-                                className="inline-flex h-10 items-center justify-center rounded-xl bg-rose-600 px-4 text-sm font-semibold text-white transition hover:bg-rose-500 active:bg-rose-700"
-                              >
-                                Delete now
-                              </button>
-                              <button
-                                type="button"
-                                onClick={cancelPendingRemoval}
-                                data-testid="workout-editor-removal-cancel-button"
-                                className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-4 text-sm font-medium text-rose-900 transition hover:bg-rose-100 active:bg-rose-200"
-                              >
-                                Keep it
-                              </button>
-                            </div>
-                          </div>
-                        ) : null}
-                        <div
-                          data-testid={`session-draft-repeat-desktop-actions-${groupIndex}`}
-                          data-desktop-layout="bottom"
-                          className="hidden flex-wrap items-end gap-2 border-t border-blue-100 pt-3 sm:flex"
-                        >
-                          <button
-                            type="button"
-                            onClick={() => insertStepAfterGroup(groupIndex)}
-                            data-testid={`session-draft-repeat-add-step-after-${groupIndex}`}
-                            className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm text-blue-800 transition hover:bg-blue-100"
-                          >
-                            Add step after
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => insertRepeatAfterGroup(groupIndex)}
-                            data-testid={`session-draft-repeat-add-repeat-after-${groupIndex}`}
-                            className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm text-blue-800 transition hover:bg-blue-100"
-                          >
-                            Add repeat after
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => duplicateRepeatGroup(group.repeatGroupId)}
-                            data-testid={`session-draft-repeat-duplicate-${groupIndex}`}
-                            className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm text-blue-800 transition hover:bg-blue-100"
-                          >
-                            Duplicate repeat
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => requestRepeatGroupRemoval(group.repeatGroupId)}
-                            data-testid={`session-draft-repeat-remove-${groupIndex}`}
-                            className="inline-flex h-10 items-center justify-center rounded-xl border border-rose-200 bg-white px-3 text-sm text-rose-700 transition hover:bg-rose-50"
-                          >
-                            Delete repeat
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => toggleRepeatEditor(group.repeatGroupId)}
-                            data-testid={`session-draft-repeat-done-bottom-${groupIndex}`}
-                            className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-blue-50 px-3 text-sm font-medium text-blue-800 transition hover:bg-blue-100 sm:ml-auto"
-                          >
-                            Done
-                          </button>
-                        </div>
-                      </div>
-                    ) : null}
-                  </section>
-                )
-              )}
-        </div>
-      </div>
+                return renderStepEditorCard(
+                  sessionStepBlock.entry.step,
+                  sessionStepBlock.entry.index,
+                  groupIndex,
+                  {
+                    linkedTopLevelRestEntry: sessionStepBlock.linkedRestEntry,
+                  }
+                );
+              })()
+            : renderRepeatSummaryCard(group, groupIndex)
+        )}
+      </SessionStepSurfaceRenderer>
 
       {poolsideNotePanel}
 

--- a/docs/design/session-step-surface-contract.md
+++ b/docs/design/session-step-surface-contract.md
@@ -6,6 +6,7 @@ Use this contract whenever the app displays, edits, rearranges, previews, prints
 
 - Reference implementation: manual pool session builder in `WorkoutEditor`.
 - Shared view-model and display contract: `components/my-library/workouts/sessionStepSurfaceContract.ts`.
+- Shared React renderer boundary: `components/my-library/workouts/SessionStepSurfaceRenderer.tsx`.
 - Domain object: canonical workout/session draft steps from `lib/session-generator-v1/shared.ts`.
 - Consumers include manual builder, AI session generator, poolside note, PDF/export previews, and later planner/program surfaces.
 - Architecture target: route-specific surfaces should adapt data into this contract; they should not fork a separate card/tab/rest-summary visual system.
@@ -48,6 +49,7 @@ Before implementing a new session-step surface:
 
 - One canonical data contract for session steps.
 - One canonical display contract per mode: `Edit`, `Rearrange`, `View`.
-- Route-specific code may supply copy or data mapping, but should not invent a separate visual system.
+- Route-specific code may supply copy, callbacks, or data mapping, but should not invent a separate visual system.
+- Renderer inputs are display-only; canonical draft mutation, save/export/PDF behavior, and edit-field state stay with the owning route/editor.
 - Tests should cover the shared contract once, then route-specific flows only where behavior differs.
-- Active hardening: `docs/task-briefs/in-progress/2026-05-01-session-step-reference-surface-architecture-hardening-10-10.md` tracks extracting this from the current large `WorkoutEditor` implementation into a clearer shared view-model/renderer contract.
+- Prior hardening: `docs/task-briefs/done/2026-05-01-session-step-reference-surface-architecture-hardening-10-10.md` extracted the shared view-model/display helpers. Current renderer extraction is tracked by `docs/task-briefs/in-progress/2026-05-03-session-step-shared-view-model-renderer-10-10.md`.

--- a/docs/task-briefs/in-progress/2026-05-03-session-step-shared-view-model-renderer-10-10.md
+++ b/docs/task-briefs/in-progress/2026-05-03-session-step-shared-view-model-renderer-10-10.md
@@ -1,0 +1,97 @@
+# Task Brief: Session Step Shared View-Model And Renderer (10/10)
+
+## Metadata
+
+- `id`: `2026-05-03-session-step-shared-view-model-renderer-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-05-03`
+- `updated`: `2026-05-03`
+- `mode`: `implementation approved`
+
+## Goal
+
+Extract the next safe React layer for session-step UI so `Edit`, `Rearrange`, and `View` use a shared renderer contract instead of keeping core presentation chrome in `WorkoutEditor`.
+
+## Audit And Reference
+
+- Canonical contract: `docs/design/session-step-surface-contract.md`.
+- Existing shared data layer: `components/my-library/workouts/sessionStepSurfaceContract.ts` from PR #570.
+- Remaining concentration point: `WorkoutEditor` still owned mode tabs, view sections, collapsed cards, repeat cards, rearrange controls, delete/undo UI, mobile actions, and edit shells.
+- Reference surface: manual pool builder in `WorkoutEditor`; AI generator is a parity consumer through `copyVariant="generator"`.
+- Held surfaces: saved-session quick view, poolside note, workout PDF, Garmin-ready export, and program export keep current output paths in this slice.
+
+## Implementation Slice
+
+Add a React-only renderer under `components/my-library/workouts/` for mode shell, empty/undo status, `View` sections, collapsed cards, repeat cards, and rearrange controls. Keep editable fields, draft mutation, persistence/export/PDF logic, save/delete orchestration, and poolside settings in `WorkoutEditor`; document that boundary, update the design contract pointer, add focused tests, capture screenshot handoff, and record perf-budget `tighten`/`hold` without changing budgets unless owner approves.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim: `UX flow clarity`, `Visual design quality`, `Business logic correctness and data integrity`, `Stack-fit and dependency discipline`, `Testing and QA automation`.
+
+| Category                                      | Mapping      | Target Threshold / Scope Rationale                                                                                     | Evidence                                                   | Expected Closeout Score |
+| --------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | One reference surface and shared renderer contract for manual and generated session-step modes.                        | brief + component diff + screenshots                       | `5/5`                   |
+| UX flow clarity                               | `target`     | Edit/Rearrange/View keep current action hierarchy, ordering, and linked-rest behavior.                                 | component tests + screenshot handoff                       | `5/5`                   |
+| Visual design quality                         | `target`     | Spacing, rails, labels, tones, and responsive behavior match approved after/reference screenshots.                     | after/reference screenshots                                | `5/5`                   |
+| Business logic correctness and data integrity | `target`     | Renderer does not mutate drafts and preserves repeats, linked rests, post-set rests, and generated summaries.          | unit tests + diff review                                   | `5/5`                   |
+| Admin editor ergonomics                       | `supporting` | Supporting only: private editor maintainability improves, no admin CRUD workflow change.                               | scope review                                               | `4/5`                   |
+| Accessibility (a11y)                          | `target`     | Mode controls, view lines, mobile toggles, and rearrange buttons keep labels, focus, and keyboard semantics.           | Testing Library assertions + Playwright spot check         | `5/5`                   |
+| Performance (CWV + payloads)                  | `target`     | No new dependency, no intentional extra step render pass, and no obvious `/my-library/*` payload regression.           | build/perf budgets + local QA                              | `5/5`                   |
+| Data placement and sync boundaries            | `target`     | Renderer receives derived presentation input only; server/local draft ownership stays unchanged.                       | code review + tests                                        | `5/5`                   |
+| Caching and invalidation strategy             | `supporting` | Supporting only: no route caching changes; renderer input recomputes from current props/state.                         | component tests                                            | `4/5`                   |
+| Reliability and failure handling              | `target`     | Empty, partial, malformed, and pending-delete states render deterministic fallback UI.                                 | negative-path component tests                              | `5/5`                   |
+| Security and authz                            | `supporting` | Supporting only: protected routes and APIs are unchanged and covered by existing gates.                                | scope review + existing tests                              | `4/5`                   |
+| Privacy and compliance                        | `supporting` | Supporting only: no new personal data exposure or storage.                                                             | data review                                                | `4/5`                   |
+| Content governance                            | `target`     | Step labels, rest wording, repeat wording, and generated-note suppression stay contract-governed.                      | contract review + tests                                    | `5/5`                   |
+| Admin workflow and editability                | `supporting` | Supporting only: editor controls stay available, no admin labels/statuses changed.                                     | manual QA                                                  | `4/5`                   |
+| SEO and crawlability                          | `N/A`        | N/A because this is authenticated/private app UI with no metadata, sitemap, robots, or crawlable route changes.        | explicit SEO scope rationale                               | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because no public semantic content or crawl-safe AI-discoverable entity surface changes.                           | explicit AI discovery scope rationale                      | `N/A`                   |
+| Analytics and KPI observability               | `supporting` | Supporting only: no new event taxonomy; stable test IDs/action semantics are preserved by tests.                       | test-id/event diff review                                  | `4/5`                   |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, entitlement, checkout, billing, or revenue workflow changes.                                   | explicit commerce scope rationale                          | `N/A`                   |
+| Incident response and support operations      | `N/A`        | N/A because no alerting, incident, support queue, or customer recovery workflow changes.                               | explicit support-ops scope rationale                       | `N/A`                   |
+| Finance and reporting operations              | `N/A`        | N/A because no payout, refund, invoice, entitlement reporting, or finance reconciliation data changes.                 | explicit finance scope rationale                           | `N/A`                   |
+| i18n operational readiness                    | `supporting` | Supporting only: centralized labels help later translation, no locale routing/storage added.                           | label centralization review                                | `4/5`                   |
+| Stack-fit and dependency discipline           | `target`     | Use React/TypeScript composition, existing contract helpers, Tailwind tokens, lucide icons, and zero new dependencies. | dependency diff + code review                              | `5/5`                   |
+| Testing and QA automation                     | `target`     | Targeted tests, screenshot handoff, `verify:pre-pr`, CI, and `verify:pre-merge` cover the change.                      | tests + screenshots + `verify:pre-pr` / `verify:pre-merge` | `5/5`                   |
+| Scalability and cost efficiency               | `target`     | Refactor reduces future renderer drift without adding runtime services, heavy assets, or duplicate output engines.     | architecture closeout + diff review                        | `5/5`                   |
+| DevOps and rollback readiness                 | `target`     | Code-only, no migration, rollbackable as one PR; perf decision recorded but not enacted by default.                    | PR diff + rollback note                                    | `5/5`                   |
+
+## Stack, Data, And Identity Contracts
+
+- React/Next.js: client-side shared renderer; no route/action/API/cache boundary changes.
+- TypeScript/domain/data: `SessionDraft`/`SessionDraftStep` stay canonical; renderer input is display-only.
+- Supabase/data layer: `N/A` with rationale: no schema, RLS, auth, storage, or generated DB type changes.
+- External services/tools: `N/A` with rationale: no external SDK, webhook, secret, retry, or idempotency changes.
+- UI/sync/cache: reuse current Tailwind/lucide/responsive patterns; renderer never mutates drafts; existing save APIs and cache behavior stay unchanged.
+- Identity/compatibility: workout IDs, step IDs, repeat IDs, display-name mutability, saved draft schema, poolside/PDF/Garmin/program readers remain unchanged.
+
+## Scope
+
+- In scope: audit boundary, shared renderer, `WorkoutEditor` wiring, code documentation, contract doc update, targeted tests, screenshot handoff, perf decision record.
+- Out of scope: schema changes, poolside/PDF/Garmin/program renderer migration, new dependencies, and budget tightening without owner approval.
+
+## Acceptance Criteria
+
+1. `WorkoutEditor` no longer owns the top-level React rendering for session-step mode shell, view sections, collapsed cards, repeat cards, and rearrange controls.
+2. Manual pool builder remains reference for `Edit`, `Rearrange`, and `View`; AI generator keeps parity through the same renderer contract.
+3. Linked top-level rests, repeat interval rests, post-set rests, standalone rests, and generated-note suppression remain unchanged.
+4. New code documents ownership, presentation-only input/callback boundary, and non-obvious invariants.
+5. Poolside note, PDF, Garmin-ready export, saved quick view, and program export outputs remain unchanged.
+6. Screenshot handoff is approved before `verify:pre-pr`; `verify:pre-pr`, CI, and `verify:pre-merge` pass before merge readiness.
+
+## Validation
+
+- Before PR: `npm run lint:briefs`, targeted unit/component tests, screenshot handoff, `npm run verify:pre-pr`.
+- Before merge recommendation: required CI green and `npm run verify:pre-merge`.
+
+## Checkpoint Log
+
+- `2026-05-03 | planning | audited current session-step architecture after PR #570/#574/#575; shared view-model helpers exist, but WorkoutEditor still owns most React rendering and mode orchestration | next: discuss scope before implementation`
+- `2026-05-03 | in-progress | owner approved renderer extraction scope, code-documentation requirements, design-contract cleanup, and perf-budget hold-by-default decision; moved brief to in-progress on branch feat/session-step-shared-renderer | next: implement shared renderer/input boundary`
+- `2026-05-03 | in-progress | extracted shared session-step surface chrome/View renderer with presentation-only docs, updated contract pointer, and added renderer unit coverage; targeted vitest, typecheck, lint, and lint:briefs passed | next: screenshot handoff`
+- `2026-05-03 | in-progress | owner approved after/reference screenshot handoff for manual builder Edit/Rearrange/View and generator consumer View parity | next: run verify:pre-pr`
+- `2026-05-03 | in-progress | npm run verify:pre-pr first hit transient poolside save-image metrics navigation failure outside renderer scope; isolated rerun passed; no e2e helper change is kept in this PR after size-check reduction | next: rerun gate before PR update`
+- `2026-05-03 | in-progress | npm run verify:pre-pr passed full lane on size-check-compatible diff (108 passed, 348 skipped; log artifacts/test-runs/20260503-163254/verify.log). Perf trend recommended tighten after 3 weekly green runs, but decision is hold without owner approval to change budgets | next: amend, push, PR, CI, verify:pre-merge`

--- a/tests/unit/session-step-surface-renderer.test.tsx
+++ b/tests/unit/session-step-surface-renderer.test.tsx
@@ -1,0 +1,173 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import {
+  SessionStepSummaryCard,
+  SessionStepSurfaceRenderer,
+} from "@/components/my-library/workouts/SessionStepSurfaceRenderer";
+import type { SessionStepViewSection } from "@/components/my-library/workouts/sessionStepSurfaceContract";
+
+const viewSections: SessionStepViewSection[] = [
+  {
+    key: "warmup-0",
+    title: "Warmup",
+    category: "warmup",
+    lines: [
+      {
+        key: "warmup-step",
+        primaryText: "400m · Freestyle · Easy",
+        secondaryText: "Rest 0:30",
+        target: { kind: "step", stepId: "warmup-step" },
+      },
+      {
+        key: "main-repeat",
+        primaryText: "4 x 100m · Freestyle · Moderate · Interval rest 0:30",
+        secondaryText: "Set rest 1:00",
+        target: { kind: "repeat", repeatGroupId: "main-repeat" },
+      },
+    ],
+  },
+];
+
+function clickAll(...testIds: string[]) {
+  testIds.forEach((testId) => fireEvent.click(screen.getByTestId(testId)));
+}
+
+function renderSurface(mode: "edit" | "view" = "edit") {
+  const action = vi.fn();
+  const callbacks = {
+    action,
+    onModeChange: vi.fn(),
+    onOpenViewStep: vi.fn(),
+    onOpenViewRepeat: vi.fn(),
+  };
+
+  render(
+    <SessionStepSurfaceRenderer
+      mode={mode}
+      title="Session steps"
+      showModeTabs
+      showAddActions={mode === "edit"}
+      hasSteps={mode !== "edit"}
+      rearrangeLiveMessage="Moved Warmup down."
+      lastRemovedLabel={mode === "edit" ? "Warmup and attached rest" : null}
+      viewSections={viewSections}
+      onModeChange={callbacks.onModeChange}
+      onAddStep={action}
+      onAddRepeat={action}
+      onUndoLastRemoval={action}
+      onDismissLastRemoval={action}
+      onOpenViewStep={callbacks.onOpenViewStep}
+      onOpenViewRepeat={callbacks.onOpenViewRepeat}
+    >
+      <article data-testid="renderer-edit-child">Editable cards</article>
+    </SessionStepSurfaceRenderer>
+  );
+
+  return callbacks;
+}
+
+function renderStepCard() {
+  const action = vi.fn();
+
+  render(
+    <SessionStepSummaryCard
+      stepId="warmup-step"
+      index={0}
+      panelId="warmup-panel"
+      canUseDesktopCardOpen
+      cardStateClass="border-dashed border-rose-300"
+      categoryRailClass="border-l-4 border-cyan-400"
+      isEditMode
+      isSummaryOnlyMode={false}
+      isOpen={false}
+      mobileActionsOpen
+      pendingDelete
+      removalLabel="Warmup and attached rest"
+      showRearrangeControls={false}
+      showMobilePrimaryAddAfter={false}
+      showMobilePrimaryAddRepeatAfter={false}
+      canAddRepeatAfter
+      isLinkedPostSetRest={false}
+      moveUpDisabled={false}
+      moveDownDisabled={false}
+      wasRecentlyMoved={false}
+      summary={{
+        label: "Warmup",
+        title: "400m · Freestyle · Easy · Rest 0:30",
+        labelClassName: "text-cyan-700",
+        pendingDelete: true,
+      }}
+      editPanel={<div data-testid="single-edit-panel" />}
+      onOpen={action}
+      onToggle={action}
+      onToggleMobileActions={action}
+      onMoveUp={action}
+      onMoveDown={action}
+      onAddStepAfter={action}
+      onAddRepeatAfter={action}
+      onDuplicate={action}
+      onRequestRemove={action}
+      onConfirmRemoval={action}
+      onCancelRemoval={action}
+    />
+  );
+
+  return action;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+it("renders shell states and delegates mode/add/undo callbacks", () => {
+  const callbacks = renderSurface();
+
+  expect(screen.getByTestId("session-draft-empty-steps")).toBeVisible();
+  expect(screen.getByTestId("workout-editor-removal-undo")).toHaveTextContent(
+    "Warmup and attached rest"
+  );
+
+  clickAll(
+    "workout-editor-builder-mode-view",
+    "session-draft-add-step",
+    "session-draft-add-repeat",
+    "workout-editor-removal-undo-button",
+    "workout-editor-removal-dismiss-button"
+  );
+
+  expect(callbacks.onModeChange).toHaveBeenCalledWith("view");
+  expect(callbacks.action).toHaveBeenCalledTimes(4);
+});
+
+it("renders view sections from presentation input and delegates targeted callbacks", () => {
+  const callbacks = renderSurface("view");
+
+  expect(screen.getAllByTestId(/workout-editor-view-section-/)).toHaveLength(1);
+  expect(screen.getByText("400m · Freestyle · Easy")).toBeVisible();
+
+  clickAll(
+    "workout-editor-view-line-warmup-0-warmup-step",
+    "workout-editor-view-repeat-main-repeat"
+  );
+
+  expect(callbacks.onOpenViewStep).toHaveBeenCalledWith("warmup-step");
+  expect(callbacks.onOpenViewRepeat).toHaveBeenCalledWith("main-repeat");
+});
+
+it("renders shared single-step chrome and delegates card/delete actions", () => {
+  const action = renderStepCard();
+
+  clickAll(
+    "session-draft-step-summary-0",
+    "session-draft-step-toggle-0",
+    "session-draft-step-mobile-add-after-0",
+    "session-draft-step-mobile-add-repeat-after-0",
+    "session-draft-step-mobile-duplicate-0",
+    "session-draft-step-mobile-remove-0",
+    "workout-editor-removal-confirm-button",
+    "workout-editor-removal-cancel-button"
+  );
+
+  expect(action).toHaveBeenCalledTimes(8);
+});


### PR DESCRIPTION
## Summary

- What changed and why? Extracted the session-step mode shell, View sections, collapsed single-step cards, repeat summary cards, rearrange controls, mobile action shells, and delete confirmation chrome into a shared `SessionStepSurfaceRenderer` so manual builder and AI generator consume the same React surface contract.
- User-visible changes: no intentional workflow or content change; Edit, Rearrange, and View should visually match the approved screenshot handoff.
- Technical changes: `WorkoutEditor` now keeps draft mutation/edit forms/persistence while the shared renderer owns presentation chrome; the session-step design contract documents the renderer boundary.
- Policy impact: no (no auth, analytics taxonomy, user-data rights, or third-party processor behavior changed).
- Policy version note: N/A (no policy-impacting scope detected).
- Brief link: `docs/task-briefs/in-progress/2026-05-03-session-step-shared-view-model-renderer-10-10.md`
- Perf budget decision: hold. `verify:pre-pr` recommended tightening one stretch target after 3 weekly green runs, but this non-budget UI architecture slice does not change budgets without explicit owner approval.

## Scope

- In scope: shared session-step renderer extraction, WorkoutEditor wiring, session-step surface contract docs, renderer unit coverage, and screenshot-approved visual parity.
- Out of scope: database/schema changes, poolside renderer migration, PDF/export contract changes, Garmin/program output changes, E2E helper hardening, and performance budget tightening.
- Changed files:
  - `components/my-library/workouts/SessionStepSurfaceRenderer.tsx`
  - `components/my-library/workouts/WorkoutEditor.tsx`
  - `docs/design/session-step-surface-contract.md`
  - `docs/task-briefs/in-progress/2026-05-03-session-step-shared-view-model-renderer-10-10.md`
  - `tests/unit/session-step-surface-renderer.test.tsx`

## Risk

- Main risk: shared renderer extraction could subtly alter step card ordering, linked-rest copy, repeat rest/post-set-rest visibility, or action callback wiring across manual and generated sessions.
- Mitigation: targeted renderer tests cover shell, callbacks, view sections, empty/undo states, and delete confirmation; screenshot handoff covered manual builder desktop/mobile plus AI generator consumer parity; full `verify:pre-pr` passed.
- Rollback plan: revert `474b15a` (`git revert 474b15a`) to restore the previous inline `WorkoutEditor` rendering.

## Test Evidence

- Policy-impact checklist: N/A (no policy-impacting scope detected in changed files).
- `npm run lint:briefs`: PASS via `npm run lint:briefs -- --all` after final checkpoint edit.
- `git diff --check`: PASS.
- `npm exec vitest run tests/unit/session-step-surface-renderer.test.tsx tests/unit/session-step-surface-contract.test.ts tests/unit/workout-builder-hub.test.tsx tests/unit/session-generator-panel.test.tsx`: PASS, 4 files / 75 tests.
- `npm run typecheck`: PASS.
- `npm run lint`: PASS.
- `npm run test:unit`: PASS inside `npm run verify:pre-pr`.
- `npm run build`: PASS inside `npm run verify:pre-pr`.
- `npm run test:e2e`: PASS inside `npm run verify:pre-pr`.
- `npm run verify:pre-pr`: PASS full-public lane, `artifacts/test-runs/20260503-163254/verify.log`, 108 passed / 348 skipped.
- `npm run verify:pre-merge`: PENDING for `474b15a`; will run after PR/CI checks.
- Local manual QA done on `http://127.0.0.1:3000` with desktop and mobile screenshot capture.
- Vercel preview manual QA: PENDING.
- QA matrix: desktop and mobile screenshot handoff plus full Playwright matrix selected by `verify:pre-pr`.

- [x] `npm run lint:briefs`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] `npm run test:e2e`
- [x] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [x] Local manual QA done on dev URL (listed above)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [x] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- Screenshot handoff type: `after/reference`.
- Artifact folder: `/Users/stianvikra/freeswimming/output/session-step-shared-renderer-2026-05-03`
- Representative screenshots:
  - `after-manual-builder-edit-desktop.png`: verifies the extracted renderer preserves Edit card chrome/actions.
  - `after-manual-builder-rearrange-desktop.png`: verifies move controls and compact cards in Rearrange.
  - `after-manual-builder-view-mobile.png`: verifies mobile View grouping and responsive spacing.
  - `after-generator-consumer-view-desktop.png`: verifies AI generator consumer parity through the shared renderer.
- Owner screenshot approval: approved in chat before `verify:pre-pr`.
- Known visual caveat: none recorded from the approved handoff.

- [x] Screenshot(s) attached or linked (if UI changed)
- [x] Mobile behavior checked (if UI changed)

## 10/10 Scorecard

- Current target scores: Product goals and IA `5/5`; UX flow clarity `5/5`; Visual design quality `5/5`; Business logic correctness and data integrity `5/5`; Accessibility `5/5`; Performance `5/5`; Data placement and sync boundaries `5/5`; Reliability and failure handling `5/5`; Content governance `5/5`; Stack-fit and dependency discipline `5/5`; Testing and QA automation `5/5`; Scalability and cost efficiency `5/5`; DevOps and rollback readiness `5/5`.
- Remaining gaps: none for the approved scope before pre-merge; Vercel preview and `verify:pre-merge` remain pending gates.
- Critical target categories for a 10/10 claim: UX flow clarity `5/5`; Visual design quality `5/5`; Business logic correctness and data integrity `5/5`; Stack-fit and dependency discipline `5/5`; Testing and QA automation `5/5`.
- 10/10 claim state: pending final pre-merge gate, but all critical target categories are currently evidenced at `5/5`.

## Checklist

- [x] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale.
- [x] Acceptance criteria are met for the approved implementation scope.
- [x] Docs updated for behavior/contract changes.
- [x] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A).
- [x] Every `target` scorecard row has measurable threshold + evidence source.
- [x] Changed `done` task briefs include achieved score + evidence for every target category and explicit `10/10 claim: yes/no`: N/A, no `done` brief changed.
- [x] If claiming `10/10`: critical target categories are listed and each is scored `5/5`.
- [x] PR is <= 500 changed lines, or intentionally split/explained: extraction is larger than 500 lines because markup moved from `WorkoutEditor` into the shared renderer; PR is kept under the 4000-line CI size gate.
- [x] No secrets or sensitive data added.

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/578`
- [ ] Required checks are green.
- [ ] Local QA + Vercel preview QA are completed.
- [ ] `Squash and merge` clicked by repo owner.

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d feat/session-step-shared-renderer`
- [ ] Optional: `git fetch --prune`
