### PR TITLE
feat: add program builder step preview parity

### DIFF
--- a/components/my-library/programs/ProgramBuilderHub.tsx
+++ b/components/my-library/programs/ProgramBuilderHub.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import CreateManualProgramButton from "@/components/my-library/programs/CreateManualProgramButton";
+import { getManualPoolCategoryLabelClass } from "@/components/my-library/workouts/sessionStepSurfaceContract";
 import {
   buildProgramGarminReadyExportFileName,
   buildProgramPdfFileName,
@@ -18,6 +19,11 @@ import {
   type ProgramSaveApiResponse,
   type ProgramSummary,
 } from "@/lib/programs/shared";
+import type {
+  WorkoutSummary,
+  WorkoutSummaryPreviewLineItem,
+  WorkoutSummaryPreviewSection,
+} from "@/lib/workouts/shared";
 
 type Props = {
   programLibrary: ProgramLibrarySnapshot;
@@ -28,6 +34,7 @@ type RetryablePreviewError = Error & {
 };
 
 const PROGRAM_EXPORT_PREVIEW_TIMEOUT_MS = 15_000;
+const PROGRAM_SCHEDULED_WORKOUT_PREVIEW_ROW_LIMIT = 6;
 
 function buildProgramExportPreviewError(message: string, status?: number): RetryablePreviewError {
   const error = new Error(message) as RetryablePreviewError;
@@ -75,6 +82,101 @@ function reindexAssignments(assignments: ProgramAssignment[]) {
         ...assignment,
         position,
       }))
+  );
+}
+
+type VisibleWorkoutPreviewSection = Omit<WorkoutSummaryPreviewSection, "rows"> & {
+  rows: WorkoutSummaryPreviewLineItem[];
+};
+
+function buildVisibleWorkoutPreviewSections(
+  sections: WorkoutSummaryPreviewSection[] | null | undefined
+): {
+  visibleSections: VisibleWorkoutPreviewSection[];
+  hiddenRowCount: number;
+} {
+  let remainingRows = PROGRAM_SCHEDULED_WORKOUT_PREVIEW_ROW_LIMIT;
+  let hiddenRowCount = 0;
+  const visibleSections: VisibleWorkoutPreviewSection[] = [];
+
+  for (const section of sections ?? []) {
+    const rows = section.rows.filter((row) => row.text.trim().length > 0);
+    if (rows.length === 0) continue;
+
+    if (remainingRows <= 0) {
+      hiddenRowCount += rows.length;
+      continue;
+    }
+
+    const visibleRows = rows.slice(0, remainingRows);
+    hiddenRowCount += rows.length - visibleRows.length;
+    visibleSections.push({
+      ...section,
+      rows: visibleRows,
+    });
+    remainingRows -= visibleRows.length;
+  }
+
+  return { visibleSections, hiddenRowCount };
+}
+
+function ScheduledWorkoutStepPreview({
+  assignmentId,
+  workout,
+}: {
+  assignmentId: string;
+  workout: WorkoutSummary;
+}) {
+  const { visibleSections, hiddenRowCount } = buildVisibleWorkoutPreviewSections(
+    workout.previewSections
+  );
+
+  if (visibleSections.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid={`program-assignment-step-preview-${assignmentId}`}
+      aria-label={`Scheduled workout step preview for ${workout.title}`}
+      className="mt-3 space-y-2 border-t border-slate-100 pt-3"
+    >
+      {visibleSections.map((section) => {
+        const category = section.category ?? "main";
+
+        return (
+          <div key={section.key} className="space-y-1.5">
+            <p
+              className={`text-[11px] font-semibold tracking-wide uppercase ${getManualPoolCategoryLabelClass(
+                category
+              )}`}
+            >
+              {section.title}
+            </p>
+            <div className="space-y-1 border-l border-slate-200 pl-2">
+              {section.rows.map((row, rowIndex) => (
+                <div key={`${section.key}-${rowIndex}`} className="space-y-0.5">
+                  <p className="text-xs leading-5 break-words text-slate-800">{row.text}</p>
+                  {row.secondaryText ? (
+                    <p className="text-xs leading-5 font-semibold text-blue-800">
+                      {row.secondaryText}
+                    </p>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+      {hiddenRowCount > 0 ? (
+        <p
+          data-testid={`program-assignment-step-preview-more-${assignmentId}`}
+          className="text-xs font-medium text-slate-500"
+        >
+          +{hiddenRowCount} more scheduled step{hiddenRowCount === 1 ? "" : "s"}
+        </p>
+      ) : null}
+    </div>
   );
 }
 
@@ -474,7 +576,7 @@ export default function ProgramBuilderHub({ programLibrary }: Props) {
               className="inline-flex h-10 items-center justify-center rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500 active:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
             />
           ) : null}
-          <p className="rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">
+          <p className="rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold tracking-wide text-blue-700 uppercase">
             Canonical program
           </p>
         </div>
@@ -587,7 +689,7 @@ export default function ProgramBuilderHub({ programLibrary }: Props) {
               <div className="max-w-[48rem]">
                 <label
                   htmlFor="program-draft-title"
-                  className="text-xs font-semibold uppercase tracking-wide text-slate-500"
+                  className="text-xs font-semibold tracking-wide text-slate-500 uppercase"
                 >
                   Program title
                 </label>
@@ -600,7 +702,7 @@ export default function ProgramBuilderHub({ programLibrary }: Props) {
                     setDraftTitle(event.target.value);
                     setSuccess("");
                   }}
-                  className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm outline-none transition focus:border-blue-400 focus:ring-2 focus:ring-blue-200"
+                  className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-200"
                 />
                 <p data-testid="program-editor-save-state" className="mt-3 text-sm text-slate-600">
                   {hasUnsavedChanges
@@ -650,12 +752,12 @@ export default function ProgramBuilderHub({ programLibrary }: Props) {
                       shell simple and canonical.
                     </p>
                   </div>
-                  <p className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600">
+                  <p className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold tracking-wide text-slate-600 uppercase">
                     {week.assignments.length} scheduled
                   </p>
                 </div>
 
-                <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-7">
+                <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
                   {PROGRAM_WEEKDAY_LABELS.map((dayLabel, dayIndex) => {
                     const pickerKey = `${week.id}-${dayIndex}`;
                     const dayAssignments = days[dayIndex];
@@ -663,7 +765,7 @@ export default function ProgramBuilderHub({ programLibrary }: Props) {
                     return (
                       <div
                         key={dayLabel}
-                        className="rounded-2xl border border-slate-200 bg-slate-50/70 p-3"
+                        className="min-w-0 rounded-2xl border border-slate-200 bg-slate-50/70 p-3"
                       >
                         <p className="text-sm font-semibold text-slate-900">{dayLabel}</p>
                         <div className="mt-3 flex flex-col gap-2">
@@ -676,7 +778,7 @@ export default function ProgramBuilderHub({ programLibrary }: Props) {
                                 [pickerKey]: event.target.value,
                               }))
                             }
-                            className="rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900"
+                            className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900"
                           >
                             <option value="">Choose workout</option>
                             {availableWorkouts.map((workout) => (
@@ -690,7 +792,7 @@ export default function ProgramBuilderHub({ programLibrary }: Props) {
                             data-testid={`program-day-add-week-${weekIndex}-day-${dayIndex}`}
                             onClick={() => addAssignment(week.id, dayIndex)}
                             disabled={!pickerSelections[pickerKey]}
-                            className="inline-flex h-10 items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm font-medium text-blue-700 transition hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-60"
+                            className="inline-flex h-10 w-full items-center justify-center rounded-xl border border-blue-200 bg-white px-3 text-sm font-medium text-blue-700 transition hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-60"
                           >
                             Add workout
                           </button>
@@ -705,9 +807,10 @@ export default function ProgramBuilderHub({ programLibrary }: Props) {
                               return (
                                 <div
                                   key={assignment.id}
-                                  className="rounded-xl border border-white bg-white p-3 shadow-sm"
+                                  data-testid={`program-assignment-card-${assignment.id}`}
+                                  className="min-w-0 rounded-xl border border-white bg-white p-3 shadow-sm"
                                 >
-                                  <p className="text-sm font-medium text-slate-900">
+                                  <p className="text-sm font-medium break-words text-slate-900">
                                     {workout?.title ?? "Missing workout reference"}
                                   </p>
                                   <p className="mt-1 text-xs text-slate-500">
@@ -725,8 +828,15 @@ export default function ProgramBuilderHub({ programLibrary }: Props) {
                                       : assignment.workoutId}
                                   </p>
 
+                                  {workout ? (
+                                    <ScheduledWorkoutStepPreview
+                                      assignmentId={assignment.id}
+                                      workout={workout}
+                                    />
+                                  ) : null}
+
                                   <div className="mt-3 space-y-2">
-                                    <label className="block text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                    <label className="block text-xs font-semibold tracking-wide text-slate-500 uppercase">
                                       Move to day
                                     </label>
                                     <select
@@ -797,7 +907,7 @@ export default function ProgramBuilderHub({ programLibrary }: Props) {
           <div className="rounded-2xl border border-slate-200 bg-white p-4">
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div>
-                <p className="text-xs font-semibold uppercase tracking-wide text-sky-700">
+                <p className="text-xs font-semibold tracking-wide text-sky-700 uppercase">
                   Garmin-ready JSON
                 </p>
                 <p className="mt-2 text-sm font-medium text-slate-900">
@@ -808,7 +918,7 @@ export default function ProgramBuilderHub({ programLibrary }: Props) {
                 <p
                   data-testid="program-editor-garmin-export-source"
                   data-export-state="canonical"
-                  className="mt-2 text-xs font-semibold uppercase tracking-wide text-slate-600"
+                  className="mt-2 text-xs font-semibold tracking-wide text-slate-600 uppercase"
                 >
                   {programExportStateLabel}
                 </p>
@@ -857,7 +967,7 @@ export default function ProgramBuilderHub({ programLibrary }: Props) {
             <div className="mt-4 overflow-hidden rounded-2xl border border-slate-200 bg-slate-950">
               <pre
                 data-testid="program-editor-garmin-export-preview"
-                className="max-h-[320px] overflow-auto whitespace-pre-wrap px-4 py-4 text-xs leading-relaxed text-slate-100"
+                className="max-h-[320px] overflow-auto px-4 py-4 text-xs leading-relaxed whitespace-pre-wrap text-slate-100"
               >
                 {programExportPreview ||
                   (isProgramExportLoading
@@ -870,7 +980,7 @@ export default function ProgramBuilderHub({ programLibrary }: Props) {
           <div className="rounded-2xl border border-slate-200 bg-white p-4">
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div>
-                <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">
+                <p className="text-xs font-semibold tracking-wide text-amber-700 uppercase">
                   Program PDF
                 </p>
                 <p className="mt-2 text-sm font-medium text-slate-900">
@@ -880,7 +990,7 @@ export default function ProgramBuilderHub({ programLibrary }: Props) {
                 <p
                   data-testid="program-editor-pdf-source"
                   data-pdf-state="canonical"
-                  className="mt-2 text-xs font-semibold uppercase tracking-wide text-slate-600"
+                  className="mt-2 text-xs font-semibold tracking-wide text-slate-600 uppercase"
                 >
                   {programPdfStateLabel}
                 </p>

--- a/docs/design/session-step-surface-contract.md
+++ b/docs/design/session-step-surface-contract.md
@@ -9,7 +9,7 @@ Use this contract whenever the app displays, edits, rearranges, previews, prints
 - Shared React renderer boundary: `components/my-library/workouts/SessionStepSurfaceRenderer.tsx`.
 - Shared export/display model: `buildWorkoutStepDisplaySections` in `lib/workouts/shared.ts`.
 - Domain object: canonical workout/session draft steps from `lib/session-generator-v1/shared.ts`.
-- Current consumers include manual builder, AI session generator, saved-workout Quick View, and Program PDF scheduled-workout sections.
+- Current consumers include manual builder, AI session generator, saved-workout Quick View, Program Builder scheduled-workout cards, and Program PDF scheduled-workout sections.
 - Later consumers include poolside note and remaining PDF/export or planner surfaces that still need step-detail parity.
 - Architecture target: route-specific surfaces should adapt data into this contract; they should not fork a separate card/tab/rest-summary visual system.
 

--- a/docs/task-briefs/in-progress/2026-05-04-program-builder-scheduled-workout-step-preview-parity-10-10.md
+++ b/docs/task-briefs/in-progress/2026-05-04-program-builder-scheduled-workout-step-preview-parity-10-10.md
@@ -1,0 +1,131 @@
+# Task Brief: Program Builder Scheduled Workout Step Preview Parity (10/10)
+
+## Metadata
+
+- `id`: `2026-05-04-program-builder-scheduled-workout-step-preview-parity-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-05-04`
+- `updated`: `2026-05-04`
+
+## Goal
+
+Make Program Builder scheduled workout cards show compact workout-step sections from the shared session-step display contract so planner review does not hide the actual session structure behind title, meters, and time only.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for `10/10` claim: `Product goals and IA`, `Visual design quality`, `Business logic correctness and data integrity`, `Stack-fit and dependency discipline`, `Testing and QA automation`.
+
+| Category                                      | Mapping      | Target Threshold / Scope Rationale                                                                                                          | Evidence                                | Expected Closeout Score |
+| --------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | Scheduled workout cards show the same compact workout structure already used by saved previews and Program PDF.                             | component diff + screenshot handoff     | `5/5`                   |
+| UX flow clarity                               | `target`     | Users can scan each scheduled day and understand warmup/main/cooldown/repeat/rest structure without opening export/PDF.                     | component test + screenshot handoff     | `5/5`                   |
+| Visual design quality                         | `target`     | Added preview sections fit existing Program Builder card rhythm on desktop and mobile without overlap, clipping, or nested-card clutter.    | after/reference screenshots             | `5/5`                   |
+| Business logic correctness and data integrity | `target`     | The UI consumes existing `WorkoutSummary.previewSections` only; no schedule assignment, workout draft, or export semantics are mutated.     | unit/component tests + diff review      | `5/5`                   |
+| Admin editor ergonomics                       | `N/A`        | N/A because this user-facing Program Builder slice does not change admin CRUD, publishing, moderation, or editorial workflows.              | explicit admin scope rationale          | `N/A`                   |
+| Accessibility (a11y)                          | `target`     | Preview sections remain readable semantic content inside each scheduled workout card and do not introduce unlabeled controls.               | Testing Library assertions + screenshot | `5/5`                   |
+| Performance (CWV + payloads)                  | `target`     | No new dependency, no extra client fetch, and no route-level data expansion; changed route stays within existing verify/build budgets.      | dependency diff + local gates           | `5/5`                   |
+| Data placement and sync boundaries            | `target`     | Program/workout records remain server-canonical; step previews are read-only derived summary data already present in the library snapshot.  | code review + data contract             | `5/5`                   |
+| Caching and invalidation strategy             | `supporting` | Supporting only: no cache mode changes; existing library snapshot freshness and program mutation refresh behavior remain in place.          | route/component review                  | `4/5`                   |
+| Reliability and failure handling              | `target`     | Missing workouts and workouts without preview sections still render deterministic fallback card content.                                    | unit/component tests                    | `5/5`                   |
+| Security and authz                            | `supporting` | Supporting only: protected program/workout reads and mutations are unchanged; this slice adds no new API path or auth boundary.             | existing route coverage + diff review   | `4/5`                   |
+| Privacy and compliance                        | `supporting` | Supporting only: no new personal data, logging, analytics payload, sharing destination, or retention behavior is introduced.                | payload/diff review                     | `4/5`                   |
+| Content governance                            | `target`     | Section labels, rest wording, and repeat wording stay centralized through existing workout preview-section helpers.                         | shared helper use + tests               | `5/5`                   |
+| Admin workflow and editability                | `N/A`        | N/A because no admin/user recovery queue, status workflow, operator label, or support action changes in this slice.                         | explicit workflow scope rationale       | `N/A`                   |
+| SEO and crawlability                          | `N/A`        | N/A because authenticated My Library planner UI changes no public metadata, sitemap, robots, canonical tags, or crawlable content.          | explicit SEO scope rationale            | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because this private planner UI change adds no public AI-discoverable entity, structured data, or crawl-safe content.                   | explicit AI-discovery scope rationale   | `N/A`                   |
+| Analytics and KPI observability               | `supporting` | Supporting only: no event taxonomy change; existing program save/export actions remain stable.                                              | test-id/event diff review               | `4/5`                   |
+| Commerce and revenue ops                      | `N/A`        | N/A because no pricing, checkout, entitlement, subscription, refund, or revenue workflow changes.                                           | explicit commerce scope rationale       | `N/A`                   |
+| Incident response and support operations      | `N/A`        | N/A because this visual planner card enhancement adds no alerting, incident path, support queue, or customer recovery workflow.             | explicit support-ops scope rationale    | `N/A`                   |
+| Finance and reporting operations              | `N/A`        | N/A because no payout, invoice, ledger, entitlement report, refund, or finance reconciliation data changes.                                 | explicit finance scope rationale        | `N/A`                   |
+| i18n operational readiness                    | `supporting` | Supporting only: centralized labels reduce future translation drift, but no locale routing/storage or translation layer changes.            | label centralization review             | `4/5`                   |
+| Stack-fit and dependency discipline           | `target`     | Use existing React/TypeScript Program Builder and shared workout preview-section contracts; add no dependency or parallel step interpreter. | dependency diff + code review           | `5/5`                   |
+| Testing and QA automation                     | `target`     | Focused Program Builder component tests, brief lint, targeted validation, screenshot handoff, `verify:pre-pr`, CI, and `verify:pre-merge`.  | test output + screenshots + gates       | `5/5`                   |
+| Scalability and cost efficiency               | `target`     | Rendering uses the already-loaded summary sections and limits visible row volume where needed to avoid large planner-card bloat.            | component diff + screenshot review      | `5/5`                   |
+| DevOps and rollback readiness                 | `target`     | Code/docs-only, no migration, no cache purge; rollback is one PR revert.                                                                    | PR diff + rollback note                 | `5/5`                   |
+
+## Stack / Architecture Best-Practice Gate
+
+- React/Next.js: update `ProgramBuilderHub` only; it stays a client component and consumes existing `WorkoutSummary.previewSections` from the server-loaded program library snapshot. No route/action/API boundary changes.
+- TypeScript/domain contracts: use `WorkoutSummaryPreviewSection` and the existing workout summary contract; do not add a program-local parser or new step grouping model.
+- Supabase/data layer: N/A with rationale: no schema, migration, RLS, storage, generated DB type, or query change.
+- External services/tools: N/A with rationale: no SDK, webhook, secret, retry, idempotency, or provider behavior change.
+- UI system: reference `docs/design/session-step-surface-contract.md`; compare changed Program Builder cards with saved-workout Quick View and Program PDF scheduled-workout sections. Screenshot handoff type is `after/reference`.
+- Testing: update focused `tests/unit/program-builder-hub.test.tsx`; run targeted tests and screenshot handoff before broad gates.
+
+## Data Placement And Sync Contract
+
+- Server-canonical data: saved programs, week/day assignments, and saved workouts remain owned by existing API/database flows.
+- Local-only data: existing unsaved Program Builder draft UI state remains local until explicit save; no new local persistence is added.
+- Sync policy: unchanged. Program save responses remain canonical; preview sections are read-only summary data from the current library snapshot.
+- Retention and sensitivity: no new persistence, logs, analytics payloads, or personal-data exposure.
+- Cache/invalidation: unchanged. The existing My Library/program page load and save refresh behavior remains the freshness boundary.
+
+## Identity And Rename Contract
+
+- Canonical stable IDs: program IDs, week IDs, assignment IDs, workout IDs, and workout step source IDs remain unchanged.
+- Human-readable identifiers: workout/program titles and section labels remain display-only and renameable.
+- Mutability rules: this slice does not mutate IDs or persisted workout/session drafts.
+- Rename vs repurpose: N/A for runtime behavior because no entity write semantics change.
+- Compatibility contract: missing workouts and workouts without preview sections keep deterministic fallback content.
+- Observability and repair: existing missing-workout warnings remain the repair surface; no new telemetry path is introduced.
+
+## Scope
+
+- `components/my-library/programs/ProgramBuilderHub.tsx`
+- `tests/unit/program-builder-hub.test.tsx`
+- `docs/design/session-step-surface-contract.md` only if the consumer list needs clarification
+- screenshot handoff artifacts for Program Builder scheduled workout cards
+
+## Out Of Scope
+
+- Program calendar/completion/history state.
+- Adding, removing, or changing program assignment persistence.
+- New export/PDF/Garmin behavior.
+- New API routes, database schema, authz/RLS, cache behavior, or dependencies.
+- Redesigning the full Program Builder page.
+
+## Acceptance Criteria
+
+1. Scheduled workout cards render compact step-section previews when `WorkoutSummary.previewSections` are present.
+2. Section labels, row text, repeat/rest wording, and row ordering come from existing workout summary preview sections.
+3. Cards still render useful fallback content for missing workouts and workouts without step preview data.
+4. The planner grid remains readable on desktop and mobile without overlapping text or hidden controls.
+5. Focused component tests pass before screenshot handoff; screenshot handoff is approved before `npm run verify:pre-pr`.
+
+## Validation
+
+- `npm run lint:briefs`
+- targeted unit/component tests:
+  - `tests/unit/program-builder-hub.test.tsx`
+- targeted screenshot handoff before `verify:pre-pr`
+- after owner screenshot approval:
+  - `npm run verify:pre-pr`
+  - CI
+  - `npm run verify:pre-merge`
+
+## Help/Guide And Operator Training Impact
+
+N/A with rationale: this slice only adds read-only detail inside an authenticated planner card. It does not rename workflow actions, support recovery behavior, admin labels, Help/Guide content contracts, or operator runbooks.
+
+## Manual QA Environments
+
+- Local URL: `http://127.0.0.1:3000`
+- Screenshot comparison type: `after/reference`
+- Required representative screenshots:
+  - `after-program-builder-scheduled-card-desktop`
+  - `after-program-builder-scheduled-card-mobile`
+  - `reference-saved-quick-view-desktop` or `reference-program-pdf-desktop`
+
+## Rollback Plan
+
+Revert this PR. No schema rollback, data repair, cache purge, finance action, or customer communication is required.
+
+## Checkpoint Log
+
+- `2026-05-04 | in-progress | created implementation brief from owner command to implement Program Builder scheduled workout step preview parity from clean main | next: render existing workout preview sections in scheduled cards and add focused tests`
+- `2026-05-04 | implementation | Program Builder scheduled workout cards now render compact read-only step previews from existing workout summary preview sections with fallback coverage for missing preview data; widened the planner day grid and fixed mobile overflow with min-width/full-width controls; targeted component test, typecheck, scoped ESLint, and lint:briefs:all pass | next: capture after/reference screenshot handoff before verify:pre-pr`
+- `2026-05-04 | screenshot-review | captured after/reference artifacts in /Users/stianvikra/freeswimming/output/program-builder-step-preview-parity-2026-05-04-131036 for Program Builder scheduled cards on desktop/mobile plus Program PDF reference; visual files were regenerated after the mobile overflow fix | next: owner screenshot approval or corrections before npm run verify:pre-pr`
+- `2026-05-04 | pre-pr | owner approved screenshot handoff; npm run verify:pre-pr passed the full lane with lint, typecheck, unit tests, build, perf budgets, and E2E (108 passed, 348 skipped); perf trend recommended tightening after four consecutive weekly green runs, held out of this parity PR and recorded for PR summary follow-up | next: commit, push, open PR, monitor CI`

--- a/tests/unit/program-builder-hub.test.tsx
+++ b/tests/unit/program-builder-hub.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ProgramBuilderHub from "@/components/my-library/programs/ProgramBuilderHub";
 import type {
@@ -31,6 +31,26 @@ function buildWorkoutSummary(overrides?: Partial<WorkoutSummary>): WorkoutSummar
     acceptedAt: "2026-03-25T12:05:00.000Z",
     sourceKind: "manual",
     status: "accepted",
+    previewSections: [
+      {
+        key: "warmup-0",
+        title: "Warmup",
+        category: "warmup",
+        rows: [{ text: "400m freestyle easy" }],
+      },
+      {
+        key: "main-1",
+        title: "Main",
+        category: "main",
+        rows: [{ text: "6 x 100m threshold", secondaryText: "Rest 20 sec" }],
+      },
+      {
+        key: "cooldown-2",
+        title: "Cooldown",
+        category: "cooldown",
+        rows: [{ text: "200m choice easy" }],
+      },
+    ],
     ...overrides,
   };
 }
@@ -170,6 +190,14 @@ describe("ProgramBuilderHub", () => {
     fireEvent.click(screen.getByTestId("program-day-add-week-0-day-0"));
 
     expect(screen.getByRole("button", { name: "Remove" })).toBeVisible();
+    expect(
+      screen.getByLabelText("Scheduled workout step preview for Threshold builder workout")
+    ).toBeVisible();
+    expect(screen.getByText("Warmup")).toBeVisible();
+    expect(screen.getByText("400m freestyle easy")).toBeVisible();
+    expect(screen.getByText("6 x 100m threshold")).toBeVisible();
+    expect(screen.getByText("Rest 20 sec")).toBeVisible();
+    expect(screen.getByText("Cooldown")).toBeVisible();
     expect(screen.getByTestId("program-editor-save-state")).toHaveTextContent(
       "Unsaved changes stay local until you save this program."
     );
@@ -209,6 +237,52 @@ describe("ProgramBuilderHub", () => {
       position: 0,
     });
     expect(screen.getByTestId("program-builder-save")).toBeDisabled();
+  });
+
+  it("keeps scheduled cards useful when workout preview sections are missing", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => buildProgramExportPreview(),
+    } as Response);
+
+    render(
+      <ProgramBuilderHub
+        programLibrary={buildProgramLibrary({
+          selectedProgram: buildProgramRecord({
+            weeks: [
+              {
+                id: "week-1",
+                label: "Week 1",
+                assignments: [
+                  {
+                    id: "assignment-no-preview",
+                    workoutId: "workout-1",
+                    dayIndex: 0,
+                    position: 0,
+                  },
+                ],
+              },
+            ],
+          }),
+          availableWorkouts: [buildWorkoutSummary({ previewSections: [] })],
+        })}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("program-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    const assignmentCard = screen.getByTestId("program-assignment-card-assignment-no-preview");
+    expect(within(assignmentCard).getByText("Threshold builder workout")).toBeVisible();
+    expect(within(assignmentCard).getByText("2200m · ~45 min")).toBeVisible();
+    expect(
+      screen.queryByTestId("program-assignment-step-preview-assignment-no-preview")
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove" })).toBeVisible();
   });
 
   it("shows canonical export preview, downloads json, and opens the program pdf print view", async () => {


### PR DESCRIPTION
## Summary

- User-visible changes: Program Builder scheduled-workout cards now show compact workout step previews so a planned day exposes warmup/main/cooldown/repeat/rest structure without opening an export.
- Technical changes: `ProgramBuilderHub` consumes existing `WorkoutSummary.previewSections`, adds row-limited fallback-safe rendering, updates focused component tests, and records Program Builder as a session-step surface consumer.
- Policy impact: no, changed files do not touch auth/session/account, analytics/consent, user data rights, privacy policy, or third-party processor behavior.
- Policy version note: N/A because this PR has no policy-impacting scope.
- Brief link(s): `docs/task-briefs/in-progress/2026-05-04-program-builder-scheduled-workout-step-preview-parity-10-10.md`
- Latest commit: `eca3cf6` - feat: add program builder step preview parity.

## Scope

- In scope: Program Builder scheduled-workout card rendering, row-limited step-preview display, missing-preview fallback behavior, focused tests, and session-step surface documentation.
- Out of scope: Program persistence semantics, calendar/completion/history state, export/PDF/Garmin behavior, API routes, database schema, authz/RLS, cache behavior, and new dependencies.

## UI Evidence

- Screenshot handoff approved by owner before broad gates.
- Screenshot artifacts: `/Users/stianvikra/freeswimming/output/program-builder-step-preview-parity-2026-05-04-131036`
- Captured: `2026-05-04 13:45`
- Handoff type: `after/reference`
- Representative files:
  - `after-program-builder-scheduled-card-desktop.png`
  - `after-program-builder-scheduled-card-mobile.png`
  - `reference-program-pdf-scheduled-sections-desktop.png`

## Risk

- Main risk: Planner-card density on unusual workout structures could make scheduled days harder to scan. Mitigated by visible-row limiting, fallback rendering, mobile screenshot review, and focused component tests.
- Rollback plan: Revert `eca3cf6` to restore title/distance/time-only scheduled cards. No schema, data repair, cache purge, or migration rollback required.

## Test Evidence

- `./node_modules/.bin/vitest run tests/unit/program-builder-hub.test.tsx`: PASS
- `npm run typecheck`: PASS
- `npx eslint components/my-library/programs/ProgramBuilderHub.tsx tests/unit/program-builder-hub.test.tsx`: PASS
- `npm run lint:briefs:all`: PASS
- `npm run verify:pre-pr`: **PASS** on `eca3cf6` (full-public lane, `artifacts/test-runs/20260504-140512`, 107 passed / 349 skipped E2E).
- `npm run verify:pre-merge`: **PASS** for `eca3cf6` (2026-05-04T12:35:08Z, lane: full, mode: skipped private gate, source: reused current-head verify PASS).
- CI checks: PASS (`verify`, `e2e-smoke`, `site-lock-smoke`, `deploy-preview`, `size-check`, `CodeQL`, `Analyze`, `Vercel`, `Vercel Preview Comments`).
- Vercel preview: https://vercel.com/stian-vikras-projects/freeswimming-org/GzcmVhhPXKkrtVd2G5APGEktWdEQ
- Policy-impact checklist: N/A because policy impact is no and changed files do not touch policy-impact paths.
- Perf note: local perf trend recommends tightening one stretch target after four consecutive weekly green runs. Held out of this parity PR because the slice does not change route budgets; record as AW-010 follow-up decision.

## Scorecard Closeout

- Critical target categories scored `5/5`: Product goals and IA, Visual design quality, Business logic correctness and data integrity, Stack-fit and dependency discipline, Testing and QA automation.
- All other target rows in the linked brief are scored `5/5`; no target category is below `4/5`.
- `10/10` claim: yes for scoped parity slice. Critical target categories are all `5/5`.
- Remaining gap: none for this slice.

## Checklist

- [x] Screenshot handoff approved for UI change
- [x] Acceptance criteria are met locally
- [x] Docs updated for session-step surface consumer contract
- [x] Changed task brief includes full 10/10 scorecard mapping
- [x] No secrets or sensitive data added
- [x] Required GitHub checks are green
- [x] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge`
