### PR TITLE
Clarify contextual sign-in copy

### DIFF
--- a/app/api/download/resend/route.ts
+++ b/app/api/download/resend/route.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { NextResponse } from "next/server";
+import { buildAuthCallbackUrl } from "@/lib/auth/sign-in-context";
 import { createAdminSupabaseClient } from "@/lib/supabase/admin";
 import { getAppUrl } from "@/lib/supabase/env";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
@@ -316,7 +317,7 @@ export async function POST(request: Request) {
     }
 
     const origin = getRequestOrigin(request);
-    const emailRedirectTo = `${origin}/auth/callback?next=${encodeURIComponent(nextPath)}`;
+    const emailRedirectTo = buildAuthCallbackUrl(origin, nextPath, source);
     const supabase = await createServerSupabaseClient();
     const { error: otpError } = await supabase.auth.signInWithOtp({
       email,

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getEmailOtpType } from "@/lib/auth/email-otp";
 import { getSafeNextPath } from "@/lib/auth/next-path";
+import { getSafeSignInContextSource } from "@/lib/auth/sign-in-context";
 import { createRouteHandlerSupabaseClient } from "@/lib/supabase/route-handler";
 
 export async function GET(request: Request) {
@@ -9,6 +10,7 @@ export async function GET(request: Request) {
   const tokenHash = requestUrl.searchParams.get("token_hash");
   const type = getEmailOtpType(requestUrl.searchParams.get("type"));
   const nextPath = getSafeNextPath(requestUrl.searchParams.get("next"));
+  const source = getSafeSignInContextSource(requestUrl.searchParams.get("source"));
   const hasAuthCallbackInput = Boolean(code || (tokenHash && type));
   const routeClient = hasAuthCallbackInput ? await createRouteHandlerSupabaseClient() : null;
 
@@ -37,6 +39,9 @@ export async function GET(request: Request) {
 
   const fallback = new URL("/auth/sign-in", requestUrl.origin);
   fallback.searchParams.set("next", nextPath);
+  if (source) {
+    fallback.searchParams.set("source", source);
+  }
   fallback.searchParams.set(
     "error",
     "Could not verify sign-in. Request a new sign-in email and try again."

--- a/app/auth/sign-in/actions.ts
+++ b/app/auth/sign-in/actions.ts
@@ -11,13 +11,25 @@ import {
 } from "@/lib/auth/magic-link-cooldown";
 import { getSafeNextPath } from "@/lib/auth/next-path";
 import { classifySignInEmailError } from "@/lib/auth/sign-in-email-error";
+import { buildAuthCallbackUrl, getSafeSignInContextSource } from "@/lib/auth/sign-in-context";
 import { isResendRequestFlag, shouldApplyMagicLinkCooldown } from "@/lib/auth/sign-in-request";
 import { reportAdminIncident, type AdminIncidentInput } from "@/lib/admin/incidents";
 import { getAppUrl } from "@/lib/supabase/env";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 
-function buildSignInPath(nextPath: string, params: Record<string, string>) {
-  const query = new URLSearchParams({ next: nextPath, ...params });
+function buildSignInPath(
+  nextPath: string,
+  params: Record<string, string>,
+  sourceInput?: string | null
+) {
+  const query = new URLSearchParams({ next: nextPath });
+  const source = getSafeSignInContextSource(sourceInput);
+  if (source) {
+    query.set("source", source);
+  }
+  for (const [key, value] of Object.entries(params)) {
+    query.set(key, value);
+  }
   return `/auth/sign-in?${query.toString()}`;
 }
 
@@ -70,6 +82,10 @@ function getNormalizedEmail(formData: FormData): string {
 
 function getNextPath(formData: FormData): string {
   return getSafeNextPath(String(formData.get("next") ?? ""));
+}
+
+function getSignInSource(formData: FormData) {
+  return getSafeSignInContextSource(String(formData.get("source") ?? ""));
 }
 
 function splitHeaderValue(value: string | null): string[] {
@@ -323,10 +339,11 @@ async function enforceRateLimitSet(rules: RateLimitRule[]) {
 export async function requestMagicLink(formData: FormData) {
   const email = getNormalizedEmail(formData);
   const nextPath = getNextPath(formData);
+  const source = getSignInSource(formData);
   const isResendRequest = isResendRequestFlag(formData.get("resend"));
 
   if (!email || !EMAIL_REGEX.test(email)) {
-    redirect(buildSignInPath(nextPath, { error: "Enter a valid email address." }));
+    redirect(buildSignInPath(nextPath, { error: "Enter a valid email address." }, source));
   }
 
   const headerStore = await headers();
@@ -338,12 +355,16 @@ export async function requestMagicLink(formData: FormData) {
   const activeCooldownMs = await getCooldownTtlMs(cooldownLockKey);
   if (shouldApplyMagicLinkCooldown(activeCooldownMs, isResendRequest)) {
     redirect(
-      buildSignInPath(nextPath, {
-        error: formatLoginCodeCooldownMessage(activeCooldownMs),
-        cooldownUntil: String(Date.now() + activeCooldownMs),
-        sent: "1",
-        email,
-      })
+      buildSignInPath(
+        nextPath,
+        {
+          error: formatLoginCodeCooldownMessage(activeCooldownMs),
+          cooldownUntil: String(Date.now() + activeCooldownMs),
+          sent: "1",
+          email,
+        },
+        source
+      )
     );
   }
 
@@ -370,11 +391,11 @@ export async function requestMagicLink(formData: FormData) {
       params.sent = "1";
     }
 
-    redirect(buildSignInPath(nextPath, params));
+    redirect(buildSignInPath(nextPath, params, source));
   }
 
   const origin = headerStore.get("origin") ?? getAppUrl();
-  const emailRedirectTo = `${origin}/auth/callback?next=${encodeURIComponent(nextPath)}`;
+  const emailRedirectTo = buildAuthCallbackUrl(origin, nextPath, source);
 
   const supabase = await createServerSupabaseClient();
   const { error } = await supabase.auth.signInWithOtp({
@@ -396,7 +417,7 @@ export async function requestMagicLink(formData: FormData) {
         params.sent = "1";
       }
 
-      redirect(buildSignInPath(nextPath, params));
+      redirect(buildSignInPath(nextPath, params, source));
     }
 
     console.error("[Auth] Could not request sign-in email.", {
@@ -441,7 +462,7 @@ export async function requestMagicLink(formData: FormData) {
       params.sent = "1";
     }
 
-    redirect(buildSignInPath(nextPath, params));
+    redirect(buildSignInPath(nextPath, params, source));
   }
 
   const cadenceCounterKey = `rate:auth:magic-link:cadence:${sessionScopedEmailHash}`;
@@ -453,11 +474,15 @@ export async function requestMagicLink(formData: FormData) {
   await setCooldownTtl(cooldownLockKey, cadenceCooldownMs);
 
   redirect(
-    buildSignInPath(nextPath, {
-      sent: "1",
-      email,
-      cooldownUntil: String(Date.now() + cadenceCooldownMs),
-    })
+    buildSignInPath(
+      nextPath,
+      {
+        sent: "1",
+        email,
+        cooldownUntil: String(Date.now() + cadenceCooldownMs),
+      },
+      source
+    )
   );
 }
 
@@ -467,18 +492,25 @@ export async function verifySignInCode(formData: FormData) {
     .trim()
     .replace(/\s+/g, "");
   const nextPath = getNextPath(formData);
+  const source = getSignInSource(formData);
 
   if (!email || !EMAIL_REGEX.test(email)) {
-    redirect(buildSignInPath(nextPath, { error: "Enter a valid email address.", sent: "1" }));
+    redirect(
+      buildSignInPath(nextPath, { error: "Enter a valid email address.", sent: "1" }, source)
+    );
   }
 
   if (!/^[A-Za-z0-9]{6,10}$/.test(token)) {
     redirect(
-      buildSignInPath(nextPath, {
-        error: "Enter the one-time code from your sign-in email.",
-        sent: "1",
-        email,
-      })
+      buildSignInPath(
+        nextPath,
+        {
+          error: "Enter the one-time code from your sign-in email.",
+          sent: "1",
+          email,
+        },
+        source
+      )
     );
   }
 
@@ -500,12 +532,16 @@ export async function verifySignInCode(formData: FormData) {
 
   if (!limitResult.ok) {
     redirect(
-      buildSignInPath(nextPath, {
-        error: `Too many sign-in attempts. Wait ${toRetrySeconds(limitResult.retryAfterMs)} seconds and try again.`,
-        cooldownUntil: String(Date.now() + limitResult.retryAfterMs),
-        sent: "1",
-        email,
-      })
+      buildSignInPath(
+        nextPath,
+        {
+          error: `Too many sign-in attempts. Wait ${toRetrySeconds(limitResult.retryAfterMs)} seconds and try again.`,
+          cooldownUntil: String(Date.now() + limitResult.retryAfterMs),
+          sent: "1",
+          email,
+        },
+        source
+      )
     );
   }
 
@@ -523,10 +559,14 @@ export async function verifySignInCode(formData: FormData) {
   }
 
   redirect(
-    buildSignInPath(nextPath, {
-      error: "Could not verify the one-time code. Request a new sign-in email and try again.",
-      sent: "1",
-      email,
-    })
+    buildSignInPath(
+      nextPath,
+      {
+        error: "Could not verify the one-time code. Request a new sign-in email and try again.",
+        sent: "1",
+        email,
+      },
+      source
+    )
   );
 }

--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -5,6 +5,7 @@ import AuthResendButton from "@/components/auth/AuthResendButton";
 import AuthSubmitButton from "@/components/auth/AuthSubmitButton";
 import SiteChrome from "@/components/SiteChrome";
 import { getSafeNextPath } from "@/lib/auth/next-path";
+import { getSignInContextCopy } from "@/lib/auth/sign-in-context";
 import { requestMagicLink, verifySignInCode } from "@/app/auth/sign-in/actions";
 import { getServerSupabaseUserIfAuthCookiePresent } from "@/lib/supabase/server";
 
@@ -22,6 +23,10 @@ export const metadata: Metadata = {
 export default async function SignInPage({ searchParams }: Props) {
   const params = await searchParams;
   const nextPath = getSafeNextPath(typeof params.next === "string" ? params.next : null);
+  const context = getSignInContextCopy(
+    nextPath,
+    typeof params.source === "string" ? params.source : null
+  );
   const { user } = await getServerSupabaseUserIfAuthCookiePresent();
 
   if (user) {
@@ -40,7 +45,13 @@ export default async function SignInPage({ searchParams }: Props) {
     <SiteChrome mobileNavMode="hidden">
       <section className="mx-auto flex min-h-screen w-full max-w-[760px] items-center px-6 pt-28 pb-16">
         <div className="w-full rounded-3xl border border-blue-100 bg-white/95 p-8 shadow-[0_16px_60px_rgba(24,58,107,0.16)]">
-          <h1 className="text-3xl font-bold text-slate-900">Sign in to My Library</h1>
+          <h1 className="text-3xl font-bold text-slate-900">{context.title}</h1>
+          <p
+            data-testid="auth-context-copy"
+            className="mt-3 text-sm leading-relaxed text-slate-600"
+          >
+            {context.description}
+          </p>
 
           <AuthRequestStatus sent={sent} error={error} cooldownUntilMs={cooldownUntil} />
 
@@ -67,6 +78,9 @@ export default async function SignInPage({ searchParams }: Props) {
               <div className="mt-4 space-y-4">
                 <form action={verifySignInCode} className="space-y-4">
                   <input type="hidden" name="next" value={nextPath} />
+                  {context.source ? (
+                    <input type="hidden" name="source" value={context.source} />
+                  ) : null}
                   <div>
                     <label
                       htmlFor="code-email"
@@ -121,6 +135,9 @@ export default async function SignInPage({ searchParams }: Props) {
 
                 <form action={requestMagicLink}>
                   <input type="hidden" name="next" value={nextPath} />
+                  {context.source ? (
+                    <input type="hidden" name="source" value={context.source} />
+                  ) : null}
                   <input type="hidden" name="email" value={email} />
                   <input type="hidden" name="resend" value="1" />
                   <AuthResendButton cooldownUntilMs={cooldownUntil} />
@@ -129,6 +146,9 @@ export default async function SignInPage({ searchParams }: Props) {
             ) : (
               <form action={requestMagicLink} className="mt-4 space-y-4">
                 <input type="hidden" name="next" value={nextPath} />
+                {context.source ? (
+                  <input type="hidden" name="source" value={context.source} />
+                ) : null}
                 <div>
                   <label htmlFor="email" className="mb-2 block text-sm font-medium text-slate-700">
                     Email

--- a/app/checkout/success/page.tsx
+++ b/app/checkout/success/page.tsx
@@ -16,7 +16,11 @@ export default async function CheckoutSuccessPage({ searchParams }: Props) {
   const rawSessionId = typeof params.session_id === "string" ? params.session_id : "";
   const sessionId = rawSessionId.startsWith("{") ? "" : rawSessionId;
   const { user } = await getServerSupabaseUserIfAuthCookiePresent();
-  const libraryHref = user ? "/my-library" : "/auth/sign-in?next=%2Fmy-library";
+  const signInQuery = new URLSearchParams({
+    next: "/my-library",
+    source: "checkout_success",
+  });
+  const libraryHref = user ? "/my-library" : `/auth/sign-in?${signInQuery.toString()}`;
   const libraryCta = user ? "Download from My Library" : "Sign in to My Library";
   const claimHref = "/claim?next=%2Fmy-library";
 

--- a/app/claim/page.tsx
+++ b/app/claim/page.tsx
@@ -37,6 +37,7 @@ export default async function ClaimPage({ searchParams }: Props) {
   }
 
   const signInQuery = new URLSearchParams({ next: nextPath });
+  signInQuery.set("source", "claim_entry");
   if (prefilledEmail) {
     signInQuery.set("email", prefilledEmail);
   }

--- a/docs/app-knowledge-book/chapters/04-auth-access-and-private-gate.md
+++ b/docs/app-knowledge-book/chapters/04-auth-access-and-private-gate.md
@@ -14,9 +14,7 @@ Evidence boundary:
 - This chapter does not include secret values, raw env values, cookies, tokens, one-time codes,
   request IPs, provider responses, personal data, or user free-text content.
 
-Evidence date:
-
-- Reviewed on `2026-05-17` against `main@eae8817`.
+- Reviewed on `2026-05-18` against `main@c6e0657` plus the contextual sign-in clarity slice.
 - External/control-plane facts remain `Unknown / To Verify` unless explicitly marked otherwise.
 
 ## Why It Matters
@@ -84,6 +82,10 @@ The user-facing sign-in page is `app/auth/sign-in/page.tsx`.
 Current behavior:
 
 - Users enter an email address and receive a secure sign-in email.
+- The sign-in page can explain the current safe entry context: Admin, My Library, checkout success,
+  or claim/download recovery.
+- Context text is explanatory only. It does not authorize admin access, billing portal access,
+  entitlements, downloads, or another user's data.
 - The primary path is the secure email link; the same email also includes a one-time code fallback.
 - iPhone Home Screen app users may see the email link open in Safari instead of the installed app;
   the robust recovery path is to return to the Home Screen app and enter the one-time code there.
@@ -94,6 +96,7 @@ Current behavior:
   session cookies to the redirect response before sending the user to the safe `next` path.
 - The fallback code form verifies through `verifySignInCode()` in `app/auth/sign-in/actions.ts`.
 - Safe redirect targets are normalized through `lib/auth/next-path.ts`.
+- Safe sign-in context copy is normalized through `lib/auth/sign-in-context.ts`.
 - Request cooldown and resend behavior are handled by helpers in `lib/auth/`.
 - Email send errors are classified so support can distinguish cooldowns, provider limits, delivery
   failures, and unknown errors.
@@ -104,6 +107,8 @@ Important boundary:
 
 - Signing in proves identity. It does not automatically grant admin access, billing access,
   entitlement access, or access to another user's data.
+- Checkout and claim contexts should ask for the checkout email, but access remains pending until
+  entitlement, billing, and download checks complete.
 - Protected route handlers must still enforce their own route class from
   `docs/architecture/data-access-authz-cache-contract-registry.md`.
 

--- a/docs/runbooks/auth-account-support.md
+++ b/docs/runbooks/auth-account-support.md
@@ -9,6 +9,7 @@ Use this runbook when users ask where account, sign-in, billing, or recovery act
 - `Manage billing` lives on `My Library` and opens the Stripe Billing Portal for the authenticated user's Stripe customer.
 - `Sign out` lives on `My Library`.
 - `/auth/sign-in` owns secure email-link sign-in plus one-time-code fallback, resend, cooldown, and spam/junk-folder guidance.
+- `/auth/sign-in` uses safe `next` and `source` query context for explanation copy only. It does not grant admin, billing, entitlement, or download access.
 - `/preview-access` owns private preview unlock guidance when site-lock is enabled.
 - `/my-library/security` is a legacy protected route that redirects signed-in users to `My Library`.
 
@@ -40,6 +41,10 @@ Use this runbook when users ask where account, sign-in, billing, or recovery act
 - If the secure email link does not open: ask them to enter the one-time code from the same email on `/auth/sign-in`.
 - If an iPhone Home Screen app user says the email link opens in Safari or Safari denies the sign-in:
   ask them to return to the Home Screen app and enter the one-time code from the same email.
+- If `/auth/sign-in?next=/admin` is shown: explain that sign-in confirms identity only. Admin access is checked after sign-in by the app's admin authorization layer.
+- If the user lands on sign-in from My Library: they should verify with the email they use for the app, then return to My Library or the member page they opened.
+- If the user lands on sign-in from checkout success or claim/download recovery: ask them to use the same email they used at checkout. Do not promise that a purchase, invoice, billing portal access, entitlement, or download exists until the normal checks complete.
+- If a checkout/claim link fails and returns to sign-in: the visible context copy may persist through a safe `source` value, but support should still diagnose entitlement, billing, and download ownership separately.
 - If the email only contains a code and no button/link: check the Supabase Magic Link email template
   includes both `{{ .ConfirmationURL }}` and `{{ .Token }}` plus the hosted PNG brand lockup.
 - If `/auth/sign-in` shows "Sign-in is temporarily unavailable because a service limit was reached":

--- a/docs/task-briefs/in-progress/2026-05-17-aw-006-contextual-sign-in-clarity-audit-10-10.md
+++ b/docs/task-briefs/in-progress/2026-05-17-aw-006-contextual-sign-in-clarity-audit-10-10.md
@@ -3,20 +3,20 @@
 ## Metadata
 
 - `id`: `2026-05-17-aw-006-contextual-sign-in-clarity-audit-10-10`
-- `status`: `planned`
+- `status`: `in-progress`
 - `owner`: `stianvikra`
 - `created`: `2026-05-17`
-- `updated`: `2026-05-17`
+- `updated`: `2026-05-18`
 - `parent_review_queue`: `docs/task-briefs/planned/2026-05-17-aw-006-ux-ui-design-review-capture-and-next-slices-10-10.md`
-- `parking_decision`: Park this follow-up until the next auth, checkout success, claim/download, billing portal, or admin sign-in touch.
+- `parking_decision`: Unparked on `2026-05-18` as the next small PR-sized UX/UI slice after Programs Poolside PDF token polish shipped.
 
 ## Brief Audit Record
 
-- `last_audited`: `2026-05-17`
-- `base`: `main@3eeba4c`
+- `last_audited`: `2026-05-18`
+- `base`: `main@c6e0657`
 - `audit_status`: `ready`
-- `decision`: Keep this as a planned AW-006 follow-up, but do not execute it immediately after the prior sign-in PR.
-- `reason`: `#732/#733` already fixed the main sign-in-link-first and one-time-code fallback issue. The remaining contextual copy audit is legitimate but lower ROI as an immediate back-to-back auth PR, so it should be picked up when a nearby auth/commerce/admin sign-in surface is next touched.
+- `decision`: Execute this as the current AW-006 UX/UI slice.
+- `reason`: Programs Poolside PDF token polish and closeout shipped through `#744/#745`, leaving this as the next small PR-sized item in the canonical AW-006 UX/UI queue.
 - `must_refresh_before_execution_if`: Refresh if `/auth/sign-in`, auth callback behavior, checkout success, claim/download recovery, billing portal entry, support runbooks, scorecard categories, screenshot handoff rules, or verification lanes change before merge.
 
 ## Goal
@@ -113,7 +113,7 @@ Update `docs/runbooks/auth-account-support.md` and the app-knowledge auth chapte
 ## Route / Label / Support Surface Sweep
 
 - Required before broad gates because auth, admin, checkout/claim, and billing support wording are touched.
-- Identifiers to search:
+- Identifiers searched:
   - `/auth/sign-in`
   - `Sign in to My Library`
   - `Sign in to Admin`
@@ -125,7 +125,7 @@ Update `docs/runbooks/auth-account-support.md` and the app-knowledge auth chapte
   - `billing portal`
   - `source=checkout_success`
   - `source=claim_entry`
-- Surfaces to check:
+- Surfaces checked:
   - `app/`
   - `components/`
   - `lib/`
@@ -139,6 +139,14 @@ Update `docs/runbooks/auth-account-support.md` and the app-knowledge auth chapte
   - support/app-knowledge docs,
   - canonical AW-006 queue refresh.
   - no Stripe API, Supabase provider setting, entitlement, route class, sitemap, metadata, Admin Help Center, or database change.
+
+## Failure-Mode Evidence
+
+- No unexpected `500` path is introduced in this slice. Callback failure, invalid email, cooldown, invalid code, and unsafe `source` inputs continue to redirect or render recoverable sign-in states.
+- Failure-mode coverage:
+  - `tests/unit/auth-callback-route.test.ts` covers failed callback recovery with safe source preservation and unsafe source dropping.
+  - `tests/unit/sign-in-context.test.ts` covers safe context parsing, generic fallback copy, and callback URL source filtering.
+  - `tests/e2e/auth-sign-in-ux.spec.ts` covers visible error/cooldown/sent/code fallback states plus admin, claim, and checkout context copy.
 
 ## Scope
 
@@ -186,4 +194,6 @@ Update `docs/runbooks/auth-account-support.md` and the app-knowledge auth chapte
 
 ## Checkpoint Log
 
-- `2026-05-17 | in-progress | started from clean main@3eeba4c after Plans conversion baseline #737 and closeout #738; post-merge preflight found no repo-managed closeout; branch ux/contextual-sign-in-clarity created; scope limited to contextual auth copy, safe source preservation, targeted tests/docs, canonical AW-006 queue refresh, and screenshot handoff | next: implement helper/page/link/docs/tests, run targeted validation, then capture before/after screenshots before broad gates`
+- `2026-05-18 | in-progress | started from clean main@c6e0657 after Programs token polish #744 and closeout #745; post-merge preflight found no repo-managed closeout; branch ux/contextual-sign-in-clarity created; scope limited to contextual auth copy, safe source preservation, targeted tests/docs, canonical AW-006 queue refresh, and screenshot handoff | next: finish implementation, run targeted validation, then capture after screenshots before broad gates`
+- `2026-05-18 | validation | implemented contextual sign-in helper/copy, preserved safe source context through request/resend/callback recovery, updated checkout/claim entry links plus support/app-knowledge docs, and refreshed AW-006 queue; targeted validation passed: npm run lint:briefs, npm run lint:briefs:all, ./node_modules/.bin/vitest run tests/unit/sign-in-context.test.ts tests/unit/auth-callback-route.test.ts, npx playwright test tests/e2e/auth-sign-in-ux.spec.ts --project=desktop-chromium, and npx playwright test tests/e2e/auth-sign-in-ux.spec.ts --project=mobile-chromium; before/after screenshot artifacts captured in output/contextual-sign-in-clarity-2026-05-18-125759 and owner approved the handoff | next: run npm run verify:pre-pr, then commit/push/open PR`
+- `2026-05-18 | validation | npm run verify:pre-pr passed full lane after brief evidence wording was tightened for failure-mode and route/support sweep evidence; perf trend recommended tightening one stretch target after 6 consecutive weekly green runs, but this UX/UI auth-copy slice holds budgets unchanged and records the tighten prompt for PR/follow-up rather than changing performance thresholds in this PR | next: commit, push, open PR, monitor CI, then run npm run verify:pre-merge`

--- a/docs/task-briefs/planned/2026-05-17-aw-006-ux-ui-design-review-capture-and-next-slices-10-10.md
+++ b/docs/task-briefs/planned/2026-05-17-aw-006-ux-ui-design-review-capture-and-next-slices-10-10.md
@@ -36,15 +36,15 @@ Make the 2026-05-16 full UX/UI design review durable in the repo, record what ha
 - Later related auth work:
   - `docs/task-briefs/done/2026-05-17-auth-sign-in-link-first-otp-fallback-clarity-10-10.md`
   - shipped via `#732/#733`.
-- Parked auth follow-up:
+- Current auth follow-up:
   - `docs/task-briefs/planned/2026-05-17-aw-006-contextual-sign-in-clarity-audit-10-10.md`
-  - keep this from being forgotten, but execute it when auth, checkout success, claim/download, billing portal, or admin sign-in is touched next.
+  - moved to `docs/task-briefs/in-progress/2026-05-17-aw-006-contextual-sign-in-clarity-audit-10-10.md` as the next AW-006 UX/UI slice after Programs shipped.
 - Latest shipped follow-up execution:
-  - `docs/task-briefs/done/2026-05-18-aw-006-design-token-foundation-public-proof-10-10.md`
-  - shipped through `#742/#743` after Public IA cleanup shipped through `#740/#741`.
+  - `docs/task-briefs/done/2026-05-18-aw-006-programs-poolside-pdf-token-polish-10-10.md`
+  - shipped through `#744/#745` after Design token foundation proof shipped through `#742/#743`.
 - Current follow-up execution:
-  - `docs/task-briefs/in-progress/2026-05-18-aw-006-programs-poolside-pdf-token-polish-10-10.md`
-  - scoped to the next small AW-006 public UX/UI token adoption on `/programs`, using Poolside Guide and Poolside/PDF print as maturity references without changing entitlement, checkout, PDF, or guide internals.
+  - `docs/task-briefs/in-progress/2026-05-17-aw-006-contextual-sign-in-clarity-audit-10-10.md`
+  - scoped to contextual `/auth/sign-in` explanation copy for admin, My Library, checkout success, and claim/download entry contexts without changing Supabase Auth, Stripe, admin authorization, entitlement, or billing behavior.
 
 ## Executive Summary From The Review
 
@@ -92,22 +92,17 @@ The app has a strong technical foundation, clear mobile-first intent, good acces
 | Plans conversion baseline      | `done`    | `#737/#738`, `docs/task-briefs/done/2026-05-17-aw-006-plans-conversion-baseline-10-10.md`                         | Shipped clearer `/plans` value, proof, and checkout expectation copy without changing Stripe mechanics.                                                                    |
 | Public IA / about cleanup      | `done`    | `#740/#741`, `docs/task-briefs/done/2026-05-17-aw-006-public-ia-about-cleanup-10-10.md`                           | Retired the stale `/about` page surface, corrected legacy redirect behavior, and made `/our-method` the canonical method page.                                             |
 | Design token foundation proof  | `done`    | `#742/#743`, `docs/task-briefs/done/2026-05-18-aw-006-design-token-foundation-public-proof-10-10.md`              | Established the first global token foundation and proved it on `/our-method` only.                                                                                         |
+| Programs Poolside PDF polish   | `done`    | `#744/#745`, `docs/task-briefs/done/2026-05-18-aw-006-programs-poolside-pdf-token-polish-10-10.md`                | Applied the token foundation to `/programs` Poolside/PDF cards and refreshed the public value path without changing checkout, entitlement, guide, or PDF internals.        |
 
 ## Remaining PR-Sized UX/UI Slices
 
 Recommended order unless the owner explicitly reprioritizes:
 
-1. `Programs Poolside PDF token polish` (current)
-   - Objective: apply the token foundation to the public `/programs` Poolside PDF/program cards, remove mobile fixed-nav overlap, and keep the Poolside/PDF value path credible without touching checkout, entitlement, guide, or PDF internals.
-   - Likely files: `app/programs/page.tsx`, `app/globals.css`, `tests/unit/design-token-contract.test.ts`, `tests/e2e/public-ia.spec.ts`, `tests/e2e/mobile-nav-state.spec.ts`.
-   - Risks: public CTA hierarchy and mobile nav expectations.
-   - Protected areas: UI/layout/brand; screenshot handoff required.
-2. `Contextual sign-in clarity audit` (parked trigger-based follow-up)
+1. `Contextual sign-in clarity audit` (current)
    - Objective: verify whether `#732/#733` fully covers `next=/admin`, `/my-library`, checkout/portal, and claim/download entry contexts; patch only remaining copy gaps.
-   - Trigger: pick this up when auth, checkout success, claim/download, billing portal, or admin sign-in is next touched.
    - Likely files: `app/auth/sign-in/page.tsx`, auth tests, support docs.
    - Risks: auth messaging, redirect context.
-   - Protected areas: auth.
+   - Protected areas: auth and UI copy; screenshot handoff required before broad gates.
 
 ## 10/10 Phase Plan Capture
 

--- a/lib/auth/sign-in-context.ts
+++ b/lib/auth/sign-in-context.ts
@@ -1,0 +1,99 @@
+export type SignInContextSource = "checkout_success" | "claim_entry";
+
+export type SignInContextKind = "admin" | "checkout" | "claim" | "library" | "generic";
+
+export type SignInContextCopy = {
+  kind: SignInContextKind;
+  source: SignInContextSource | null;
+  title: string;
+  description: string;
+};
+
+export function getSafeSignInContextSource(
+  input: string | null | undefined
+): SignInContextSource | null {
+  if (input === "checkout_success" || input === "claim_entry") {
+    return input;
+  }
+
+  return null;
+}
+
+function getSafePathname(nextPath: string): string {
+  try {
+    return new URL(nextPath, "https://freeswimming.local").pathname;
+  } catch {
+    return "/my-library";
+  }
+}
+
+export function getSignInContextCopy(
+  nextPath: string,
+  sourceInput: string | null | undefined
+): SignInContextCopy {
+  const source = getSafeSignInContextSource(sourceInput);
+  const pathname = getSafePathname(nextPath);
+
+  if (pathname === "/admin" || pathname.startsWith("/admin/")) {
+    return {
+      kind: "admin",
+      source,
+      title: "Sign in to continue",
+      description:
+        "Use your email to confirm your identity. Admin access is checked after sign-in, so this step does not grant admin access by itself.",
+    };
+  }
+
+  if (source === "checkout_success") {
+    return {
+      kind: "checkout",
+      source,
+      title: "Sign in to My Library",
+      description:
+        "Use the same email you used at checkout. We confirm your identity first, then entitlement checks attach any available access to My Library.",
+    };
+  }
+
+  if (source === "claim_entry") {
+    return {
+      kind: "claim",
+      source,
+      title: "Sign in to claim access",
+      description:
+        "Use the same email you used at checkout. We verify your identity first, then claim checks decide which downloads or library items are available.",
+    };
+  }
+
+  if (pathname === "/my-library" || pathname.startsWith("/my-library/")) {
+    return {
+      kind: "library",
+      source,
+      title: "Sign in to My Library",
+      description:
+        "After verification, you will return to My Library or the member page you opened.",
+    };
+  }
+
+  return {
+    kind: "generic",
+    source,
+    title: "Sign in to continue",
+    description: "After verification, you will return to the page you opened if it is available.",
+  };
+}
+
+export function buildAuthCallbackUrl(
+  origin: string,
+  nextPath: string,
+  sourceInput?: string | null
+): string {
+  const callbackUrl = new URL("/auth/callback", origin);
+  callbackUrl.searchParams.set("next", nextPath);
+
+  const source = getSafeSignInContextSource(sourceInput);
+  if (source) {
+    callbackUrl.searchParams.set("source", source);
+  }
+
+  return callbackUrl.toString();
+}

--- a/tests/e2e/auth-sign-in-ux.spec.ts
+++ b/tests/e2e/auth-sign-in-ux.spec.ts
@@ -23,6 +23,9 @@ test.describe("auth sign-in ux", () => {
     await gotoWithTransientRetry(page, `/auth/sign-in?${params.toString()}`);
 
     await expect(page.getByTestId("auth-passkey-readiness")).toHaveCount(0);
+    await expect(page.getByTestId("auth-context-copy")).toContainText(
+      "After verification, you will return to My Library or the member page you opened."
+    );
     await expect(page.getByTestId("auth-request-status")).toContainText(
       "Sign-in email sent. Open the secure link first."
     );
@@ -86,6 +89,44 @@ test.describe("auth sign-in ux", () => {
     await expect(page.getByTestId("auth-submit-request")).toContainText("Email sign-in link");
   });
 
+  test("explains admin context without promising admin access", async ({ page }, testInfo) => {
+    runOnceOnDesktopChromium(testInfo.project.name);
+
+    await gotoWithTransientRetry(page, "/auth/sign-in?next=%2Fadmin");
+
+    await expect(page.getByRole("heading", { name: "Sign in to continue" })).toBeVisible();
+    await expect(page.getByTestId("auth-context-copy")).toContainText(
+      "Use your email to confirm your identity."
+    );
+    await expect(page.getByTestId("auth-context-copy")).toContainText(
+      "Admin access is checked after sign-in"
+    );
+    await expect(page.getByTestId("auth-context-copy")).toContainText(
+      "does not grant admin access by itself"
+    );
+    await expect(page.getByRole("heading", { name: "Email sign-in link" })).toBeVisible();
+  });
+
+  test("explains claim context without promising downloads before checks", async ({
+    page,
+  }, testInfo) => {
+    runOnceOnDesktopChromium(testInfo.project.name);
+
+    const params = new URLSearchParams({
+      next: "/my-library",
+      source: "claim_entry",
+      email: "buyer@example.com",
+    });
+    await gotoWithTransientRetry(page, `/auth/sign-in?${params.toString()}`);
+
+    await expect(page.getByRole("heading", { name: "Sign in to claim access" })).toBeVisible();
+    await expect(page.getByTestId("auth-context-copy")).toContainText(
+      "Use the same email you used at checkout."
+    );
+    await expect(page.getByTestId("auth-context-copy")).toContainText("claim checks decide");
+    await expect(page.locator('input[name="source"]').first()).toHaveValue("claim_entry");
+  });
+
   test("keeps mobile code fallback clear of the fixed bottom nav", async ({ page }, testInfo) => {
     runOnceOnMobileChromium(testInfo.project.name);
 
@@ -104,5 +145,26 @@ test.describe("auth sign-in ux", () => {
       )
     ).toBeVisible();
     await expect(page.getByTestId("auth-submit-code")).toBeVisible();
+  });
+
+  test("keeps checkout context readable on mobile", async ({ page }, testInfo) => {
+    runOnceOnMobileChromium(testInfo.project.name);
+
+    const params = new URLSearchParams({
+      next: "/my-library",
+      source: "checkout_success",
+    });
+    await gotoWithTransientRetry(page, `/auth/sign-in?${params.toString()}`);
+
+    await expect(page.getByTestId("mobile-fixed-nav")).toHaveCount(0);
+    await expect(page.getByRole("heading", { name: "Sign in to My Library" })).toBeVisible();
+    await expect(page.getByTestId("auth-context-copy")).toContainText(
+      "Use the same email you used at checkout."
+    );
+    await expect(page.getByTestId("auth-context-copy")).toContainText(
+      "entitlement checks attach any available access"
+    );
+    await expect(page.locator('input[name="source"]').first()).toHaveValue("checkout_success");
+    await expect(page.getByTestId("auth-submit-request")).toBeVisible();
   });
 });

--- a/tests/unit/auth-callback-route.test.ts
+++ b/tests/unit/auth-callback-route.test.ts
@@ -102,4 +102,35 @@ describe("/auth/callback route", () => {
     expect(location.searchParams.get("next")).toBe("/my-library");
     expect(location.searchParams.get("error")).toContain("Request a new sign-in email");
   });
+
+  it("preserves safe source context on failed callback recovery", async () => {
+    const routeClient = buildRouteClient({ exchangeError: new Error("expired") });
+    createRouteHandlerSupabaseClientMock.mockResolvedValue(routeClient);
+
+    const response = await GET(
+      new Request(
+        "https://freeswimming.org/auth/callback?code=expired&next=%2Fmy-library&source=claim_entry"
+      )
+    );
+    const location = new URL(response.headers.get("location") ?? "");
+
+    expect(location.pathname).toBe("/auth/sign-in");
+    expect(location.searchParams.get("next")).toBe("/my-library");
+    expect(location.searchParams.get("source")).toBe("claim_entry");
+    expect(location.searchParams.get("error")).toContain("Request a new sign-in email");
+  });
+
+  it("drops unsafe source context on failed callback recovery", async () => {
+    const response = await GET(
+      new Request(
+        "https://freeswimming.org/auth/callback?next=%2Fmy-library&source=https%3A%2F%2Fevil.example"
+      )
+    );
+    const location = new URL(response.headers.get("location") ?? "");
+
+    expect(createRouteHandlerSupabaseClientMock).not.toHaveBeenCalled();
+    expect(location.pathname).toBe("/auth/sign-in");
+    expect(location.searchParams.get("next")).toBe("/my-library");
+    expect(location.searchParams.get("source")).toBeNull();
+  });
 });

--- a/tests/unit/sign-in-context.test.ts
+++ b/tests/unit/sign-in-context.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAuthCallbackUrl,
+  getSafeSignInContextSource,
+  getSignInContextCopy,
+} from "@/lib/auth/sign-in-context";
+
+describe("sign-in context helpers", () => {
+  it("allows only known sign-in context sources", () => {
+    expect(getSafeSignInContextSource("checkout_success")).toBe("checkout_success");
+    expect(getSafeSignInContextSource("claim_entry")).toBe("claim_entry");
+    expect(getSafeSignInContextSource("library_recovery")).toBeNull();
+    expect(getSafeSignInContextSource("https://evil.example")).toBeNull();
+    expect(getSafeSignInContextSource(null)).toBeNull();
+  });
+
+  it("explains admin sign-in without granting admin access", () => {
+    const copy = getSignInContextCopy("/admin", null);
+
+    expect(copy.kind).toBe("admin");
+    expect(copy.title).toBe("Sign in to continue");
+    expect(copy.description).toContain("confirm your identity");
+    expect(copy.description).toContain("Admin access is checked after sign-in");
+    expect(copy.description).toContain("does not grant admin access");
+  });
+
+  it("explains protected My Library destinations", () => {
+    const copy = getSignInContextCopy("/my-library/workouts", null);
+
+    expect(copy.kind).toBe("library");
+    expect(copy.title).toBe("Sign in to My Library");
+    expect(copy.description).toContain("return to My Library or the member page");
+  });
+
+  it("explains checkout and claim contexts without promising access", () => {
+    const checkout = getSignInContextCopy("/my-library", "checkout_success");
+    const claim = getSignInContextCopy("/my-library", "claim_entry");
+
+    expect(checkout.kind).toBe("checkout");
+    expect(checkout.description).toContain("same email you used at checkout");
+    expect(checkout.description).toContain("entitlement checks attach any available access");
+    expect(claim.kind).toBe("claim");
+    expect(claim.title).toBe("Sign in to claim access");
+    expect(claim.description).toContain("claim checks decide");
+  });
+
+  it("preserves safe source values on callback URLs only as query context", () => {
+    const callbackUrl = new URL(
+      buildAuthCallbackUrl("https://freeswimming.org", "/my-library", "checkout_success")
+    );
+    const unsafeCallbackUrl = new URL(
+      buildAuthCallbackUrl("https://freeswimming.org", "/my-library", "evil")
+    );
+
+    expect(callbackUrl.pathname).toBe("/auth/callback");
+    expect(callbackUrl.searchParams.get("next")).toBe("/my-library");
+    expect(callbackUrl.searchParams.get("source")).toBe("checkout_success");
+    expect(unsafeCallbackUrl.searchParams.get("source")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-05-18T11:17:23.151Z for branch `ux/contextual-sign-in-clarity` (base ref `origin/main`).
- Latest commit: `9f8b005` - Clarify contextual sign-in copy.
- Plain-language done summary: This PR delivers the brief goal for the touched product area: Make /auth/sign-in explain why the user is signing in for the current entry context while preserving the existing secure email-link-first and one-time-code fallback behavior.
- Recommended next step: Monitor required GitHub checks, then run `npm run verify:pre-merge` on the current HEAD before merge.
- User-visible changes: Admin-facing behavior/guardrails may change in touched admin routes or APIs.
- Technical changes: Updated 14 file(s): `app/api/download/resend/route.ts`, `app/auth/callback/route.ts`, `app/auth/sign-in/actions.ts`, `app/auth/sign-in/page.tsx`, `app/checkout/success/page.tsx`, `... and 9 more file(s)`.
- Policy impact: yes (inferred from changed scope: `app/api/download/resend/route.ts`, `app/auth/callback/route.ts`, `app/auth/sign-in/actions.ts` (+1 more)).
- Policy version note: N/A (if policy text/version changes, replace with YYYY-MM-DD.rev and rationale).
- Brief link(s): `docs/task-briefs/in-progress/2026-05-17-aw-006-contextual-sign-in-clarity-audit-10-10.md`
- Scorecard target outcomes: 14 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (4); tests (3); API handlers (1); runtime UI/routes/components (6).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (14):
  - `app/api/download/resend/route.ts`
  - `app/auth/callback/route.ts`
  - `app/auth/sign-in/actions.ts`
  - `app/auth/sign-in/page.tsx`
  - `app/checkout/success/page.tsx`
  - `app/claim/page.tsx`
  - `docs/app-knowledge-book/chapters/04-auth-access-and-private-gate.md`
  - `docs/runbooks/auth-account-support.md`
  - `... and 6 more file(s)`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `9f8b005` (`git revert 9f8b005`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **PASS** (artifacts/test-runs/20260518-130947, lane: full-public)
- `npm run verify:pre-merge`: **PENDING** for `9f8b005` (last green marker: `d02afcc` at 2026-05-18T10:51:39Z; rerun on current HEAD).
- Policy-impact checklist: PENDING (run docs/checklists/policy-impact-release-review.md and update to PASS/FAIL).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  -   -  560 [desktop-firefox] › tests/e2e/private-access-gate.spec.ts:75:7 › private access gate › keeps indexing metadata locked while site is private
  -   -  561 [desktop-firefox] › tests/e2e/public-ia.spec.ts:10:7 › public route IA › keeps legacy about as a temporary alias for the canonical method page
  -   -  562 [desktop-firefox] › tests/e2e/public-ia.spec.ts:49:7 › public route IA › keeps programs cards token-backed with clear CTA destinations
  -   ✓  563 [desktop-firefox] › tests/e2e/sitemap.spec.ts:32:5 › sitemap contains canonical public routes (6ms)
  -   ✓  564 [desktop-firefox] › tests/e2e/soft-launch-banner.spec.ts:9:5 › public pages do not render legacy under-construction banner (853ms)
  -   97 passed (4.7m)
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] Changed `done` task briefs include achieved score + evidence for every target category and explicit `10/10 claim: yes/no`
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
