### PR TITLE
fix(auth): reduce supabase egress and classify quota failures

### DIFF
--- a/app/api/course/content/route.ts
+++ b/app/api/course/content/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { COURSE_MODULES } from "@/app/course/courseData";
-import { loadCourseModulesByStatus } from "@/lib/admin/content-course";
+import {
+  loadCourseModulesByStatus,
+  loadPublishedCourseModulesCached,
+  PUBLIC_COURSE_CONTENT_REVALIDATE_SECONDS,
+} from "@/lib/admin/content-course";
 import { requireAdminRoleFromSupabase } from "@/lib/admin/server";
 import {
   resolveCourseContentStatusesForPreviewMode,
@@ -27,6 +31,14 @@ function noStoreJson(
   return NextResponse.json(body, {
     status: init?.status ?? 200,
     headers,
+  });
+}
+
+function publicCachedJson(body: Record<string, unknown>) {
+  return NextResponse.json(body, {
+    headers: {
+      "Cache-Control": `public, max-age=0, s-maxage=${PUBLIC_COURSE_CONTENT_REVALIDATE_SECONDS}, stale-while-revalidate=86400`,
+    },
   });
 }
 
@@ -90,12 +102,8 @@ export async function GET(request: Request) {
       );
     }
 
-    const modules = await loadCourseModulesByStatus({
-      statuses: ["published"],
-      fallback: COURSE_MODULES,
-      autoSeedWhenEmpty: true,
-    });
-    return noStoreJson({
+    const modules = await loadPublishedCourseModulesCached();
+    return publicCachedJson({
       ok: true,
       modules: modules.length > 0 ? modules : COURSE_MODULES,
       preview: {

--- a/app/api/my-library/new-content-signal/route.ts
+++ b/app/api/my-library/new-content-signal/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { isUnauthenticatedAuthUserLookupError } from "@/lib/admin/access";
-import { loadCourseModulesByStatus } from "@/lib/admin/content-course";
+import { loadPublishedCourseModulesCached } from "@/lib/admin/content-course";
 import {
   buildMyLibraryCourseSignal,
   resolveMyLibraryViewerSince,
@@ -68,11 +68,7 @@ export async function GET() {
       );
     }
 
-    const modules = await loadCourseModulesByStatus({
-      statuses: ["published"],
-      fallback: [],
-      autoSeedWhenEmpty: true,
-    });
+    const modules = await loadPublishedCourseModulesCached();
     const signal = buildMyLibraryCourseSignal(modules, {
       viewerSince: resolveMyLibraryViewerSince({
         profileCreatedAt: profileCreatedResult.data?.created_at ?? null,

--- a/app/api/progress/course/route.ts
+++ b/app/api/progress/course/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { COURSE_MODULES } from "@/app/course/courseData";
-import { loadCourseModulesByStatus } from "@/lib/admin/content-course";
+import { loadPublishedCourseModulesCached } from "@/lib/admin/content-course";
 import {
   MAX_COURSE_PROGRESS_ROWS,
   normalizeCourseProgressRows,
@@ -52,11 +51,7 @@ async function getSignedInUserId() {
 }
 
 async function getCourseProgressLessonIdResolver(): Promise<CourseProgressLessonIdResolver> {
-  const modules = await loadCourseModulesByStatus({
-    statuses: ["published"],
-    fallback: COURSE_MODULES,
-    autoSeedWhenEmpty: false,
-  });
+  const modules = await loadPublishedCourseModulesCached();
   const canonicalLessonIdByAlias = buildCanonicalCourseLessonIdMap(modules);
 
   return (lessonId) => canonicalizeCourseLessonRuntimeId(lessonId, canonicalLessonIdByAlias);

--- a/app/api/user/export/route.ts
+++ b/app/api/user/export/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from "next/server";
-import { COURSE_MODULES } from "@/app/course/courseData";
 import {
   isAthleteProfileSchemaMissing,
   isPersonalRecordsSchemaMissing,
   isTrainingMetricSchemaMissing,
   isTrainingPreferencesSchemaMissing,
 } from "@/lib/athlete-profile/schema";
-import { loadCourseModulesByStatus } from "@/lib/admin/content-course";
+import { loadPublishedCourseModulesCached } from "@/lib/admin/content-course";
 import { normalizeCourseProgressRows } from "@/lib/course/progress";
 import {
   buildCanonicalCourseLessonIdMap,
@@ -41,11 +40,7 @@ export async function GET() {
 
   const userId = user.id;
   const generatedAt = new Date().toISOString();
-  const courseModules = await loadCourseModulesByStatus({
-    statuses: ["published"],
-    fallback: COURSE_MODULES,
-    autoSeedWhenEmpty: false,
-  });
+  const courseModules = await loadPublishedCourseModulesCached();
   const canonicalLessonIdByAlias = buildCanonicalCourseLessonIdMap(courseModules);
   const resolveLessonId = (lessonId: string) =>
     canonicalizeCourseLessonRuntimeId(lessonId, canonicalLessonIdByAlias);

--- a/app/auth/sign-in/actions.ts
+++ b/app/auth/sign-in/actions.ts
@@ -10,6 +10,7 @@ import {
   toRetrySeconds,
 } from "@/lib/auth/magic-link-cooldown";
 import { getSafeNextPath } from "@/lib/auth/next-path";
+import { classifySignInEmailError } from "@/lib/auth/sign-in-email-error";
 import { isResendRequestFlag, shouldApplyMagicLinkCooldown } from "@/lib/auth/sign-in-request";
 import { getAppUrl } from "@/lib/supabase/env";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
@@ -379,9 +380,10 @@ export async function requestMagicLink(formData: FormData) {
   });
 
   if (error) {
-    if (error.message.toLowerCase().includes("rate limit")) {
+    const classification = classifySignInEmailError(error);
+    if (classification.kind === "rate_limited") {
       const params: Record<string, string> = {
-        error: "Please wait about a minute before requesting a new login code.",
+        error: classification.userMessage,
         cooldownUntil: String(Date.now() + 60_000),
         email,
       };
@@ -393,12 +395,13 @@ export async function requestMagicLink(formData: FormData) {
     }
 
     console.error("[Auth] Could not request sign-in email.", {
+      kind: classification.kind,
       message: error.message,
       status: error.status,
       code: error.code,
     });
     const params: Record<string, string> = {
-      error: "Could not send sign-in email right now. Please try again.",
+      error: classification.userMessage,
       email,
     };
     if (isResendRequest) {

--- a/app/course/page.tsx
+++ b/app/course/page.tsx
@@ -682,12 +682,13 @@ function CoursePageClient() {
       }
       const requestPath =
         params.size > 0 ? `/api/course/content?${params.toString()}` : "/api/course/content";
+      const requestCache: RequestCache = previewEnabled ? "no-store" : "force-cache";
 
       try {
         const response = await fetch(requestPath, {
           method: "GET",
           credentials: "same-origin",
-          cache: "no-store",
+          cache: requestCache,
         });
 
         const payload = (await response.json()) as {

--- a/app/plans/page.tsx
+++ b/app/plans/page.tsx
@@ -6,13 +6,12 @@ import TrackedLink from "@/components/analytics/TrackedLink";
 import PageTemplate from "@/components/PageTemplate";
 import PageIntro from "@/components/PageIntro";
 import CheckoutButton from "@/components/my-library/CheckoutButton";
-import { createServerSupabaseClient } from "@/lib/supabase/server";
-import { buildCatalogOverridesFromRows } from "@/lib/commerce/catalog-overrides";
+import { loadPublicCatalogOverridesCached } from "@/lib/commerce/catalog-server";
 import {
   getCatalogProductsWithAvailability,
+  type CatalogProductOverridesById,
   type CatalogProductAvailability,
 } from "@/lib/commerce/catalog";
-import type { CatalogProductOverridesById } from "@/lib/commerce/catalog";
 
 export const dynamic = "force-dynamic";
 
@@ -60,10 +59,10 @@ function PlanCard({ product }: { product: CatalogProductAvailability }) {
   const copy = getPlanCopy(product);
 
   return (
-    <article className="bg-white/92 relative overflow-hidden rounded-[22px] border border-slate-200/70 p-6 shadow-[0_14px_34px_rgba(15,23,42,0.08)]">
+    <article className="relative overflow-hidden rounded-[22px] border border-slate-200/70 bg-white/92 p-6 shadow-[0_14px_34px_rgba(15,23,42,0.08)]">
       <div className="absolute inset-x-0 top-0 h-[2px] bg-gradient-to-r from-[#5aa6ff] via-[#93c8ff] to-transparent opacity-70" />
 
-      <div className="text-[12px] font-semibold uppercase tracking-wide text-slate-500">
+      <div className="text-[12px] font-semibold tracking-wide text-slate-500 uppercase">
         {product.kind === "analysis" ? "Video feedback" : "Guide"}
       </div>
       <h2 className="mt-2 text-[18px] font-semibold text-slate-900">{product.title}</h2>
@@ -101,17 +100,7 @@ function PlanCard({ product }: { product: CatalogProductAvailability }) {
 export default async function PlansPage() {
   let catalogOverrides: CatalogProductOverridesById = {};
   try {
-    const supabase = await createServerSupabaseClient();
-    const { data: productRows, error: productRowsError } = await supabase
-      .from("products")
-      .select("id, slug, title, kind, active")
-      .order("created_at", { ascending: true });
-
-    if (productRowsError) {
-      console.error("[Plans] Could not load product catalog overrides", productRowsError);
-    } else {
-      catalogOverrides = buildCatalogOverridesFromRows(productRows ?? []);
-    }
+    catalogOverrides = await loadPublicCatalogOverridesCached();
   } catch (error) {
     console.error("[Plans] Falling back to env catalog due override lookup failure", error);
   }

--- a/docs/runbooks/auth-account-support.md
+++ b/docs/runbooks/auth-account-support.md
@@ -32,6 +32,11 @@ Use this runbook when users ask where account, sign-in, billing, or recovery act
   - verify `invoice_creation.enabled=true` and an invoice ID exists for the session,
   - treat older sandbox purchases made before invoice creation was enabled as receipt/charge-only records; they do not retroactively gain portal invoice history.
 - If a sign-in code does not arrive: ask them to check spam/junk, wait for any cooldown, then request a new code on `/auth/sign-in`.
+- If `/auth/sign-in` shows "Sign-in is temporarily unavailable because a service limit was reached":
+  - check Vercel logs for `[Auth] Could not request sign-in email` with `kind: "service_restricted"`,
+  - check Supabase Dashboard -> Organization Usage -> Egress for `exceed_egress_quota` or Fair Use restrictions,
+  - do not ask the user to retry repeatedly until Supabase usage/billing restriction is resolved,
+  - tell the user sign-in is temporarily unavailable and that we are resolving a service limit.
 - If a code expires or fails: request a new code from `/auth/sign-in`.
 - If preview access is blocked while the site is private: authenticated admins should be issued access automatically through `/preview-access/admin-unlock`; anonymous visitors and non-admin testers still use `/preview-access` until the test-user access brief ships.
 - If `Micro Sessions` shows "still syncing" under `Dryland Sessions`: verify the linked Supabase environment has applied `20260508101500_dryland_micro_plans.sql`, then confirm `dryland_micro_plans` RLS allows owner-scoped authenticated reads/writes. Saved dryland sessions should remain available while this is repaired.

--- a/docs/task-briefs/in-progress/2026-05-09-supabase-egress-audit-and-reduction-10-10.md
+++ b/docs/task-briefs/in-progress/2026-05-09-supabase-egress-audit-and-reduction-10-10.md
@@ -1,0 +1,228 @@
+# Task Brief: Supabase Egress Audit And Reduction (10/10)
+
+## Metadata
+
+- `id`: `2026-05-09-supabase-egress-audit-and-reduction-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-05-09`
+- `updated`: `2026-05-09`
+
+## Goal
+
+Reduce avoidable Supabase egress and make quota/restriction failures support-diagnosable before more feature work continues.
+
+## Product Decision
+
+Treat the current Supabase `402 exceed_egress_quota` incident as real production risk. The first slice should ship low-risk reduction and diagnostics now:
+
+- cache public published content reads,
+- keep admin preview/draft/session-bound reads uncached,
+- classify Supabase quota/project restriction auth failures with a clear safe user message,
+- update support/runbook guidance.
+
+Do not build the larger admin incident/status-banner system in this slice; that belongs in a later brief.
+
+Observed evidence before implementation:
+
+- Supabase Usage screenshot shows `18.614 GB` egress on Free Plan for `2026-04-16` to `2026-05-16`.
+- Vercel production logs showed `POST /auth/sign-in` failing with Supabase status `402` and `exceed_egress_quota`.
+- Supabase docs state Free includes `5 GB` uncached egress, egress spans Database/Auth/Storage/API/etc., and Fair Use restrictions can respond with `402`.
+
+References:
+
+- https://supabase.com/docs/guides/platform/manage-your-usage/egress
+- https://supabase.com/docs/guides/platform/billing-faq#fair-use-policy
+
+## Relevance Assessment Before Scoring
+
+Relevant target categories are reliability, caching, performance/cost, auth failure handling, privacy-safe diagnostics, support operations, and testing. Visual design is supporting only because this slice may change auth error copy but not layout. Admin editor CRUD, finance reporting, commerce checkout, SEO/AI content, and i18n are not primary targets.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for a `10/10` claim:
+
+- Business logic correctness and data integrity
+- Caching and invalidation strategy
+- Reliability and failure handling
+- Security and authz
+- Privacy and compliance
+- Incident response and support operations
+- Stack-fit and dependency discipline
+- Testing and QA automation
+- Scalability and cost efficiency
+
+| Category                                      | Mapping      | Target Threshold / Scope Rationale                                                                                                                          | Evidence                                           | Expected Closeout Score |
+| --------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | The slice has one clear job: reduce avoidable Supabase egress while preserving public/admin/user route purpose.                                             | brief scope + route audit                          | `5/5`                   |
+| UX flow clarity                               | `target`     | Auth users get a clearer safe message for service restriction failures without misleading countdowns.                                                       | unit tests + screenshot handoff if UI copy changes | `5/5`                   |
+| Visual design quality                         | `supporting` | Supporting only: auth error copy may change, but layout and visual system should remain unchanged.                                                          | screenshot handoff if rendered auth copy changes   | `4/5`                   |
+| Business logic correctness and data integrity | `target`     | Public cache changes do not cache user-specific, admin preview, draft, or session-bound data across users.                                                  | route/cache review + tests                         | `5/5`                   |
+| Admin editor ergonomics                       | `supporting` | Supporting only: admin preview/draft content remains uncached and current admin editing behavior remains unchanged.                                         | admin preview cache review                         | `4/5`                   |
+| Accessibility (a11y)                          | `supporting` | Supporting only: existing auth status semantics and labels remain intact when error copy changes.                                                           | component review + existing auth tests             | `4/5`                   |
+| Performance (CWV + payloads)                  | `target`     | Public content reads use cache/revalidation and avoid per-view Supabase egress; no new client dependency or payload growth.                                 | implementation review + build/test evidence        | `5/5`                   |
+| Data placement and sync boundaries            | `target`     | Published public content is cacheable server data; preview/admin/user data remains server-canonical and uncached where session-bound.                       | data-boundary section + code review                | `5/5`                   |
+| Caching and invalidation strategy             | `target`     | Public published content has explicit revalidation; preview/admin/draft/auth routes remain `no-store` or request-bound.                                     | route headers/cache helper tests                   | `5/5`                   |
+| Reliability and failure handling              | `target`     | Supabase quota/project restriction during sign-in produces deterministic non-500 UX and support-visible logs.                                               | auth error classifier tests + runbook update       | `5/5`                   |
+| Security and authz                            | `target`     | Cache is not applied to protected data; admin/service-role reads expose only intended public projections.                                                   | code review + negative-path tests where applicable | `5/5`                   |
+| Privacy and compliance                        | `target`     | Logs and UI do not expose raw tokens, allowlists, provider internals, or unnecessary PII.                                                                   | log review + tests                                 | `5/5`                   |
+| Content governance                            | `supporting` | Supporting only: published content remains the source for public reads; cache freshness is explicitly bounded.                                              | cache contract review                              | `4/5`                   |
+| Admin workflow and editability                | `supporting` | Supporting only: no admin editing UI changes; admin preview/draft still bypasses public cache.                                                              | admin preview route review                         | `4/5`                   |
+| SEO and crawlability                          | `supporting` | Supporting only: public route cache changes must not loosen private site-lock, robots, sitemap, or preview noindex behavior.                                | private-gate/public route review                   | `4/5`                   |
+| AI discoverability                            | `N/A`        | N/A because this slice does not add, remove, or restructure AI-discoverable public content semantics.                                                       | explicit scope rationale                           | `N/A`                   |
+| Analytics and KPI observability               | `supporting` | Supporting only: no product analytics taxonomy expansion; server diagnostics must identify quota/restriction category safely.                               | log category review                                | `4/5`                   |
+| Commerce and revenue ops                      | `supporting` | Supporting only: public catalog overrides may be cached, but checkout, entitlements, pricing contracts, refunds, and payouts are unchanged.                 | plans/catalog regression tests                     | `4/5`                   |
+| Incident response and support operations      | `target`     | Runbook tells support/admin how to detect `402 exceed_egress_quota`, what dashboard to check, and what user-facing message means.                           | runbook diff + log evidence                        | `5/5`                   |
+| Finance and reporting operations              | `N/A`        | N/A because this slice does not change invoices, payouts, refunds, subscriptions, or revenue reporting.                                                     | explicit scope rationale                           | `N/A`                   |
+| i18n operational readiness                    | `supporting` | Supporting only: new auth copy remains concise and structurally localizable; no locale routing or content model change.                                     | copy review                                        | `4/5`                   |
+| Stack-fit and dependency discipline           | `target`     | Use Next.js cache/revalidation primitives, existing Supabase helpers, typed projections, and no new dependency.                                             | architecture review + dependency diff              | `5/5`                   |
+| Testing and QA automation                     | `target`     | Add focused tests for error classification and cache/user-boundary behavior; broad gates pass.                                                              | unit tests + `verify:pre-pr` + `verify:pre-merge`  | `5/5`                   |
+| Scalability and cost efficiency               | `target`     | Public traffic no longer causes one Supabase published-content read per page/API view; documented follow-up if further dashboard data shows another source. | audit notes + code review                          | `5/5`                   |
+| DevOps and rollback readiness                 | `target`     | Rollback is safe by reverting cache/auth classifier changes; no migration required; runbook documents operational fallback.                                 | rollback note + validation gates                   | `5/5`                   |
+
+## Stack / Architecture Best-Practice Gate
+
+- React/Next.js:
+  - Use Next server-side cache/revalidation for public published content.
+  - Keep admin preview/draft and auth/session-bound handlers dynamic/no-store.
+  - Do not trust client cache for auth, admin, preview, or My Library data.
+- TypeScript/domain contracts:
+  - Add a typed Supabase auth error classifier with deterministic categories.
+  - Keep public data projections explicit; do not use `select("*")`.
+- Supabase/data layer:
+  - No schema migration.
+  - Public cache reads may use service-role only for narrow public-safe projections already rendered on public pages.
+  - User-specific and protected reads remain RLS/session-bound and uncached across users.
+- External services/tools:
+  - Supabase and Vercel logs are diagnostic sources.
+  - No secret values or raw provider payloads are exposed to users.
+- UI system:
+  - Reuse existing `AuthRequestStatus` and sign-in layout if copy changes.
+  - Screenshot handoff is required only for rendered auth UI copy changes.
+- Testing:
+  - Unit tests for auth error classification.
+  - Route/cache tests or focused unit coverage for public cache helpers.
+  - Existing auth/sign-in and private-gate tests remain valid.
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - Supabase Auth, user sessions, admin roles, content publish state, product catalog overrides.
+- Cacheable public data:
+  - published course modules/lessons and public catalog projections only.
+- Local/browser:
+  - no new local state.
+- Sync policy:
+  - public cache revalidates on a bounded TTL; admin preview/draft remains live/no-store.
+- Retention and sensitivity:
+  - no new retained user data.
+  - auth diagnostic logs must avoid tokens, preview cookies, allowlists, and raw email lists.
+- Cache/invalidation:
+  - public published content has explicit revalidate TTL and public response cache headers.
+  - admin preview/draft/session-bound routes keep `no-store`.
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - existing Supabase row ids and runtime content ids remain unchanged.
+- Human-readable identifiers:
+  - existing slugs/titles remain unchanged.
+- Mutability rules:
+  - no rename behavior is changed.
+- Compatibility contract:
+  - existing content runtime alias/repair behavior remains unchanged.
+- Observability and repair:
+  - auth errors are classified into safe categories; unresolved content identity handling remains existing behavior.
+
+## Scope
+
+- Audit Supabase-heavy public/dynamic routes.
+- Cache low-risk public published content/catalog reads.
+- Preserve no-store behavior for admin preview/draft/user-specific data.
+- Improve sign-in error classification for Supabase quota/project restriction.
+- Update auth/support runbook.
+- Add focused tests.
+
+## Out Of Scope
+
+- Supabase billing/plan changes.
+- Admin incident dashboard/status-banner system.
+- Admin incident alert email; follow-up brief:
+  `docs/task-briefs/planned/2026-05-09-admin-incident-alerts-and-status-ops-10-10.md`.
+- Schema migrations.
+- Storage/CDN migration.
+- Dryland builder changes.
+- Habit/micro/statistics implementation.
+
+## Acceptance Criteria
+
+1. Public published course content no longer requires a Supabase DB read for every public course content request.
+2. Public catalog override reads are cached or otherwise bounded.
+3. Preview/admin/draft/user-specific reads remain request-bound and are not globally cached.
+4. Supabase `402`, `exceed_egress_quota`, or project-restricted auth errors show a clear safe sign-in failure message without countdown.
+5. Rate-limit auth errors still show cooldown countdown.
+6. Runbook documents how to diagnose Supabase egress restriction and the expected UI/log behavior.
+7. No new dependencies or secrets are added.
+
+## Validation
+
+- `npm run lint:briefs`
+- focused unit tests for auth error classification/cache behavior
+- targeted auth sign-in UI/e2e if rendered copy changes
+- screenshot handoff if rendered auth UI copy changes
+- `npm run verify:pre-pr`
+- `npm run verify:pre-merge`
+
+## Quality Gate Evidence
+
+- API and server actions unexpected 500/failure-mode evidence:
+  `classifySignInEmailError` converts Supabase `402`, `exceed_egress_quota`, project-restricted, provider delivery, and rate-limit failures into deterministic action-state messages instead of unexpected 500 behavior. Unknown failures still return the existing safe generic message.
+- External services official integration pattern:
+  The implementation uses existing Supabase server helpers and Next.js `unstable_cache`/response cache headers; no new SDK or dependency was added. Supabase egress and fair-use behavior is grounded in official docs linked in this brief.
+- Route/label/support sweep identifiers and surfaces:
+  Identifiers searched: `force-dynamic`, `no-store`, `/api/course/content`, `loadCourseModulesByStatus`, `signInWithOtp`, `Could not send sign-in email`, `exceed_egress_quota`, `products`, and `select("*")`.
+  Directories/surfaces checked: `app/`, `lib/`, `tests/unit/`, `docs/runbooks/`, and active/planned task briefs. Fallout handled in auth support runbook and focused unit tests.
+- Reference surface or shared UI contract:
+  Rendered auth copy keeps the existing sign-in route, card structure, `AuthRequestStatus`, form controls, and layout. The change is message semantics only; no new visual component was introduced.
+- Screenshot artifact handoff:
+  Screenshot artifacts were captured in `output/supabase-egress-hotfix-20260509-084249` with `after-sign-in-service-limit-desktop.png`, `after-sign-in-service-limit-mobile.png`, and `reference-sign-in-default-desktop.png`.
+- Screenshot comparison naming:
+  The handoff used `after/reference` naming because it compared the changed service-limit auth state to the unchanged default sign-in surface.
+- Owner screenshot approval stop:
+  The screenshot handoff was presented before continuing into `verify:pre-pr`; owner approved continuation with `ok, gjør som anbefalt`.
+- High-cost UI/export debug path:
+  UI capture followed `docs/runbooks/ui-debug-hypothesis-and-handoff.md`; the actual consumed artifact files in `output/` were inspected by handoff before gates continued.
+
+## Manual QA Environments
+
+- Local auth/sign-in error-state rendering when feasible.
+- Production Supabase Usage remains owner-verified from dashboard because Codex cannot access dashboard internals.
+
+## Help / Guide Impact
+
+Update `docs/runbooks/auth-account-support.md` with the Supabase `402 exceed_egress_quota` diagnostic path and user-facing guidance.
+
+## Route / Label / Support Surface Sweep
+
+Search targets before broad gates:
+
+- `force-dynamic`
+- `no-store`
+- `/api/course/content`
+- `loadCourseModulesByStatus`
+- `signInWithOtp`
+- `Could not send sign-in email`
+- `exceed_egress_quota`
+- `products`
+- `select("*")`
+
+## Rollback
+
+Revert this PR to return to previous uncached public reads and generic auth error handling. No migration rollback is required.
+
+## Checkpoint Log
+
+- `2026-05-09` - Created after Supabase dashboard confirmed `18.614 GB` egress on Free Plan and production logs showed `402 exceed_egress_quota` blocking sign-in. Next: implement low-risk cache and auth error diagnostics.
+- `2026-05-09` - Implemented public published-content/catalog caching, auth failure classification, runbook update, focused tests, and screenshot handoff. Next: rerun `npm run verify:pre-pr`.

--- a/docs/task-briefs/planned/2026-05-09-admin-incident-alerts-and-status-ops-10-10.md
+++ b/docs/task-briefs/planned/2026-05-09-admin-incident-alerts-and-status-ops-10-10.md
@@ -1,0 +1,182 @@
+# Task Brief: Admin Incident Alerts And Status Ops (10/10)
+
+## Metadata
+
+- `id`: `2026-05-09-admin-incident-alerts-and-status-ops-10-10`
+- `status`: `planned`
+- `owner`: `stianvikra`
+- `created`: `2026-05-09`
+- `updated`: `2026-05-09`
+
+## Goal
+
+Notify admin about critical user-facing failures with enough safe diagnostic context to fix the issue quickly without collecting unnecessary user data.
+
+## Product Decision
+
+Build this as a separate ops/incident slice, not inside the Supabase egress hotfix and not inside admin user management.
+
+The system should deduplicate critical alerts, send actionable admin email, and optionally support a user-facing status/banner later. It should prioritize anonymous aggregate failure context over user-identifying data. Concrete user identifiers should only be captured when required for an authenticated support case or a user-owned account workflow.
+
+First target incident categories:
+
+- `auth_sign_in_service_restricted`
+- `auth_sign_in_email_delivery_failed`
+- `preview_access_unlock_failed`
+- `checkout_unavailable`
+- `save_export_failed`
+
+## Relevance Assessment Before Scoring
+
+Relevant categories are incident response, admin workflow, reliability, privacy, security, observability, and cost/scalability. Visual design is supporting unless a status/banner UI is included. Commerce and finance are supporting only because checkout alerts may be covered, but reconciliation/reporting is not changed in V1.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for a `10/10` claim:
+
+- Business logic correctness and data integrity
+- Reliability and failure handling
+- Security and authz
+- Privacy and compliance
+- Incident response and support operations
+- Analytics and KPI observability
+- Testing and QA automation
+
+| Category                                      | Mapping      | Target Threshold / Scope Rationale                                                                                                    | Evidence                                     | Expected Closeout Score |
+| --------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | Admin can understand what failed, where to look, and what to do next without entering unrelated admin surfaces.                       | admin workflow QA + runbook                  | `5/5`                   |
+| UX flow clarity                               | `target`     | User-facing errors remain calm and non-technical; admin-facing alert has clear next action.                                           | screenshot/copy review where UI changes      | `5/5`                   |
+| Visual design quality                         | `supporting` | Supporting unless a status/banner UI is included; any UI must reuse existing admin/status primitives.                                 | screenshot handoff if UI changes             | `4/5`                   |
+| Business logic correctness and data integrity | `target`     | Alerts are deduplicated by category/window, do not double-send on retries, and preserve event counts.                                 | unit tests + integration tests               | `5/5`                   |
+| Admin editor ergonomics                       | `target`     | Admin email and/or admin surface gives one concise action path, including Codex-ready diagnostic prompt and runbook link.             | admin QA + email snapshot                    | `5/5`                   |
+| Accessibility (a11y)                          | `supporting` | Supporting: any status/banner/admin UI keeps labels, focus order, and readable contrast.                                              | a11y review if UI changes                    | `4/5`                   |
+| Performance (CWV + payloads)                  | `supporting` | Alert instrumentation must not add heavy client payload or block critical user actions.                                               | bundle/build review                          | `4/5`                   |
+| Data placement and sync boundaries            | `target`     | Incident events are server-canonical; client only sends safe category/context where needed; no browser-local source of truth.         | data-boundary review + tests                 | `5/5`                   |
+| Caching and invalidation strategy             | `supporting` | Supporting: dedupe windows and status state have explicit TTL/cache behavior; user/auth/admin routes keep existing cache contracts.   | cache/TTL review                             | `4/5`                   |
+| Reliability and failure handling              | `target`     | Alert delivery failures degrade safely, do not break user flow, and are retryable/idempotent.                                         | negative-path tests                          | `5/5`                   |
+| Security and authz                            | `target`     | Only authorized admins can manage status/alert settings; alert endpoints fail closed.                                                 | authz tests                                  | `5/5`                   |
+| Privacy and compliance                        | `target`     | Default payload excludes raw email, tokens, cookies, IP, and provider secrets; user identifiers require explicit support-case reason. | privacy review + tests                       | `5/5`                   |
+| Content governance                            | `supporting` | Supporting: status/banner messages, if included, have owner, publish/unpublish, and rollback path.                                    | admin/status review                          | `4/5`                   |
+| Admin workflow and editability                | `target`     | Admin can view current critical incident category, suppression state, and last alert timestamp.                                       | admin QA                                     | `5/5`                   |
+| SEO and crawlability                          | `N/A`        | N/A because incident emails/status ops do not change public crawlable route metadata or sitemap behavior in V1.                       | explicit scope rationale                     | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because this is internal ops/support workflow and does not add public AI-discoverable content.                                    | explicit scope rationale                     | `N/A`                   |
+| Analytics and KPI observability               | `target`     | Critical failures emit safe event category, count, first/last seen, and affected flow for admin review.                               | event tests + admin/email evidence           | `5/5`                   |
+| Commerce and revenue ops                      | `supporting` | Supporting: checkout incident category may alert admin, but pricing, invoices, entitlements, refunds, and reporting are unchanged.    | checkout alert negative-path test if touched | `4/5`                   |
+| Incident response and support operations      | `target`     | Admin receives deduped actionable email and runbook gives exact diagnostic path and Codex prompt.                                     | email snapshot + runbook                     | `5/5`                   |
+| Finance and reporting operations              | `N/A`        | N/A because this slice does not change finance reports, invoices, payouts, refunds, or reconciliation.                                | explicit scope rationale                     | `N/A`                   |
+| i18n operational readiness                    | `supporting` | Supporting: user/status copy remains concise and structurally localizable; internal admin emails may remain English in V1.            | copy review                                  | `4/5`                   |
+| Stack-fit and dependency discipline           | `target`     | Use existing admin message/email provider patterns, Upstash/Supabase where already established, and no new vendor without rationale.  | architecture review + dependency diff        | `5/5`                   |
+| Testing and QA automation                     | `target`     | Unit/integration tests cover dedupe, privacy redaction, authz, delivery failure, and representative incident categories.              | tests + `verify:pre-pr` + `verify:pre-merge` | `5/5`                   |
+| Scalability and cost efficiency               | `target`     | Alerts are rate-limited/deduped and cannot spam email or create unbounded incident rows.                                              | load/dedupe tests + code review              | `5/5`                   |
+| DevOps and rollback readiness                 | `target`     | Feature can be disabled by config/flag; rollback path does not affect auth/checkout/save core flows.                                  | flag/rollback evidence + runbook             | `5/5`                   |
+
+## Stack / Architecture Best-Practice Gate
+
+- React/Next.js:
+  - Alert ingestion should happen server-side near critical failure handlers.
+  - Any admin/status UI must reuse existing admin surfaces and primitives.
+- TypeScript/domain contracts:
+  - Define typed incident categories, severity, dedupe key, and safe diagnostic payload.
+  - Redaction must be deterministic and tested.
+- Supabase/data layer:
+  - If persisted, use explicit migration, RLS/admin-only access, indexes for category/window, and generated DB type update.
+  - If using Upstash for dedupe, document TTL and fallback behavior.
+- External services:
+  - Use existing email provider contract.
+  - Email delivery must be idempotent/deduped.
+- UI system:
+  - User-facing copy is optional V1; if included, screenshot handoff is required.
+- Testing:
+  - Unit tests for redaction/dedupe.
+  - Route/integration tests for representative incident ingestion and admin authz.
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - incident category, severity, count, first seen, last seen, dedupe window, delivery status.
+- Local data:
+  - none.
+- Sync policy:
+  - failures enqueue/record incident server-side and return the normal safe user-facing error.
+  - delivery retry must not duplicate admin email within the dedupe window.
+- Retention and sensitivity:
+  - default incident payload excludes raw email, IP, tokens, cookies, and provider secrets.
+  - concrete user linkage requires explicit support-case reason.
+- Cache/invalidation:
+  - dedupe TTL/window is explicit; admin status view uses no-store or short server cache.
+
+## Identity And Rename Contract
+
+- Canonical stable ID:
+  - incident event id or dedupe key composed from category + environment + affected flow + window.
+- Human-readable identifiers:
+  - incident title/category is renameable only through compatibility mapping if persisted.
+- Mutability rules:
+  - event rows are append-only where persisted; incident aggregate status may update counts/timestamps.
+- Rename vs repurpose:
+  - materially different failure class gets a new category.
+- Compatibility:
+  - legacy category names remain readable through aliases if changed.
+- Observability:
+  - unresolved category payloads fail closed to `unknown_critical_failure` without PII.
+
+## Scope
+
+- Incident category contract.
+- Dedupe/rate-limited admin email alert.
+- Privacy-safe diagnostic payload.
+- Runbook and Codex-ready prompt template.
+- Optional admin/status surface only if scoped explicitly during implementation.
+
+## Out Of Scope
+
+- Full admin user management.
+- Full public status page.
+- User-specific support ticketing system.
+- Billing plan changes.
+- Broad analytics dashboard.
+
+## Acceptance Criteria
+
+1. Critical failure can trigger one deduped admin email with safe diagnostic context.
+2. Repeated failures in the dedupe window increment count but do not spam email.
+3. Email includes affected flow, category, first/last seen, environment, log query hint, runbook link, and Codex-ready prompt.
+4. Raw user email, tokens, cookies, IP, provider secrets, and allowlists are not included by default.
+5. Admin route/settings, if included, are admin-only and fail closed.
+6. Runbook explains how admin should triage and resolve the incident.
+
+## Validation
+
+- `npm run lint:briefs`
+- unit tests for category/dedupe/redaction
+- route/integration tests for alert ingestion
+- email snapshot test
+- authz negative-path tests if admin UI/API is included
+- screenshot handoff if UI/status banner changes
+- `npm run verify:pre-pr`
+- `npm run verify:pre-merge`
+
+## Help / Guide Impact
+
+Update relevant runbooks for any incident categories shipped in V1. Help/Guide end-user content is optional unless a user-facing status/banner is included.
+
+## Route / Label / Support Surface Sweep
+
+Search targets:
+
+- `Could not request sign-in email`
+- `exceed_egress_quota`
+- `preview access`
+- `checkout`
+- `save image`
+- `export`
+- `admin_messages`
+- `message_delivery`
+- `incident`
+- `alert`
+
+## Checkpoint Log
+
+- `2026-05-09` - Planned after Supabase egress incident showed auth could fail without admin receiving proactive alert. Next: schedule after Supabase egress hotfix and before broad public launch.

--- a/lib/admin/content-course.ts
+++ b/lib/admin/content-course.ts
@@ -4,6 +4,7 @@ import {
   type CourseModule,
   type CourseSupportActionId,
 } from "@/app/course/courseData";
+import { unstable_cache } from "next/cache";
 import { ensurePlatformContentSeeded } from "@/lib/admin/content-import-apply";
 import { isAdminContentSchemaMissing } from "@/lib/admin/schema";
 import {
@@ -16,6 +17,8 @@ import {
 import type { CourseContentReadStatus } from "@/lib/course/preview";
 import { createAdminSupabaseClient } from "@/lib/supabase/admin";
 import type { Database, Json } from "@/types/database";
+
+export const PUBLIC_COURSE_CONTENT_REVALIDATE_SECONDS = 60 * 60;
 
 type AdminContentRow = Database["public"]["Tables"]["admin_content_items"]["Row"];
 
@@ -422,10 +425,20 @@ export async function loadCourseModulesByStatus(
   }
 }
 
+export const loadPublishedCourseModulesCached = unstable_cache(
+  async () =>
+    loadCourseModulesByStatus({
+      statuses: ["published"],
+      fallback: COURSE_MODULES,
+      autoSeedWhenEmpty: true,
+    }),
+  ["published-course-modules-v1"],
+  {
+    revalidate: PUBLIC_COURSE_CONTENT_REVALIDATE_SECONDS,
+    tags: ["published-course-content"],
+  }
+);
+
 export async function loadPublishedCourseModules(): Promise<CourseModule[]> {
-  return loadCourseModulesByStatus({
-    statuses: ["published"],
-    fallback: COURSE_MODULES,
-    autoSeedWhenEmpty: true,
-  });
+  return loadPublishedCourseModulesCached();
 }

--- a/lib/admin/content-published.ts
+++ b/lib/admin/content-published.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from "next/cache";
 import { ensurePlatformContentSeeded } from "@/lib/admin/content-import-apply";
 import { isAdminContentSchemaMissing } from "@/lib/admin/schema";
 import {
@@ -8,6 +9,8 @@ import { createAdminSupabaseClient } from "@/lib/supabase/admin";
 import { GUIDE_0_TO_1000M_SESSIONS, type Guide0To1000Session } from "@/lib/guides/guide-0-1000m";
 import { GUIDE_POOLSIDE_DRILLS, type PoolsideDrill } from "@/lib/guides/guide-poolside";
 import type { Database, Json } from "@/types/database";
+
+export const PUBLIC_GUIDE_CONTENT_REVALIDATE_SECONDS = 60 * 60;
 
 type AdminContentType = Database["public"]["Enums"]["admin_content_type"];
 type AdminContentRow = Database["public"]["Tables"]["admin_content_items"]["Row"];
@@ -212,14 +215,36 @@ export function toPublishedPoolsideDrills(
   return normalized.length > 0 ? normalized : fallback;
 }
 
+export const loadPublishedGuide0To1000SessionsCached = unstable_cache(
+  async () => {
+    const rows = await loadPublishedContentRows("guide_session");
+    if (!rows) return GUIDE_0_TO_1000M_SESSIONS;
+    return toPublishedGuide0To1000Sessions(rows);
+  },
+  ["published-guide-0-1000m-sessions-v1"],
+  {
+    revalidate: PUBLIC_GUIDE_CONTENT_REVALIDATE_SECONDS,
+    tags: ["published-guide-content"],
+  }
+);
+
 export async function loadPublishedGuide0To1000Sessions(): Promise<Guide0To1000Session[]> {
-  const rows = await loadPublishedContentRows("guide_session");
-  if (!rows) return GUIDE_0_TO_1000M_SESSIONS;
-  return toPublishedGuide0To1000Sessions(rows);
+  return loadPublishedGuide0To1000SessionsCached();
 }
 
 export async function loadPublishedPoolsideDrills(): Promise<PoolsideDrill[]> {
-  const rows = await loadPublishedContentRows("guide_drill");
-  if (!rows) return GUIDE_POOLSIDE_DRILLS;
-  return toPublishedPoolsideDrills(rows);
+  return loadPublishedPoolsideDrillsCached();
 }
+
+export const loadPublishedPoolsideDrillsCached = unstable_cache(
+  async () => {
+    const rows = await loadPublishedContentRows("guide_drill");
+    if (!rows) return GUIDE_POOLSIDE_DRILLS;
+    return toPublishedPoolsideDrills(rows);
+  },
+  ["published-poolside-drills-v1"],
+  {
+    revalidate: PUBLIC_GUIDE_CONTENT_REVALIDATE_SECONDS,
+    tags: ["published-guide-content"],
+  }
+);

--- a/lib/auth/sign-in-email-error.ts
+++ b/lib/auth/sign-in-email-error.ts
@@ -1,0 +1,78 @@
+export type SignInEmailErrorKind =
+  | "rate_limited"
+  | "service_restricted"
+  | "email_delivery"
+  | "unknown";
+
+type SignInEmailErrorInput = {
+  message?: unknown;
+  status?: unknown;
+  code?: unknown;
+};
+
+export type SignInEmailErrorClassification = {
+  kind: SignInEmailErrorKind;
+  userMessage: string;
+};
+
+export const SIGN_IN_SERVICE_RESTRICTED_MESSAGE =
+  "Sign-in is temporarily unavailable because a service limit was reached. Please try again later.";
+
+export const SIGN_IN_EMAIL_DELIVERY_MESSAGE =
+  "Email code could not be sent right now. Please try again later.";
+
+export const SIGN_IN_UNKNOWN_EMAIL_ERROR_MESSAGE =
+  "Could not send sign-in email right now. Please try again.";
+
+function normalizeLowerText(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function normalizeStatus(value: unknown): number | null {
+  const status = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(status) ? status : null;
+}
+
+export function classifySignInEmailError(
+  error: SignInEmailErrorInput
+): SignInEmailErrorClassification {
+  const message = normalizeLowerText(error.message);
+  const code = normalizeLowerText(error.code);
+  const status = normalizeStatus(error.status);
+
+  if (status === 429 || message.includes("rate limit") || code.includes("rate_limit")) {
+    return {
+      kind: "rate_limited",
+      userMessage: "Please wait about a minute before requesting a new login code.",
+    };
+  }
+
+  if (
+    status === 402 ||
+    message.includes("exceed_egress_quota") ||
+    message.includes("service for this project is restricted") ||
+    message.includes("fair use")
+  ) {
+    return {
+      kind: "service_restricted",
+      userMessage: SIGN_IN_SERVICE_RESTRICTED_MESSAGE,
+    };
+  }
+
+  if (
+    message.includes("smtp") ||
+    message.includes("email provider") ||
+    message.includes("email rate") ||
+    code.includes("email")
+  ) {
+    return {
+      kind: "email_delivery",
+      userMessage: SIGN_IN_EMAIL_DELIVERY_MESSAGE,
+    };
+  }
+
+  return {
+    kind: "unknown",
+    userMessage: SIGN_IN_UNKNOWN_EMAIL_ERROR_MESSAGE,
+  };
+}

--- a/lib/commerce/catalog-server.ts
+++ b/lib/commerce/catalog-server.ts
@@ -1,0 +1,33 @@
+import { unstable_cache } from "next/cache";
+import { buildCatalogOverridesFromRows } from "@/lib/commerce/catalog-overrides";
+import type { CatalogProductOverridesById } from "@/lib/commerce/catalog";
+import { createAdminSupabaseClient } from "@/lib/supabase/admin";
+
+export const PUBLIC_CATALOG_REVALIDATE_SECONDS = 60 * 60;
+
+async function loadPublicCatalogOverrides(): Promise<CatalogProductOverridesById> {
+  const supabase = createAdminSupabaseClient();
+  const { data, error } = await supabase
+    .from("products")
+    .select("id, slug, title, kind, active")
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    console.error("[Catalog] Could not load public product catalog overrides", {
+      message: error.message,
+      code: error.code,
+    });
+    return {};
+  }
+
+  return buildCatalogOverridesFromRows(data ?? []);
+}
+
+export const loadPublicCatalogOverridesCached = unstable_cache(
+  loadPublicCatalogOverrides,
+  ["public-catalog-overrides-v1"],
+  {
+    revalidate: PUBLIC_CATALOG_REVALIDATE_SECONDS,
+    tags: ["public-catalog"],
+  }
+);

--- a/lib/goals/server.ts
+++ b/lib/goals/server.ts
@@ -1,6 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { COURSE_MODULES } from "@/app/course/courseData";
-import { loadCourseModulesByStatus } from "@/lib/admin/content-course";
+import { loadPublishedCourseModulesCached } from "@/lib/admin/content-course";
 import {
   buildCourseLessonModuleIdMap,
   inferCourseModuleRuntimeIdFromLessonRuntimeId,
@@ -142,11 +141,7 @@ export async function loadGoalProgressContext(
   } else {
     const courseModules =
       courseResult.data && courseResult.data.length > 0
-        ? await loadCourseModulesByStatus({
-            statuses: ["published"],
-            fallback: COURSE_MODULES,
-            autoSeedWhenEmpty: false,
-          })
+        ? await loadPublishedCourseModulesCached()
         : [];
     const lessonToModuleId = buildCourseLessonModuleIdMap(courseModules);
 

--- a/tests/unit/course-content-route.test.ts
+++ b/tests/unit/course-content-route.test.ts
@@ -2,11 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   loadCourseModulesByStatusMock,
+  loadPublishedCourseModulesCachedMock,
   requireAdminRoleFromSupabaseMock,
   createRouteHandlerSupabaseClientMock,
 } = vi.hoisted(() => {
   return {
     loadCourseModulesByStatusMock: vi.fn(),
+    loadPublishedCourseModulesCachedMock: vi.fn(),
     requireAdminRoleFromSupabaseMock: vi.fn(),
     createRouteHandlerSupabaseClientMock: vi.fn(),
   };
@@ -14,6 +16,8 @@ const {
 
 vi.mock("@/lib/admin/content-course", () => ({
   loadCourseModulesByStatus: loadCourseModulesByStatusMock,
+  loadPublishedCourseModulesCached: loadPublishedCourseModulesCachedMock,
+  PUBLIC_COURSE_CONTENT_REVALIDATE_SECONDS: 3600,
 }));
 
 vi.mock("@/lib/admin/server", () => ({
@@ -32,7 +36,7 @@ function buildRequest(path: string): Request {
 
 describe("/api/course/content route", () => {
   beforeEach(() => {
-    loadCourseModulesByStatusMock.mockResolvedValue([
+    const courseModules = [
       {
         id: "mod1",
         title: "Intro",
@@ -51,7 +55,9 @@ describe("/api/course/content route", () => {
           },
         ],
       },
-    ]);
+    ];
+    loadCourseModulesByStatusMock.mockResolvedValue(courseModules);
+    loadPublishedCourseModulesCachedMock.mockResolvedValue(courseModules);
 
     requireAdminRoleFromSupabaseMock.mockResolvedValue({
       ok: true,
@@ -82,11 +88,9 @@ describe("/api/course/content route", () => {
       enabled: false,
       mode: "published",
     });
-    expect(loadCourseModulesByStatusMock).toHaveBeenCalledWith({
-      statuses: ["published"],
-      fallback: expect.any(Array),
-      autoSeedWhenEmpty: true,
-    });
+    expect(response.headers.get("cache-control")).toContain("s-maxage=3600");
+    expect(loadPublishedCourseModulesCachedMock).toHaveBeenCalledTimes(1);
+    expect(loadCourseModulesByStatusMock).not.toHaveBeenCalled();
     expect(requireAdminRoleFromSupabaseMock).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/course-progress-route.test.ts
+++ b/tests/unit/course-progress-route.test.ts
@@ -1,20 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createServerSupabaseClientMock, loadCourseModulesByStatusMock, trackAnalyticsEventMock } =
-  vi.hoisted(() => {
-    return {
-      createServerSupabaseClientMock: vi.fn(),
-      loadCourseModulesByStatusMock: vi.fn(),
-      trackAnalyticsEventMock: vi.fn(),
-    };
-  });
+const {
+  createServerSupabaseClientMock,
+  loadPublishedCourseModulesCachedMock,
+  trackAnalyticsEventMock,
+} = vi.hoisted(() => {
+  return {
+    createServerSupabaseClientMock: vi.fn(),
+    loadPublishedCourseModulesCachedMock: vi.fn(),
+    trackAnalyticsEventMock: vi.fn(),
+  };
+});
 
 vi.mock("@/lib/supabase/server", () => ({
   createServerSupabaseClient: createServerSupabaseClientMock,
 }));
 
 vi.mock("@/lib/admin/content-course", () => ({
-  loadCourseModulesByStatus: loadCourseModulesByStatusMock,
+  loadPublishedCourseModulesCached: loadPublishedCourseModulesCachedMock,
 }));
 
 vi.mock("@/lib/analytics/events", () => ({
@@ -87,7 +90,7 @@ function buildPostSupabase() {
 
 describe("/api/progress/course route", () => {
   beforeEach(() => {
-    loadCourseModulesByStatusMock.mockResolvedValue([
+    loadPublishedCourseModulesCachedMock.mockResolvedValue([
       {
         id: "intro-course",
         title: "Intro",
@@ -153,11 +156,7 @@ describe("/api/progress/course route", () => {
         },
       ],
     });
-    expect(loadCourseModulesByStatusMock).toHaveBeenCalledWith({
-      statuses: ["published"],
-      fallback: expect.any(Array),
-      autoSeedWhenEmpty: false,
-    });
+    expect(loadPublishedCourseModulesCachedMock).toHaveBeenCalledTimes(1);
     expect(supabase.upsert).toHaveBeenCalledWith(
       [
         {

--- a/tests/unit/goals-server.test.ts
+++ b/tests/unit/goals-server.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { loadCourseModulesByStatusMock } = vi.hoisted(() => ({
-  loadCourseModulesByStatusMock: vi.fn(),
+const { loadPublishedCourseModulesCachedMock } = vi.hoisted(() => ({
+  loadPublishedCourseModulesCachedMock: vi.fn(),
 }));
 
 vi.mock("@/lib/admin/content-course", () => ({
-  loadCourseModulesByStatus: loadCourseModulesByStatusMock,
+  loadPublishedCourseModulesCached: loadPublishedCourseModulesCachedMock,
 }));
 
 import { loadGoalProgressContext } from "@/lib/goals/server";
@@ -56,11 +56,11 @@ function createSupabaseStub(params: {
 
 describe("loadGoalProgressContext", () => {
   beforeEach(() => {
-    loadCourseModulesByStatusMock.mockReset();
+    loadPublishedCourseModulesCachedMock.mockReset();
   });
 
   it("counts completed lessons by published module membership instead of hyphen parsing", async () => {
-    loadCourseModulesByStatusMock.mockResolvedValue([
+    loadPublishedCourseModulesCachedMock.mockResolvedValue([
       {
         id: "intro-course",
         title: "Introduction to the Course",
@@ -85,16 +85,12 @@ describe("loadGoalProgressContext", () => {
       "user-1"
     );
 
-    expect(loadCourseModulesByStatusMock).toHaveBeenCalledWith({
-      statuses: ["published"],
-      fallback: expect.any(Array),
-      autoSeedWhenEmpty: false,
-    });
+    expect(loadPublishedCourseModulesCachedMock).toHaveBeenCalledTimes(1);
     expect(context.completedModuleLessonCounts.get("intro-course")).toBe(1);
   });
 
   it("falls back to compatibility inference when published module lookup misses a legacy lesson id", async () => {
-    loadCourseModulesByStatusMock.mockResolvedValue([]);
+    loadPublishedCourseModulesCachedMock.mockResolvedValue([]);
 
     const context = await loadGoalProgressContext(
       createSupabaseStub({

--- a/tests/unit/my-library-new-content-signal-route.test.ts
+++ b/tests/unit/my-library-new-content-signal-route.test.ts
@@ -1,14 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { loadCourseModulesByStatusMock, createRouteHandlerSupabaseClientMock } = vi.hoisted(() => {
-  return {
-    loadCourseModulesByStatusMock: vi.fn(),
-    createRouteHandlerSupabaseClientMock: vi.fn(),
-  };
-});
+const { loadPublishedCourseModulesCachedMock, createRouteHandlerSupabaseClientMock } = vi.hoisted(
+  () => {
+    return {
+      loadPublishedCourseModulesCachedMock: vi.fn(),
+      createRouteHandlerSupabaseClientMock: vi.fn(),
+    };
+  }
+);
 
 vi.mock("@/lib/admin/content-course", () => ({
-  loadCourseModulesByStatus: loadCourseModulesByStatusMock,
+  loadPublishedCourseModulesCached: loadPublishedCourseModulesCachedMock,
 }));
 
 vi.mock("@/lib/supabase/route-handler", () => ({
@@ -51,7 +53,7 @@ function buildSupabaseClient(userId: string | null) {
 
 describe("/api/my-library/new-content-signal route", () => {
   beforeEach(() => {
-    loadCourseModulesByStatusMock.mockResolvedValue([
+    loadPublishedCourseModulesCachedMock.mockResolvedValue([
       {
         id: "mod1",
         title: "Intro",
@@ -114,7 +116,7 @@ describe("/api/my-library/new-content-signal route", () => {
       },
       applySupabaseCookies: <T>(response: T) => response,
     });
-    loadCourseModulesByStatusMock.mockResolvedValueOnce([
+    loadPublishedCourseModulesCachedMock.mockResolvedValueOnce([
       {
         id: "mod1",
         title: "Intro",
@@ -180,15 +182,11 @@ describe("/api/my-library/new-content-signal route", () => {
       publishedAt: "2026-04-03T08:00:00.000Z",
     });
     expect(payload.signal?.lessons?.[0]?.lessonToken).toMatch(/^[0-9a-f]{16}$/);
-    expect(loadCourseModulesByStatusMock).toHaveBeenCalledWith({
-      statuses: ["published"],
-      fallback: [],
-      autoSeedWhenEmpty: true,
-    });
+    expect(loadPublishedCourseModulesCachedMock).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to auth-user creation when athlete profile is missing", async () => {
-    loadCourseModulesByStatusMock.mockResolvedValueOnce([
+    loadPublishedCourseModulesCachedMock.mockResolvedValueOnce([
       {
         id: "mod1",
         title: "Intro",

--- a/tests/unit/sign-in-email-error.test.ts
+++ b/tests/unit/sign-in-email-error.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifySignInEmailError,
+  SIGN_IN_EMAIL_DELIVERY_MESSAGE,
+  SIGN_IN_SERVICE_RESTRICTED_MESSAGE,
+  SIGN_IN_UNKNOWN_EMAIL_ERROR_MESSAGE,
+} from "@/lib/auth/sign-in-email-error";
+
+describe("sign-in email error classification", () => {
+  it("classifies provider rate limits as cooldown-backed rate limits", () => {
+    expect(
+      classifySignInEmailError({
+        message: "Email rate limit exceeded",
+        status: 429,
+      })
+    ).toEqual({
+      kind: "rate_limited",
+      userMessage: "Please wait about a minute before requesting a new login code.",
+    });
+  });
+
+  it("classifies Supabase egress quota restrictions as service restrictions", () => {
+    expect(
+      classifySignInEmailError({
+        message:
+          "Service for this project is restricted due to the following violations: exceed_egress_quota.",
+        status: 402,
+      })
+    ).toEqual({
+      kind: "service_restricted",
+      userMessage: SIGN_IN_SERVICE_RESTRICTED_MESSAGE,
+    });
+  });
+
+  it("classifies email-provider failures without exposing raw provider details", () => {
+    expect(
+      classifySignInEmailError({
+        message: "SMTP provider rejected the message",
+        status: 500,
+      })
+    ).toEqual({
+      kind: "email_delivery",
+      userMessage: SIGN_IN_EMAIL_DELIVERY_MESSAGE,
+    });
+  });
+
+  it("falls back to the generic sign-in email error", () => {
+    expect(classifySignInEmailError({ message: "unexpected provider response" })).toEqual({
+      kind: "unknown",
+      userMessage: SIGN_IN_UNKNOWN_EMAIL_ERROR_MESSAGE,
+    });
+  });
+});

--- a/tests/unit/supabase-egress-cache-contract.test.ts
+++ b/tests/unit/supabase-egress-cache-contract.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function readRepoFile(path: string): string {
+  return readFileSync(join(process.cwd(), path), "utf8");
+}
+
+describe("Supabase egress cache contract", () => {
+  it("uses cached published course content for the public course API path", () => {
+    const source = readRepoFile("app/api/course/content/route.ts");
+
+    expect(source).toContain("loadPublishedCourseModulesCached");
+    expect(source).toContain("publicCachedJson");
+    expect(source).toContain("s-maxage=");
+    expect(source).toContain("noStoreJson");
+  });
+
+  it("keeps the client course content fetch cacheable outside preview mode", () => {
+    const source = readRepoFile("app/course/page.tsx");
+
+    expect(source).toContain('previewEnabled ? "no-store" : "force-cache"');
+  });
+
+  it("uses cached public catalog overrides on the plans page", () => {
+    const source = readRepoFile("app/plans/page.tsx");
+
+    expect(source).toContain("loadPublicCatalogOverridesCached");
+    expect(source).not.toContain('from("products")');
+  });
+});


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-05-09T09:20:25.279Z for branch `hotfix/supabase-egress-audit-reduction-2026-05-09` (base ref `origin/main`).
- Latest commit: `c6bb03f` - fix(auth): reduce supabase egress and classify quota failures.
- Plain-language done summary: This PR reduces repeated public Supabase reads after the `402 exceed_egress_quota` incident and gives users/admins a clearer sign-in failure path when a service limit blocks email codes.
- Recommended next step: Owner can merge this PR after required GitHub checks and any listed QA are complete.
- User-visible changes: If Supabase blocks sign-in email due to quota/project restriction, the sign-in page now shows a clear temporary service-limit message without a misleading resend countdown.
- Technical changes: Added bounded Next.js caching for public published content/catalog reads, preserved no-store/request-bound protected reads, added an auth email error classifier, updated runbook guidance, and added focused unit/cache tests.
- Policy impact: yes, support/runbook handling for auth/service-limit incidents changed; no privacy, terms, billing, or legal policy text changed.
- Policy version note: N/A because this changes operational support guidance, not external policy documents.
- Brief link(s): `docs/task-briefs/in-progress/2026-05-09-supabase-egress-audit-and-reduction-10-10.md`
- Scorecard target outcomes: 14 target scorecard categories are defined in the linked brief.

## Scope

- In scope: public cache/revalidation for published content/catalog reads, auth quota/project-restriction classification, support runbook update, focused tests, active hotfix brief, and planned admin incident follow-up brief.
- Out of scope: Supabase plan/billing changes, admin incident alert email implementation, database migrations, Dryland changes, habit/micro/statistics implementation, and secret/credential policy changes.
- Changed files (21):
  - `app/api/course/content/route.ts`
  - `app/api/my-library/new-content-signal/route.ts`
  - `app/api/progress/course/route.ts`
  - `app/api/user/export/route.ts`
  - `app/auth/sign-in/actions.ts`
  - `app/course/page.tsx`
  - `app/plans/page.tsx`
  - `docs/runbooks/auth-account-support.md`
  - `... and 13 more file(s)`

## Risk

- Main risk: public published content/catalog updates can take up to the configured revalidation window to appear on public surfaces.
- Guardrail: admin preview/draft and user/session-bound data remain request-bound and uncached across users.
- Rollback plan: Revert `c6bb03f` (`git revert c6bb03f`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **PASS** (artifacts/test-runs/20260509-111436, lane: full-public)
- `npm run verify:pre-merge`: **PASS** for `c6bb03f` (2026-05-09T09:20:15Z, lane: full, mode: skipped).
- Full pre-merge lane included lint, typecheck, 183 unit files / 989 tests, build, perf budgets, and 82 passing e2e tests.
- Perf-budget note: PASS; gate recommended tightening one stretch target after consecutive green runs. Decision for this hotfix is to hold budget tightening outside the incident fix and record it for the next performance-governance slice.
- Policy-impact checklist: PENDING (run docs/checklists/policy-impact-release-review.md and update to PASS/FAIL).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  -   -  452 [desktop-firefox] › tests/e2e/private-access-gate.spec.ts:14:7 › private access gate › redirects public users to preview access and unlocks
  -   -  453 [desktop-firefox] › tests/e2e/private-access-gate.spec.ts:68:7 › private access gate › blocks protected api paths for unauthenticated public request context
  -   -  454 [desktop-firefox] › tests/e2e/private-access-gate.spec.ts:75:7 › private access gate › keeps indexing metadata locked while site is private
  -   ✓  455 [desktop-firefox] › tests/e2e/sitemap.spec.ts:32:5 › sitemap contains canonical public routes (6ms)
  -   ✓  456 [desktop-firefox] › tests/e2e/soft-launch-banner.spec.ts:9:5 › public pages do not render legacy under-construction banner (853ms)
  -   82 passed (4.4m)
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr`
- [x] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [x] Screenshot(s) attached (if UI changed): `output/supabase-egress-hotfix-20260509-084249`
- [x] Mobile behavior checked (if UI changed): `after-sign-in-service-limit-mobile.png`
- Screenshot handoff captured 2026-05-09 10:42 Europe/Oslo with `after/reference` files:
  - `after-sign-in-service-limit-desktop.png`
  - `after-sign-in-service-limit-mobile.png`
  - `reference-sign-in-default-desktop.png`
- Owner screenshot approval stop completed in chat with `ok, gjør som anbefalt`.
- No product-rendering files changed after screenshot capture.

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] Changed `done` task briefs include achieved score + evidence for every target category and explicit `10/10 claim: yes/no`
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
