### PR TITLE
feat: align saved workout quick view

### DIFF
--- a/components/my-library/workouts/SavedWorkoutsPanel.tsx
+++ b/components/my-library/workouts/SavedWorkoutsPanel.tsx
@@ -4,9 +4,17 @@ import Link from "next/link";
 import { ChevronUp, Ellipsis } from "lucide-react";
 import { useEffect, useState } from "react";
 import PoolsideNotePanel from "@/components/my-library/workouts/PoolsideNotePanel";
+import { SessionStepViewSections } from "@/components/my-library/workouts/SessionStepSurfaceRenderer";
+import type {
+  SessionStepViewSection,
+  SessionStepViewSectionLine,
+} from "@/components/my-library/workouts/sessionStepSurfaceContract";
 import {
+  SESSION_DRAFT_STEP_CATEGORIES,
   formatDistanceMetersLabel,
+  getSessionStepCategoryLabel,
   resolveSessionDraftPoolLengthUnit,
+  type SessionDraftStep,
 } from "@/lib/session-generator-v1/shared";
 import { buildWorkoutPoolsidePreviewHref } from "@/lib/workouts/poolside-preview";
 import type { WorkoutPoolsideFocusOption, WorkoutSummary } from "@/lib/workouts/shared";
@@ -45,19 +53,19 @@ type Props = {
   swimmerName?: string | null;
 };
 
-type QuickPreviewRow = {
-  key: string;
-  primaryText: string;
-  secondaryText?: string | null;
-};
+function inferQuickPreviewCategory(title: string | null | undefined): SessionDraftStep["category"] {
+  const normalizedTitle = title?.trim().toLowerCase() ?? "";
 
-type QuickPreviewSection = {
-  key: string;
-  title?: string | null;
-  rows: QuickPreviewRow[];
-};
+  return (
+    SESSION_DRAFT_STEP_CATEGORIES.find(
+      (category) => getSessionStepCategoryLabel(category).toLowerCase() === normalizedTitle
+    ) ?? "main"
+  );
+}
 
-function buildQuickPreviewRowsFromPreviewText(workout: WorkoutSummary): QuickPreviewRow[] {
+function buildQuickPreviewRowsFromPreviewText(
+  workout: WorkoutSummary
+): SessionStepViewSectionLine[] {
   if (!workout.previewText) {
     return [];
   }
@@ -85,12 +93,13 @@ function buildQuickPreviewRowsFromPreviewText(workout: WorkoutSummary): QuickPre
     });
 }
 
-function buildQuickPreviewSections(workout: WorkoutSummary): QuickPreviewSection[] {
+function buildQuickPreviewSections(workout: WorkoutSummary): SessionStepViewSection[] {
   if (workout.previewSections && workout.previewSections.length > 0) {
     return workout.previewSections.map((section, sectionIndex) => ({
       key: section.key || `${workout.id}-preview-section-${sectionIndex}`,
       title: section.title,
-      rows: section.rows.map((lineItem, lineIndex) => ({
+      category: section.category ?? inferQuickPreviewCategory(section.title),
+      lines: section.rows.map((lineItem, lineIndex) => ({
         key: `${section.key || `${workout.id}-preview-section-${sectionIndex}`}-line-${lineIndex}`,
         primaryText: lineItem.text,
         secondaryText: lineItem.secondaryText ?? null,
@@ -102,8 +111,9 @@ function buildQuickPreviewSections(workout: WorkoutSummary): QuickPreviewSection
     return [
       {
         key: `${workout.id}-preview-section-0`,
-        title: null,
-        rows: workout.previewLineItems.map((lineItem, index) => ({
+        title: "Workout",
+        category: "main",
+        lines: workout.previewLineItems.map((lineItem, index) => ({
           key: `${workout.id}-preview-${index}`,
           primaryText: lineItem.text,
           secondaryText: lineItem.secondaryText ?? null,
@@ -117,8 +127,9 @@ function buildQuickPreviewSections(workout: WorkoutSummary): QuickPreviewSection
     ? [
         {
           key: `${workout.id}-preview-section-0`,
-          title: null,
-          rows: fallbackRows,
+          title: "Workout",
+          category: "main",
+          lines: fallbackRows,
         },
       ]
     : [];
@@ -205,7 +216,10 @@ export default function SavedWorkoutsPanel({
   }, [poolsideWorkoutId, workouts]);
 
   useEffect(() => {
-    if (mobileActionsWorkoutId && !workouts.some((workout) => workout.id === mobileActionsWorkoutId)) {
+    if (
+      mobileActionsWorkoutId &&
+      !workouts.some((workout) => workout.id === mobileActionsWorkoutId)
+    ) {
       setMobileActionsWorkoutId(null);
     }
   }, [mobileActionsWorkoutId, workouts]);
@@ -269,7 +283,7 @@ export default function SavedWorkoutsPanel({
           <div>
             <h3 className="text-sm font-semibold text-slate-900">{heading}</h3>
             {description ? <p className="mt-1 text-sm text-slate-600">{description}</p> : null}
-            <p className="mt-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <p className="mt-2 text-xs font-semibold tracking-wide text-slate-500 uppercase">
               {workouts.length} saved session{workouts.length === 1 ? "" : "s"}
             </p>
           </div>
@@ -294,7 +308,9 @@ export default function SavedWorkoutsPanel({
               <div>
                 <p className="text-sm font-semibold text-slate-900">Library cleanup</p>
                 {bulkSelectionMode ? (
-                  <p className="mt-1 text-sm text-slate-600">{selectedWorkoutIds.length} selected</p>
+                  <p className="mt-1 text-sm text-slate-600">
+                    {selectedWorkoutIds.length} selected
+                  </p>
                 ) : null}
               </div>
               <div className="flex flex-wrap items-center gap-2">
@@ -614,36 +630,14 @@ export default function SavedWorkoutsPanel({
                     className="mt-3 rounded-2xl border border-slate-200 bg-slate-50/80 p-4"
                   >
                     <div className="space-y-3">
-                      {quickPreviewSections.map((section) => (
-                        <section
-                          key={section.key}
-                          className="rounded-xl border border-white/80 bg-white px-3 py-3"
-                        >
-                          {section.title ? (
-                            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                              {section.title}
-                            </p>
-                          ) : null}
-                          <div className={`${section.title ? "mt-2" : ""} space-y-2`}>
-                            {section.rows.map((line) => (
-                              <div key={line.key}>
-                                <p className="text-sm leading-6 text-slate-800">
-                                  {line.primaryText}
-                                </p>
-                                {line.secondaryText ? (
-                                  <p className="text-sm font-semibold text-blue-800">
-                                    {line.secondaryText}
-                                  </p>
-                                ) : null}
-                              </div>
-                            ))}
-                          </div>
-                        </section>
-                      ))}
+                      <SessionStepViewSections
+                        sections={quickPreviewSections}
+                        sectionTestIdPrefix={`saved-workouts-preview-section-${workout.id}`}
+                      />
                     </div>
                     {totalDistanceQuickLabel ? (
                       <div className="mt-4 flex flex-wrap items-center justify-between gap-2 rounded-xl border border-slate-200 bg-white px-3 py-3">
-                        <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
+                        <p className="text-xs font-semibold tracking-wide text-blue-700 uppercase">
                           Total
                         </p>
                         <p className="text-lg font-semibold text-slate-900">

--- a/components/my-library/workouts/SessionStepSurfaceRenderer.tsx
+++ b/components/my-library/workouts/SessionStepSurfaceRenderer.tsx
@@ -228,12 +228,14 @@ export function SessionStepSurfaceRenderer({
 
 type SessionStepViewSectionsProps = {
   sections: readonly SessionStepViewSection[];
-  onOpenStep: (stepId: string) => void;
-  onOpenRepeat: (repeatGroupId: string) => void;
+  sectionTestIdPrefix?: string;
+  onOpenStep?: (stepId: string) => void;
+  onOpenRepeat?: (repeatGroupId: string) => void;
 };
 
-function SessionStepViewSections({
+export function SessionStepViewSections({
   sections,
+  sectionTestIdPrefix = "workout-editor-view-section",
   onOpenStep,
   onOpenRepeat,
 }: SessionStepViewSectionsProps) {
@@ -242,7 +244,7 @@ function SessionStepViewSections({
       {sections.map((section) => (
         <section
           key={section.key}
-          data-testid={`workout-editor-view-section-${section.key}`}
+          data-testid={`${sectionTestIdPrefix}-${section.key}`}
           data-view-category={section.category}
           className={`overflow-hidden rounded-2xl border bg-white ${getManualPoolViewSectionToneClass(
             section.category
@@ -272,7 +274,7 @@ function SessionStepViewSections({
                 </div>
               );
 
-              if (lineTarget?.kind === "repeat") {
+              if (lineTarget?.kind === "repeat" && onOpenRepeat) {
                 return (
                   <button
                     key={line.key}
@@ -286,7 +288,7 @@ function SessionStepViewSections({
                 );
               }
 
-              if (lineTarget?.kind === "step") {
+              if (lineTarget?.kind === "step" && onOpenStep) {
                 return (
                   <button
                     key={line.key}

--- a/docs/design/session-step-surface-contract.md
+++ b/docs/design/session-step-surface-contract.md
@@ -8,7 +8,8 @@ Use this contract whenever the app displays, edits, rearranges, previews, prints
 - Shared view-model and display contract: `components/my-library/workouts/sessionStepSurfaceContract.ts`.
 - Shared React renderer boundary: `components/my-library/workouts/SessionStepSurfaceRenderer.tsx`.
 - Domain object: canonical workout/session draft steps from `lib/session-generator-v1/shared.ts`.
-- Consumers include manual builder, AI session generator, poolside note, PDF/export previews, and later planner/program surfaces.
+- Current consumers include manual builder, AI session generator, and saved-workout Quick View.
+- Later consumers include poolside note, PDF/export previews, and planner/program surfaces.
 - Architecture target: route-specific surfaces should adapt data into this contract; they should not fork a separate card/tab/rest-summary visual system.
 
 ## Required Behavior
@@ -40,7 +41,7 @@ Use this contract whenever the app displays, edits, rearranges, previews, prints
 
 Before implementing a new session-step surface:
 
-1. Identify whether manual pool builder, AI generated session, poolside note, or PDF/export already solves the same display problem.
+1. Identify whether manual pool builder, AI generated session, saved-workout Quick View, poolside note, or PDF/export already solves the same display problem.
 2. Reuse the shared renderer/view-model contract where practical.
 3. If behavior differs, record the reason in the task brief and screenshot handoff.
 4. Capture `after/reference` screenshots when the owner is asked to approve visual parity.
@@ -52,4 +53,4 @@ Before implementing a new session-step surface:
 - Route-specific code may supply copy, callbacks, or data mapping, but should not invent a separate visual system.
 - Renderer inputs are display-only; canonical draft mutation, save/export/PDF behavior, and edit-field state stay with the owning route/editor.
 - Tests should cover the shared contract once, then route-specific flows only where behavior differs.
-- Prior hardening: `docs/task-briefs/done/2026-05-01-session-step-reference-surface-architecture-hardening-10-10.md` extracted the shared view-model/display helpers. Current renderer extraction is tracked by `docs/task-briefs/in-progress/2026-05-03-session-step-shared-view-model-renderer-10-10.md`.
+- Prior hardening: `docs/task-briefs/done/2026-05-01-session-step-reference-surface-architecture-hardening-10-10.md` extracted the shared view-model/display helpers, and `docs/task-briefs/done/2026-05-03-session-step-shared-view-model-renderer-10-10.md` extracted the shared React renderer. Saved-workout Quick View parity is tracked by `docs/task-briefs/in-progress/2026-05-03-session-step-saved-quick-view-contract-10-10.md`.

--- a/docs/task-briefs/in-progress/2026-05-03-session-step-saved-quick-view-contract-10-10.md
+++ b/docs/task-briefs/in-progress/2026-05-03-session-step-saved-quick-view-contract-10-10.md
@@ -1,0 +1,141 @@
+# Task Brief: Session Step Saved Quick View Contract (10/10)
+
+## Metadata
+
+- `id`: `2026-05-03-session-step-saved-quick-view-contract-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-05-03`
+- `updated`: `2026-05-03`
+
+## Goal
+
+Make saved-workout `Quick View` consume the shared session-step `View` display contract so saved session previews do not drift from the manual builder reference surface.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim: `UX flow clarity`, `Visual design quality`, `Business logic correctness and data integrity`, `Stack-fit and dependency discipline`, `Testing and QA automation`.
+
+| Category                                      | Mapping      | Target Threshold / Scope Rationale                                                                                               | Evidence                                  | Expected Closeout Score |
+| --------------------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | Saved session previews use the same session-step view section contract as the reference builder surface.                         | component diff + screenshot handoff       | `5/5`                   |
+| UX flow clarity                               | `target`     | `Quick View` remains a compact read-only preview with clear section grouping, rest summaries, and total distance.                | unit tests + screenshot handoff           | `5/5`                   |
+| Visual design quality                         | `target`     | Saved quick-view sections reuse the shared view styling, category tones, and spacing without introducing a separate card system. | after/reference screenshots               | `5/5`                   |
+| Business logic correctness and data integrity | `target`     | Preview sections preserve contiguous workout order, category identity, linked rests, repeat rests, and total labels.             | `workouts-shared` + component tests       | `5/5`                   |
+| Admin editor ergonomics                       | `N/A`        | N/A because this private end-user saved-session preview does not change admin editing or publishing workflows.                   | explicit admin scope rationale            | `N/A`                   |
+| Accessibility (a11y)                          | `target`     | Read-only quick-view rows remain semantic sections without misleading edit buttons, and builder view buttons keep labels.        | Testing Library assertions                | `5/5`                   |
+| Performance (CWV + payloads)                  | `target`     | No new dependency and no new server read; preview adapts existing summary data into the shared renderer.                         | dependency diff + targeted tests          | `5/5`                   |
+| Data placement and sync boundaries            | `target`     | Saved workout rows remain server-canonical; quick view uses derived display-only preview data.                                   | brief + code review                       | `5/5`                   |
+| Caching and invalidation strategy             | `supporting` | Supporting only: no route cache changes; previews refresh through existing saved-workout reads after save/delete.                | scope review                              | `4/5`                   |
+| Reliability and failure handling              | `target`     | Missing legacy category data falls back deterministically instead of breaking saved preview rendering.                           | backward-compat component tests           | `5/5`                   |
+| Security and authz                            | `supporting` | Supporting only: protected workout routes and APIs are unchanged and keep existing authz gates.                                  | scope review + existing gates             | `4/5`                   |
+| Privacy and compliance                        | `supporting` | Supporting only: no new personal data, logging, export destination, or retention behavior.                                       | data review                               | `4/5`                   |
+| Content governance                            | `target`     | Section labels, rest wording, and repeat wording remain centralized through the session-step display contract.                   | contract tests + docs update              | `5/5`                   |
+| Admin workflow and editability                | `N/A`        | N/A because no admin/user recovery workflow, status label, or support queue behavior changes.                                    | explicit workflow scope rationale         | `N/A`                   |
+| SEO and crawlability                          | `N/A`        | N/A because this authenticated app UI changes no public route metadata, sitemap, robots, or crawlable content.                   | explicit SEO scope rationale              | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because this private saved-workout preview changes no public AI-discoverable entity or semantic content.                     | explicit AI-discovery scope rationale     | `N/A`                   |
+| Analytics and KPI observability               | `supporting` | Supporting only: existing quick-view action/test IDs remain stable; no event taxonomy is added.                                  | test-id diff review                       | `4/5`                   |
+| Commerce and revenue ops                      | `N/A`        | N/A because no checkout, entitlement, pricing, billing, refund, or revenue workflow changes.                                     | explicit commerce scope rationale         | `N/A`                   |
+| Incident response and support operations      | `N/A`        | N/A because this preview-only UI change adds no alerting, incident path, support queue, or customer recovery workflow.           | explicit support-ops scope rationale      | `N/A`                   |
+| Finance and reporting operations              | `N/A`        | N/A because no payout, invoice, ledger, entitlement report, refund, or finance reconciliation data changes.                      | explicit finance scope rationale          | `N/A`                   |
+| i18n operational readiness                    | `supporting` | Supporting only: shared labels improve later localization, but no locale routing/storage or translation layer changes.           | label centralization review               | `4/5`                   |
+| Stack-fit and dependency discipline           | `target`     | Reuse React/TypeScript shared renderer, existing preview data, Tailwind tokens, and zero new dependencies.                       | dependency diff + code review             | `5/5`                   |
+| Testing and QA automation                     | `target`     | Targeted unit/component tests pass before screenshot handoff; `verify:pre-pr` waits for owner visual approval.                   | tests + screenshots + later gate evidence | `5/5`                   |
+| Scalability and cost efficiency               | `target`     | Reuse reduces future saved-preview drift without additional runtime services, exports, or duplicate render engines.              | architecture closeout + diff review       | `5/5`                   |
+| DevOps and rollback readiness                 | `target`     | Code-only, no migration, no cache purge; rollback is a single PR revert.                                                         | PR diff + rollback note                   | `5/5`                   |
+
+## Stack / Architecture Best-Practice Gate
+
+- React/Next.js: reference surface is `SessionStepSurfaceRenderer` and its `View` sections. Saved `Quick View` stays client-rendered inside `SavedWorkoutsPanel`; no route, action, API, or cache boundary changes.
+- TypeScript/domain contracts: extend `WorkoutSummaryPreviewSection` with optional category identity and adapt it to `SessionStepViewSection`; legacy summaries without category fall back from section title.
+- Supabase/data layer: N/A with rationale: no schema, RLS, auth, storage, migration, or generated DB type changes.
+- External services/tools: N/A with rationale: no SDK, webhook, secret, retry, or idempotency behavior changes.
+- UI system: use `docs/design/session-step-surface-contract.md`; screenshot handoff is `after/reference` comparing saved Quick View with the builder `View` reference.
+- Testing: update focused unit/component tests for summary sections, saved quick view rendering, and shared renderer read-only behavior.
+
+## Data Placement And Sync Contract
+
+- Server-canonical data: saved workout rows and canonical draft steps remain owned by the existing `workouts` table/API read path.
+- Local-only data: quick-view open/closed state remains browser component state only.
+- Sync policy: no new sync; saved preview data is regenerated from canonical draft data when workout summaries are loaded or saved.
+- Retention and sensitivity: no new persistence or logging; step preview text remains existing saved-workout display data.
+- Cache/invalidation: unchanged; save/delete paths already refresh the saved-workout library snapshot.
+
+## Identity And Rename Contract
+
+- Canonical stable ID: workout IDs, step IDs, and repeat IDs remain unchanged.
+- Human-readable identifiers: workout titles and section labels remain display-only and renameable.
+- Mutability rules: this slice does not mutate entities; preview rows are derived display output.
+- Rename vs repurpose: N/A for runtime behavior because no persisted identifier changes.
+- Compatibility contract: legacy `previewSections` without category still render with deterministic title-based fallback.
+- Observability and repair: invalid stored workout summaries continue to be filtered by existing server safeguards.
+
+## Scope
+
+- `components/my-library/workouts/SavedWorkoutsPanel.tsx`
+- `components/my-library/workouts/SessionStepSurfaceRenderer.tsx`
+- `lib/workouts/shared.ts`
+- Focused unit/component tests for saved quick view and preview section contracts.
+- `docs/design/session-step-surface-contract.md`
+
+## Out Of Scope
+
+- Poolside note print/export rendering.
+- Workout PDF HTML renderer migration.
+- Garmin-ready export payload changes.
+- Program PDF/export migration.
+- Schema, API, authz, or cache changes.
+- New dependencies.
+
+## Acceptance Criteria
+
+1. Saved-workout `Quick View` renders preview sections through the shared session-step view renderer.
+2. Builder `View` behavior remains interactive and unchanged.
+3. Saved `Quick View` is read-only and does not expose misleading edit/open actions.
+4. Preview section category identity is preserved when generated from canonical drafts and falls back safely for legacy test data.
+5. Linked rests, repeat interval rests, post-set rests, standalone rests, and total distance labels still render deterministically.
+6. Screenshot handoff is approved before `npm run verify:pre-pr`.
+
+## Validation
+
+- `npm run lint:briefs`
+- targeted unit/component tests:
+  - `tests/unit/session-step-surface-renderer.test.tsx`
+  - `tests/unit/workouts-shared.test.ts`
+  - `tests/unit/workouts-server.test.ts`
+  - `tests/unit/workout-builder-hub.test.tsx`
+- screenshot handoff before `verify:pre-pr`
+- after owner screenshot approval:
+  - `npm run verify:pre-pr`
+  - CI
+  - `npm run verify:pre-merge`
+
+## Local Tooling Prerequisite
+
+- Node.js and npm from the repo runtime are available locally.
+- Use the repo `nvm` bootstrap before reporting missing `node`/`npm`.
+
+## Manual QA Environments
+
+- Local URL: `http://127.0.0.1:3000`.
+- Screenshot handoff required because saved `Quick View` is a user-facing visual surface.
+- Handoff comparison type: `after/reference`.
+- Representative screenshots:
+  - after saved-workout Quick View desktop,
+  - after saved-workout Quick View mobile,
+  - reference builder `View` desktop or mobile.
+
+## Constraints
+
+- Keep the patch narrow and do not redesign saved-workout cards beyond the shared preview section renderer.
+- Preserve existing quick-view button labels and test IDs where practical.
+- Do not change poolside/PDF/Garmin/program output paths in this slice.
+
+## Checkpoint Log
+
+- `2026-05-03 | in-progress | created implementation brief from post-merge scope review; saved-workout Quick View is the next small session-step contract consumer after PR #578/#581 | next: implement shared view-section reuse and targeted tests`
+- `2026-05-03 | implementation | exported shared read-only view-section rendering, moved saved-workout Quick View onto the session-step view section contract, added category-preserving summary preview sections with legacy fallback, and updated focused tests/docs | next: screenshot handoff before verify:pre-pr`
+- `2026-05-03 | screenshot-review | targeted validation passed: lint, typecheck, lint:briefs:all, and focused Vitest suite; after/reference screenshots captured in /Users/stianvikra/freeswimming/output/session-step-saved-quick-view-2026-05-03 | next: owner visual approval or corrections before verify:pre-pr`
+- `2026-05-03 | pre-pr gate | owner approved screenshot handoff; `npm run verify:pre-pr` passed full lane (`167`unit files /`870`unit tests, production build, perf budgets, and Playwright`108 passed`/`348 skipped`) | perf-budget trend recommended `tighten`, decision: `hold/carry-forward` because this UI parity slice does not own public route budgets and repo cadence already records the latest 2026-04-26 ratchet as too recent for another non-maintenance threshold change | next: commit, push, open PR, monitor CI, then run verify:pre-merge before merge recommendation`

--- a/lib/workouts/shared.ts
+++ b/lib/workouts/shared.ts
@@ -80,6 +80,7 @@ export type WorkoutSummaryPreviewLineItem = {
 export type WorkoutSummaryPreviewSection = {
   key: string;
   title: string;
+  category?: SessionDraftStep["category"] | null;
   rows: WorkoutSummaryPreviewLineItem[];
 };
 
@@ -4410,14 +4411,7 @@ export function buildWorkoutSummaryPreviewText(draft: SessionDraft | null | unde
 }
 
 export function buildWorkoutSummaryPreviewSections(draft: SessionDraft | null | undefined) {
-  return buildRawWorkoutPoolsideSectionsForDraft(draft).map((section) => ({
-    key: section.key,
-    title: section.title,
-    rows: section.items.map((lineItem) => ({
-      text: lineItem.text,
-      secondaryText: lineItem.secondaryText ?? null,
-    })),
-  }));
+  return buildWorkoutSummaryViewSections(draft);
 }
 
 export function buildWorkoutSummaryPreviewLineItems(draft: SessionDraft | null | undefined) {
@@ -4429,6 +4423,233 @@ export function buildWorkoutSummaryPreviewLineItems(draft: SessionDraft | null |
 
 function buildWorkoutPoolsideLines(draft: SessionDraft | null | undefined) {
   return buildWorkoutPoolsideLineItemsForDraft(draft).items.map(formatWorkoutPoolsideLineItemText);
+}
+
+function buildWorkoutSummaryViewSections(
+  draft: SessionDraft | null | undefined
+): WorkoutSummaryPreviewSection[] {
+  if (!draft) {
+    return [];
+  }
+
+  const poolLengthUnit = getWorkoutPoolLengthUnit(draft);
+  const groups = buildWorkoutHandoffGroups(draft.steps);
+  const sections: WorkoutSummaryPreviewSection[] = [];
+
+  for (let groupIndex = 0; groupIndex < groups.length; groupIndex += 1) {
+    const group = groups[groupIndex];
+    if (!group) continue;
+
+    if (group.kind === "single") {
+      const result = buildWorkoutSummarySingleViewRows(
+        group.entries[0],
+        groups.slice(groupIndex + 1),
+        draft.basePaceSecondsPer100m,
+        draft.environment,
+        poolLengthUnit
+      );
+      const section = getOrCreateWorkoutSummaryPreviewSection(sections, result.category);
+      section.rows.push(...result.rows);
+      groupIndex += result.consumedFollowingGroups;
+      continue;
+    }
+
+    const result = buildWorkoutSummaryRepeatViewRow(
+      group,
+      groups.slice(groupIndex + 1),
+      draft.basePaceSecondsPer100m,
+      draft.environment,
+      poolLengthUnit
+    );
+    const section = getOrCreateWorkoutSummaryPreviewSection(sections, result.category);
+    section.rows.push(result.row);
+    groupIndex += result.consumedFollowingGroups;
+  }
+
+  return sections.filter((section) => section.rows.length > 0);
+}
+
+function getOrCreateWorkoutSummaryPreviewSection(
+  sections: WorkoutSummaryPreviewSection[],
+  category: SessionDraftStep["category"]
+) {
+  const title = getSessionStepCategoryLabel(category);
+  const currentSection = sections[sections.length - 1] ?? null;
+
+  if (currentSection?.category === category && currentSection.title === title) {
+    return currentSection;
+  }
+
+  const nextSection: WorkoutSummaryPreviewSection = {
+    key: `${title.toLowerCase().replace(/\s+/g, "-")}-${sections.length}`,
+    title,
+    category,
+    rows: [],
+  };
+  sections.push(nextSection);
+  return nextSection;
+}
+
+function buildWorkoutSummarySingleViewRows(
+  entry: WorkoutHandoffEntry | undefined,
+  followingGroups: WorkoutHandoffGroup[],
+  basePaceSecondsPer100m: number,
+  environment: SessionGeneratorEnvironment,
+  poolLengthUnit: SessionDraftPoolLengthUnit
+) {
+  const fallbackCategory: SessionDraftStep["category"] = "main";
+  if (!entry) {
+    return {
+      category: fallbackCategory,
+      rows: [],
+      consumedFollowingGroups: 0,
+    };
+  }
+
+  if (isWorkoutPoolsideRecoveryStep(entry.step, environment)) {
+    return {
+      category: entry.step.category,
+      rows: [
+        {
+          text: buildWorkoutPoolsideRecoveryText(
+            entry.step,
+            basePaceSecondsPer100m,
+            environment,
+            poolLengthUnit,
+            "standalone"
+          ),
+          secondaryText: null,
+        },
+      ],
+      consumedFollowingGroups: 0,
+    };
+  }
+
+  const linkedRestSteps: SessionDraftStep[] = [];
+  let consumedFollowingGroups = 0;
+
+  for (const nextGroup of followingGroups) {
+    if (nextGroup.kind !== "single") {
+      break;
+    }
+
+    const nextStep = nextGroup.entries[0]?.step;
+    if (
+      !nextStep ||
+      !shouldInlineWorkoutPoolsideRecoveryStep(nextStep, environment) ||
+      nextStep.postSetRestForRepeatGroupId
+    ) {
+      break;
+    }
+
+    linkedRestSteps.push(nextStep);
+    consumedFollowingGroups += 1;
+  }
+
+  return {
+    category: entry.step.category,
+    rows: [
+      {
+        text: buildWorkoutPoolsideIntervalLabel(
+          entry.step,
+          basePaceSecondsPer100m,
+          environment,
+          poolLengthUnit
+        ),
+        secondaryText: buildWorkoutPoolsideRecoverySummary(
+          linkedRestSteps,
+          basePaceSecondsPer100m,
+          environment,
+          poolLengthUnit,
+          "standalone"
+        ),
+      },
+    ],
+    consumedFollowingGroups,
+  };
+}
+
+function buildWorkoutSummaryRepeatViewRow(
+  group: Extract<WorkoutHandoffGroup, { kind: "repeat" }>,
+  followingGroups: WorkoutHandoffGroup[],
+  basePaceSecondsPer100m: number,
+  environment: SessionGeneratorEnvironment,
+  poolLengthUnit: SessionDraftPoolLengthUnit
+) {
+  const workEntry = group.entries.find(
+    (entry) => !isWorkoutPoolsideRecoveryStep(entry.step, environment)
+  );
+  const workStep = workEntry?.step ?? group.entries[0]?.step ?? null;
+  const category = getWorkoutPoolsideGroupCategory(group);
+  const repeatCountLabel = group.repeatCount ? `${group.repeatCount} x ` : "";
+  let text = workStep
+    ? `${repeatCountLabel}${buildWorkoutPoolsideIntervalLabel(
+        workStep,
+        basePaceSecondsPer100m,
+        environment,
+        poolLengthUnit
+      )}`
+    : "Set the work interval for this repeat block.";
+
+  const workEntryIndex =
+    workEntry !== undefined ? group.entries.findIndex((entry) => entry === workEntry) : -1;
+  const followingEntry = workEntryIndex >= 0 ? group.entries[workEntryIndex + 1] : null;
+  const followingStep = followingEntry?.step ?? null;
+
+  if (followingStep) {
+    if (shouldInlineWorkoutPoolsideRecoveryStep(followingStep, environment)) {
+      text = `${text} · ${buildWorkoutPoolsideRecoveryText(
+        followingStep,
+        basePaceSecondsPer100m,
+        environment,
+        poolLengthUnit,
+        "interval"
+      )}`;
+    } else {
+      text = `${text} · Recovery ${buildWorkoutPoolsideIntervalLabel(
+        followingStep,
+        basePaceSecondsPer100m,
+        environment,
+        poolLengthUnit
+      )}`;
+    }
+  }
+
+  const postSetRestSteps: SessionDraftStep[] = [];
+  let consumedFollowingGroups = 0;
+
+  for (const nextGroup of followingGroups) {
+    if (nextGroup.kind !== "single") {
+      break;
+    }
+
+    const nextStep = nextGroup.entries[0]?.step;
+    if (
+      !nextStep ||
+      !shouldInlineWorkoutPoolsideRecoveryStep(nextStep, environment) ||
+      nextStep.postSetRestForRepeatGroupId !== group.repeatGroupId
+    ) {
+      break;
+    }
+
+    postSetRestSteps.push(nextStep);
+    consumedFollowingGroups += 1;
+  }
+
+  return {
+    category,
+    row: {
+      text,
+      secondaryText: buildWorkoutPoolsideRecoverySummary(
+        postSetRestSteps,
+        basePaceSecondsPer100m,
+        environment,
+        poolLengthUnit,
+        "repeat"
+      ),
+    },
+    consumedFollowingGroups,
+  };
 }
 
 type WorkoutPoolsideFormattingOptions = {
@@ -4445,6 +4666,7 @@ type WorkoutPoolsideFormattingResult = {
 type WorkoutPoolsideSection = {
   key: string;
   title: string;
+  category: SessionDraftStep["category"];
   items: WorkoutPoolsideLineItem[];
 };
 
@@ -4466,6 +4688,7 @@ function getWorkoutPoolsideGroupCategory(group: WorkoutHandoffGroup) {
 
 function pushWorkoutPoolsideSection(
   sections: WorkoutPoolsideSection[],
+  category: SessionDraftStep["category"],
   title: string,
   items: WorkoutPoolsideLineItem[]
 ) {
@@ -4474,7 +4697,7 @@ function pushWorkoutPoolsideSection(
   }
 
   const previousSection = sections[sections.length - 1];
-  if (previousSection?.title === title) {
+  if (previousSection?.category === category && previousSection.title === title) {
     previousSection.items.push(...items);
     return;
   }
@@ -4482,6 +4705,7 @@ function pushWorkoutPoolsideSection(
   sections.push({
     key: `${title.toLowerCase().replace(/\s+/g, "-")}-${sections.length}`,
     title,
+    category,
     items: [...items],
   });
 }
@@ -4498,7 +4722,8 @@ function buildRawWorkoutPoolsideSectionsForDraft(draft: SessionDraft | null | un
   for (let groupIndex = 0; groupIndex < groups.length; groupIndex += 1) {
     const group = groups[groupIndex];
     if (!group) continue;
-    const sectionTitle = getSessionStepCategoryLabel(getWorkoutPoolsideGroupCategory(group));
+    const sectionCategory = getWorkoutPoolsideGroupCategory(group);
+    const sectionTitle = getSessionStepCategoryLabel(sectionCategory);
 
     if (group.kind === "single") {
       const result = buildWorkoutPoolsideSingleGroupLineItems(
@@ -4508,7 +4733,7 @@ function buildRawWorkoutPoolsideSectionsForDraft(draft: SessionDraft | null | un
         draft.environment,
         poolLengthUnit
       );
-      pushWorkoutPoolsideSection(sections, sectionTitle, result.items);
+      pushWorkoutPoolsideSection(sections, sectionCategory, sectionTitle, result.items);
       if (result.consumedFollowingGroups > 0) {
         groupIndex += result.consumedFollowingGroups;
       }
@@ -4524,7 +4749,7 @@ function buildRawWorkoutPoolsideSectionsForDraft(draft: SessionDraft | null | un
       draft.environment,
       poolLengthUnit
     );
-    pushWorkoutPoolsideSection(sections, sectionTitle, result.items);
+    pushWorkoutPoolsideSection(sections, sectionCategory, sectionTitle, result.items);
     if (result.consumedFollowingGroups > 0) {
       groupIndex += result.consumedFollowingGroups;
     }

--- a/tests/unit/session-step-surface-renderer.test.tsx
+++ b/tests/unit/session-step-surface-renderer.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, expect, it, vi } from "vitest";
 import {
   SessionStepSummaryCard,
   SessionStepSurfaceRenderer,
+  SessionStepViewSections,
 } from "@/components/my-library/workouts/SessionStepSurfaceRenderer";
 import type { SessionStepViewSection } from "@/components/my-library/workouts/sessionStepSurfaceContract";
 
@@ -153,6 +154,22 @@ it("renders view sections from presentation input and delegates targeted callbac
 
   expect(callbacks.onOpenViewStep).toHaveBeenCalledWith("warmup-step");
   expect(callbacks.onOpenViewRepeat).toHaveBeenCalledWith("main-repeat");
+});
+
+it("renders shared view sections as read-only when no open callbacks are provided", () => {
+  render(
+    <SessionStepViewSections sections={viewSections} sectionTestIdPrefix="saved-preview-section" />
+  );
+
+  expect(screen.getByTestId("saved-preview-section-warmup-0")).toHaveAttribute(
+    "data-view-category",
+    "warmup"
+  );
+  expect(screen.getByText("400m · Freestyle · Easy")).toBeVisible();
+  expect(
+    screen.queryByRole("button", { name: /400m · Freestyle · Easy/i })
+  ).not.toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: /4 x 100m/i })).not.toBeInTheDocument();
 });
 
 it("renders shared single-step chrome and delegates card/delete actions", () => {

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -2959,6 +2959,19 @@ describe("WorkoutBuilderHub", () => {
       "8 x 25m Kick · Easy"
     );
     expect(screen.getByTestId("saved-workouts-preview-workout-2")).toHaveTextContent("Rest 0:20");
+    expect(screen.getByTestId("saved-workouts-preview-section-workout-2-warmup-0")).toHaveAttribute(
+      "data-view-category",
+      "warmup"
+    );
+    expect(screen.getByTestId("saved-workouts-preview-section-workout-2-main-1")).toHaveAttribute(
+      "data-view-category",
+      "main"
+    );
+    expect(
+      within(screen.getByTestId("saved-workouts-preview-workout-2")).queryByRole("button", {
+        name: /8 x 25m kick/i,
+      })
+    ).not.toBeInTheDocument();
     expect(screen.getByTestId("saved-workouts-preview-workout-2")).toHaveTextContent("Total");
     expect(screen.queryByText("Select session")).not.toBeInTheDocument();
 

--- a/tests/unit/workouts-server.test.ts
+++ b/tests/unit/workouts-server.test.ts
@@ -549,6 +549,11 @@ describe("workouts server", () => {
     expect(editorRecord.draft.title).toBe("Threshold / CSS 25m Pool draft");
     expect(summary.title).toBe("Threshold / CSS 25m Pool draft");
     expect(summary.totalDistanceM).toBe(2200);
+    expect(summary.previewSections?.map((section) => section.category)).toEqual([
+      "warmup",
+      "main",
+      "cooldown",
+    ]);
   });
 
   it("tolerates legacy persisted workout rows without a description", () => {

--- a/tests/unit/workouts-shared.test.ts
+++ b/tests/unit/workouts-shared.test.ts
@@ -1925,6 +1925,12 @@ describe("workouts shared readiness", () => {
       "Cooldown",
       "Main",
     ]);
+    expect(sections.map((section) => section.category)).toEqual([
+      "warmup",
+      "main",
+      "cooldown",
+      "main",
+    ]);
     expect(sections[0]?.rows[0]).toMatchObject({
       text: "400m · Freestyle · Easy",
       secondaryText: "Rest 0:30",


### PR DESCRIPTION
## Summary

- User-visible changes: Saved-workout `Quick View` now renders session sections through the same shared view surface as the manual builder reference, while staying read-only.
- Technical changes: Reused `SessionStepViewSections`, extended `WorkoutSummaryPreviewSection` with optional category identity, added legacy category fallback, updated summary preview row building, docs, and focused tests.
- Policy impact: no - changed files do not touch auth/session/account, analytics consent, user data rights, third-party processor policy, or public policy text.
- Policy version note: N/A - no policy-impacting behavior or legal/support-surface contract changed.
- Brief link(s): `docs/task-briefs/in-progress/2026-05-03-session-step-saved-quick-view-contract-10-10.md`
- Latest commit: `8c406a0` - feat: align saved workout quick view.

## Scope

- In scope: Saved-workout Quick View rendering, shared session-step view renderer read-only support, summary preview section category data, session-step surface contract docs, and focused tests.
- Out of scope: Poolside note rendering, workout PDF HTML, Garmin-ready export payloads, program PDF/export, schema, API, authz, cache, or dependency changes.
- Changed files:
  - `components/my-library/workouts/SavedWorkoutsPanel.tsx`
  - `components/my-library/workouts/SessionStepSurfaceRenderer.tsx`
  - `lib/workouts/shared.ts`
  - `docs/design/session-step-surface-contract.md`
  - `docs/task-briefs/in-progress/2026-05-03-session-step-saved-quick-view-contract-10-10.md`
  - `tests/unit/session-step-surface-renderer.test.tsx`
  - `tests/unit/workout-builder-hub.test.tsx`
  - `tests/unit/workouts-server.test.ts`
  - `tests/unit/workouts-shared.test.ts`

## Risk

- Main risk: Saved workout preview drift or incorrect legacy category fallback could make Quick View differ from builder View.
- Rollback plan: Revert `8c406a0` to restore the previous saved-preview implementation.
- Mitigation: shared renderer reuse, deterministic fallback, focused unit/component coverage, approved screenshot handoff, and full local/CI verification.
- Data/security note: no schema, migration, secret, authz, external service, or cache behavior changed.

## Test Evidence

- `./node_modules/.bin/vitest run tests/unit/session-step-surface-renderer.test.tsx tests/unit/workouts-shared.test.ts tests/unit/workouts-server.test.ts tests/unit/workout-builder-hub.test.tsx`: **PASS** (`4` files, `125` tests).
- `npm run lint:briefs`: **PASS** in `npm run verify:pre-pr` on `8c406a0` for the new in-progress brief.
- `npm run lint`: **PASS** in `npm run verify:pre-pr` on `8c406a0`.
- `npm run typecheck`: **PASS** in `npm run verify:pre-pr` on `8c406a0`.
- `npm run test:unit`: **PASS** in `npm run verify:pre-pr` on `8c406a0` (`167` files / `870` tests).
- `npm run build`: **PASS** in `npm run verify:pre-pr` on `8c406a0`.
- `npm run test:e2e`: **PASS** in `npm run verify:pre-pr` on `8c406a0` (`108 passed`, `348 skipped`).
- `npm run verify:pre-pr`: **PASS** on `8c406a0` (full public lane, artifacts `artifacts/test-runs/20260503-205034`).
- `npm run verify:pre-merge`: **PASS** on `8c406a0` (recorded `artifacts/verify-pre-merge/20260503-192024.json`; reused full-public local PASS for current HEAD; private-gate skipped because `SITE_LOCK_ENABLED!=1`).
- Policy-impact checklist: N/A - policy impact is `no` because this PR changes authenticated workout UI preview rendering/tests/docs only.
- Screenshot handoff: **PASS** owner approved `after/reference` artifacts in `/Users/stianvikra/freeswimming/output/session-step-saved-quick-view-2026-05-03`.
- Local manual QA URL: `http://127.0.0.1:3000`.
- Screenshot artifacts:
  - `after-saved-quick-view-desktop.png`
  - `after-saved-quick-view-mobile.png`
  - `reference-builder-view-desktop.png`
  - `reference-builder-view-mobile.png`
- Vercel preview QA: **PENDING**.
- CI: **PASS** for PR #582 (`verify`, CodeQL, Vercel, deploy-preview, e2e-smoke, site-lock-smoke, size-check).

## UI Evidence

- Screenshot handoff type: `after/reference`.
- Owner approval: approved in chat on 2026-05-03 before `npm run verify:pre-pr`.
- Known visual judgment call: interval rest remains inline with repeat work; set/post-repeat rest remains a secondary line because they represent different timing semantics.

## Perf Budget Ratchet

- `npm run verify:pre-pr` recorded perf-budget PASS at `8c406a0` with `25.1%` worst margin and recommended `tighten`.
- Decision for this PR: `hold/carry-forward`.
- Rationale: this UI parity slice does not own public route performance budgets, and repo cadence records the latest 2026-04-26 JS budget ratchet as too recent for another non-maintenance threshold change.

## Scorecard Closeout

Critical target categories for the `10/10` claim are all scored `5/5` in the linked brief:

- UX flow clarity: `5/5`
- Visual design quality: `5/5`
- Business logic correctness and data integrity: `5/5`
- Stack-fit and dependency discipline: `5/5`
- Testing and QA automation: `5/5`

Remaining gaps: none for this scope. Deferred parity consumers: poolside/PDF/program surfaces.

## Checklist

- [x] `npm run lint:briefs`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] `npm run test:e2e`
- [x] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge`
- [x] Local manual QA done on dev URL (screenshot handoff against `http://127.0.0.1:3000`)
- [ ] Vercel preview manual QA done
- [x] QA covered relevant matrix for this change (unit/component, mobile screenshots, desktop screenshots, full Playwright matrix)
- [x] Screenshot handoff completed for UI change
- [x] Acceptance criteria are met
- [x] Docs updated for behavior/contract changes
- [x] Changed task brief includes full 10/10 scorecard mapping
- [x] No secrets or sensitive data added
