### PR TITLE
Add admin analytics dashboard

### DIFF
--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -1,0 +1,7 @@
+import { redirect } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+
+export default function AdminAnalyticsRouteAlias() {
+  redirect("/admin?tab=analytics");
+}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -42,7 +42,7 @@ export default async function AdminLayout({ children }: AdminLayoutProps) {
 
   if (!gate.ok) {
     return (
-      <SiteChrome>
+      <SiteChrome mobileNavMode="hidden">
         <section className={adminWorkspaceClass}>
           <div className={adminShellCardClass}>
             <p className={adminEyebrowClass}>Admin access required</p>
@@ -65,7 +65,7 @@ export default async function AdminLayout({ children }: AdminLayoutProps) {
   const { role } = gate;
 
   return (
-    <SiteChrome>
+    <SiteChrome mobileNavMode="hidden">
       <section className={`${adminWorkspaceClass} ${adminWorkspaceGridClass}`}>
         <header
           className={`${adminShellCardClass} lg:col-start-2`}

--- a/components/admin/AdminAnalyticsDashboard.tsx
+++ b/components/admin/AdminAnalyticsDashboard.tsx
@@ -1,0 +1,372 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import AdminManagerState from "@/components/admin/AdminManagerState";
+import { cx } from "@/components/ui/cx";
+import {
+  ANALYTICS_DASHBOARD_RANGE_OPTIONS,
+  buildAnalyticsDashboardViewModel,
+  normalizeAnalyticsDashboardRangeDays,
+  type AnalyticsDashboardApiResponse,
+  type AnalyticsDashboardPayload,
+  type AnalyticsDashboardRangeDays,
+  type AnalyticsDashboardViewModel,
+} from "@/lib/analytics/admin-dashboard";
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "error"; error: string }
+  | { status: "loaded"; payload: AnalyticsDashboardPayload };
+
+const managerHeaderClass = "fs-library-card fs-library-card-accent p-4 sm:p-5";
+const panelClass = "fs-library-card p-4 sm:p-5";
+const mutedPanelClass = "fs-library-card fs-library-card-muted p-4 sm:p-5";
+const mutedTextClass = "text-sm leading-6 text-[color:var(--fs-color-muted)]";
+const eyebrowClass = "text-[13px] font-semibold text-[color:var(--fs-color-brand-700)]";
+const headingClass = "text-lg font-semibold text-[color:var(--fs-color-ink-strong)]";
+const secondaryActionClass =
+  "fs-cta-secondary inline-flex min-h-10 items-center justify-center px-4 text-sm font-semibold transition-colors hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-700 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60";
+const rangeButtonBaseClass =
+  "inline-flex min-h-9 items-center justify-center rounded-[var(--fs-radius-control)] px-3 text-xs font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-700 focus-visible:ring-offset-2";
+const metadataLabelClass =
+  "text-xs font-semibold tracking-wide text-[color:var(--fs-color-muted)] uppercase";
+
+function stateTone(state: AnalyticsDashboardViewModel["state"]) {
+  if (state === "schema-missing" || state === "capped" || state === "quiet") return "warning";
+  if (state === "no-data") return "empty";
+  return "success";
+}
+
+function buildInsightsUrl(rangeDays: AnalyticsDashboardRangeDays): string {
+  const params = new URLSearchParams();
+  params.set("rangeDays", String(rangeDays));
+  return `/api/admin/analytics/insights?${params.toString()}`;
+}
+
+function isLoadedPayload(
+  payload: AnalyticsDashboardApiResponse
+): payload is AnalyticsDashboardPayload {
+  return payload.ok === true;
+}
+
+async function fetchAnalyticsState(
+  rangeDays: AnalyticsDashboardRangeDays
+): Promise<Extract<LoadState, { status: "error" | "loaded" }>> {
+  const normalizedRange = normalizeAnalyticsDashboardRangeDays(rangeDays);
+  try {
+    const response = await fetch(buildInsightsUrl(normalizedRange), {
+      method: "GET",
+      credentials: "same-origin",
+      cache: "no-store",
+    });
+    const payload = (await response.json()) as AnalyticsDashboardApiResponse;
+    if (!response.ok || !isLoadedPayload(payload)) {
+      return {
+        status: "error",
+        error: isLoadedPayload(payload)
+          ? "Could not load analytics dashboard."
+          : (payload.error ?? "Could not load analytics dashboard."),
+      };
+    }
+
+    return { status: "loaded", payload };
+  } catch {
+    return { status: "error", error: "Could not load analytics dashboard." };
+  }
+}
+
+function ListPanel({
+  emptyLabel,
+  items,
+  title,
+  testId,
+}: {
+  emptyLabel: string;
+  items: AnalyticsDashboardViewModel["eventItems"];
+  title: string;
+  testId: string;
+}) {
+  return (
+    <section className={panelClass} data-testid={testId}>
+      <h3 className="text-base font-semibold text-[color:var(--fs-color-ink-strong)]">{title}</h3>
+      {items.length === 0 ? (
+        <p className={cx("mt-3", mutedTextClass)}>{emptyLabel}</p>
+      ) : (
+        <ul className="mt-3 space-y-2">
+          {items.map((item, index) => (
+            <li
+              key={`${testId}:${item.key}:${index}`}
+              className="flex min-w-0 items-start justify-between gap-3 rounded-[var(--fs-radius-control)] border border-[color:var(--fs-border-soft)] bg-white/75 px-3 py-2"
+            >
+              <div className="min-w-0">
+                <p className="text-sm font-semibold break-words text-[color:var(--fs-color-ink-strong)]">
+                  {item.label}
+                </p>
+                {item.secondary ? (
+                  <p className="mt-0.5 text-xs break-words text-[color:var(--fs-color-muted)]">
+                    {item.secondary}
+                  </p>
+                ) : null}
+              </div>
+              <p className="shrink-0 text-right text-sm font-semibold text-[color:var(--fs-color-ink-strong)] tabular-nums">
+                {item.count}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+export default function AdminAnalyticsDashboard() {
+  const [rangeDays, setRangeDays] = useState<AnalyticsDashboardRangeDays>(30);
+  const [loadState, setLoadState] = useState<LoadState>({ status: "loading" });
+
+  const reloadAnalytics = useCallback(async (nextRangeDays: AnalyticsDashboardRangeDays) => {
+    setLoadState({ status: "loading" });
+    setLoadState(await fetchAnalyticsState(nextRangeDays));
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadSelectedRange() {
+      const nextState = await fetchAnalyticsState(rangeDays);
+      if (active) setLoadState(nextState);
+    }
+
+    void loadSelectedRange();
+    return () => {
+      active = false;
+    };
+  }, [rangeDays]);
+
+  const viewModel = useMemo(
+    () =>
+      loadState.status === "loaded" ? buildAnalyticsDashboardViewModel(loadState.payload) : null,
+    [loadState]
+  );
+
+  function selectRange(nextRangeDays: AnalyticsDashboardRangeDays) {
+    if (nextRangeDays === rangeDays) return;
+    setLoadState({ status: "loading" });
+    setRangeDays(nextRangeDays);
+  }
+
+  return (
+    <section className="space-y-4" data-testid="admin-analytics-dashboard">
+      <div className={managerHeaderClass} data-testid="admin-analytics-dashboard-header">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className={eyebrowClass}>Analytics</p>
+            <h2 className={cx("mt-1", headingClass)}>Read-only insight dashboard</h2>
+            <p className={cx("mt-2 max-w-3xl", mutedTextClass)}>
+              Privacy-safe product, route, and commerce signals from first-party events only.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void reloadAnalytics(rangeDays)}
+            className={secondaryActionClass}
+          >
+            Refresh
+          </button>
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <p id="admin-analytics-range-label" className={metadataLabelClass}>
+            Range
+          </p>
+          <div
+            role="group"
+            aria-labelledby="admin-analytics-range-label"
+            className="inline-flex flex-wrap gap-2"
+          >
+            {ANALYTICS_DASHBOARD_RANGE_OPTIONS.map((option) => {
+              const selected = option === rangeDays;
+              return (
+                <button
+                  key={option}
+                  type="button"
+                  aria-pressed={selected}
+                  onClick={() => selectRange(option)}
+                  className={cx(
+                    rangeButtonBaseClass,
+                    selected
+                      ? "bg-[color:var(--fs-color-brand-700)] text-white"
+                      : "border border-[color:var(--fs-border-soft)] bg-white/85 text-[color:var(--fs-color-muted)] hover:border-[color:var(--fs-border-brand)] hover:text-[color:var(--fs-color-brand-700)]"
+                  )}
+                >
+                  {option} days
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {loadState.status === "loading" ? (
+        <AdminManagerState tone="loading">Loading analytics dashboard...</AdminManagerState>
+      ) : null}
+
+      {loadState.status === "error" ? (
+        <AdminManagerState
+          tone="error"
+          actions={
+            <button
+              type="button"
+              onClick={() => void reloadAnalytics(rangeDays)}
+              className={secondaryActionClass}
+            >
+              Retry
+            </button>
+          }
+        >
+          {loadState.error}
+        </AdminManagerState>
+      ) : null}
+
+      {viewModel ? (
+        <>
+          <section className={mutedPanelClass} data-testid="admin-analytics-health">
+            <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
+              <div>
+                <p className={metadataLabelClass}>Data health</p>
+                <p className="mt-1 text-base font-semibold text-[color:var(--fs-color-ink-strong)]">
+                  {viewModel.stateLabel}
+                </p>
+                <p className={cx("mt-1", mutedTextClass)}>{viewModel.stateDetail}</p>
+              </div>
+              <dl className="grid gap-2 text-sm sm:grid-cols-2 xl:grid-cols-4">
+                <div>
+                  <dt className={metadataLabelClass}>Range</dt>
+                  <dd className="mt-1 font-semibold text-[color:var(--fs-color-ink-strong)]">
+                    {viewModel.rangeLabel}
+                  </dd>
+                </div>
+                <div>
+                  <dt className={metadataLabelClass}>Generated</dt>
+                  <dd className="mt-1 font-semibold text-[color:var(--fs-color-ink-strong)]">
+                    {viewModel.generatedAtLabel}
+                  </dd>
+                </div>
+                <div>
+                  <dt className={metadataLabelClass}>Last event</dt>
+                  <dd className="mt-1 font-semibold text-[color:var(--fs-color-ink-strong)]">
+                    {viewModel.lastEventLabel}
+                  </dd>
+                </div>
+                <div>
+                  <dt className={metadataLabelClass}>Row cap</dt>
+                  <dd className="mt-1 font-semibold text-[color:var(--fs-color-ink-strong)]">
+                    {viewModel.rowCapLabel}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+            <AdminManagerState
+              tone={stateTone(viewModel.state)}
+              density="compact"
+              className="mt-4"
+              testId="admin-analytics-trust-state"
+            >
+              {viewModel.stateDetail}
+            </AdminManagerState>
+          </section>
+
+          <section
+            aria-label="Analytics metrics"
+            className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3"
+            data-testid="admin-analytics-kpis"
+          >
+            {viewModel.metrics.map((metric) => (
+              <article key={metric.id} className={panelClass}>
+                <p className={metadataLabelClass}>{metric.label}</p>
+                <p className="mt-2 text-xl font-semibold break-words text-[color:var(--fs-color-ink-strong)]">
+                  {metric.value}
+                </p>
+                <p className={cx("mt-1", mutedTextClass)}>{metric.detail}</p>
+              </article>
+            ))}
+          </section>
+
+          <section className={panelClass} data-testid="admin-analytics-funnel">
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div>
+                <p className={metadataLabelClass}>Funnel</p>
+                <h3 className="mt-1 text-base font-semibold text-[color:var(--fs-color-ink-strong)]">
+                  Public to entitlement signal
+                </h3>
+              </div>
+              <p className="text-xs font-semibold text-[color:var(--fs-color-muted)]">
+                Read-only proxy
+              </p>
+            </div>
+            {viewModel.funnel.length === 0 ? (
+              <p className={cx("mt-3", mutedTextClass)}>Funnel is not counted yet.</p>
+            ) : (
+              <ol className="mt-4 space-y-3">
+                {viewModel.funnel.map((step) => (
+                  <li key={step.id}>
+                    <div className="flex min-w-0 items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="text-sm font-semibold text-[color:var(--fs-color-ink-strong)]">
+                          {step.label}
+                        </p>
+                        <p className="mt-0.5 text-xs text-[color:var(--fs-color-muted)]">
+                          {step.detail}
+                        </p>
+                      </div>
+                      <p className="shrink-0 text-right text-sm font-semibold text-[color:var(--fs-color-ink-strong)] tabular-nums">
+                        {step.count}
+                      </p>
+                    </div>
+                    <div className="mt-2 h-2 rounded-full bg-slate-100" aria-hidden="true">
+                      <div
+                        className="h-2 rounded-full bg-[color:var(--fs-color-brand-600)]"
+                        style={{ width: `${step.percentOfMax}%` }}
+                      />
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </section>
+
+          <div className="grid gap-4 lg:grid-cols-3" data-testid="admin-analytics-top-lists">
+            <ListPanel
+              title="Top events"
+              emptyLabel="No event counts in this range."
+              items={viewModel.eventItems}
+              testId="admin-analytics-top-events"
+            />
+            <ListPanel
+              title="Top routes"
+              emptyLabel="No route counts in this range."
+              items={viewModel.routeItems}
+              testId="admin-analytics-top-routes"
+            />
+            <ListPanel
+              title="Top products"
+              emptyLabel="No product counts in this range."
+              items={viewModel.productItems}
+              testId="admin-analytics-top-products"
+            />
+          </div>
+
+          <section className={mutedPanelClass} data-testid="admin-analytics-caveats">
+            <h3 className="text-base font-semibold text-[color:var(--fs-color-ink-strong)]">
+              Caveats
+            </h3>
+            <ul className="mt-3 list-inside list-disc space-y-1 text-sm leading-6 text-[color:var(--fs-color-muted)]">
+              {viewModel.caveats.map((caveat) => (
+                <li key={caveat}>{caveat}</li>
+              ))}
+            </ul>
+          </section>
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/components/admin/AdminHelpCenter.tsx
+++ b/components/admin/AdminHelpCenter.tsx
@@ -19,7 +19,7 @@ type ActionGroup = {
   actions: Array<{ label: string; meaning: string }>;
 };
 
-const LAST_UPDATED = "2026-05-07";
+const LAST_UPDATED = "2026-06-09";
 
 export const ADMIN_HELP_QUICK_ACTIONS = [
   { id: "overview", label: "Start here" },
@@ -29,6 +29,7 @@ export const ADMIN_HELP_QUICK_ACTIONS = [
   { id: "qr-links", label: "QR workflow" },
   { id: "email-templates", label: "Email templates" },
   { id: "messages", label: "Messages" },
+  { id: "analytics", label: "Analytics" },
   { id: "buttons", label: "Buttons explained" },
   { id: "quality-matrix", label: "10/10 matrix" },
   { id: "controls", label: "Doc controls" },
@@ -58,6 +59,13 @@ const DASHBOARD_TABS: TabGuide[] = [
     name: "Operations",
     primaryJob: "Control runtime flags and private-access lock behavior.",
     commonRisk: "Flag changes without verification can hide or expose routes unexpectedly.",
+  },
+  {
+    name: "Analytics",
+    primaryJob:
+      "Inspect privacy-safe event health, funnel counts, route/product activity, and dashboard caveats.",
+    commonRisk:
+      "Treating bounded revenue-proxy counts as finance reconciliation or linking public aggregate traffic to users.",
   },
   {
     name: "Email templates",
@@ -250,6 +258,34 @@ const MESSAGE_WORKFLOW = [
     title: "Diagnose notification issues",
     detail:
       "Check notification status and delivery attempts to answer whether the platform received the request and whether provider notification was accepted, disabled, or failed. A failed notification never means the stored request is lost.",
+  },
+];
+
+const ANALYTICS_WORKFLOW = [
+  {
+    title: "Start with data health",
+    detail:
+      "Check range, generated time, last event, schema state, and row cap before reading any KPI. Capped or schema-missing data must be treated as incomplete.",
+  },
+  {
+    title: "Use the KPI strip for a quick pulse",
+    detail:
+      "Total events, public aggregate, known users, client/server split, and checkout rate answer whether safe instrumentation is active in the selected range.",
+  },
+  {
+    title: "Read funnel as product signal only",
+    detail:
+      "Plans, product, checkout, and entitlement counts are useful for product review. They do not replace Stripe, accounting, finance reconciliation, refunds, invoices, payouts, or revenue recognition.",
+  },
+  {
+    title: "Use top lists for direction, not raw investigation",
+    detail:
+      "Top events, routes, and products use stable event names, route templates, and product IDs. The dashboard intentionally does not show raw payload JSON, raw URLs, emails, IPs, user agents, visitor IDs, notes, cart details, or payment/shipping data.",
+  },
+  {
+    title: "Respect the public privacy boundary",
+    detail:
+      "Public aggregate traffic is not linked to signed-in user profiles, even when the same browser may later authenticate. Unknown or unmapped values should be treated as not counted or generic until explicitly mapped.",
   },
 ];
 
@@ -458,6 +494,26 @@ const BUTTON_GUIDE: ActionGroup[] = [
     ],
   },
   {
+    section: "Analytics tab",
+    actions: [
+      {
+        label: "7 days / 30 days / 90 days",
+        meaning:
+          "Switches the bounded read range only. It does not write analytics rows, browser tracking state, cookies, visitor IDs, or admin preferences.",
+      },
+      {
+        label: "Refresh / Retry",
+        meaning:
+          "Reloads the same selected range from the admin insights endpoint. Use it after deploys, migrations, or quiet periods to confirm freshness.",
+      },
+      {
+        label: "Data health states",
+        meaning:
+          "Fresh means recent safe events exist. Quiet means no recent event is visible. Capped means totals may be incomplete. Schema missing means the migration/setup is not ready. No data yet means the selected range has no matching rows.",
+      },
+    ],
+  },
+  {
     section: "Notes, Categories, and Commerce",
     actions: [
       {
@@ -611,6 +667,13 @@ const CONNECTED_SERVICES = [
     caution:
       "A disabled or failed notification does not mean the platform lost the request; check Messages first.",
   },
+  {
+    name: "First-party analytics",
+    purpose:
+      "Stores sanitized aggregate/product/funnel events and renders read-only admin insights without third-party scripts.",
+    caution:
+      "Do not treat dashboard counts as finance truth, user-level attribution, or approval for cookies/vendor tracking.",
+  },
 ];
 
 const DAILY_PLAYBOOKS: Playbook[] = [
@@ -687,6 +750,7 @@ const RUNBOOK_LINKS = [
   "docs/runbooks/admin-message-inbox.md",
   "docs/checklists/admin-message-v1-pre-live-smoke.md",
   "docs/runbooks/admin-email-template-governance.md",
+  "docs/runbooks/public-analytics-privacy-assessment.md",
   "docs/runbooks/private-access-gate.md",
   "docs/runbooks/post-merge-local-sync.md",
   "docs/runbooks/ci-unblock.md",
@@ -837,6 +901,23 @@ export default function AdminHelpCenter() {
         </div>
       </section>
 
+      <section id="analytics" className={helpSectionClass}>
+        <h3 className={helpHeadingClass}>How Analytics works</h3>
+        <p className={helpBodyClass}>
+          Analytics is a read-only operational dashboard over sanitized first-party events. Use it
+          for product and support direction, not finance reconciliation or user-level public traffic
+          attribution.
+        </p>
+        <div className="mt-3 space-y-3">
+          {ANALYTICS_WORKFLOW.map((item) => (
+            <article key={item.title} className={helpItemClass}>
+              <p className={helpItemTitleClass}>{item.title}</p>
+              <p className={helpItemBodyClass}>{item.detail}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
       <section id="buttons" className={helpSectionClass}>
         <h3 className={helpHeadingClass}>Buttons and what they do</h3>
         <p className={helpBodyClass}>
@@ -877,6 +958,7 @@ export default function AdminHelpCenter() {
                 required for publish/revert).
               </li>
               <li>Read, filter, status, archive, soft-delete, and restore stored messages.</li>
+              <li>Inspect privacy-safe analytics event health and read-only funnel signals.</li>
               <li>Maintain notes, categories, and commerce labels.</li>
               <li>Run revision restore and QR rollback operations.</li>
             </ul>
@@ -1005,6 +1087,17 @@ export default function AdminHelpCenter() {
               Treat the message row as received. Check delivery attempts for disabled config,
               retryable provider failure, or final provider rejection before escalating. If a
               response is needed, reply from the normal email inbox and mark the row replied.
+            </p>
+          </article>
+          <article className={cx(helpCalloutClass, "border-amber-200 bg-amber-50")}>
+            <p className="text-sm font-semibold text-amber-900">
+              Analytics is empty, quiet, capped, or schema-missing
+            </p>
+            <p className="mt-1 text-sm text-amber-800">
+              Check Data health first. Empty can mean no traffic in range, Quiet can mean no recent
+              event, Capped means totals are bounded, and Schema missing means the analytics_events
+              migration/setup is not ready. Do not infer missing revenue, user attribution, or
+              finance truth from this dashboard alone.
             </p>
           </article>
           <article className={cx(helpCalloutClass, "border-amber-200 bg-amber-50")}>

--- a/components/admin/AdminWorkspace.tsx
+++ b/components/admin/AdminWorkspace.tsx
@@ -3,6 +3,7 @@
 import { startTransition, useMemo } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import AdminNoteQuickCaptureLauncher from "@/components/admin/AdminNoteQuickCaptureLauncher";
+import AdminAnalyticsDashboard from "@/components/admin/AdminAnalyticsDashboard";
 import AdminCommerceManager from "@/components/admin/AdminCommerceManager";
 import AdminContentManager from "@/components/admin/AdminContentManager";
 import AdminCategoriesManager from "@/components/admin/AdminCategoriesManager";
@@ -40,6 +41,11 @@ const TAB_LABELS: Array<{ id: AdminTab; label: string; subtitle: string }> = [
     id: "operations",
     label: "Operations",
     subtitle: "Runtime flags and private-access status",
+  },
+  {
+    id: "analytics",
+    label: "Analytics",
+    subtitle: "Safe event dashboard, funnel, and data health",
   },
   {
     id: "email-templates",
@@ -208,6 +214,7 @@ export default function AdminWorkspace({ role }: Props) {
           {activeTab === "qr-links" ? <AdminQrLinksManager /> : null}
           {activeTab === "commerce" ? <AdminCommerceManager /> : null}
           {activeTab === "operations" ? <AdminOperationsManager /> : null}
+          {activeTab === "analytics" ? <AdminAnalyticsDashboard /> : null}
           {activeTab === "email-templates" ? <AdminEmailTemplatesManager /> : null}
           {activeTab === "messages" ? <AdminMessagesManager adminRole={role} /> : null}
           {activeTab === "notes" ? <AdminNotesManager /> : null}

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -313,6 +313,13 @@
   - `rangeDays`: optional integer. Defaults to `30`; max is `90`.
 - Data source: sanitized `analytics_events` rows only.
 - Cache: `no-store`.
+- Admin UI: the read-only Analytics tab in `/admin?tab=analytics` renders this response. The
+  `/admin/analytics` route is an alias into the same admin workspace tab.
+- Caveat: checkout and entitlement counts are product/revenue-proxy signals only. They are not
+  Stripe reconciliation, accounting, refunds, payouts, invoices, or revenue recognition.
+- Privacy boundary: public aggregate events are not linked to user profiles and the dashboard must
+  not display raw payload JSON, raw URLs, emails, IPs, user agents, visitor IDs, notes, cart details,
+  shipping, or payment data.
 
 ### Response
 

--- a/docs/task-briefs/deferred/2026-02-18-analytics-persistence-and-admin-insights.md
+++ b/docs/task-briefs/deferred/2026-02-18-analytics-persistence-and-admin-insights.md
@@ -8,11 +8,13 @@
 - `created`: `2026-02-18`
 - `updated`: `2026-06-09`
 
-## V1 Child Slice
+## Child Slices
 
-- Active child: `docs/task-briefs/in-progress/2026-06-09-privacy-safe-analytics-persistence-admin-insights-v1-10-10.md`
-- V1 scope: additive `analytics_events` persistence, fail-soft event writes, and admin-only JSON insights.
-- Still deferred here: visible admin dashboard, charts, CSV export, retention cleanup, materialized rollups, broader product/auth/library reliability modules, and finance-grade reporting.
+- Done child: `docs/task-briefs/done/2026-06-09-privacy-safe-analytics-persistence-admin-insights-v1-10-10.md`
+- Active child: `docs/task-briefs/in-progress/2026-06-09-admin-analytics-dashboard-read-only-v1-10-10.md`
+- Completed V1 scope: additive `analytics_events` persistence, fail-soft event writes, and admin-only JSON insights.
+- Planned read-only dashboard scope: visible admin dashboard over the existing insights contract, without new persistence, vendors, cookies, visitor IDs, CSV export, rollups, retention cleanup, or finance-grade reporting.
+- Still deferred here: CSV export, retention cleanup, materialized rollups, broader product/auth/library reliability modules, and finance-grade reporting.
 
 ## Goal
 

--- a/docs/task-briefs/in-progress/2026-06-09-admin-analytics-dashboard-read-only-v1-10-10.md
+++ b/docs/task-briefs/in-progress/2026-06-09-admin-analytics-dashboard-read-only-v1-10-10.md
@@ -1,0 +1,465 @@
+# Task Brief: Admin Analytics Dashboard Read-Only V1 (10/10)
+
+## Metadata
+
+- `id`: `2026-06-09-admin-analytics-dashboard-read-only-v1-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-06-09`
+- `updated`: `2026-06-09`
+- `branch`: `admin-analytics-dashboard-read-only-v1`
+- `parent_brief`: `docs/task-briefs/deferred/2026-02-18-analytics-persistence-and-admin-insights.md`
+- `depends_on`: `docs/task-briefs/done/2026-06-09-privacy-safe-analytics-persistence-admin-insights-v1-10-10.md`
+- `execution_mode`: `owner explicitly said implement on 2026-06-09`
+
+## Brief Audit Record
+
+- `last_audited`: `2026-06-09`
+- `base`: `main@c4da03ba`
+- `audit_status`: `ready`
+- `decision`: Execute this bounded analytics child brief now.
+- `reason`: Owner explicitly said `implementer Admin Analytics Dashboard Read-Only V1` on `2026-06-09`. PR `#1043` and closeout PR `#1044` completed privacy-safe first-party analytics persistence and admin-only JSON insights, so the next smallest useful step is to render those existing insights for admins without adding new vendors, identifiers, CSV export, rollups, retention jobs, or finance reporting.
+- `must_refresh_before_execution_if`: Refresh if AGENTS.md, scorecard categories, admin workspace/navigation patterns, `/api/admin/analytics/insights`, `lib/analytics/admin-insights.ts`, `analytics_events` schema/RLS, public analytics privacy assessment, Help/Guide contracts, screenshot handoff rules, route/label/support sweep rules, or verification lanes change before implementation starts.
+
+## Goal
+
+Create an admin-only, read-only analytics dashboard that turns the existing privacy-safe insights JSON into a clear operational view for product and support decisions.
+
+## Pre-Implementation Owner Explanation
+
+Vi lager en enkel adminside som viser tallene som allerede lagres trygt: hvor mange events som finnes, hvilke ruter og produkter som dukker opp, en liten funnel, og om datagrunnlaget er tomt, gammelt eller begrenset av radtak. Det betyr noe fordi analytics naa er lagret i databasen, men admin trenger en lesbar visning i stedet for aa bruke ra SQL eller JSON. Utenfor scope er tredjeparts analytics, cookies, visitor-ID, kobling av anonym trafikk til brukerprofil, CSV-export, retention cleanup, materialized rollups, finance-grade rapportering og nye kommersielle CTA-/funnel-endringer.
+
+Forward-compatibility-intent: nye godkjente events, produkter og ruter skal kunne dukke opp i generiske event-, produkt- og rutelister fra eksisterende typed contracts; nye KPI-moduler, route-kategorier, export-formater eller finance-grade rapportering krever eksplisitt mapping, brief, tester og eierbeslutning.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for a `10/10` claim:
+
+- Product goals and IA
+- UX flow clarity
+- Visual design quality
+- Business logic correctness and data integrity
+- Admin workflow and editability
+- Accessibility (a11y)
+- Reliability and failure handling
+- Security and authz
+- Privacy and compliance
+- Analytics and KPI observability
+- Stack-fit and dependency discipline
+- Testing and QA automation
+
+| Category                                      | Mapping      | Target Threshold / Scope Rationale                                                                                                                                                                         | Evidence                                                           | Expected Closeout Score |
+| --------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ----------------------- |
+| Product goals and IA                          | `target`     | Dashboard answers one V1 admin question set: traffic/funnel health, top events, route/product counts, freshness, and data caveats in one admin route.                                                      | route QA + component tests + screenshot handoff                    | `5/5`                   |
+| UX flow clarity                               | `target`     | Read-only dashboard has a fixed information hierarchy, obvious range controls, loading/empty/error/retry/schema-missing/capped states, and no dead-end path on desktop or mobile.                          | component tests + admin QA + screenshots                           | `5/5`                   |
+| Visual design quality                         | `target`     | UI reuses existing admin workspace/card/action/table language and stays quiet, dense, scan-friendly, readable, and responsive without horizontal mobile overflow.                                          | after/reference screenshot handoff                                 | `5/5`                   |
+| Business logic correctness and data integrity | `target`     | Metrics render directly from `/api/admin/analytics/insights`; no client-side reinterpretation can change event identity, user linkage, or sanitized counts.                                                | view-model tests + API contract review                             | `5/5`                   |
+| Admin editor ergonomics                       | `supporting` | Supporting only: this is read-only analytics, not an editor; admin still needs fast inspection, range switching, and clear caveats.                                                                        | admin QA + Help/Guide update                                       | `4/5`                   |
+| Accessibility (a11y)                          | `target`     | Tables, metric cards, range controls, retry actions, headings, and caveats are keyboard/screen-reader usable with clear labels.                                                                            | Testing Library assertions + screenshot/keyboard QA                | `5/5`                   |
+| Performance (CWV + payloads)                  | `target`     | The `/admin?tab=analytics` dashboard, with `/admin/analytics` as alias, avoids new heavy chart dependencies, uses bounded JSON reads, and keeps dashboard JS/CSS within existing admin route expectations. | dependency diff + build/perf review + bounded endpoint tests       | `5/5`                   |
+| Data placement and sync boundaries            | `target`     | Analytics rows remain server-canonical; dashboard filter/range selection is local or query-only and never writes analytics state.                                                                          | data-boundary review + tests                                       | `5/5`                   |
+| Caching and invalidation strategy             | `target`     | Dashboard reads use dynamic/no-store behavior and expose `generatedAt`, `lastEventAt`, `rangeDays`, `rowCap`, and `capped` caveats visibly.                                                                | route/component tests + header review                              | `5/5`                   |
+| Reliability and failure handling              | `target`     | Unauthenticated, forbidden, schema-missing, empty, capped, fetch-error, and retry states are deterministic and never show raw payload data.                                                                | negative-path tests + manual QA                                    | `5/5`                   |
+| Security and authz                            | `target`     | Only admin viewer+ roles can access the dashboard and route; protected reads fail closed with `401`/`403`.                                                                                                 | admin route/auth tests + access review                             | `5/5`                   |
+| Privacy and compliance                        | `target`     | Dashboard shows only aggregate/sanitized fields and never displays raw URLs, emails, IPs, user agents, visitor IDs, notes, cart data, or raw payload JSON.                                                 | privacy review + unsafe-field tests                                | `5/5`                   |
+| Content governance                            | `target`     | Metric labels, caveats, and interpretation rules are documented as admin guidance and API contract notes.                                                                                                  | Help/Guide/API docs diff + assertions                              | `5/5`                   |
+| Admin workflow and editability                | `target`     | Admin can inspect analytics without raw SQL/JSON and understands when data is missing, capped, stale, or schema-not-ready.                                                                                 | admin QA + Help/Guide update + screenshots                         | `5/5`                   |
+| SEO and crawlability                          | `N/A`        | N/A because this adds an admin-only protected route and changes no public metadata, sitemap, robots, canonical URL, or crawlable content.                                                                  | explicit scope rationale                                           | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because this adds no public semantic content, structured data, public entity page, or AI-facing crawl surface.                                                                                         | explicit scope rationale                                           | `N/A`                   |
+| Analytics and KPI observability               | `target`     | Persisted analytics become dashboardable through stable event, funnel, route, product, freshness, and cap views without expanding payload collection.                                                      | view-model tests + dashboard QA                                    | `5/5`                   |
+| Commerce and revenue ops                      | `supporting` | Supporting only: dashboard may show checkout/entitlement proxy counts but does not change Stripe truth, checkout, entitlement grants, refunds, or pricing.                                                 | commerce boundary review                                           | `4/5`                   |
+| Incident response and support operations      | `target`     | Support/admin can diagnose schema readiness, last event time, capped reads, and missing events through visible caveats plus Help/Guide troubleshooting.                                                    | Help/Guide/runbook update + failure-state tests                    | `5/5`                   |
+| Finance and reporting operations              | `supporting` | Supporting only: revenue-proxy counts may inform product review, but no finance reconciliation, revenue recognition, payout, invoice, or accounting changes.                                               | explicit finance scope rationale + Help/Guide caveat               | `4/5`                   |
+| i18n operational readiness                    | `supporting` | Supporting only: dashboard copy stays structurally localizable and uses stable event/product IDs rather than translated labels as analytics identity.                                                      | copy/layout review + future-label fallback tests                   | `4/5`                   |
+| Stack-fit and dependency discipline           | `target`     | Reuse existing Next.js App Router, admin auth/workspace patterns, TypeScript view-models, Supabase-backed insights route, and UI primitives; add no chart dependency.                                      | architecture review + dependency diff                              | `5/5`                   |
+| Testing and QA automation                     | `target`     | View-model, component state, admin auth/negative paths, Help/Guide assertion, screenshot handoff, and `verify:pre-pr`/`verify:pre-merge` cover the slice.                                                  | targeted Vitest/Testing Library + screenshots + verification gates | `5/5`                   |
+| Scalability and cost efficiency               | `target`     | V1 uses the existing bounded insights endpoint and avoids materialized rollups, exports, or client-heavy chart libraries until separate briefs justify them.                                               | row-cap tests + dependency/build review                            | `4/5`                   |
+| DevOps and rollback readiness                 | `target`     | Route can be reverted cleanly without migration rollback; no new env vars, providers, workflows, cookies, or background jobs are introduced.                                                               | changed-files review + pre-pr/pre-merge gates + rollback note      | `5/5`                   |
+
+## Stack / Architecture Best-Practice Gate
+
+- React/Next.js:
+  - Add a protected Analytics tab in the existing `/admin` workspace, with `/admin/analytics` as an alias redirect to `/admin?tab=analytics`.
+  - Reuse existing admin workspace/navigation/reference surfaces instead of creating a separate design language or separate route shell.
+  - Prefer a small server wrapper plus focused client component only where range switching/retry needs interactivity.
+  - Keep reads dynamic/no-store and sourced from `/api/admin/analytics/insights`.
+- TypeScript/domain contracts:
+  - Reuse the existing admin insights response contract from `lib/analytics/admin-insights.ts`.
+  - Add a narrow dashboard view-model for metric cards, top lists, funnel conversion, caveats, and unknown-value fallbacks.
+  - Do not infer business meaning from display labels.
+- Supabase/data layer:
+  - No migration in this slice.
+  - The dashboard reads through the existing admin insights route and its viewer+ auth/RLS boundary.
+  - Retention cleanup/materialized rollups remain separate future work.
+- External services/tools:
+  - No Plausible, Simple Analytics, GA4, Meta, GTM, Hotjar, Clarity, pixels, tag managers, cookies, localStorage visitor IDs, or new SDKs.
+- UI system:
+  - Reuse current admin card/table/action/status patterns, `fs-cta-*`, `fs-library-card`, `ui-field`, `AdminManagerState`-style empty/error/loading treatment where practical, and responsive admin layout rules.
+  - Because this changes visible admin UI, implementation must pause for screenshot handoff before `npm run verify:pre-pr`.
+  - Screenshot comparison type: `after/reference`, comparing the new dashboard to a mature admin manager/workspace reference surface.
+- Testing:
+  - Unit/component tests for view-model formatting, unknown values, empty/schema-missing/capped states, retry, accessible labels, and no raw payload rendering.
+  - Route/auth tests remain aligned with `/api/admin/analytics/insights`.
+  - Playwright smoke or targeted admin component tests should cover the rendered route if local auth test helpers support it.
+
+## Dashboard UX / Readability Contract
+
+Maturity references used for the implementation brief:
+
+- PostHog dashboard docs show the value of a dashboard-level date range/filter model and note that smaller screens stack dashboard tiles into a single column: `https://posthog.com/docs/product-analytics/dashboards`.
+- Plausible docs model explicit date ranges, metrics, dimensions, response metadata/warnings, and a strict no-PII custom-property boundary: `https://plausible.io/docs/stats-api` and `https://plausible.io/docs/custom-props/introduction`.
+- Stripe dashboard/reporting docs separate operational dashboard insight from accounting-grade reporting/export workflows: `https://docs.stripe.com/dashboard` and `https://docs.stripe.com/stripe-reports`.
+- These are product-pattern references only. This slice must not add those vendors, APIs, cookies, scripts, exports, or finance-reporting behavior.
+
+Required information order:
+
+1. Data health bar:
+   - range,
+   - `generatedAt`,
+   - `lastEventAt`,
+   - `schemaReady`,
+   - `rowCap`,
+   - capped/not capped.
+2. KPI strip with `4-6` scan-first metrics:
+   - total events,
+   - last event freshness,
+   - public aggregate events,
+   - unique known users,
+   - client/server split,
+   - checkout completion rate when available.
+3. Funnel:
+   - public page viewed,
+   - plans viewed,
+   - product viewed,
+   - checkout started,
+   - checkout completed,
+   - entitlement granted.
+4. Top lists:
+   - events,
+   - routes,
+   - products.
+5. Caveats:
+   - what is not counted,
+   - what revenue proxy does not prove,
+   - why public aggregate traffic is not linked to users,
+   - how capped/schema-missing/empty data should be interpreted.
+
+Desktop layout requirements:
+
+- Use a compact admin dashboard layout, not a marketing or decorative analytics page.
+- Keep a constrained admin content width consistent with mature admin workspace surfaces.
+- KPI cards should sit in a stable grid above the detail sections.
+- Funnel and top lists may sit side by side on wider desktop, but must preserve the same reading order as the required information order.
+- Tables/lists must be scan-friendly with right-aligned numeric counts, short labels, and secondary caveat text.
+- Avoid nested cards, decorative chart containers, gradient/orb backgrounds, and heavy chart-library visuals.
+- If visual bars are useful, use lightweight CSS progress rows only.
+
+Mobile and tablet layout requirements:
+
+- Use one column in the same priority order as desktop.
+- Do not require horizontal scrolling for tables.
+- Convert top lists into compact rows/cards with label, count, and one optional secondary line.
+- Range controls must remain a small segmented control or compact select; they must not become a large filter panel in V1.
+- KPI cards must keep stable dimensions and readable text; long event/product/route labels must wrap or truncate with accessible full-label text.
+- Primary support/retry action must remain visible without pushing the data health state out of view.
+
+Readability and formatting requirements:
+
+- Counts use localized readable grouping such as `1,234`.
+- Percentages use whole percentages unless precision materially changes the decision.
+- Dates use human-readable freshness such as `Today 14:31` or `2 days ago`; raw ISO timestamps are reserved for tooltips, details, or test fixtures.
+- Unknown values render as `Unknown event`, `Unknown route`, `Unknown product`, or `Not counted`.
+- Capped values show a visible caveat near affected metrics, not only at page bottom.
+- Labels must not be analytics identity; stable event/route/product IDs remain the source of truth.
+- Copy must stay short and operational. Do not add visible tutorial text, keyboard shortcut explanations, or product marketing language.
+- Text must fit on desktop and mobile without overlapping, clipped button labels, or incoherent wrapping.
+
+Required trust states:
+
+- `Fresh`: schema is ready and `lastEventAt` is inside the expected recent window.
+- `Quiet`: schema is ready but no recent events exist; explain that this may mean low traffic or missing instrumentation.
+- `Capped`: read hit `rowCap`; explain that totals are bounded and not complete.
+- `Schema missing`: migration/setup is not ready; show deterministic setup/support guidance.
+- `No data yet`: schema is ready but no matching events exist for the selected range.
+- `Fetch failed`: show retry and a short support diagnostic without raw error payloads.
+
+Interaction requirements:
+
+- Default range is `30` days.
+- Range options should be the existing bounded contract, for example `7`, `30`, and `90` days.
+- Range changes update dashboard data only; they must not write analytics rows, browser tracking state, or admin preferences.
+- Retry refetches the same selected range.
+- No edit, delete, export, raw-event drilldown, or custom dashboard-builder interaction ships in V1.
+
+Test and screenshot evidence required for this contract:
+
+- Component/view-model tests for desktop/mobile-friendly rendering order where practical.
+- Tests for unknown event, route, and product labels.
+- Tests for capped, schema-missing, no-data, quiet/fresh, and fetch-failed states.
+- Tests or deterministic assertions that raw payload keys/values are not rendered.
+- Screenshot handoff must include desktop, mobile or tablet, and at least one non-happy state (`empty`, `capped`, `schema-missing`, or `fetch-failed`).
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - `analytics_events` rows and `/api/admin/analytics/insights` aggregate response.
+- Local/browser:
+  - Selected range/filter UI state only; no analytics visitor ID, public tracking storage, event mutation, or persisted admin preference is added in this slice.
+- Sync policy:
+  - Dashboard fetches current bounded aggregate data on load and when range changes.
+  - Failed reads show retry; they do not mutate events or infer fallback counts.
+- Retention and sensitivity:
+  - Existing retention gap remains deferred.
+  - Dashboard must never display raw payload JSON, raw URLs, emails, IPs, user agents, tokens, notes, cart details, payment/shipping details, or visitor identifiers.
+- Cache/invalidation:
+  - Dashboard and insights route use no-store/dynamic reads.
+  - Freshness is communicated with `generatedAt` and `lastEventAt`; stale/missing data is an admin-visible caveat, not hidden state.
+
+## Identity And Rename Contract
+
+- Canonical stable IDs:
+  - Event identity: `event_name`.
+  - Route identity: `route_template`.
+  - Product identity: `product_id` and `product_type` when present.
+  - User counts: aggregate `uniqueKnownUsers`; public aggregate traffic stays unlinked from `user_id`.
+- Human-readable identifiers:
+  - Dashboard labels and Help/Guide copy are display-only and may be renamed without changing metric identity.
+- Mutability rules:
+  - Event names, route templates, and product IDs remain stable analytics contract values.
+  - Labels can be renamed in place when the underlying event/product/route meaning is unchanged.
+- Rename vs repurpose:
+  - Materially different business meaning requires a new event/dimension mapping and tests, not a label rename.
+- Compatibility contract:
+  - Deprecated/historical values may remain visible as rows.
+  - Unknown values render as safe generic labels and do not fall back to raw payload fields.
+- Observability and repair:
+  - Dashboard caveats expose capped reads, missing schema, no data, and last-event freshness so support can separate broken ingestion from quiet traffic.
+
+## Forward Compatibility Contract
+
+- Extensibility surfaces:
+  - Analytics event names, route templates/categories, product IDs/types, funnel steps, date ranges, admin navigation surfaces, metric labels, Help/Guide assertions, and future export/rollup modules.
+- Source of truth:
+  - Dashboard data comes from `/api/admin/analytics/insights`.
+  - Event names come from the typed analytics event contract.
+  - Route/product dimensions come from sanitized persisted rows and canonical public analytics/catalog payloads.
+- Additive behavior:
+  - New approved events should appear in generic event-count tables automatically once the existing insights endpoint returns them.
+  - New route templates and product IDs should appear in generic route/product rows without dashboard code changes.
+  - New safe funnel rows can be added behind the existing view-model without changing stored payload privacy rules.
+- Explicit mapping requirements:
+  - New KPI modules, route-category-specific copy, CSV/export formats, materialized rollups, retention cleanup, finance-grade reporting, vendor analytics, public-to-user profile bridge, or ad attribution require a separate brief, tests, docs, and owner decision.
+- Unknown or deprecated values:
+  - Unknown events/products/routes render with safe generic labels such as `Unknown event`, `Unknown product`, or `Unknown route`.
+  - Unsafe/missing dimensions are `not counted` rather than displayed as raw payload data.
+  - Invalid event names remain rejected upstream.
+- Test/evidence:
+  - Include future/unknown-value fixtures for event, route, and product rows.
+  - Include tests proving no raw payload field is rendered.
+  - Run route/label/support sweep for dashboard route/nav/help labels before broad gates.
+
+## Scope
+
+- Implementation scope:
+  - Add an admin-only read-only Analytics tab in the existing admin workspace.
+  - Add `/admin/analytics` as an alias into the Analytics tab.
+  - Add admin navigation entry consistent with current admin workspace IA.
+  - Render existing admin insights data: total events, latest event, known users, public/client/server split, funnel, top events, top routes, top products, row cap/capped/freshness/schema caveats.
+  - Add local range control for existing allowed `rangeDays` values.
+  - Add loading, empty, schema-missing, error, retry, and capped states.
+  - Implement the `Dashboard UX / Readability Contract` above for desktop, tablet/mobile, formatting, trust states, and no-horizontal-scroll behavior.
+  - Hide the redundant global mobile bottom navigation on admin routes so long admin tab lists and analytics content are not covered by fixed mobile chrome.
+  - Update Help/Guide/API or runbook notes for interpreting the dashboard.
+  - Add focused tests and screenshot handoff.
+
+## Out Of Scope
+
+- New analytics vendors, third-party scripts, pixels, tag managers, cookies, visitor IDs, localStorage tracking, heatmaps, session replay, ad retargeting, or public-to-user bridge.
+- New analytics persistence schema, migrations, RLS changes, materialized rollups, retention cleanup jobs, or archival policy.
+- CSV export, BI warehouse, finance-grade reporting, revenue recognition, Stripe reconciliation, payout reporting, or invoice/refund workflows.
+- Editing analytics events, deleting rows, changing event taxonomy, or admin CRUD for analytics.
+- New commercial CTA placement rules, funnel experimentation, or workout-builder funnel implementation.
+- Public page changes, SEO changes, or AI-discoverability changes.
+
+## Acceptance Criteria
+
+1. Admin viewer+ can open the read-only analytics dashboard; unauthenticated/forbidden users fail closed.
+2. Dashboard renders the existing insights contract without raw JSON inspection.
+3. Dashboard clearly shows `schemaReady: false`, empty data, capped data, stale/missing last event, fetch error, and retry states.
+4. Dashboard never renders unsafe payload fields, raw URLs, emails, IPs, user agents, visitor IDs, notes, cart details, shipping/payment data, or raw payload JSON.
+5. Date-range switching uses bounded allowed values and never writes analytics state.
+6. New/unknown event, route, and product values render safely in generic lists.
+7. Desktop and mobile/tablet layouts preserve the required information order, avoid horizontal overflow, and keep metric/list text readable.
+8. Help/Guide or runbook content explains what the dashboard can and cannot be used for.
+9. Screenshot handoff is owner-approved or explicitly waived before `verify:pre-pr`.
+
+## Validation
+
+- Brief creation:
+  - `npm run lint:briefs:all`
+- Later implementation:
+  - targeted unit/component tests for analytics dashboard view-model and states
+  - targeted readability/layout assertions for required information order, unknown values, capped caveats, and no raw payload rendering
+  - targeted route/auth tests for admin-only access where touched
+  - Help/Guide assertion updates if Help/Guide content changes
+  - screenshot handoff with `after/reference` artifacts before `npm run verify:pre-pr`
+  - `npm run lint:briefs`
+  - `npm run lint:quality-gates`
+  - `npm run typecheck`
+  - `git diff --check`
+  - `npm run verify:pre-pr`
+  - PR CI
+  - `npm run verify:pre-merge`
+
+## Manual QA Environments
+
+- Local:
+  - `http://127.0.0.1:3000/admin?tab=analytics`
+  - `http://127.0.0.1:3000/admin/analytics` as alias/redirect check
+  - desktop Chromium and Safari/WebKit-equivalent where practical
+  - mobile/tablet viewport screenshot proving single-column order and no horizontal table overflow
+- Vercel preview:
+  - verify protected admin route access, dashboard loading, and no raw payload rendering.
+
+## Screenshot Handoff Requirement
+
+Required because the implementation changes visible admin UI.
+
+- Capture folder: `output/admin-analytics-dashboard-read-only-v1-YYYY-MM-DD-HHMMSS`.
+- Handoff type: `after/reference`.
+- Required examples:
+  - `after-admin-analytics-dashboard-desktop.png`
+  - `after-admin-analytics-dashboard-mobile.png` or tablet if mobile admin access is intentionally secondary
+  - `reference-admin-workspace-desktop.png`
+  - one non-happy state: `after-admin-analytics-dashboard-empty-desktop.png`, `after-admin-analytics-dashboard-capped-desktop.png`, `after-admin-analytics-dashboard-schema-missing-desktop.png`, or `after-admin-analytics-dashboard-fetch-failed-desktop.png`
+- Screenshot approval stop: stop after screenshot handoff and wait for owner approval or visual corrections before `npm run verify:pre-pr`.
+
+## Help / Guide Impact
+
+Required. This slice adds a visible admin analytics workflow and dashboard labels. Update admin Help/Guide or a closely linked runbook with:
+
+- what the dashboard shows,
+- what it intentionally cannot prove,
+- how to interpret capped, empty, stale, or schema-missing data,
+- why revenue-proxy counts are not finance reconciliation,
+- why anonymous public traffic is not linked to user profiles.
+
+Add or update at least one assertion/test that protects the Help/Guide contract if the existing test surface supports it.
+
+## Route / Label / Support Surface Sweep
+
+Required before the first broad gate because this adds a route/nav/support surface.
+
+Search at minimum:
+
+- `/admin/analytics`
+- `Admin Analytics`
+- `analytics dashboard`
+- `admin analytics`
+- `/api/admin/analytics/insights`
+- `analytics_events`
+- `rangeDays`
+- `rowCap`
+- `capped`
+- `schemaReady`
+- `revenue proxy`
+- `finance reconciliation`
+
+Check at minimum `app/`, `components/`, `tests/`, `docs/api-contracts.md`, `docs/runbooks/`, Help/Guide sources, and active/planned/deferred analytics briefs.
+
+- Executed sweep on `2026-06-09`.
+- Identifiers searched: `/admin/analytics`, `Admin Analytics`, `analytics dashboard`, `admin analytics`, `/api/admin/analytics/insights`, `analytics_events`, `rangeDays`, `rowCap`, `capped`, `schemaReady`, `revenue proxy`, `Stripe reconciliation`, `not linked to user profiles`, `ADMIN_TAB_VALUES`, `TAB_LABELS`, `ADMIN_HELP_QUICK_ACTIONS`, `DASHBOARD_TABS`, `RUNBOOK_LINKS`, `CONNECTED_SERVICES`, `ADMIN_WORKSPACE_MODULE_BOUNDARIES`, `parseAdminTab`, `AdminWorkspace`, and broad `analytics`.
+- Directories/surfaces checked: `app/`, `components/`, `lib/`, `tests/`, `docs/api-contracts.md`, `docs/runbooks/`, active/deferred/planned/done task briefs, admin Help/Guide source/tests, admin workspace source/tests, and analytics API/helper source/tests.
+- Fallout handled: added `/admin/analytics` alias, Analytics admin tab wiring, admin workspace boundary metadata, Help/Guide tab/service/workflow/troubleshooting copy, API contract notes, parent analytics brief pointer, targeted unit/component assertions, and admin-only mobile chrome hiding to prevent overlay on long admin tab/dashboard content. No public route, SEO, cookie/privacy policy, analytics collection, Stripe/finance, migration, workflow, or support-runbook behavior change was required for this read-only dashboard slice.
+
+## Security, Privacy, And Compliance
+
+- Route and data access must fail closed to admin viewer+.
+- No secrets, env values, raw Supabase credentials, or raw event payloads may be committed or displayed.
+- Dashboard must preserve the V1 privacy boundary:
+  - no cookies,
+  - no visitor ID,
+  - no public anonymous to user-profile bridge,
+  - no raw URL/referrer/IP/User-Agent display,
+  - no email/payment/shipping/cart/note/private training content display.
+- Privacy/cookie policy pages do not need updates unless the implementation changes collection behavior, vendor usage, browser storage, or public tracking copy.
+
+## Observability And KPI Contract
+
+- Dashboard KPIs:
+  - total accepted events,
+  - latest event timestamp,
+  - public aggregate vs known-user/server-client split,
+  - funnel counts and conversion where already defined by the insights endpoint,
+  - top event/route/product counts,
+  - capped and schema-ready status.
+- Success threshold:
+  - admin can answer whether analytics is collecting recent safe events and where the main public/commerce activity appears without inspecting raw JSON.
+- Failure threshold:
+  - schema missing, no events, capped reads, and fetch errors are visible and actionable.
+
+## Design And Usability Done Bar
+
+- Desktop and mobile screenshots prove the same core hierarchy:
+  - data health,
+  - KPI strip,
+  - funnel,
+  - top lists,
+  - caveats.
+- No mobile table requires horizontal scrolling.
+- No button, filter, KPI, list row, caveat, or heading has clipped or overlapping text.
+- Dashboard uses at most lightweight CSS bars/progress rows; no new chart dependency ships in V1.
+- Admin can answer these questions in under one minute from the first screen:
+  - Is analytics collecting recent safe events?
+  - Is the schema ready?
+  - Are counts capped?
+  - What are the highest-volume events/routes/products?
+  - Where is the commerce funnel dropping?
+  - What should not be treated as finance truth?
+
+## Session Continuity And Recovery
+
+- Canonical source of truth:
+  - this brief path and the implementation branch once created.
+- Recovery protocol:
+  1. `git status -sb`
+  2. `git log --oneline -n 10`
+  3. reopen this brief and continue from the latest checkpoint.
+
+## Git Rhythm Defaults
+
+- Implementation flow:
+  - branch created from clean synced `main`,
+  - this brief moved to `in-progress`,
+  - implement in one bounded UI/API-doc/test slice,
+  - pause after screenshot handoff,
+  - after owner approval, run `npm run verify:pre-pr`,
+  - commit, push, open/update PR, monitor CI,
+  - run `npm run verify:pre-merge` before merge recommendation.
+
+## Automation Mode
+
+Automation-first after explicit implementation approval. The assistant owns implementation, tests, git, PR prep, CI monitoring, and merge-readiness summary unless blocked by sandbox approval, credentials, missing context that cannot be safely discovered, visual approval stop, or a real product decision.
+
+## Branch Hygiene Defaults
+
+- Post-merge:
+  - sync `main`,
+  - prune deleted refs,
+  - run post-merge preflight,
+  - complete any repo-managed docs-only closeout if surfaced and eligible,
+  - perform mandatory chat-handoff assessment before starting another brief.
+
+## PR Browser Rule
+
+Use the repo-standard Safari PR flow, preferably `npm run pr:create:safari`, unless owner explicitly requests otherwise.
+
+## Checkpoint Log
+
+- `2026-06-09 | planned | created from clean synced main@c4da03ba after PR #1043 and repo-managed closeout PR #1044; scope is a future read-only admin UI over the existing privacy-safe insights endpoint, with no new vendor, cookies, visitor ID, retention, CSV, rollups, finance reporting, or public-to-user bridge | next: wait for owner to explicitly say execute/build/implement before moving to in-progress and creating the implementation branch`
+- `2026-06-09 | in-progress | owner explicitly said implement; branch admin-analytics-dashboard-read-only-v1 created from main@c4da03ba with prior planned brief/parent docs changes carried forward; brief moved to in-progress | next: inspect admin workspace, analytics insights route, Help/Guide patterns, then implement UI/view-model/docs/tests`
+- `2026-06-09 | implemented + screenshot stop | added read-only Analytics tab, /admin/analytics alias, dashboard view-model/component, admin mobile chrome polish, Help/Guide/API/parent brief updates, route-label-support sweep evidence, and targeted tests; local validation passed: targeted Vitest 6 files / 25 tests, npm run typecheck, npm run lint, npm run lint:briefs:all, npm run lint:quality-gates, slicewise Prettier check, git diff --check; screenshot handoff captured after/reference desktop/mobile/schema-missing artifacts in output/admin-analytics-dashboard-read-only-v1-2026-06-09-210601 using a temporary visual harness that was removed after capture | next: owner screenshot approval before npm run verify:pre-pr`
+- `2026-06-09 | screenshot approved | owner approved the after/reference screenshot handoff; no product-rendering files changed after capture | next: run npm run verify:pre-pr before commit/push/PR`
+- `2026-06-09 | pre-pr gate passed | npm run verify:pre-pr passed full lane after rerunning an unrelated habit-perfect-day unit flake that passed in targeted isolation; branch remained current with origin/main c4da03ba | next: commit, push, open PR, monitor CI, then run npm run verify:pre-merge`

--- a/lib/admin/admin-workspace.ts
+++ b/lib/admin/admin-workspace.ts
@@ -3,6 +3,7 @@ export const ADMIN_TAB_VALUES = [
   "qr-links",
   "commerce",
   "operations",
+  "analytics",
   "email-templates",
   "messages",
   "notes",
@@ -56,7 +57,26 @@ export const ADMIN_MESSAGES_WORKSPACE_BOUNDARY = {
   activationBrief: "docs/task-briefs/in-progress/2026-05-06-admin-message-inbox-10-10.md",
 } as const satisfies AdminWorkspaceModuleBoundary;
 
+export const ADMIN_ANALYTICS_WORKSPACE_BOUNDARY = {
+  id: "analytics",
+  status: "active",
+  label: "Analytics",
+  routePath: "/admin",
+  tabQueryValue: "analytics",
+  orchestrationBoundary:
+    "Admin Analytics owns read-only range selection, retry, and dashboard state over the existing admin insights endpoint.",
+  mutationBoundary:
+    "Admin Analytics does not mutate analytics rows; it reads /api/admin/analytics/insights through the existing admin viewer+ route boundary.",
+  viewBoundary:
+    "Admin analytics metrics, funnel, top lists, caveats, and trust states live under a dedicated dashboard component boundary.",
+  serverCanonicalData: ["sanitized analytics_events rows", "admin analytics insights response"],
+  localOnlyState: ["selected range", "loading/error/retry state"],
+  activationBrief:
+    "docs/task-briefs/in-progress/2026-06-09-admin-analytics-dashboard-read-only-v1-10-10.md",
+} as const satisfies AdminWorkspaceModuleBoundary;
+
 export const ADMIN_WORKSPACE_MODULE_BOUNDARIES = [
+  ADMIN_ANALYTICS_WORKSPACE_BOUNDARY,
   ADMIN_MESSAGES_WORKSPACE_BOUNDARY,
 ] as const satisfies readonly AdminWorkspaceModuleBoundary[];
 

--- a/lib/analytics/admin-dashboard.ts
+++ b/lib/analytics/admin-dashboard.ts
@@ -1,0 +1,401 @@
+import type { AnalyticsInsightsResponse } from "@/lib/analytics/admin-insights";
+
+export const ANALYTICS_DASHBOARD_RANGE_OPTIONS = [7, 30, 90] as const;
+export const ANALYTICS_DASHBOARD_DEFAULT_RANGE_DAYS = 30;
+export const ANALYTICS_DASHBOARD_FRESH_WINDOW_HOURS = 48;
+
+export type AnalyticsDashboardRangeDays = (typeof ANALYTICS_DASHBOARD_RANGE_OPTIONS)[number];
+
+export type AnalyticsInsightsSchemaMissingResponse = {
+  ok: true;
+  schemaReady: false;
+  warning?: string;
+  generatedAt?: string;
+  rangeDays: number;
+  items?: unknown[];
+};
+
+export type AnalyticsInsightsErrorResponse = {
+  ok: false;
+  error?: string;
+};
+
+export type AnalyticsDashboardPayload =
+  | AnalyticsInsightsResponse
+  | AnalyticsInsightsSchemaMissingResponse;
+
+export type AnalyticsDashboardApiResponse =
+  | AnalyticsDashboardPayload
+  | AnalyticsInsightsErrorResponse;
+
+export type AnalyticsDashboardTrustState =
+  | "fresh"
+  | "quiet"
+  | "capped"
+  | "schema-missing"
+  | "no-data";
+
+export type AnalyticsDashboardMetric = {
+  id: string;
+  label: string;
+  value: string;
+  detail: string;
+};
+
+export type AnalyticsDashboardListItem = {
+  key: string;
+  label: string;
+  secondary: string | null;
+  count: string;
+};
+
+export type AnalyticsDashboardFunnelStep = {
+  id: string;
+  label: string;
+  count: string;
+  value: number;
+  percentOfMax: number;
+  detail: string;
+};
+
+export type AnalyticsDashboardViewModel = {
+  state: AnalyticsDashboardTrustState;
+  stateLabel: string;
+  stateDetail: string;
+  rangeLabel: string;
+  generatedAtLabel: string;
+  lastEventLabel: string;
+  rowCapLabel: string;
+  metrics: AnalyticsDashboardMetric[];
+  funnel: AnalyticsDashboardFunnelStep[];
+  eventItems: AnalyticsDashboardListItem[];
+  routeItems: AnalyticsDashboardListItem[];
+  productItems: AnalyticsDashboardListItem[];
+  caveats: string[];
+};
+
+const countFormatter = new Intl.NumberFormat("en-US");
+
+const EVENT_LABELS: Record<string, string> = {
+  checkout_completed: "Checkout completed",
+  checkout_started: "Checkout started",
+  entitlement_granted: "Entitlement granted",
+  plans_viewed: "Plans viewed",
+  product_viewed: "Product viewed",
+  public_cta_clicked: "Public CTA clicked",
+  public_page_viewed: "Public page viewed",
+};
+
+export function normalizeAnalyticsDashboardRangeDays(value: number): AnalyticsDashboardRangeDays {
+  return ANALYTICS_DASHBOARD_RANGE_OPTIONS.includes(value as AnalyticsDashboardRangeDays)
+    ? (value as AnalyticsDashboardRangeDays)
+    : ANALYTICS_DASHBOARD_DEFAULT_RANGE_DAYS;
+}
+
+function isSchemaMissingPayload(
+  payload: AnalyticsDashboardPayload
+): payload is AnalyticsInsightsSchemaMissingResponse {
+  return payload.schemaReady === false;
+}
+
+export function formatAnalyticsCount(value: number | null | undefined): string {
+  if (!Number.isFinite(value ?? Number.NaN) || (value ?? 0) < 0) return "0";
+  return countFormatter.format(value ?? 0);
+}
+
+export function formatAnalyticsPercent(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) return "Not counted";
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatUtcTime(date: Date): string {
+  return `${String(date.getUTCHours()).padStart(2, "0")}:${String(date.getUTCMinutes()).padStart(
+    2,
+    "0"
+  )}`;
+}
+
+function startOfUtcDay(date: Date): number {
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+export function formatAnalyticsTimestamp(
+  isoValue: string | null | undefined,
+  now: Date = new Date()
+): string {
+  if (!isoValue) return "No event yet";
+  const date = new Date(isoValue);
+  if (Number.isNaN(date.getTime())) return "Unknown time";
+
+  const dayDiff = Math.floor((startOfUtcDay(now) - startOfUtcDay(date)) / (24 * 60 * 60 * 1000));
+  if (dayDiff === 0) return `Today ${formatUtcTime(date)}`;
+  if (dayDiff === 1) return `Yesterday ${formatUtcTime(date)}`;
+  if (dayDiff > 1 && dayDiff < 7) return `${dayDiff} days ago`;
+  return `${date.toISOString().slice(0, 10)} ${formatUtcTime(date)}`;
+}
+
+function isSafeAnalyticsIdentifier(value: string | null | undefined): value is string {
+  if (!value) return false;
+  if (value.length > 120) return false;
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) return false;
+  return /^[a-zA-Z0-9_./:-]+$/.test(value);
+}
+
+function titleCaseWords(value: string): string {
+  return value
+    .replace(/^\/+/, "")
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+export function formatAnalyticsIdentifierLabel(
+  value: string | null | undefined,
+  fallback: "event" | "route" | "product"
+): { label: string; secondary: string | null; key: string } {
+  if (!isSafeAnalyticsIdentifier(value)) {
+    const label =
+      fallback === "event"
+        ? "Unknown event"
+        : fallback === "route"
+          ? "Unknown route"
+          : "Unknown product";
+    return { label, secondary: null, key: label };
+  }
+
+  if (fallback === "event") {
+    return {
+      label: EVENT_LABELS[value] ?? titleCaseWords(value),
+      secondary: value,
+      key: value,
+    };
+  }
+
+  if (fallback === "route") {
+    return {
+      label: value,
+      secondary: value.startsWith("/") ? "Route template" : "Route",
+      key: value,
+    };
+  }
+
+  return {
+    label: titleCaseWords(value),
+    secondary: value,
+    key: value,
+  };
+}
+
+function getFreshnessHours(lastEventAt: string | null, now: Date): number | null {
+  if (!lastEventAt) return null;
+  const date = new Date(lastEventAt);
+  if (Number.isNaN(date.getTime())) return null;
+  return Math.max(0, (now.getTime() - date.getTime()) / (60 * 60 * 1000));
+}
+
+function buildListItems(
+  items: Array<{
+    key: string;
+    count: number;
+    category?: string | null;
+    productType?: string | null;
+  }>,
+  fallback: "event" | "route" | "product"
+): AnalyticsDashboardListItem[] {
+  return items.slice(0, 6).map((item) => {
+    const identity = formatAnalyticsIdentifierLabel(item.key, fallback);
+    const safeCategory = isSafeAnalyticsIdentifier(item.category) ? item.category : null;
+    const safeProductType = isSafeAnalyticsIdentifier(item.productType) ? item.productType : null;
+    const safeSecondary =
+      fallback === "route"
+        ? safeCategory || identity.secondary
+        : fallback === "product"
+          ? safeProductType || identity.secondary
+          : identity.secondary;
+    return {
+      key: identity.key,
+      label: identity.label,
+      secondary: safeSecondary,
+      count: formatAnalyticsCount(item.count),
+    };
+  });
+}
+
+function buildFunnel(payload: AnalyticsInsightsResponse): AnalyticsDashboardFunnelStep[] {
+  const steps = [
+    {
+      id: "public-page-viewed",
+      label: "Public page viewed",
+      value: payload.funnel.publicPageViewed,
+      detail: "Aggregate public traffic",
+    },
+    {
+      id: "plans-viewed",
+      label: "Plans viewed",
+      value: payload.funnel.plansViewed,
+      detail: "Pricing and offer view",
+    },
+    {
+      id: "product-viewed",
+      label: "Product viewed",
+      value: payload.funnel.productViewed,
+      detail: "Specific product interest",
+    },
+    {
+      id: "checkout-started",
+      label: "Checkout started",
+      value: payload.funnel.checkoutStarted,
+      detail: "Stripe handoff started",
+    },
+    {
+      id: "checkout-completed",
+      label: "Checkout completed",
+      value: payload.funnel.checkoutCompleted,
+      detail: `${formatAnalyticsPercent(payload.funnel.checkoutCompletionRate)} of started`,
+    },
+    {
+      id: "entitlement-granted",
+      label: "Entitlement granted",
+      value: payload.funnel.entitlementGranted,
+      detail: `${formatAnalyticsPercent(payload.funnel.entitlementGrantRate)} of completed`,
+    },
+  ];
+
+  const max = Math.max(1, ...steps.map((step) => step.value));
+  return steps.map((step) => ({
+    ...step,
+    count: formatAnalyticsCount(step.value),
+    percentOfMax: Math.max(4, Math.round((step.value / max) * 100)),
+  }));
+}
+
+export function buildAnalyticsDashboardViewModel(
+  payload: AnalyticsDashboardPayload,
+  options: { now?: Date } = {}
+): AnalyticsDashboardViewModel {
+  const now = options.now ?? new Date();
+  const rangeDays = normalizeAnalyticsDashboardRangeDays(payload.rangeDays);
+  const rangeLabel = `${rangeDays} days`;
+  const generatedAtLabel = formatAnalyticsTimestamp(payload.generatedAt, now);
+
+  if (isSchemaMissingPayload(payload)) {
+    return {
+      state: "schema-missing",
+      stateLabel: "Schema missing",
+      stateDetail:
+        payload.warning ??
+        "Analytics persistence is not ready. Apply the analytics_events migration first.",
+      rangeLabel,
+      generatedAtLabel,
+      lastEventLabel: "No event yet",
+      rowCapLabel: "Not counted",
+      metrics: [
+        {
+          id: "schema",
+          label: "Schema",
+          value: "Not ready",
+          detail: "analytics_events is not queryable yet.",
+        },
+      ],
+      funnel: [],
+      eventItems: [],
+      routeItems: [],
+      productItems: [],
+      caveats: [
+        "Setup is incomplete, so counts are hidden instead of inferred.",
+        "This state does not expose raw payloads or database errors.",
+      ],
+    };
+  }
+
+  const freshnessHours = getFreshnessHours(payload.lastEventAt, now);
+  const isNoData = payload.totalEvents === 0;
+  const state: AnalyticsDashboardTrustState = isNoData
+    ? "no-data"
+    : payload.capped
+      ? "capped"
+      : freshnessHours !== null && freshnessHours <= ANALYTICS_DASHBOARD_FRESH_WINDOW_HOURS
+        ? "fresh"
+        : "quiet";
+  const stateLabel =
+    state === "no-data"
+      ? "No data yet"
+      : state === "capped"
+        ? "Capped read"
+        : state === "fresh"
+          ? "Fresh"
+          : "Quiet";
+  const stateDetail =
+    state === "no-data"
+      ? "No matching analytics events were found for this range."
+      : state === "capped"
+        ? "This range hit the bounded row cap, so totals may be incomplete."
+        : state === "fresh"
+          ? "Analytics has recent safe events in this range."
+          : "No recent event is visible in this range; traffic may be quiet or instrumentation may need review.";
+
+  const clientServerDetail = `${formatAnalyticsCount(payload.clientEvents)} client / ${formatAnalyticsCount(
+    payload.serverEvents
+  )} server`;
+
+  return {
+    state,
+    stateLabel,
+    stateDetail,
+    rangeLabel,
+    generatedAtLabel,
+    lastEventLabel: formatAnalyticsTimestamp(payload.lastEventAt, now),
+    rowCapLabel: `${payload.capped ? "Reached" : "Below"} ${formatAnalyticsCount(payload.rowCap)}`,
+    metrics: [
+      {
+        id: "total-events",
+        label: "Total events",
+        value: formatAnalyticsCount(payload.totalEvents),
+        detail: payload.capped ? "Bounded by row cap" : `In the last ${rangeLabel}`,
+      },
+      {
+        id: "last-event",
+        label: "Last event",
+        value: formatAnalyticsTimestamp(payload.lastEventAt, now),
+        detail: state === "quiet" ? "Needs review if traffic is expected" : "Freshness signal",
+      },
+      {
+        id: "public-aggregate",
+        label: "Public aggregate",
+        value: formatAnalyticsCount(payload.publicAggregateEvents),
+        detail: "Not linked to user profiles",
+      },
+      {
+        id: "known-users",
+        label: "Known users",
+        value: formatAnalyticsCount(payload.uniqueKnownUsers),
+        detail: "Distinct signed-in users in safe events",
+      },
+      {
+        id: "client-server",
+        label: "Client / server",
+        value: clientServerDetail,
+        detail: "Source split",
+      },
+      {
+        id: "checkout-rate",
+        label: "Checkout rate",
+        value: formatAnalyticsPercent(payload.funnel.checkoutCompletionRate),
+        detail: "Checkout completed / started",
+      },
+    ],
+    funnel: buildFunnel(payload),
+    eventItems: buildListItems(payload.eventCounts, "event"),
+    routeItems: buildListItems(payload.routeCounts, "route"),
+    productItems: buildListItems(payload.productCounts, "product"),
+    caveats: [
+      payload.capped
+        ? `This range hit the ${formatAnalyticsCount(payload.rowCap)} row cap. Treat totals as bounded.`
+        : `This range is below the ${formatAnalyticsCount(payload.rowCap)} row cap.`,
+      "Revenue proxy counts are product signals only; they are not Stripe reconciliation, finance reporting, or revenue recognition.",
+      "Public aggregate events are intentionally not linked to user profiles.",
+      "Raw URLs, emails, IPs, user agents, notes, cart details, and raw payload JSON are not shown.",
+    ],
+  };
+}

--- a/tests/unit/admin-analytics-dashboard-view-model.test.ts
+++ b/tests/unit/admin-analytics-dashboard-view-model.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAnalyticsDashboardViewModel,
+  formatAnalyticsIdentifierLabel,
+  formatAnalyticsPercent,
+  normalizeAnalyticsDashboardRangeDays,
+  type AnalyticsDashboardPayload,
+} from "@/lib/analytics/admin-dashboard";
+
+const now = new Date("2026-06-09T12:00:00.000Z");
+
+const basePayload: AnalyticsDashboardPayload = {
+  ok: true,
+  schemaReady: true,
+  generatedAt: "2026-06-09T12:00:00.000Z",
+  rangeDays: 30,
+  since: "2026-05-10T12:00:00.000Z",
+  until: "2026-06-09T12:00:00.000Z",
+  rowCap: 5000,
+  capped: false,
+  totalEvents: 4,
+  lastEventAt: "2026-06-09T10:15:00.000Z",
+  uniqueKnownUsers: 1,
+  publicAggregateEvents: 2,
+  clientEvents: 2,
+  serverEvents: 2,
+  eventCounts: [
+    { key: "plans_viewed", count: 2 },
+    { key: "new_safe_event", count: 1 },
+  ],
+  routeCounts: [{ key: "/plans", category: "pricing", count: 2 }],
+  productCounts: [{ key: "guide_poolside", productType: "course_addon", count: 2 }],
+  funnel: {
+    publicPageViewed: 2,
+    plansViewed: 2,
+    productViewed: 1,
+    checkoutStarted: 1,
+    checkoutCompleted: 1,
+    entitlementGranted: 1,
+    checkoutCompletionRate: 1,
+    entitlementGrantRate: 1,
+  },
+};
+
+describe("admin analytics dashboard view model", () => {
+  it("normalizes ranges and formats percentages for compact controls", () => {
+    expect(normalizeAnalyticsDashboardRangeDays(7)).toBe(7);
+    expect(normalizeAnalyticsDashboardRangeDays(120)).toBe(30);
+    expect(formatAnalyticsPercent(0.5)).toBe("50%");
+    expect(formatAnalyticsPercent(null)).toBe("Not counted");
+  });
+
+  it("builds a fixed dashboard order with fresh health, metrics, funnel, lists, and caveats", () => {
+    const viewModel = buildAnalyticsDashboardViewModel(basePayload, { now });
+
+    expect(viewModel.state).toBe("fresh");
+    expect(viewModel.stateLabel).toBe("Fresh");
+    expect(viewModel.rangeLabel).toBe("30 days");
+    expect(viewModel.lastEventLabel).toBe("Today 10:15");
+    expect(viewModel.metrics.map((metric) => metric.id)).toEqual([
+      "total-events",
+      "last-event",
+      "public-aggregate",
+      "known-users",
+      "client-server",
+      "checkout-rate",
+    ]);
+    expect(viewModel.metrics[0]).toMatchObject({ label: "Total events", value: "4" });
+    expect(viewModel.funnel.map((step) => step.id)).toEqual([
+      "public-page-viewed",
+      "plans-viewed",
+      "product-viewed",
+      "checkout-started",
+      "checkout-completed",
+      "entitlement-granted",
+    ]);
+    expect(viewModel.eventItems[0]).toMatchObject({
+      label: "Plans viewed",
+      secondary: "plans_viewed",
+      count: "2",
+    });
+    expect(viewModel.routeItems[0]).toMatchObject({
+      label: "/plans",
+      secondary: "pricing",
+      count: "2",
+    });
+    expect(viewModel.productItems[0]).toMatchObject({
+      label: "Guide Poolside",
+      secondary: "course_addon",
+      count: "2",
+    });
+    expect(viewModel.caveats.join(" ")).toContain("not Stripe reconciliation");
+    expect(viewModel.caveats.join(" ")).toContain("not linked to user profiles");
+  });
+
+  it("renders capped, quiet, no-data, and schema-missing trust states deterministically", () => {
+    expect(buildAnalyticsDashboardViewModel({ ...basePayload, capped: true }, { now }).state).toBe(
+      "capped"
+    );
+    expect(
+      buildAnalyticsDashboardViewModel(
+        { ...basePayload, lastEventAt: "2026-06-01T10:15:00.000Z" },
+        { now }
+      ).state
+    ).toBe("quiet");
+    expect(
+      buildAnalyticsDashboardViewModel(
+        {
+          ...basePayload,
+          totalEvents: 0,
+          lastEventAt: null,
+          eventCounts: [],
+          routeCounts: [],
+          productCounts: [],
+        },
+        { now }
+      ).state
+    ).toBe("no-data");
+    expect(
+      buildAnalyticsDashboardViewModel(
+        {
+          ok: true,
+          schemaReady: false,
+          warning: "Analytics persistence is not ready yet.",
+          generatedAt: "2026-06-09T12:00:00.000Z",
+          rangeDays: 30,
+          items: [],
+        },
+        { now }
+      )
+    ).toMatchObject({
+      state: "schema-missing",
+      stateLabel: "Schema missing",
+      metrics: [{ id: "schema", value: "Not ready" }],
+    });
+  });
+
+  it("does not expose unsafe raw payload-like identifiers in labels or secondary text", () => {
+    const viewModel = buildAnalyticsDashboardViewModel(
+      {
+        ...basePayload,
+        eventCounts: [{ key: "email=user@example.com", count: 1 }],
+        routeCounts: [
+          {
+            key: "https://example.com/plans",
+            category: "email=user@example.com",
+            count: 1,
+          },
+        ],
+        productCounts: [
+          { key: "customer@example.com", productType: "email=user@example.com", count: 1 },
+        ],
+      },
+      { now }
+    );
+
+    expect(viewModel.eventItems[0]).toMatchObject({
+      label: "Unknown event",
+      secondary: null,
+    });
+    expect(viewModel.routeItems[0]).toMatchObject({
+      label: "Unknown route",
+      secondary: null,
+    });
+    expect(viewModel.productItems[0]).toMatchObject({
+      label: "Unknown product",
+      secondary: null,
+    });
+    expect(JSON.stringify(viewModel)).not.toContain("user@example.com");
+    expect(formatAnalyticsIdentifierLabel("future_safe_event", "event")).toMatchObject({
+      label: "Future Safe Event",
+      secondary: "future_safe_event",
+    });
+    expect(formatAnalyticsIdentifierLabel("https://example.com/plans", "route")).toMatchObject({
+      label: "Unknown route",
+      secondary: null,
+    });
+  });
+});

--- a/tests/unit/admin-analytics-dashboard.test.tsx
+++ b/tests/unit/admin-analytics-dashboard.test.tsx
@@ -1,0 +1,188 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import AdminAnalyticsDashboard from "@/components/admin/AdminAnalyticsDashboard";
+import type { AnalyticsDashboardPayload } from "@/lib/analytics/admin-dashboard";
+import type { AnalyticsInsightsResponse } from "@/lib/analytics/admin-insights";
+
+const basePayload: AnalyticsInsightsResponse = {
+  ok: true,
+  schemaReady: true,
+  generatedAt: "2026-06-09T12:00:00.000Z",
+  rangeDays: 30,
+  since: "2026-05-10T12:00:00.000Z",
+  until: "2026-06-09T12:00:00.000Z",
+  rowCap: 5000,
+  capped: false,
+  totalEvents: 4,
+  lastEventAt: "2026-06-09T10:15:00.000Z",
+  uniqueKnownUsers: 1,
+  publicAggregateEvents: 2,
+  clientEvents: 2,
+  serverEvents: 2,
+  eventCounts: [{ key: "plans_viewed", count: 2 }],
+  routeCounts: [{ key: "/plans", category: "pricing", count: 2 }],
+  productCounts: [{ key: "guide_poolside", productType: "course_addon", count: 2 }],
+  funnel: {
+    publicPageViewed: 2,
+    plansViewed: 2,
+    productViewed: 1,
+    checkoutStarted: 1,
+    checkoutCompleted: 1,
+    entitlementGranted: 1,
+    checkoutCompletionRate: 1,
+    entitlementGrantRate: 1,
+  },
+};
+
+function okResponse(payload: AnalyticsDashboardPayload = basePayload) {
+  return {
+    ok: true,
+    json: async () => payload,
+  };
+}
+
+function errorResponse(error = "Could not load analytics insights right now.") {
+  return {
+    ok: false,
+    json: async () => ({
+      ok: false,
+      error,
+    }),
+  };
+}
+
+describe("AdminAnalyticsDashboard", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the read-only dashboard in the required scan order", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AdminAnalyticsDashboard />);
+
+    expect(screen.getByTestId("admin-analytics-dashboard-header")).toHaveClass(
+      "fs-library-card",
+      "fs-library-card-accent"
+    );
+    expect(screen.getByRole("status")).toHaveTextContent("Loading analytics dashboard...");
+
+    await screen.findByTestId("admin-analytics-health");
+    expect(screen.getByTestId("admin-analytics-kpis")).toBeVisible();
+    expect(screen.getByTestId("admin-analytics-funnel")).toBeVisible();
+    expect(screen.getByTestId("admin-analytics-top-lists")).toBeVisible();
+    expect(screen.getByTestId("admin-analytics-caveats")).toBeVisible();
+
+    expect(screen.getByText("Fresh")).toBeVisible();
+    expect(
+      within(screen.getByTestId("admin-analytics-funnel")).getByText("Checkout completed")
+    ).toBeVisible();
+    expect(
+      within(screen.getByTestId("admin-analytics-top-events")).getByText("Plans viewed")
+    ).toBeVisible();
+    expect(
+      within(screen.getByTestId("admin-analytics-top-routes")).getByText("/plans")
+    ).toBeVisible();
+    expect(
+      within(screen.getByTestId("admin-analytics-top-products")).getByText("Guide Poolside")
+    ).toBeVisible();
+    expect(
+      within(screen.getByTestId("admin-analytics-caveats")).getByText(/not Stripe reconciliation/i)
+    ).toBeVisible();
+    expect(
+      within(screen.getByTestId("admin-analytics-caveats")).getByText(
+        /not linked to user profiles/i
+      )
+    ).toBeVisible();
+    expect(fetchMock).toHaveBeenCalledWith("/api/admin/analytics/insights?rangeDays=30", {
+      method: "GET",
+      credentials: "same-origin",
+      cache: "no-store",
+    });
+  });
+
+  it("switches bounded ranges without writing analytics state", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(okResponse())
+      .mockResolvedValueOnce(okResponse({ ...basePayload, rangeDays: 7 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AdminAnalyticsDashboard />);
+
+    await screen.findByTestId("admin-analytics-health");
+    fireEvent.click(screen.getByRole("button", { name: "7 days" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenLastCalledWith("/api/admin/analytics/insights?rangeDays=7", {
+        method: "GET",
+        credentials: "same-origin",
+        cache: "no-store",
+      });
+    });
+    expect(screen.getByRole("button", { name: "7 days" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("shows schema-missing, capped, and no-data caveats without raw payloads", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      okResponse({
+        ok: true,
+        schemaReady: false,
+        warning: "Analytics persistence is not ready yet.",
+        generatedAt: "2026-06-09T12:00:00.000Z",
+        rangeDays: 30,
+        items: [],
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AdminAnalyticsDashboard />);
+
+    expect(await screen.findByText("Schema missing")).toBeVisible();
+    expect(screen.getByText("Not ready")).toBeVisible();
+    expect(screen.getByText(/database errors/i)).toBeVisible();
+    expect(screen.queryByText(/payload/i, { selector: "code" })).not.toBeInTheDocument();
+  });
+
+  it("keeps unsafe identifiers out of rendered labels and supports retry", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(errorResponse())
+      .mockResolvedValueOnce(
+        okResponse({
+          ...basePayload,
+          eventCounts: [{ key: "email=user@example.com", count: 1 }],
+          routeCounts: [
+            { key: "https://example.com/?email=user@example.com", category: null, count: 1 },
+          ],
+          productCounts: [{ key: "customer@example.com", productType: null, count: 1 }],
+        })
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AdminAnalyticsDashboard />);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Could not load analytics insights right now.");
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await screen.findByText("Unknown event");
+    expect(screen.getByText("Unknown route")).toBeVisible();
+    expect(screen.getByText("Unknown product")).toBeVisible();
+    expect(document.body).not.toHaveTextContent("user@example.com");
+  });
+
+  it("renders top lists as compact list rows instead of horizontal tables", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AdminAnalyticsDashboard />);
+
+    const topLists = await screen.findByTestId("admin-analytics-top-lists");
+    expect(within(topLists).queryByRole("table")).not.toBeInTheDocument();
+    expect(within(topLists).getAllByRole("list")).toHaveLength(3);
+    expect(topLists).toHaveClass("grid", "lg:grid-cols-3");
+  });
+});

--- a/tests/unit/admin-help-center.test.tsx
+++ b/tests/unit/admin-help-center.test.tsx
@@ -49,6 +49,7 @@ describe("AdminHelpCenter", () => {
       screen.getByRole("heading", { name: "Dashboard tabs and when to use them" })
     ).toBeVisible();
     expect(screen.getByRole("heading", { name: "Buttons and what they do" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "How Analytics works" })).toBeVisible();
     expect(screen.getByRole("heading", { name: "Troubleshoot fast" })).toBeVisible();
 
     expect(screen.getByTestId("admin-help-quick-action-learning-path")).toHaveAttribute(
@@ -59,15 +60,25 @@ describe("AdminHelpCenter", () => {
       "href",
       "#change-log"
     );
+    expect(screen.getByTestId("admin-help-quick-action-analytics")).toHaveAttribute(
+      "href",
+      "#analytics"
+    );
 
     expect(screen.getByText("Course Workspace / All Content tabs:")).toBeVisible();
+    expect(screen.getByText("7 days / 30 days / 90 days:")).toBeVisible();
     expect(screen.getByText("Open hello inbox:")).toBeVisible();
     expect(screen.getByText("Move to deleted / Confirm delete:")).toBeVisible();
+    expect(
+      screen.getByText(/not finance reconciliation or user-level public traffic/i)
+    ).toBeVisible();
+    expect(screen.getByText(/Do not infer missing revenue, user attribution/i)).toBeVisible();
     expect(
       screen.getByText(
         "Every new/updated brief must declare Help/Guide impact as: required update or explicit N/A with reason."
       )
     ).toBeVisible();
+    expect(screen.getByText("docs/runbooks/public-analytics-privacy-assessment.md")).toBeVisible();
     expect(screen.getByText("docs/runbooks/admin-email-template-governance.md")).toBeVisible();
   });
 });

--- a/tests/unit/admin-workspace-shell.test.tsx
+++ b/tests/unit/admin-workspace-shell.test.tsx
@@ -36,6 +36,7 @@ function mockManager(testId: string) {
   };
 }
 
+vi.mock("@/components/admin/AdminAnalyticsDashboard", () => mockManager("admin-manager-analytics"));
 vi.mock("@/components/admin/AdminCommerceManager", () => mockManager("admin-manager-commerce"));
 vi.mock("@/components/admin/AdminContentManager", () => mockManager("admin-manager-content"));
 vi.mock("@/components/admin/AdminCategoriesManager", () => mockManager("admin-manager-categories"));
@@ -117,12 +118,13 @@ describe("AdminWorkspace shell", () => {
 
     const adminSections = screen.getByRole("navigation", { name: "Admin sections" });
     const sectionButtons = within(adminSections).getAllByRole("button");
-    expect(sectionButtons).toHaveLength(9);
+    expect(sectionButtons).toHaveLength(10);
     expect(sectionButtons.map((button) => button.textContent)).toEqual([
       "ContentLessons, guides, and publish state",
       "QR LinksStable redirect registry and ownership",
       "CommerceProducts, titles, and active sales status",
       "OperationsRuntime flags and private-access status",
+      "AnalyticsSafe event dashboard, funnel, and data health",
       "Email templatesDraft, review, publish, and rollback-safe message copy",
       "MessagesStored intake, triage status, and notification diagnostics",
       "NotesInternal tasks, categories, and completion status",
@@ -140,7 +142,17 @@ describe("AdminWorkspace shell", () => {
     ).toHaveLength(1);
     expect(
       sectionButtons.filter((button) => button.getAttribute("aria-pressed") === "false")
-    ).toHaveLength(8);
+    ).toHaveLength(9);
+  });
+
+  it("renders the Analytics workspace from typed tab state", () => {
+    searchParamsValue.current = "tab=analytics";
+
+    render(<AdminWorkspace role="viewer" />);
+
+    expect(screen.getByTestId("admin-tab-analytics")).toHaveClass("fs-library-card-accent");
+    expect(screen.getByTestId("admin-active-section-label")).toHaveTextContent("Analytics");
+    expect(screen.getByTestId("admin-manager-analytics")).toBeVisible();
   });
 
   it("shows Help/Guide section links in the active desktop rail", () => {

--- a/tests/unit/admin-workspace-state.test.ts
+++ b/tests/unit/admin-workspace-state.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  ADMIN_ANALYTICS_WORKSPACE_BOUNDARY,
   ADMIN_MESSAGES_WORKSPACE_BOUNDARY,
   applyAdminTabToSearchParams,
   buildAdminWorkspaceModuleHref,
@@ -13,6 +14,7 @@ describe("admin workspace tab URL state", () => {
     expect(parseAdminTab("notes")).toBe("notes");
     expect(parseAdminTab("content")).toBe("content");
     expect(parseAdminTab("messages")).toBe("messages");
+    expect(parseAdminTab("analytics")).toBe("analytics");
     expect(parseAdminTab("unknown")).toBeNull();
     expect(parseAdminTab(null)).toBeNull();
   });
@@ -27,6 +29,19 @@ describe("admin workspace tab URL state", () => {
       id: "messages",
       label: "Messages",
       viewBoundary: expect.stringContaining("dedicated admin messages component boundary"),
+    });
+  });
+
+  it("keeps admin analytics behind a typed read-only module boundary", () => {
+    expect(parseAdminWorkspaceModuleId("analytics")).toBe("analytics");
+    expect(ADMIN_ANALYTICS_WORKSPACE_BOUNDARY.status).toBe("active");
+    expect(buildAdminWorkspaceModuleHref(ADMIN_ANALYTICS_WORKSPACE_BOUNDARY)).toBe(
+      "/admin?tab=analytics"
+    );
+    expect(getAdminWorkspaceModuleBoundary("analytics")).toMatchObject({
+      id: "analytics",
+      label: "Analytics",
+      mutationBoundary: expect.stringContaining("does not mutate analytics rows"),
     });
   });
 


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-06-09T19:39:40.320Z for branch `admin-analytics-dashboard-read-only-v1` (base ref `origin/main`).
- Latest commit: `3436e337` - Add admin analytics dashboard.
- Plain-language done summary: This PR delivers the brief goal for the touched product area: Create an admin-only, read-only analytics dashboard that turns the existing privacy-safe insights JSON into a clear operational view for product and support decisions.
- Recommended next step: Monitor required GitHub checks, then run `npm run verify:pre-merge` on the current HEAD before merge.
- User-visible changes: Admin-facing behavior/guardrails may change in touched admin routes or APIs.
- Technical changes: Updated 15 file(s): `app/admin/analytics/page.tsx`, `app/admin/layout.tsx`, `components/admin/AdminAnalyticsDashboard.tsx`, `components/admin/AdminHelpCenter.tsx`, `components/admin/AdminWorkspace.tsx`, `... and 10 more file(s)`.
- Policy impact: yes (inferred from changed scope: `app/admin/analytics/page.tsx`, `lib/analytics/admin-dashboard.ts`).
- Policy version note: N/A (if policy text/version changes, replace with YYYY-MM-DD.rev and rationale).
- Brief link(s): `docs/task-briefs/in-progress/2026-06-09-admin-analytics-dashboard-read-only-v1-10-10.md`
- Scorecard target outcomes: 19 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (3); tests (5); runtime UI/routes/components (7).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (15):
  - `app/admin/analytics/page.tsx`
  - `app/admin/layout.tsx`
  - `components/admin/AdminAnalyticsDashboard.tsx`
  - `components/admin/AdminHelpCenter.tsx`
  - `components/admin/AdminWorkspace.tsx`
  - `docs/api-contracts.md`
  - `docs/task-briefs/deferred/2026-02-18-analytics-persistence-and-admin-insights.md`
  - `docs/task-briefs/in-progress/2026-06-09-admin-analytics-dashboard-read-only-v1-10-10.md`
  - `... and 7 more file(s)`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `3436e337` (`git revert 3436e337`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **PASS** (artifacts/test-runs/20260609-213306, lane: full-public)
- `npm run verify:pre-merge`: **PENDING** for `3436e337` (last green marker: `8ed200e8` at 2026-06-09T18:11:21Z; rerun on current HEAD).
- Policy-impact checklist: PENDING (run docs/checklists/policy-impact-release-review.md and update to PASS/FAIL).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  -   -  632 [desktop-firefox] › tests/e2e/public-ia.spec.ts:10:7 › public route IA › keeps legacy about as a temporary alias for the canonical method page
  -   -  633 [desktop-firefox] › tests/e2e/public-ia.spec.ts:49:7 › public route IA › keeps programs cards token-backed with clear CTA destinations
  -   -  634 [desktop-firefox] › tests/e2e/public-ia.spec.ts:99:7 › public route IA › keeps contact and analysis request guidance clear
  -   ✓  635 [desktop-firefox] › tests/e2e/sitemap.spec.ts:32:5 › sitemap contains canonical public routes (10ms)
  -   ✓  636 [desktop-firefox] › tests/e2e/soft-launch-banner.spec.ts:9:5 › public pages do not render legacy under-construction banner (849ms)
  -   106 passed (5.1m)
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] Changed `done` task briefs include achieved score + evidence for every target category and explicit `10/10 claim: yes/no`
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
