### PR TITLE
feat: add existing upsell admin analytics baseline

### DIFF
--- a/components/admin/AdminAnalyticsDashboard.tsx
+++ b/components/admin/AdminAnalyticsDashboard.tsx
@@ -165,6 +165,77 @@ function WorkoutBuilderFunnelPanel({
   );
 }
 
+function ExistingUpsellBaselinePanel({
+  baseline,
+}: {
+  baseline: AnalyticsDashboardViewModel["existingUpsellBaseline"];
+}) {
+  return (
+    <section
+      aria-labelledby="admin-analytics-existing-upsell-heading"
+      className={panelClass}
+      data-testid="admin-analytics-existing-upsell-baseline"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className={metadataLabelClass}>Commerce</p>
+          <h3
+            id="admin-analytics-existing-upsell-heading"
+            className="mt-1 text-base font-semibold text-[color:var(--fs-color-ink-strong)]"
+          >
+            Existing upsell baseline
+          </h3>
+          <p className={cx("mt-1", mutedTextClass)}>{baseline.detail}</p>
+        </div>
+        <p className="text-xs font-semibold text-[color:var(--fs-color-muted)]">Current surfaces</p>
+      </div>
+
+      <dl className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+        {baseline.metrics.map((metric) => (
+          <div key={metric.id} className="min-w-0">
+            <dt className={metadataLabelClass}>{metric.label}</dt>
+            <dd className="mt-1">
+              <p className="text-xl font-semibold break-words text-[color:var(--fs-color-ink-strong)] tabular-nums">
+                {metric.value}
+              </p>
+              <p className={cx("mt-1", mutedTextClass)}>{metric.detail}</p>
+            </dd>
+          </div>
+        ))}
+      </dl>
+
+      {baseline.sourceItems.length === 0 ? (
+        <p className={cx("mt-4", mutedTextClass)}>{baseline.emptyLabel}</p>
+      ) : (
+        <ul className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+          {baseline.sourceItems.map((item, index) => (
+            <li
+              key={`existing-upsell:${item.key}:${index}`}
+              className="flex min-w-0 items-start justify-between gap-3 rounded-[var(--fs-radius-control)] border border-[color:var(--fs-border-soft)] bg-white/75 px-3 py-2"
+            >
+              <div className="min-w-0">
+                <p className="text-sm font-semibold break-words text-[color:var(--fs-color-ink-strong)]">
+                  {item.label}
+                </p>
+                {item.secondary ? (
+                  <p className="mt-0.5 text-xs break-words text-[color:var(--fs-color-muted)]">
+                    {item.secondary}
+                  </p>
+                ) : null}
+              </div>
+              <p className="shrink-0 text-right text-sm font-semibold text-[color:var(--fs-color-ink-strong)] tabular-nums">
+                {item.count}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <p className={cx("mt-4", mutedTextClass)}>{baseline.caveat}</p>
+    </section>
+  );
+}
+
 function WorkoutBuilderSourceBreakdownPanel({
   breakdown,
 }: {
@@ -545,6 +616,7 @@ export default function AdminAnalyticsDashboard() {
             )}
           </section>
 
+          <ExistingUpsellBaselinePanel baseline={viewModel.existingUpsellBaseline} />
           <WorkoutBuilderFunnelPanel funnel={viewModel.workoutBuilderFunnel} />
           <WorkoutBuilderSourceBreakdownPanel breakdown={viewModel.workoutBuilderSourceBreakdown} />
           <WorkoutBuilderTemplateGeneratedCompletionPanel

--- a/components/admin/AdminHelpCenter.tsx
+++ b/components/admin/AdminHelpCenter.tsx
@@ -63,9 +63,9 @@ const DASHBOARD_TABS: TabGuide[] = [
   {
     name: "Analytics",
     primaryJob:
-      "Inspect privacy-safe event health, funnel counts, workout-builder save-rate, generated completion, route/product activity, and dashboard caveats.",
+      "Inspect privacy-safe event health, funnel counts, existing upsell baseline, workout-builder save-rate, generated completion, route/product activity, and dashboard caveats.",
     commonRisk:
-      "Treating bounded revenue-proxy, builder save-rate, or generated completion counts as finance reconciliation, checkout conversion, template usage, or user-level attribution.",
+      "Treating bounded revenue-proxy, existing upsell, builder save-rate, or generated completion counts as finance reconciliation, checkout conversion, template usage, or user-level attribution.",
   },
   {
     name: "Email templates",
@@ -276,6 +276,11 @@ const ANALYTICS_WORKFLOW = [
     title: "Read workout builder save-rate as product telemetry",
     detail:
       "Started counts workout_builder_started, Saved counts workout_builder_saved, and Save rate is Saved / Started for the selected range. Duplicate starts and saves can exist, so this is not unique-user conversion, checkout performance, Stripe reconciliation, or finance reporting.",
+  },
+  {
+    title: "Read existing upsell baseline as current-surface signal",
+    detail:
+      "Presented counts upsell_presented on current commercial surfaces, Accepted counts clicked commercial actions, and Cancelled returns counts the existing checkout-cancel return signal. Accepted is not checkout completion, cancelled returns are not all declined users, and neither value is entitlement, Stripe reconciliation, revenue, or finance truth.",
   },
   {
     title: "Read workout builder source breakdown as product telemetry",
@@ -532,6 +537,11 @@ const BUTTON_GUIDE: ActionGroup[] = [
           "Shows the workout-builder product telemetry for the selected range. It is useful for builder completion review, not user-level attribution, checkout conversion, Stripe reconciliation, export, or finance reporting.",
       },
       {
+        label: "Existing upsell baseline",
+        meaning:
+          "Shows current /plans and My Library upsell presentation, click, and checkout-cancel return events. Use it as a commercial surface baseline only, not checkout completion, entitlement, revenue, or finance evidence.",
+      },
+      {
         label: "Generated completion / Template usage",
         meaning:
           "Shows generated drafts and generated saves from supported events, plus template selections from workout_builder_template_selected only. Unknown template keys stay unmapped until explicitly reviewed.",
@@ -695,9 +705,9 @@ const CONNECTED_SERVICES = [
   {
     name: "First-party analytics",
     purpose:
-      "Stores sanitized aggregate/product/funnel events and renders read-only admin insights without third-party scripts.",
+      "Stores sanitized aggregate/product/funnel/upsell events and renders read-only admin insights without third-party scripts.",
     caution:
-      "Do not treat dashboard counts as finance truth, user-level attribution, or approval for cookies/vendor tracking.",
+      "Do not treat dashboard counts, including existing upsell accepted/cancelled signals, as finance truth, user-level attribution, or approval for cookies/vendor tracking.",
   },
 ];
 
@@ -983,7 +993,10 @@ export default function AdminHelpCenter() {
                 required for publish/revert).
               </li>
               <li>Read, filter, status, archive, soft-delete, and restore stored messages.</li>
-              <li>Inspect privacy-safe analytics event health and read-only funnel signals.</li>
+              <li>
+                Inspect privacy-safe analytics event health, read-only funnel signals, and existing
+                upsell baseline caveats.
+              </li>
               <li>Maintain notes, categories, and commerce labels.</li>
               <li>Run revision restore and QR rollback operations.</li>
             </ul>

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -329,6 +329,12 @@
   `/admin/analytics` route is an alias into the same admin workspace tab.
 - Caveat: checkout and entitlement counts are product/revenue-proxy signals only. They are not
   Stripe reconciliation, accounting, refunds, payouts, invoices, or revenue recognition.
+- Existing upsell caveat: `existingUpsellBaseline` is current-surface commercial telemetry derived
+  from `upsell_presented`, `upsell_accepted`, and `upsell_declined`. `upsell_presented` is surface
+  visibility, not checkout start. `upsell_accepted` is clicked intent, not checkout completion.
+  `upsell_declined` is the current checkout-cancel return signal, not all users who ignored,
+  dismissed, or failed to convert. Unknown source/product values remain separate until explicitly
+  mapped.
 - Workout builder caveat: `workoutBuilderFunnel` is product telemetry derived from
   `workout_builder_started` and `workout_builder_saved`. Save rate is saved/start count for the
   selected range, not unique-user conversion, checkout performance, Stripe reconciliation, export,
@@ -406,6 +412,43 @@
     "entitlementGranted": 1,
     "checkoutCompletionRate": 0.5,
     "entitlementGrantRate": 1
+  },
+  "existingUpsellBaseline": {
+    "presented": 4,
+    "accepted": 2,
+    "declined": 1,
+    "acceptedRate": 0.5,
+    "declineRate": 0.25,
+    "unknownSourceEvents": 1,
+    "sourceCounts": [
+      {
+        "key": "plans",
+        "presented": 3,
+        "accepted": 1,
+        "declined": 1,
+        "total": 5,
+        "acceptedRate": 0.333,
+        "declineRate": 0.333
+      },
+      {
+        "key": "library_explore",
+        "presented": 1,
+        "accepted": 1,
+        "declined": 0,
+        "total": 2,
+        "acceptedRate": 1,
+        "declineRate": 0
+      },
+      {
+        "key": "unknown",
+        "presented": 0,
+        "accepted": 1,
+        "declined": 0,
+        "total": 1,
+        "acceptedRate": null,
+        "declineRate": null
+      }
+    ]
   },
   "workoutBuilderFunnel": {
     "started": 5,

--- a/docs/task-briefs/in-progress/2026-06-11-existing-upsell-event-admin-analytics-baseline-v1-10-10.md
+++ b/docs/task-briefs/in-progress/2026-06-11-existing-upsell-event-admin-analytics-baseline-v1-10-10.md
@@ -1,0 +1,351 @@
+# Task Brief: Existing Upsell Event Admin Analytics Baseline V1 (10/10)
+
+## Metadata
+
+- `id`: `2026-06-11-existing-upsell-event-admin-analytics-baseline-v1-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-06-11`
+- `updated`: `2026-06-11`
+- `parent_brief`: `docs/task-briefs/planned/2026-02-28-workout-commercial-analytics-funnel-10-10.md`
+- `depends_on`:
+  - `docs/task-briefs/done/2026-06-10-workout-context-upsell-placement-policy-v1-10-10.md`
+  - `docs/architecture/workout-context-upsell-placement-policy.md`
+- `related_briefs`:
+  - `docs/task-briefs/done/2026-06-09-workout-builder-funnel-instrumentation-v1-10-10.md`
+  - `docs/task-briefs/done/2026-06-10-workout-builder-funnel-dashboard-v1-10-10.md`
+  - `docs/task-briefs/done/2026-06-10-workout-builder-source-breakdown-dashboard-v1-10-10.md`
+  - `docs/task-briefs/done/2026-06-10-workout-builder-template-usage-admin-analytics-mapping-v1-10-10.md`
+- `execution_mode`: `end-to-end-after-explicit-implement`
+- `branch`: `existing-upsell-event-admin-analytics-baseline-v1`
+
+## Brief Audit Record
+
+- `last_audited`: `2026-06-11`
+- `base`: clean synced `main@13b3b072` after PR `#1067` closed the workout-context upsell placement policy closeout and `npm run post-merge:preflight` was clean.
+- `audit_status`: `ready`
+- `decision`: Execute this as the bounded child after the owner explicitly requested `xecute Existing Upsell Event Admin Analytics Baseline V1`.
+- `reason`: Existing `upsell_presented`, `upsell_accepted`, and `upsell_declined` events already describe current `/plans` and My Library commercial surfaces, while the placement policy forbids inferring workout-context CTA performance, checkout completion, entitlement truth, or finance results from adjacent workout telemetry. A read-only Admin Analytics baseline can clarify today's commercial signals before any workout-context CTA runtime work.
+- `must_refresh_before_execution_if`: Refresh before execution if AGENTS.md, the task brief template, scorecard categories, analytics event taxonomy, `analytics_events` persistence/extraction, `/api/admin/analytics/insights`, `lib/analytics/admin-insights.ts`, `lib/analytics/admin-dashboard.ts`, `components/admin/AdminAnalyticsDashboard.tsx`, `components/analytics/TrackCheckoutCancel.tsx`, `components/my-library/CheckoutButton.tsx`, `app/plans/page.tsx`, `components/my-library/MyLibraryHub.tsx`, product catalog helpers, checkout/Stripe contracts, Admin Help/Guide contracts, screenshot handoff rules, or route/label/support sweep rules change.
+
+## Goal
+
+Add a read-only Admin Analytics baseline for existing `upsell_*` events so the owner can see today's commercial CTA visibility and intent signals without adding workout-context CTA behavior or treating product telemetry as checkout, entitlement, or finance truth.
+
+## Pre-Implementation Owner Explanation
+
+Vi lager en avgrenset Admin Analytics-baseline for `upsell_*`-hendelsene som allerede finnes pa `/plans` og My Library. Det gir et tryggere bilde av dagens kommersielle flater for vi vurderer workout-context CTA. Utenfor scope er ny workout-CTA, nye event-navn eller callsites, checkout-/Stripe-endringer, entitlement, finance, export, tredjeparts analytics, raw drilldown og builder/generator UX.
+
+Forward-compatibility-intent: nye CTA-flater, produkt-ID-er og workout-context placements skal bare telle i en dedikert modul nar de er eksplisitt mappet med tester og support-kopi. Ukjente eller umappede values skal fa trygg unknown/fail-closed behandling, ikke bli tolket som konvertering.
+
+## Product Questions
+
+This child answers only these implementation questions:
+
+1. How many existing `upsell_presented`, `upsell_accepted`, and `upsell_declined` events happened in the selected Admin Analytics range?
+2. How should current `plans` and `library_explore` sources be shown without implying checkout completion, entitlement grant, revenue, or finance reconciliation?
+3. How should zero, duplicate, capped, schema-missing, stale, unknown-surface, unknown-product, and failed-read states be described for admin/support?
+4. Which future CTA placements or products must require explicit mapping before they can appear in a dedicated commercial baseline module?
+
+## Planned Product Decision
+
+If executed, this child should implement only a read-only Admin Analytics baseline for existing events and current commercial surfaces:
+
+- Count `upsell_presented`, `upsell_accepted`, and `upsell_declined` from persisted first-party analytics rows.
+- Treat `upsell_presented` as commercial surface visibility, not checkout start.
+- Treat `upsell_accepted` as user click/intent, not checkout completion.
+- Treat `upsell_declined` as the existing checkout-cancel return signal, not a complete measure of all users who ignored or dismissed an offer.
+- Prefer safe `source` payload values for surface mapping:
+  - `plans`
+  - `library_explore`
+  - `unknown`
+- Use `surface` only as a safe fallback where current events provide it.
+- Keep product identity tied to existing safe product/catalog analytics extraction, not button text.
+- Do not add workout-context placement IDs, runtime CTA UI, new `upsell_*` meanings, checkout attribution, entitlement targeting, or finance reporting.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for the 10/10 claim gate:
+
+- Product goals and IA
+- Business logic correctness and data integrity
+- Data placement and sync boundaries
+- Reliability and failure handling
+- Security and authz
+- Privacy and compliance
+- Analytics and KPI observability
+- Commerce and revenue ops
+- Finance and reporting operations
+- Stack-fit and dependency discipline
+- Testing and QA automation
+
+| Category                                      | Mapping      | Target Threshold / Scope Rationale                                                                                                                                                                | Evidence                                                                   | Expected Closeout Score |
+| --------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | Admin Analytics gains one clearly labeled existing-upsell baseline that separates current commercial surfaces from future workout-context CTA work.                                               | view-model/component tests + screenshot handoff + Help/Guide copy          | `5/5`                   |
+| UX flow clarity                               | `target`     | The dashboard panel explains presented, accepted, declined/cancelled, and rates without dead ends or misleading conversion language.                                                              | component tests + screenshot review                                        | `5/5`                   |
+| Visual design quality                         | `target`     | The panel reuses existing Admin Analytics cards/KPI/list styling, fits desktop/mobile, and has no clipped or overlapping text.                                                                    | after/reference screenshot artifacts                                       | `5/5`                   |
+| Business logic correctness and data integrity | `target`     | Counts only `upsell_presented`, `upsell_accepted`, and `upsell_declined`; ratios define zero denominator behavior and never infer unique users, checkout, entitlement, revenue, or finance truth. | admin-insights/view-model tests with zero, duplicate, unknown, capped data | `5/5`                   |
+| Admin editor ergonomics                       | `supporting` | Supporting only: this is read-only Admin Analytics, not an admin editor or placement config workflow.                                                                                             | admin scope rationale + unchanged edit flows                               | `4/5`                   |
+| Accessibility (a11y)                          | `target`     | Changed Admin Analytics headings, lists, status text, and range states remain semantic, keyboard reachable, and screen-reader friendly.                                                           | Testing Library assertions + screenshot/manual review                      | `5/5`                   |
+| Performance (CWV + payloads)                  | `supporting` | Supporting only: reuse existing endpoint/view-model and add no chart library, vendor script, route, or dependency.                                                                                | package diff + build/perf gate                                             | `4/5`                   |
+| Data placement and sync boundaries            | `target`     | Server-canonical analytics rows remain the only source; payload inspection is server-side and only safe low-cardinality aggregates reach Admin UI.                                                | data contract review + unsafe-field tests                                  | `5/5`                   |
+| Caching and invalidation strategy             | `target`     | Admin insights remain `no-store`; range changes refetch the same bounded endpoint with no new cache or background job.                                                                            | route/cache review + existing endpoint tests                               | `5/5`                   |
+| Reliability and failure handling              | `target`     | Zero, capped, stale, schema-missing, unknown, and failed-read states render deterministic trust/caveat text and do not produce unexpected `500` behavior.                                         | negative-path unit/component tests                                         | `5/5`                   |
+| Security and authz                            | `target`     | No public or user route access is widened; existing protected Admin Analytics endpoint remains fail-closed for unauthorized reads.                                                                | auth boundary review + existing/targeted negative-path tests               | `5/5`                   |
+| Privacy and compliance                        | `target`     | Admin UI must not expose raw payload JSON, raw URLs, emails, user IDs, visitor IDs, IPs, user agents, Stripe IDs, payment details, workout content, or free text.                                 | payload-filter tests + route/support sweep                                 | `5/5`                   |
+| Content governance                            | `target`     | Admin labels, Help/Guide copy, API caveats, parent checkpoint, and support interpretation all state what the baseline does and does not mean.                                                     | docs/help updates + route/label/support sweep                              | `5/5`                   |
+| Admin workflow and editability                | `supporting` | Supporting only: no editable placement config, role workflow, publish flow, or support mutation ships in this baseline.                                                                           | admin workflow scope rationale                                             | `4/5`                   |
+| SEO and crawlability                          | `N/A`        | N/A because this changes protected Admin Analytics only and adds no public route, metadata, sitemap, robots, canonical URL, structured data, or crawlable content.                                | explicit SEO scope rationale                                               | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because this adds no public semantic page, public docs page, structured data, or AI-facing crawl surface.                                                                                     | explicit AI-discoverability scope rationale                                | `N/A`                   |
+| Analytics and KPI observability               | `target`     | The module surfaces existing upsell visibility/intent/cancel signals with caveats and no inferred checkout, entitlement, revenue, or unique-user conversion.                                      | admin-insights/view-model/component tests + Help/Guide assertions          | `5/5`                   |
+| Commerce and revenue ops                      | `target`     | Current commercial signals stay separate from checkout start, checkout completion, entitlement grants, Stripe reconciliation, and product catalog truth.                                          | commerce boundary tests/review + API docs                                  | `5/5`                   |
+| Incident response and support operations      | `target`     | Support can explain missing, unknown, stale, capped, and cancelled-return states without raw event drilldown or payment data.                                                                     | Help/Guide/runbook copy + route/support sweep                              | `5/5`                   |
+| Finance and reporting operations              | `target`     | No upsell baseline value is described as revenue, refund, payout, invoice, accounting export, or Stripe reconciliation evidence.                                                                  | finance caveat in Admin/Help/API docs + tests for label text               | `5/5`                   |
+| i18n operational readiness                    | `supporting` | Supporting only: labels remain short/display-only and surface/product IDs remain locale-independent for later localization.                                                                       | copy review + identity contract                                            | `4/5`                   |
+| Stack-fit and dependency discipline           | `target`     | Reuse existing Next.js, TypeScript, Admin Analytics endpoint, view-model, UI primitives, and tests; add no dependency, migration, vendor, or new route.                                           | changed-files/package diff + code review                                   | `5/5`                   |
+| Testing and QA automation                     | `target`     | Add focused insight, view-model, component, unsafe-field, unknown-value, and screenshot evidence before `verify:pre-pr`; run pre-merge gate before merge.                                         | targeted tests + screenshots + `verify:pre-pr` + CI + `verify:pre-merge`   | `5/5`                   |
+| Scalability and cost efficiency               | `target`     | Aggregation stays bounded to existing range-capped rows and low-cardinality dimensions; no per-user/per-workout drilldown or warehouse/export path is introduced.                                 | query/row-cap review + tests                                               | `5/5`                   |
+| DevOps and rollback readiness                 | `target`     | No migration, provider, env, secret, or checkout runtime change; rollback is a revert of dashboard/view-model/docs/tests.                                                                         | PR rollback note + verify gates                                            | `5/5`                   |
+
+## Stack / Architecture Best-Practice Gate
+
+- React/Next.js:
+  - Reuse `components/admin/AdminAnalyticsDashboard.tsx` and the existing panel/card/list patterns.
+  - Keep the dashboard read-only inside the existing Admin Analytics route and endpoint.
+  - Do not add a new route, tab, chart dependency, modal, placement editor, or runtime CTA surface.
+- TypeScript/domain contracts:
+  - Use existing typed `ANALYTICS_EVENT_NAMES` event names.
+  - Add narrow typed view-model helpers in `lib/analytics/admin-dashboard.ts`.
+  - Add aggregation in `lib/analytics/admin-insights.ts` without exposing raw payload JSON.
+  - Define ratio behavior for zero denominators and duplicate client events.
+  - Safely map current low-cardinality source values: `plans`, `library_explore`, and `unknown`.
+- Supabase/data layer:
+  - Use existing `analytics_events` rows and bounded admin insight reads.
+  - No migration, index, RLS policy, generated type update, storage object, rollup job, raw drilldown, or export path.
+  - Protected admin reads must keep existing fail-closed behavior.
+- External services/tools:
+  - No Stripe API, checkout flow, webhook, idempotency, SDK, secret, vendor analytics, tag manager, cookie, consent banner, or finance provider change.
+  - Existing checkout/Stripe events may be referenced only as interpretation boundaries.
+- UI system:
+  - Reuse current Admin Analytics visual language, `AdminManagerState` trust states, metric cards, lists, and caveat text.
+  - Screenshot handoff type: `after/reference`, comparing the new baseline panel to the existing Admin Analytics funnel/workout-builder panels.
+  - Owner screenshot approval is required before `npm run verify:pre-pr` if this child is executed.
+- Testing:
+  - Unit tests for admin insights aggregation, safe source/product mapping, zero denominators, duplicate events, unknown values, and unsafe payload filtering.
+  - View-model tests for labels, rates, empty/capped/schema-missing/stale states, and caveats.
+  - Component tests for rendered panel semantics and no misleading conversion/finance labels.
+  - Screenshot artifacts for desktop, mobile, and at least one no-data or schema/trust state when practical.
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - Existing persisted `analytics_events` rows remain the source of truth.
+  - Existing product/catalog/checkout/entitlement/finance sources remain separate and are not joined into this baseline.
+- Local/browser:
+  - No browser analytics identity, cookie, visitor ID, localStorage attribution, admin preference, or user-to-public bridge is added.
+  - Existing client-side `upsell_*` emission remains best-effort and may duplicate.
+- Sync behavior:
+  - Admin reads remain bounded aggregate reads from `/api/admin/analytics/insights`.
+  - Range changes refetch the same endpoint.
+  - Duplicate client events are counted as events and caveated as not unique-user conversion.
+- Retention and sensitivity:
+  - Existing analytics retention/rollup lifecycle applies.
+  - Raw payload JSON, raw URLs/referrers, emails, user IDs, visitor IDs, IPs, user agents, Stripe IDs, payment data, workout content, support messages, and free text must not reach Admin UI.
+- Cache/invalidation:
+  - Analytics ingestion and Admin Analytics reads remain `no-store`.
+  - No new cache, revalidation tag, stale runtime config, or background aggregation job is introduced.
+
+## Identity And Rename Contract
+
+- Canonical stable IDs:
+  - Event identity is the append-only event name: `upsell_presented`, `upsell_accepted`, `upsell_declined`.
+  - Current commercial surface identity is the safe source/surface value, primarily `plans` and `library_explore`.
+  - Product identity comes from existing safe analytics/product catalog extraction, not visible button copy.
+- Human-readable identifiers:
+  - Dashboard labels, CTA copy, product names, and Help/Guide text are display-only and may be renamed when meaning is unchanged.
+- Mutability rules:
+  - Existing event names and meanings are not changed by this child.
+  - Counting a new action under an existing event or changing what `declined` means is repurpose and requires a new child.
+- Rename vs repurpose:
+  - Label-only clarity changes are renames.
+  - Moving a CTA into workout context, adding a new placement ID, treating checkout cancel as full decline rate, or treating `accepted` as checkout completion is repurpose and requires explicit owner mapping.
+- Compatibility contract:
+  - Unknown, deprecated, disabled, or unmapped source/product values must render as safe unknown states or be excluded from dedicated known-surface rates with a caveat.
+  - Future workout-context placement IDs require mapping before they appear in the dedicated baseline module.
+- Observability and repair:
+  - Unknown safe values should be countable as unknown aggregates for support, without raw payload drilldown.
+  - Schema-missing, failed-read, stale, capped, and no-data states must remain visible.
+
+## Forward Compatibility Contract
+
+- Extensibility surfaces:
+  - CTA event names, source/surface values, placement IDs, product IDs, catalog availability, checkout events, entitlement states, route templates, dashboard KPI modules, Help/Guide copy, locales, export formats, vendor forwarding, and finance/reporting surfaces.
+- Source of truth:
+  - Event names come from `ANALYTICS_EVENT_NAMES`.
+  - Current source/surface values come from sanitized event payloads and analytics extraction.
+  - Product identity comes from existing product/catalog analytics contracts.
+  - Checkout truth comes from checkout events and Stripe/webhook contracts, not `upsell_*` events.
+  - Finance truth comes from Stripe/accounting reconciliation contracts, not Admin Analytics product telemetry.
+- Additive behavior:
+  - New known event rows continue to appear in generic top-event lists automatically.
+  - Existing `plans` and `library_explore` source values should continue to populate the baseline if current event meanings remain unchanged.
+  - Safe unknown source/product values should render as unknown aggregate states rather than disappear silently.
+- Explicit mapping requirements:
+  - New workout-context placements, new product purchase models, new `upsell_*` meanings, new CTA source values, checkout attribution, entitlement-aware targeting, finance reporting, raw drilldown, CSV/export, vendor analytics, and localized commercial claims require explicit owner mapping, docs, and tests before release.
+- Unknown or deprecated values:
+  - Unknown or deprecated placement/product/source values must not imply CTA conversion.
+  - Unknown values may be shown only as safe aggregate diagnostics and must be excluded from known-surface-specific rates unless a later child maps them.
+- Test/evidence:
+  - Future implementation must include fixtures for `plans`, `library_explore`, unknown source, unknown product, zero presented, duplicate accepted, checkout-cancel declined, capped rows, schema-missing, and unsafe payload fields.
+  - Run route/label/support sweep for event taxonomy, Admin Analytics labels, Help/Guide, API docs, checkout interpretation, finance wording, and the parent brief.
+
+## Help / Guide Impact
+
+Planned brief creation: no visible Help/Guide change.
+
+Execution: Admin Help/Guide or linked runbook must be updated because visible Admin Analytics labels and support interpretation will change.
+
+If executed, this child must update Admin Help/Guide or linked runbook text for:
+
+- what `upsell_presented`, `upsell_accepted`, and `upsell_declined` mean,
+- what they do not mean: unique users, checkout completion, entitlement, revenue, Stripe reconciliation, or finance truth,
+- how zero, duplicate, capped, schema-missing, stale, unknown, and failed-read states should be interpreted,
+- why workout-context CTA performance is absent until a later mapped runtime child exists.
+
+## Screenshot / Visual Impact
+
+Required if this child is executed because it changes visible Admin Analytics UI.
+
+- Capture folder: `output/existing-upsell-event-admin-analytics-baseline-v1-YYYY-MM-DD-HHMMSS`.
+- Handoff type: `after/reference`.
+- Required examples:
+  - `after-existing-upsell-baseline-desktop.png`
+  - `after-existing-upsell-baseline-mobile.png`
+  - `after-existing-upsell-baseline-empty-or-trust-state-desktop.png`
+  - `reference-admin-analytics-commercial-funnel-desktop.png`
+- Screenshot approval stop: stop after screenshot handoff and wait for owner approval or visual corrections before `npm run verify:pre-pr`, PR creation, or `npm run verify:pre-merge`.
+
+Screenshot evidence on `2026-06-11`:
+
+- Artifact folder: `output/existing-upsell-event-admin-analytics-baseline-v1-2026-06-11-074931`
+- Captured: `2026-06-11 07:49` local time
+- Handoff type: `after/reference`
+- Files captured:
+  - `after-existing-upsell-baseline-desktop.png`
+  - `after-existing-upsell-baseline-mobile.png`
+  - `after-existing-upsell-baseline-empty-or-trust-state-desktop.png`
+  - `reference-admin-analytics-commercial-funnel-desktop.png`
+- Capture note: protected `/admin` requires a real admin session locally, so artifacts were captured through a temporary local screenshot harness that imported the same `AdminAnalyticsDashboard` component and stubbed only `/api/admin/analytics/insights`; the harness and capture script were removed after artifact generation.
+- Owner approval status: approved in chat on `2026-06-11`; proceed to `npm run verify:pre-pr`, PR prep, CI, and pre-merge validation.
+
+## Route / Label / Support Surface Sweep
+
+Required before broad gates if this child is executed because it changes Admin Analytics labels, dashboard modules, Help/Guide interpretation, and commercial/support wording.
+
+Search at minimum:
+
+- `upsell_presented`
+- `upsell_accepted`
+- `upsell_declined`
+- `checkout_started`
+- `checkout_completed`
+- `entitlement_granted`
+- `Stripe`
+- `finance`
+- `revenue`
+- `Admin Analytics`
+- `Help/Guide`
+- `library_explore`
+- `plans`
+- `workout-context`
+- `CTA`
+
+Check at minimum:
+
+- `app/`
+- `components/`
+- `components/admin/`
+- `components/analytics/`
+- `components/my-library/`
+- `lib/analytics/`
+- `lib/commerce/` and `lib/admin/products.ts` as the current product/commerce catalog paths
+- `tests/`
+- `docs/api-contracts.md`
+- `docs/architecture/`
+- `docs/runbooks/`
+- active/planned/done workout, analytics, commerce, checkout, Stripe, finance, and AW-006 briefs.
+
+Sweep evidence on `2026-06-11`:
+
+- Command: `rg -n "upsell_presented|upsell_accepted|upsell_declined|checkout_started|checkout_completed|entitlement_granted|Stripe|finance|revenue|Admin Analytics|Help/Guide|library_explore|plans|workout-context|CTA" app components components/admin components/analytics components/my-library lib/analytics lib/commerce lib/admin/products.ts tests docs/api-contracts.md docs/architecture docs/runbooks docs/task-briefs/planned docs/task-briefs/in-progress docs/task-briefs/done`
+- Findings: required fallout is limited to Admin Analytics aggregation/view-model/UI, Admin Help/Guide interpretation, API contract caveats, targeted analytics tests, this active child brief, and the parent checkpoint.
+- No runtime workout-context CTA, new event callsite, checkout, Stripe, entitlement, finance, vendor analytics, export, raw drilldown, migration, RLS, product catalog mutation, route, or builder/generator UX change is required for this slice.
+
+## Scope
+
+- Create read-only Admin Analytics insight/view-model/UI support for existing `upsell_*` events.
+- Add safe current-surface/source aggregation for `plans`, `library_explore`, and unknown.
+- Add caveats for duplicate client telemetry and checkout-cancel-only decline semantics.
+- Update Admin Help/Guide/API docs and parent checkpoint if implementation proceeds.
+- Add targeted unit/component tests and screenshot handoff if implementation proceeds.
+
+## Out Of Scope
+
+- Runtime workout-context CTA UI.
+- New `upsell_*` event names or changed meanings.
+- New event callsites for builder/generator/workout review.
+- Checkout, Stripe, webhook, entitlement, catalog mutation, pricing, finance, refunds, payouts, invoices, or accounting export changes.
+- Third-party analytics/vendor forwarding.
+- Raw event drilldown, CSV/export, warehouse, rollup job, migration, RLS, generated DB type update, or new admin editor.
+- Builder/generator UX, template usage, workout save behavior, or workout route changes.
+- Treating `upsell_accepted` as checkout completion or `upsell_declined` as all non-converting users.
+
+## Acceptance Criteria
+
+1. Brief is moved to `docs/task-briefs/in-progress/` and parent brief points to it as the active child approved for implementation.
+2. If executed, Admin Analytics shows existing upsell baseline totals and rates only from `upsell_presented`, `upsell_accepted`, and `upsell_declined`.
+3. Current `plans` and `library_explore` sources are mapped explicitly; unknown safe values render as unknown/fallback without raw payload exposure.
+4. Zero-denominator, duplicate, capped, schema-missing, stale, no-data, unknown, and failed-read states have deterministic labels and caveats.
+5. The dashboard and Help/Guide copy do not imply unique-user conversion, checkout completion, entitlement, revenue, Stripe reconciliation, or finance truth.
+6. No runtime workout-context CTA, checkout, Stripe, entitlement, finance, vendor, export, migration, RLS, raw drilldown, or builder/generator UX scope is added.
+7. UI implementation, if later approved, includes screenshot handoff and owner approval before `npm run verify:pre-pr`.
+8. Changed briefs pass `npm run lint:briefs`.
+
+## Validation
+
+Completed so far:
+
+- `./node_modules/.bin/vitest run tests/unit/admin-analytics-insights.test.ts tests/unit/admin-analytics-dashboard-view-model.test.ts tests/unit/admin-analytics-dashboard.test.tsx` PASS (`3` files, `21` tests)
+- `npm run typecheck` PASS
+- `npm run lint:quality-gates` PASS
+- `npm run lint:briefs:all` PASS, including this in-progress brief
+- `git diff --check` PASS
+- Route/label/support-surface sweep completed with findings recorded above
+- owner screenshot approval: approved in chat on `2026-06-11`
+- `npm run verify:pre-pr` PASS on `2026-06-11` (`artifacts/test-runs/20260611-085859/verify.log`; full lane with typecheck, unit tests, build, performance budgets, and Playwright)
+
+Pending after PR creation:
+
+- required PR CI checks
+- `npm run verify:pre-merge`
+
+## Session Continuity And Recovery
+
+- Parent path: `docs/task-briefs/planned/2026-02-28-workout-commercial-analytics-funnel-10-10.md`
+- Active child path: `docs/task-briefs/in-progress/2026-06-11-existing-upsell-event-admin-analytics-baseline-v1-10-10.md`
+- Placement policy path: `docs/architecture/workout-context-upsell-placement-policy.md`
+- Recovery protocol:
+  1. `git status -sb`
+  2. `git log --oneline -n 10`
+  3. reopen this child and the parent brief, then continue from the latest checkpoint.
+
+## Checkpoint Log
+
+- `2026-06-11 | planned child created | created planned child brief from clean synced main@13b3b072 after PR #1067 closeout and clean post-merge preflight; implementation is not approved yet and must remain scoped to read-only Admin Analytics visibility for existing upsell events on current commercial surfaces | next: wait for owner implementation approval or scope edits`
+- `2026-06-11 | child moved to in-progress | owner requested execution, branch existing-upsell-event-admin-analytics-baseline-v1 is active, and the child moved to docs/task-briefs/in-progress/2026-06-11-existing-upsell-event-admin-analytics-baseline-v1-10-10.md; scope remains read-only Admin Analytics visibility for existing upsell events and excludes runtime workout-context CTA, new event callsites/meanings, checkout, Stripe, entitlement, finance, vendor, export, raw drilldown, migration, RLS, and builder/generator UX | next: audit existing Admin Analytics contracts and implement the baseline`
+- `2026-06-11 | implementation validation before screenshot | implemented read-only existing upsell aggregation, Admin Analytics panel, Help/Guide/API-contract support copy, targeted tests, and route/label/support sweep evidence; targeted Vitest, typecheck, quality-gates, lint:briefs:all, and diff-check pass, with no runtime workout-context CTA, new event callsite, checkout, Stripe, entitlement, finance, vendor, export, raw drilldown, migration, RLS, product catalog mutation, route, or builder/generator UX scope added | next: capture screenshot handoff and wait for owner approval before npm run verify:pre-pr`
+- `2026-06-11 | screenshot approval stop | captured after/reference screenshot artifacts at output/existing-upsell-event-admin-analytics-baseline-v1-2026-06-11-074931 using the same AdminAnalyticsDashboard component with a temporary local harness removed after capture; no product rendering files changed after the final capture, and owner visual approval remains pending | next: wait for owner screenshot approval or visual corrections before npm run verify:pre-pr`
+- `2026-06-11 | screenshots approved | owner approved the screenshot handoff in chat; no product rendering files changed after the final capture | next: run npm run verify:pre-pr`
+- `2026-06-11 | pre-pr passed | child passed npm run verify:pre-pr full lane with typecheck, unit tests, build, performance budgets, and Playwright; scope still excludes runtime workout-context CTA, new event callsite, checkout, Stripe, entitlement, finance, vendor, export, raw drilldown, migration, RLS, product catalog mutation, route, and builder/generator UX | next: commit, push, open PR, monitor CI, then run npm run verify:pre-merge`

--- a/docs/task-briefs/planned/2026-02-28-workout-commercial-analytics-funnel-10-10.md
+++ b/docs/task-briefs/planned/2026-02-28-workout-commercial-analytics-funnel-10-10.md
@@ -11,11 +11,11 @@
 
 ## Brief Audit Record
 
-- `last_audited`: `2026-06-10`
-- `base`: clean synced `main@56701757` after PR `#1066` closed the workout-context upsell placement policy child.
+- `last_audited`: `2026-06-11`
+- `base`: clean synced `main@13b3b072` after PR `#1067` closed the workout-context upsell placement policy closeout.
 - `audit_status`: `ready`
 - `decision`: Use this as the refreshed parent for bounded child briefs only; do not execute this parent directly.
-- `reason`: The first telemetry/dashboard children are complete: PR `#1049` shipped privacy-safe workout builder start/save events, PR `#1051` shipped read-only Admin Analytics visibility for started, saved, and save-rate, PR `#1053` shipped source breakdown visibility for manual-vs-generated contribution, PR `#1055` shipped generated draft/save/completion visibility while keeping template usage as not instrumented, PR `#1057` closed the template identity/selection contract, PR `#1059` shipped the runtime template source plus explicit `Use template` selection surface, PR `#1061` shipped the typed privacy-safe template-selection event, PR `#1063` shipped read-only Admin Analytics template usage mapping for that event, and PR `#1066` closed the docs-only workout-context upsell placement policy. No commercial implementation child is approved.
+- `reason`: The first telemetry/dashboard children are complete: PR `#1049` shipped privacy-safe workout builder start/save events, PR `#1051` shipped read-only Admin Analytics visibility for started, saved, and save-rate, PR `#1053` shipped source breakdown visibility for manual-vs-generated contribution, PR `#1055` shipped generated draft/save/completion visibility while keeping template usage as not instrumented, PR `#1057` closed the template identity/selection contract, PR `#1059` shipped the runtime template source plus explicit `Use template` selection surface, PR `#1061` shipped the typed privacy-safe template-selection event, PR `#1063` shipped read-only Admin Analytics template usage mapping for that event, PR `#1066` closed the docs-only workout-context upsell placement policy, and PR `#1067` closed its repo-managed docs-only closeout. Existing Upsell Event Admin Analytics Baseline V1 is now the active child after owner execution approval.
 - `must_refresh_before_execution_if`: Refresh before any child starts if AGENTS.md, the task brief template, scorecard categories, analytics event taxonomy, `analytics_events` schema, `/api/admin/analytics/insights`, Admin Analytics UI, Help/Guide contracts, checkout/Stripe contracts, product catalog, workout builder save/generator routes, or route/label/support sweep rules change.
 
 ## Goal
@@ -61,10 +61,15 @@ Forward-compatibility-intent: nye builder-/generator-events skal enten flyte try
   - Closed by PR `#1066` / squash commit `56701757`.
   - Owns only the docs-only policy decision for where workout-context upsell CTA may appear and which existing first-party signals it may read.
   - Runtime CTA, CTA events/dashboard, checkout, Stripe, entitlement, finance, vendor analytics, export, raw drilldown, migrations, and builder/generator UX remain out of scope.
+- Active child: `docs/task-briefs/in-progress/2026-06-11-existing-upsell-event-admin-analytics-baseline-v1-10-10.md`
+  - Created from clean synced `main@13b3b072` after PR `#1067`.
+  - Owner requested execution on `2026-06-11`.
+  - Owns only read-only Admin Analytics baseline visibility for existing `upsell_presented`, `upsell_accepted`, and `upsell_declined` events on current `/plans` and My Library commercial surfaces.
+  - Runtime workout-context CTA, new event callsites/meanings, checkout, Stripe, entitlement, finance, vendor analytics, export, raw drilldown, migrations, RLS, and builder/generator UX remain out of scope.
 - Still deferred after the placement-policy child:
   - generated plan/completion definitions beyond existing `session_draft_generated`,
   - runtime commercial CTA implementation,
-  - CTA instrumentation/dashboard,
+  - workout-context CTA instrumentation/dashboard beyond existing current-surface baseline,
   - broader dedicated KPI modules,
   - CSV/export,
   - finance-grade reporting,
@@ -73,13 +78,19 @@ Forward-compatibility-intent: nye builder-/generator-events skal enten flyte try
 
 ## Next Child
 
-No active child is approved.
+Active child:
 
-The placement-policy child is closed. Future work must still start as a separate owner-approved child and must not add runtime CTA, CTA events/dashboard, checkout, Stripe, entitlement, finance, vendor analytics, export, raw drilldown, migration, RLS, or builder/generator UX changes without that explicit child scope.
+- `docs/task-briefs/in-progress/2026-06-11-existing-upsell-event-admin-analytics-baseline-v1-10-10.md`
 
-Safe follow-up candidate families after the policy child exists:
+The placement-policy child is closed. Future work must still start as a separate owner-approved child and must not add runtime workout-context CTA, new CTA event callsites/meanings, checkout, Stripe, entitlement, finance, vendor analytics, export, raw drilldown, migration, RLS, or builder/generator UX changes without that explicit child scope.
 
-- CTA instrumentation/dashboard: add privacy-safe `upsell_presented` / `upsell_accepted` / `upsell_declined` visibility only after placement policy is executed and closed.
+Current planned candidate after the policy child:
+
+- Existing Upsell Event Admin Analytics Baseline V1: add read-only Admin Analytics visibility for existing `upsell_presented` / `upsell_accepted` / `upsell_declined` events on current commercial surfaces only.
+
+Safe follow-up candidate families after the current planned child is either executed or deferred:
+
+- Workout-context CTA instrumentation/dashboard: add privacy-safe workout-context `upsell_presented` / `upsell_accepted` / `upsell_declined` visibility only after placement policy and existing-surface baseline boundaries are explicit.
 - Checkout attribution and finance separation: define how product telemetry, checkout conversion, entitlement truth, Stripe reconciliation, and finance reporting stay separate before any commerce implementation.
 - Export, CSV, raw drilldown, or third-party analytics: still deferred until the owner explicitly chooses those surfaces and their privacy/support boundaries.
 
@@ -87,7 +98,7 @@ Current guardrails:
 
 - Do not reopen the completed template usage mapping scope as the next child.
 - Do not infer revenue, unique-user conversion, checkout readiness, or finance truth from builder, generator, or template telemetry.
-- Do not add CTA, checkout, Stripe, entitlement, finance, vendor analytics, export, raw drilldown, migration, RLS, or builder/generator UX changes without a new approved child brief.
+- Do not add runtime CTA, new event callsites/meanings, checkout, Stripe, entitlement, finance, vendor analytics, export, raw drilldown, migration, RLS, or builder/generator UX changes without a new approved child brief.
 - Any next child must include the pre-implementation owner explanation, scorecard mapping, data-boundary decisions, forward-compatibility contract, route/label/support sweep triggers, Help/Guide impact, and validation plan before implementation starts.
 
 ## Scope
@@ -329,7 +340,7 @@ Future child implementation:
 - Canonical parent path: `docs/task-briefs/planned/2026-02-28-workout-commercial-analytics-funnel-10-10.md`
 - Last completed child path: `docs/task-briefs/done/2026-06-10-workout-context-upsell-placement-policy-v1-10-10.md`
 - Planned child path: none
-- Active child path: none
+- Active child path: `docs/task-briefs/in-progress/2026-06-11-existing-upsell-event-admin-analytics-baseline-v1-10-10.md`
 - Done placement policy child path: `docs/task-briefs/done/2026-06-10-workout-context-upsell-placement-policy-v1-10-10.md`
 - Done unblock child path: `docs/task-briefs/done/2026-06-10-workout-builder-template-identity-selection-contract-v1-10-10.md`
 - Done runtime source child path: `docs/task-briefs/done/2026-06-10-workout-builder-template-runtime-source-selection-surface-v1-10-10.md`
@@ -370,3 +381,9 @@ Future child implementation:
 - `2026-06-10 | planned placement-policy child created | owner selected Workout Context Upsell Placement Policy V1 as the next bounded child; created docs/task-briefs/planned/2026-06-10-workout-context-upsell-placement-policy-v1-10-10.md from clean synced main@451ba841, with implementation still blocked on explicit owner execute/build/implement instruction and no runtime CTA, analytics event, dashboard, checkout, Stripe, entitlement, finance, vendor, export, migration, or builder/generator UX scope approved | next: wait for owner implementation approval or scope edits`
 - `2026-06-10 | placement-policy child in progress | owner requested execution of Workout Context Upsell Placement Policy V1 on branch workout-context-upsell-placement-policy-v1; child moved to docs/task-briefs/in-progress/2026-06-10-workout-context-upsell-placement-policy-v1-10-10.md and remains docs-only, with no runtime CTA, analytics event, dashboard, checkout, Stripe, entitlement, finance, vendor, export, migration, or builder/generator UX scope approved | next: complete child validation and PR`
 - `2026-06-11 | placement-policy child merged | PR #1066 merged at squash commit 56701757 after green docs-only local pre-pr, CI, and pre-merge gates; parent has no active child, and runtime CTA, CTA events/dashboard, checkout, Stripe, entitlement, finance, vendor, export, raw drilldown, migration, RLS, and builder/generator UX remain deferred | next: finish docs-only closeout PR and rerun post-merge-preflight`
+- `2026-06-11 | planned existing upsell baseline child created | owner selected Existing Upsell Event Admin Analytics Baseline V1 as the next bounded child; created docs/task-briefs/planned/2026-06-11-existing-upsell-event-admin-analytics-baseline-v1-10-10.md from clean synced main@13b3b072 after PR #1067 and clean post-merge preflight, with implementation still blocked on explicit owner execute/build/implement instruction and no runtime workout-context CTA, new event callsites/meanings, checkout, Stripe, entitlement, finance, vendor, export, raw drilldown, migration, RLS, or builder/generator UX scope approved | next: wait for owner implementation approval or scope edits`
+- `2026-06-11 | existing upsell baseline child in progress | owner requested execution of Existing Upsell Event Admin Analytics Baseline V1 on branch existing-upsell-event-admin-analytics-baseline-v1; child moved to docs/task-briefs/in-progress/2026-06-11-existing-upsell-event-admin-analytics-baseline-v1-10-10.md and remains scoped to read-only Admin Analytics visibility for existing upsell events, with no runtime workout-context CTA, new event callsites/meanings, checkout, Stripe, entitlement, finance, vendor, export, raw drilldown, migration, RLS, or builder/generator UX approved | next: implement child and stop at screenshot handoff before verify:pre-pr`
+- `2026-06-11 | existing upsell baseline validation before screenshot | active child implemented read-only existing upsell aggregation/UI, Help/Guide/API-contract support copy, targeted tests, and route/label/support sweep evidence; targeted Vitest, typecheck, quality-gates, lint:briefs:all, and diff-check pass, with no runtime workout-context CTA, new event callsite, checkout, Stripe, entitlement, finance, vendor, export, raw drilldown, migration, RLS, route, product catalog mutation, or builder/generator UX added | next: child screenshot handoff and owner approval stop before verify:pre-pr`
+- `2026-06-11 | existing upsell baseline screenshot stop | active child captured after/reference screenshot artifacts at output/existing-upsell-event-admin-analytics-baseline-v1-2026-06-11-074931; temporary local capture harness was removed after generation, no product rendering files changed after final capture, and owner visual approval is pending before verify:pre-pr | next: wait for owner screenshot approval or visual corrections`
+- `2026-06-11 | existing upsell baseline screenshots approved | owner approved the child screenshot handoff in chat; no product rendering files changed after final capture | next: child verify:pre-pr`
+- `2026-06-11 | existing upsell baseline pre-pr passed | active child passed npm run verify:pre-pr full lane with typecheck, unit tests, build, performance budgets, and Playwright; no runtime workout-context CTA, new event callsite, checkout, Stripe, entitlement, finance, vendor, export, raw drilldown, migration, RLS, route, product catalog mutation, or builder/generator UX scope was added | next: commit, push, open PR, monitor CI, then run child pre-merge gate`

--- a/lib/analytics/admin-dashboard.ts
+++ b/lib/analytics/admin-dashboard.ts
@@ -85,6 +85,14 @@ export type AnalyticsDashboardWorkoutBuilderTemplateUsage = {
   caveat: string;
 };
 
+export type AnalyticsDashboardExistingUpsellBaseline = {
+  metrics: AnalyticsDashboardMetric[];
+  sourceItems: AnalyticsDashboardListItem[];
+  emptyLabel: string;
+  detail: string;
+  caveat: string;
+};
+
 export type AnalyticsDashboardViewModel = {
   state: AnalyticsDashboardTrustState;
   stateLabel: string;
@@ -95,6 +103,7 @@ export type AnalyticsDashboardViewModel = {
   rowCapLabel: string;
   metrics: AnalyticsDashboardMetric[];
   funnel: AnalyticsDashboardFunnelStep[];
+  existingUpsellBaseline: AnalyticsDashboardExistingUpsellBaseline;
   workoutBuilderFunnel: AnalyticsDashboardWorkoutBuilderFunnel;
   workoutBuilderSourceBreakdown: AnalyticsDashboardWorkoutBuilderSourceBreakdown;
   workoutBuilderTemplateGeneratedCompletion: AnalyticsDashboardWorkoutBuilderTemplateGeneratedCompletion;
@@ -111,6 +120,9 @@ const WORKOUT_BUILDER_SAVED_EVENT = "workout_builder_saved" satisfies AnalyticsE
 const WORKOUT_BUILDER_TEMPLATE_SELECTED_EVENT =
   "workout_builder_template_selected" satisfies AnalyticsEventName;
 const SESSION_DRAFT_GENERATED_EVENT = "session_draft_generated" satisfies AnalyticsEventName;
+const UPSELL_PRESENTED_EVENT = "upsell_presented" satisfies AnalyticsEventName;
+const UPSELL_ACCEPTED_EVENT = "upsell_accepted" satisfies AnalyticsEventName;
+const UPSELL_DECLINED_EVENT = "upsell_declined" satisfies AnalyticsEventName;
 
 const EVENT_LABELS: Record<string, string> = {
   checkout_completed: "Checkout completed",
@@ -121,6 +133,9 @@ const EVENT_LABELS: Record<string, string> = {
   public_cta_clicked: "Public CTA clicked",
   public_page_viewed: "Public page viewed",
   session_draft_generated: "Session draft generated",
+  upsell_accepted: "Upsell accepted",
+  upsell_declined: "Upsell declined",
+  upsell_presented: "Upsell presented",
   workout_builder_saved: "Workout builder saved",
   workout_builder_started: "Workout builder started",
   workout_builder_template_selected: "Workout builder template selected",
@@ -318,6 +333,12 @@ function buildFunnel(payload: AnalyticsInsightsResponse): AnalyticsDashboardFunn
   }));
 }
 
+function formatExistingUpsellSourceLabel(key: string | null | undefined): string {
+  if (key === "plans") return "Plans";
+  if (key === "library_explore") return "My Library explore";
+  return "Unknown source";
+}
+
 function findEventCount(
   items: AnalyticsInsightsResponse["eventCounts"],
   eventName: AnalyticsEventName
@@ -328,6 +349,116 @@ function findEventCount(
 function rate(numerator: number, denominator: number): number | null {
   if (denominator <= 0) return null;
   return Math.round((numerator / denominator) * 1000) / 1000;
+}
+
+function buildExistingUpsellBaseline(
+  payload: AnalyticsInsightsResponse
+): AnalyticsDashboardExistingUpsellBaseline {
+  const baseline = payload.existingUpsellBaseline;
+  const presented =
+    baseline?.presented ?? findEventCount(payload.eventCounts, UPSELL_PRESENTED_EVENT);
+  const accepted = baseline?.accepted ?? findEventCount(payload.eventCounts, UPSELL_ACCEPTED_EVENT);
+  const declined = baseline?.declined ?? findEventCount(payload.eventCounts, UPSELL_DECLINED_EVENT);
+  const acceptedRate = baseline?.acceptedRate ?? rate(accepted, presented);
+  const declineRate = baseline?.declineRate ?? rate(declined, presented);
+  const unknownSourceEvents = baseline?.unknownSourceEvents ?? 0;
+  const sourceItems =
+    baseline?.sourceCounts?.slice(0, 5).map((item): AnalyticsDashboardListItem => {
+      const key = item.key === "plans" || item.key === "library_explore" ? item.key : "unknown";
+      return {
+        key,
+        label: formatExistingUpsellSourceLabel(key),
+        secondary: `${formatAnalyticsCount(item.presented)} presented / ${formatAnalyticsCount(
+          item.accepted
+        )} accepted / ${formatAnalyticsCount(item.declined)} cancelled`,
+        count: formatAnalyticsCount(item.total),
+      };
+    }) ?? [];
+
+  return {
+    metrics: [
+      {
+        id: "upsell-presented",
+        label: "Presented",
+        value: formatAnalyticsCount(presented),
+        detail: "Current commercial surfaces",
+      },
+      {
+        id: "upsell-accepted",
+        label: "Accepted",
+        value: formatAnalyticsCount(accepted),
+        detail: "Clicked commercial action",
+      },
+      {
+        id: "upsell-accepted-rate",
+        label: "Accepted rate",
+        value: formatAnalyticsPercent(acceptedRate),
+        detail: "Accepted / presented",
+      },
+      {
+        id: "upsell-declined",
+        label: "Cancelled returns",
+        value: formatAnalyticsCount(declined),
+        detail: "Checkout cancelled return",
+      },
+      {
+        id: "upsell-decline-rate",
+        label: "Cancel rate",
+        value: formatAnalyticsPercent(declineRate),
+        detail: "Cancelled / presented",
+      },
+    ],
+    sourceItems,
+    emptyLabel: "No existing upsell events in this range.",
+    detail: "Read-only baseline for current /plans and My Library commercial surfaces.",
+    caveat:
+      presented === 0
+        ? "Accepted and cancelled rates are not counted until an upsell presentation exists in this range."
+        : unknownSourceEvents > 0
+          ? "Unknown source events are kept separate until their surface/product mapping is explicitly approved."
+          : "Duplicate client events can exist; accepted is not checkout completion and cancelled returns are not all declined users.",
+  };
+}
+
+function buildSchemaMissingExistingUpsellBaseline(): AnalyticsDashboardExistingUpsellBaseline {
+  return {
+    metrics: [
+      {
+        id: "upsell-presented",
+        label: "Presented",
+        value: "Not counted",
+        detail: "Schema missing",
+      },
+      {
+        id: "upsell-accepted",
+        label: "Accepted",
+        value: "Not counted",
+        detail: "Clicked commercial action",
+      },
+      {
+        id: "upsell-accepted-rate",
+        label: "Accepted rate",
+        value: "Not counted",
+        detail: "Accepted / presented",
+      },
+      {
+        id: "upsell-declined",
+        label: "Cancelled returns",
+        value: "Not counted",
+        detail: "Checkout cancelled return",
+      },
+      {
+        id: "upsell-decline-rate",
+        label: "Cancel rate",
+        value: "Not counted",
+        detail: "Cancelled / presented",
+      },
+    ],
+    sourceItems: [],
+    emptyLabel: "Existing upsell baseline is hidden until analytics schema is ready.",
+    detail: "Existing upsell baseline is hidden until analytics schema is ready.",
+    caveat: "Apply the analytics_events migration before reading existing upsell counts.",
+  };
 }
 
 function buildWorkoutBuilderFunnel(
@@ -731,6 +862,7 @@ export function buildAnalyticsDashboardViewModel(
         },
       ],
       funnel: [],
+      existingUpsellBaseline: buildSchemaMissingExistingUpsellBaseline(),
       workoutBuilderFunnel: buildSchemaMissingWorkoutBuilderFunnel(),
       workoutBuilderSourceBreakdown: buildSchemaMissingWorkoutBuilderSourceBreakdown(),
       workoutBuilderTemplateGeneratedCompletion:
@@ -823,6 +955,7 @@ export function buildAnalyticsDashboardViewModel(
       },
     ],
     funnel: buildFunnel(payload),
+    existingUpsellBaseline: buildExistingUpsellBaseline(payload),
     workoutBuilderFunnel: buildWorkoutBuilderFunnel(payload),
     workoutBuilderSourceBreakdown: buildWorkoutBuilderSourceBreakdown(payload),
     workoutBuilderTemplateGeneratedCompletion:
@@ -836,6 +969,7 @@ export function buildAnalyticsDashboardViewModel(
         ? `This range hit the ${formatAnalyticsCount(payload.rowCap)} row cap. Treat totals as bounded.`
         : `This range is below the ${formatAnalyticsCount(payload.rowCap)} row cap.`,
       "Revenue proxy counts are product signals only; they are not Stripe reconciliation, finance reporting, or revenue recognition.",
+      "Existing upsell baseline counts current commercial surface visibility and clicked intent only; accepted is not checkout completion, cancelled returns are not all declined users, and neither value is entitlement or finance truth.",
       "Workout builder save-rate is product telemetry only; it is not unique-user conversion, checkout performance, or finance truth.",
       "Workout builder source breakdown is product telemetry only; it is not export success, revenue attribution, Stripe reconciliation, or finance truth.",
       "Template usage is product telemetry only and counts explicit template-selection events; do not infer it from session type, generator block toggles, draft creation, source kind, visible labels, or adjacent activity.",

--- a/lib/analytics/admin-insights.ts
+++ b/lib/analytics/admin-insights.ts
@@ -40,6 +40,16 @@ export type WorkoutBuilderTemplateUsageCount = {
   count: number;
 };
 
+export type ExistingUpsellSourceCount = {
+  key: string;
+  presented: number;
+  accepted: number;
+  declined: number;
+  total: number;
+  acceptedRate: number | null;
+  declineRate: number | null;
+};
+
 export type AnalyticsInsightsResponse = {
   ok: true;
   schemaReady: true;
@@ -68,6 +78,15 @@ export type AnalyticsInsightsResponse = {
     entitlementGranted: number;
     checkoutCompletionRate: number | null;
     entitlementGrantRate: number | null;
+  };
+  existingUpsellBaseline: {
+    presented: number;
+    accepted: number;
+    declined: number;
+    acceptedRate: number | null;
+    declineRate: number | null;
+    unknownSourceEvents: number;
+    sourceCounts: ExistingUpsellSourceCount[];
   };
   workoutBuilderFunnel: {
     started: number;
@@ -107,8 +126,12 @@ const WORKOUT_BUILDER_SAVED_EVENT = "workout_builder_saved" satisfies AnalyticsE
 const WORKOUT_BUILDER_TEMPLATE_SELECTED_EVENT =
   "workout_builder_template_selected" satisfies AnalyticsEventName;
 const SESSION_DRAFT_GENERATED_EVENT = "session_draft_generated" satisfies AnalyticsEventName;
+const UPSELL_PRESENTED_EVENT = "upsell_presented" satisfies AnalyticsEventName;
+const UPSELL_ACCEPTED_EVENT = "upsell_accepted" satisfies AnalyticsEventName;
+const UPSELL_DECLINED_EVENT = "upsell_declined" satisfies AnalyticsEventName;
 const MANUAL_WORKOUT_SOURCE_KIND = "manual" satisfies WorkoutSourceKind;
 const AI_SESSION_WORKOUT_SOURCE_KIND = "ai_session_v1" satisfies WorkoutSourceKind;
+const EXISTING_UPSELL_SOURCE_VALUES = new Set(["plans", "library_explore"]);
 
 export function selectAnalyticsInsightFields() {
   return `
@@ -164,6 +187,56 @@ function getSafeTemplateSelectionKey(payload: AnalyticsEventInsightRow["payload"
   const parsedKey = parseWorkoutTemplateKey(candidate.templateKey);
   if (!parsedKey || parsedKey !== candidate.templateKey) return null;
   return parsedKey;
+}
+
+function getSafePayloadDimension(
+  payload: AnalyticsEventInsightRow["payload"],
+  key: "source" | "surface"
+): string | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+  const value = (payload as Record<string, unknown>)[key];
+  if (typeof value !== "string") return null;
+  if (!/^[a-z][a-z0-9_:-]{0,80}$/.test(value)) return null;
+  return value;
+}
+
+function normalizeExistingUpsellSource(row: AnalyticsEventInsightRow): string {
+  const candidates = [
+    row.source,
+    getSafePayloadDimension(row.payload, "source"),
+    getSafePayloadDimension(row.payload, "surface"),
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    if (candidate === "my_library") return "library_explore";
+    if (EXISTING_UPSELL_SOURCE_VALUES.has(candidate)) return candidate;
+  }
+
+  return "unknown";
+}
+
+function buildEmptyUpsellSourceCount(key: string): ExistingUpsellSourceCount {
+  return {
+    key,
+    presented: 0,
+    accepted: 0,
+    declined: 0,
+    total: 0,
+    acceptedRate: null,
+    declineRate: null,
+  };
+}
+
+function getUpsellSourceCount(
+  map: Map<string, ExistingUpsellSourceCount>,
+  key: string
+): ExistingUpsellSourceCount {
+  const existing = map.get(key);
+  if (existing) return existing;
+  const next = buildEmptyUpsellSourceCount(key);
+  map.set(key, next);
+  return next;
 }
 
 export function buildAnalyticsInsights(input: {
@@ -222,9 +295,25 @@ export function buildAnalyticsInsights(input: {
   let unknownSaves = 0;
   let knownTemplateSelections = 0;
   let unknownTemplateSelections = 0;
+  let unknownUpsellSourceEvents = 0;
   const templateSelectionCounts = new Map<string, number>();
+  const upsellSourceCounts = new Map<string, ExistingUpsellSourceCount>();
 
   for (const row of input.rows) {
+    if (
+      row.event_name === UPSELL_PRESENTED_EVENT ||
+      row.event_name === UPSELL_ACCEPTED_EVENT ||
+      row.event_name === UPSELL_DECLINED_EVENT
+    ) {
+      const source = normalizeExistingUpsellSource(row);
+      const sourceCount = getUpsellSourceCount(upsellSourceCounts, source);
+      sourceCount.total += 1;
+      if (source === "unknown") unknownUpsellSourceEvents += 1;
+      if (row.event_name === UPSELL_PRESENTED_EVENT) sourceCount.presented += 1;
+      if (row.event_name === UPSELL_ACCEPTED_EVENT) sourceCount.accepted += 1;
+      if (row.event_name === UPSELL_DECLINED_EVENT) sourceCount.declined += 1;
+    }
+
     if (row.event_name === WORKOUT_BUILDER_SAVED_EVENT) {
       const sourceKind = getSafePayloadSourceKind(row.payload);
       if (sourceKind === MANUAL_WORKOUT_SOURCE_KIND) {
@@ -259,6 +348,16 @@ export function buildAnalyticsInsights(input: {
     };
   });
   const templateSelections = eventCounts.get(WORKOUT_BUILDER_TEMPLATE_SELECTED_EVENT) ?? 0;
+  const upsellPresented = eventCounts.get(UPSELL_PRESENTED_EVENT) ?? 0;
+  const upsellAccepted = eventCounts.get(UPSELL_ACCEPTED_EVENT) ?? 0;
+  const upsellDeclined = eventCounts.get(UPSELL_DECLINED_EVENT) ?? 0;
+  const upsellSourceCountItems = [...upsellSourceCounts.values()]
+    .map((item) => ({
+      ...item,
+      acceptedRate: ratio(item.accepted, item.presented),
+      declineRate: ratio(item.declined, item.presented),
+    }))
+    .sort((a, b) => b.total - a.total || a.key.localeCompare(b.key));
 
   return {
     ok: true,
@@ -299,6 +398,15 @@ export function buildAnalyticsInsights(input: {
       entitlementGranted: eventCounts.get("entitlement_granted") ?? 0,
       checkoutCompletionRate: ratio(checkoutCompleted, checkoutStarted),
       entitlementGrantRate: ratio(eventCounts.get("entitlement_granted") ?? 0, checkoutCompleted),
+    },
+    existingUpsellBaseline: {
+      presented: upsellPresented,
+      accepted: upsellAccepted,
+      declined: upsellDeclined,
+      acceptedRate: ratio(upsellAccepted, upsellPresented),
+      declineRate: ratio(upsellDeclined, upsellPresented),
+      unknownSourceEvents: unknownUpsellSourceEvents,
+      sourceCounts: upsellSourceCountItems,
     },
     workoutBuilderFunnel: {
       started: workoutBuilderStarted,

--- a/tests/unit/admin-analytics-dashboard-view-model.test.ts
+++ b/tests/unit/admin-analytics-dashboard-view-model.test.ts
@@ -60,6 +60,25 @@ const basePayload: AnalyticsDashboardPayload = {
     checkoutCompletionRate: 1,
     entitlementGrantRate: 1,
   },
+  existingUpsellBaseline: {
+    presented: 1,
+    accepted: 1,
+    declined: 1,
+    acceptedRate: 1,
+    declineRate: 1,
+    unknownSourceEvents: 0,
+    sourceCounts: [
+      {
+        key: "plans",
+        presented: 1,
+        accepted: 1,
+        declined: 1,
+        total: 3,
+        acceptedRate: 1,
+        declineRate: 1,
+      },
+    ],
+  },
   workoutBuilderFunnel: {
     started: 5,
     saved: 3,
@@ -135,6 +154,47 @@ describe("admin analytics dashboard view model", () => {
       "checkout-completed",
       "entitlement-granted",
     ]);
+    expect(viewModel.existingUpsellBaseline.metrics).toEqual([
+      {
+        id: "upsell-presented",
+        label: "Presented",
+        value: "1",
+        detail: "Current commercial surfaces",
+      },
+      {
+        id: "upsell-accepted",
+        label: "Accepted",
+        value: "1",
+        detail: "Clicked commercial action",
+      },
+      {
+        id: "upsell-accepted-rate",
+        label: "Accepted rate",
+        value: "100%",
+        detail: "Accepted / presented",
+      },
+      {
+        id: "upsell-declined",
+        label: "Cancelled returns",
+        value: "1",
+        detail: "Checkout cancelled return",
+      },
+      {
+        id: "upsell-decline-rate",
+        label: "Cancel rate",
+        value: "100%",
+        detail: "Cancelled / presented",
+      },
+    ]);
+    expect(viewModel.existingUpsellBaseline.sourceItems).toEqual([
+      {
+        key: "plans",
+        label: "Plans",
+        secondary: "1 presented / 1 accepted / 1 cancelled",
+        count: "3",
+      },
+    ]);
+    expect(viewModel.existingUpsellBaseline.caveat).toContain("not checkout completion");
     expect(viewModel.workoutBuilderFunnel.metrics).toEqual([
       {
         id: "builder-started",
@@ -291,6 +351,7 @@ describe("admin analytics dashboard view model", () => {
       count: "2",
     });
     expect(viewModel.caveats.join(" ")).toContain("not Stripe reconciliation");
+    expect(viewModel.caveats.join(" ")).toContain("accepted is not checkout completion");
     expect(viewModel.caveats.join(" ")).toContain("not linked to user profiles");
   });
 
@@ -313,6 +374,15 @@ describe("admin analytics dashboard view model", () => {
           eventCounts: [],
           routeCounts: [],
           productCounts: [],
+          existingUpsellBaseline: {
+            presented: 0,
+            accepted: 0,
+            declined: 0,
+            acceptedRate: null,
+            declineRate: null,
+            unknownSourceEvents: 0,
+            sourceCounts: [],
+          },
           workoutBuilderFunnel: {
             started: 0,
             saved: 0,
@@ -368,6 +438,15 @@ describe("admin analytics dashboard view model", () => {
           { id: "builder-save-rate", value: "Not counted" },
         ],
       },
+      existingUpsellBaseline: {
+        metrics: [
+          { id: "upsell-presented", value: "Not counted" },
+          { id: "upsell-accepted", value: "Not counted" },
+          { id: "upsell-accepted-rate", value: "Not counted" },
+          { id: "upsell-declined", value: "Not counted" },
+          { id: "upsell-decline-rate", value: "Not counted" },
+        ],
+      },
       workoutBuilderSourceBreakdown: {
         metrics: [
           { id: "source-manual-starts", value: "Not counted" },
@@ -409,6 +488,25 @@ describe("admin analytics dashboard view model", () => {
           started: 0,
           saved: 2,
           saveRate: null,
+        },
+        existingUpsellBaseline: {
+          presented: 0,
+          accepted: 2,
+          declined: 1,
+          acceptedRate: null,
+          declineRate: null,
+          unknownSourceEvents: 0,
+          sourceCounts: [
+            {
+              key: "plans",
+              presented: 0,
+              accepted: 2,
+              declined: 1,
+              total: 3,
+              acceptedRate: null,
+              declineRate: null,
+            },
+          ],
         },
         workoutBuilderSourceBreakdown: {
           manualStarts: 0,
@@ -458,6 +556,15 @@ describe("admin analytics dashboard view model", () => {
       },
     ]);
     expect(zeroStarts.workoutBuilderFunnel.caveat).toContain("until a builder start exists");
+    expect(zeroStarts.existingUpsellBaseline.metrics).toContainEqual({
+      id: "upsell-accepted-rate",
+      label: "Accepted rate",
+      value: "Not counted",
+      detail: "Accepted / presented",
+    });
+    expect(zeroStarts.existingUpsellBaseline.caveat).toContain(
+      "until an upsell presentation exists"
+    );
     expect(zeroStarts.workoutBuilderSourceBreakdown.metrics).toContainEqual({
       id: "source-manual-save-rate",
       label: "Manual save rate",
@@ -487,6 +594,25 @@ describe("admin analytics dashboard view model", () => {
           started: 2,
           saved: 3,
           saveRate: 1.5,
+        },
+        existingUpsellBaseline: {
+          presented: 2,
+          accepted: 3,
+          declined: 0,
+          acceptedRate: 1.5,
+          declineRate: 0,
+          unknownSourceEvents: 1,
+          sourceCounts: [
+            {
+              key: "future_source",
+              presented: 1,
+              accepted: 0,
+              declined: 0,
+              total: 1,
+              acceptedRate: 0,
+              declineRate: 0,
+            },
+          ],
         },
         workoutBuilderSourceBreakdown: {
           manualStarts: 2,
@@ -526,6 +652,17 @@ describe("admin analytics dashboard view model", () => {
       label: "Save rate",
       value: "150%",
     });
+    expect(duplicateTelemetry.existingUpsellBaseline.metrics).toContainEqual({
+      id: "upsell-accepted-rate",
+      label: "Accepted rate",
+      value: "150%",
+      detail: "Accepted / presented",
+    });
+    expect(duplicateTelemetry.existingUpsellBaseline.sourceItems[0]).toMatchObject({
+      key: "unknown",
+      label: "Unknown source",
+    });
+    expect(duplicateTelemetry.existingUpsellBaseline.caveat).toContain("Unknown source events");
     expect(duplicateTelemetry.workoutBuilderFunnel.caveat).toContain("Duplicate starts and saves");
     expect(duplicateTelemetry.workoutBuilderSourceBreakdown.metrics).toContainEqual({
       id: "source-generated-save-rate",
@@ -644,6 +781,18 @@ describe("admin analytics dashboard view model", () => {
     ).toMatchObject({
       label: "Workout builder template selected",
       secondary: "workout_builder_template_selected",
+    });
+    expect(formatAnalyticsIdentifierLabel("upsell_presented", "event")).toMatchObject({
+      label: "Upsell presented",
+      secondary: "upsell_presented",
+    });
+    expect(formatAnalyticsIdentifierLabel("upsell_accepted", "event")).toMatchObject({
+      label: "Upsell accepted",
+      secondary: "upsell_accepted",
+    });
+    expect(formatAnalyticsIdentifierLabel("upsell_declined", "event")).toMatchObject({
+      label: "Upsell declined",
+      secondary: "upsell_declined",
     });
     expect(formatAnalyticsIdentifierLabel("session_draft_generated", "event")).toMatchObject({
       label: "Session draft generated",

--- a/tests/unit/admin-analytics-dashboard.test.tsx
+++ b/tests/unit/admin-analytics-dashboard.test.tsx
@@ -54,6 +54,25 @@ const basePayload: AnalyticsInsightsResponse = {
     checkoutCompletionRate: 1,
     entitlementGrantRate: 1,
   },
+  existingUpsellBaseline: {
+    presented: 1,
+    accepted: 1,
+    declined: 1,
+    acceptedRate: 1,
+    declineRate: 1,
+    unknownSourceEvents: 0,
+    sourceCounts: [
+      {
+        key: "plans",
+        presented: 1,
+        accepted: 1,
+        declined: 1,
+        total: 3,
+        acceptedRate: 1,
+        declineRate: 1,
+      },
+    ],
+  },
   workoutBuilderFunnel: {
     started: 5,
     saved: 3,
@@ -135,6 +154,7 @@ describe("AdminAnalyticsDashboard", () => {
     await screen.findByTestId("admin-analytics-health");
     expect(screen.getByTestId("admin-analytics-kpis")).toBeVisible();
     expect(screen.getByTestId("admin-analytics-funnel")).toBeVisible();
+    expect(screen.getByTestId("admin-analytics-existing-upsell-baseline")).toBeVisible();
     expect(screen.getByTestId("admin-analytics-workout-builder-funnel")).toBeVisible();
     expect(screen.getByTestId("admin-analytics-workout-builder-source-breakdown")).toBeVisible();
     expect(
@@ -148,6 +168,18 @@ describe("AdminAnalyticsDashboard", () => {
     expect(
       within(screen.getByTestId("admin-analytics-funnel")).getByText("Checkout completed")
     ).toBeVisible();
+    const existingUpsell = screen.getByTestId("admin-analytics-existing-upsell-baseline");
+    expect(within(existingUpsell).getByText("Existing upsell baseline")).toBeVisible();
+    expect(within(existingUpsell).getByText("Presented")).toBeVisible();
+    expect(within(existingUpsell).getByText("Accepted")).toBeVisible();
+    expect(within(existingUpsell).getByText("Accepted rate")).toBeVisible();
+    expect(within(existingUpsell).getByText("Cancelled returns")).toBeVisible();
+    expect(within(existingUpsell).getByText("Cancel rate")).toBeVisible();
+    expect(within(existingUpsell).getByText("Plans")).toBeVisible();
+    expect(
+      within(existingUpsell).getByText("1 presented / 1 accepted / 1 cancelled")
+    ).toBeVisible();
+    expect(within(existingUpsell).queryByRole("button")).not.toBeInTheDocument();
     const builderFunnel = screen.getByTestId("admin-analytics-workout-builder-funnel");
     expect(within(builderFunnel).getByText("Started to saved signal")).toBeVisible();
     expect(within(builderFunnel).getByText("Started")).toBeVisible();
@@ -264,6 +296,9 @@ describe("AdminAnalyticsDashboard", () => {
     expect(screen.getByTestId("admin-analytics-workout-builder-funnel")).toHaveTextContent(
       "Not counted"
     );
+    expect(screen.getByTestId("admin-analytics-existing-upsell-baseline")).toHaveTextContent(
+      "Not counted"
+    );
     expect(
       screen.getByTestId("admin-analytics-workout-builder-source-breakdown")
     ).toHaveTextContent("Not counted");
@@ -289,6 +324,25 @@ describe("AdminAnalyticsDashboard", () => {
             { key: "https://example.com/?email=user@example.com", category: null, count: 1 },
           ],
           productCounts: [{ key: "customer@example.com", productType: null, count: 1 }],
+          existingUpsellBaseline: {
+            presented: 0,
+            accepted: 1,
+            declined: 0,
+            acceptedRate: null,
+            declineRate: null,
+            unknownSourceEvents: 1,
+            sourceCounts: [
+              {
+                key: "customer@example.com",
+                presented: 0,
+                accepted: 1,
+                declined: 0,
+                total: 1,
+                acceptedRate: null,
+                declineRate: null,
+              },
+            ],
+          },
           workoutBuilderFunnel: {
             started: 0,
             saved: 2,
@@ -342,6 +396,9 @@ describe("AdminAnalyticsDashboard", () => {
     );
     expect(screen.getByText("Unknown route")).toBeVisible();
     expect(screen.getByText("Unknown product")).toBeVisible();
+    expect(screen.getByTestId("admin-analytics-existing-upsell-baseline")).toHaveTextContent(
+      "Unknown source"
+    );
     expect(document.body).not.toHaveTextContent("user@example.com");
   });
 

--- a/tests/unit/admin-analytics-insights.test.ts
+++ b/tests/unit/admin-analytics-insights.test.ts
@@ -329,6 +329,101 @@ describe("admin analytics insights", () => {
     });
   });
 
+  it("maps existing upsell events by safe current surface without exposing raw payload", () => {
+    const insights = buildAnalyticsInsights({
+      rows: [
+        {
+          ...baseRow,
+          event_name: "upsell_presented",
+          source: "plans",
+          payload: {
+            source: "plans",
+            email: "user@example.com",
+            rawUrl: "https://example.com/?email=user@example.com",
+          },
+        },
+        {
+          ...baseRow,
+          event_name: "upsell_accepted",
+          source: "plans",
+          payload: { source: "plans" },
+        },
+        {
+          ...baseRow,
+          event_name: "upsell_declined",
+          source: "plans",
+          payload: { source: "plans", reason: "checkout_cancelled" },
+        },
+        {
+          ...baseRow,
+          event_name: "upsell_presented",
+          source: null,
+          payload: { surface: "library_explore" },
+        },
+        {
+          ...baseRow,
+          event_name: "upsell_accepted",
+          source: "library_explore",
+          payload: { source: "library_explore" },
+        },
+        {
+          ...baseRow,
+          event_name: "upsell_declined",
+          source: null,
+          payload: { surface: "my_library", reason: "checkout_cancelled" },
+        },
+        {
+          ...baseRow,
+          event_name: "upsell_accepted",
+          source: "future_surface",
+          payload: { source: "future_surface" },
+        },
+      ],
+      generatedAt: new Date("2026-06-09T11:00:00.000Z"),
+      rangeDays: 30,
+    });
+
+    expect(insights.existingUpsellBaseline).toEqual({
+      presented: 2,
+      accepted: 3,
+      declined: 2,
+      acceptedRate: 1.5,
+      declineRate: 1,
+      unknownSourceEvents: 1,
+      sourceCounts: [
+        {
+          key: "library_explore",
+          presented: 1,
+          accepted: 1,
+          declined: 1,
+          total: 3,
+          acceptedRate: 1,
+          declineRate: 1,
+        },
+        {
+          key: "plans",
+          presented: 1,
+          accepted: 1,
+          declined: 1,
+          total: 3,
+          acceptedRate: 1,
+          declineRate: 1,
+        },
+        {
+          key: "unknown",
+          presented: 0,
+          accepted: 1,
+          declined: 0,
+          total: 1,
+          acceptedRate: null,
+          declineRate: null,
+        },
+      ],
+    });
+    expect(JSON.stringify(insights.existingUpsellBaseline)).not.toContain("user@example.com");
+    expect(JSON.stringify(insights.existingUpsellBaseline)).not.toContain("future_surface");
+  });
+
   it("keeps malformed and missing workout save source kinds unmapped", () => {
     const insights = buildAnalyticsInsights({
       rows: [


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-06-11T07:07:25.180Z for branch `existing-upsell-event-admin-analytics-baseline-v1` (base ref `origin/main`).
- Latest commit: `d8048ae8` - feat: add existing upsell admin analytics baseline.
- Plain-language done summary: This PR delivers the brief goal for the touched product area: Add a read-only Admin Analytics baseline for existing upsell_* events so the owner can see today's commercial CTA visibility and intent signals without adding workout-context CTA behavior or treating product telemetry as checkout, entitlement, or finance truth.
- Recommended next step: Monitor required GitHub checks, then run `npm run verify:pre-merge` on the current HEAD before merge.
- User-visible changes: Admin-facing behavior/guardrails may change in touched admin routes or APIs.
- Technical changes: Updated 10 file(s): `components/admin/AdminAnalyticsDashboard.tsx`, `components/admin/AdminHelpCenter.tsx`, `docs/api-contracts.md`, `docs/task-briefs/in-progress/2026-06-11-existing-upsell-event-admin-analytics-baseline-v1-10-10.md`, `docs/task-briefs/planned/2026-02-28-workout-commercial-analytics-funnel-10-10.md`, `... and 5 more file(s)`.
- Policy impact: yes (inferred from changed scope: `lib/analytics/admin-dashboard.ts`, `lib/analytics/admin-insights.ts`).
- Policy version note: N/A (if policy text/version changes, replace with YYYY-MM-DD.rev and rationale).
- Brief link(s): `docs/task-briefs/in-progress/2026-06-11-existing-upsell-event-admin-analytics-baseline-v1-10-10.md`
- Scorecard target outcomes: 19 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (3); tests (3); runtime UI/routes/components (4).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (10):
  - `components/admin/AdminAnalyticsDashboard.tsx`
  - `components/admin/AdminHelpCenter.tsx`
  - `docs/api-contracts.md`
  - `docs/task-briefs/in-progress/2026-06-11-existing-upsell-event-admin-analytics-baseline-v1-10-10.md`
  - `docs/task-briefs/planned/2026-02-28-workout-commercial-analytics-funnel-10-10.md`
  - `lib/analytics/admin-dashboard.ts`
  - `lib/analytics/admin-insights.ts`
  - `tests/unit/admin-analytics-dashboard-view-model.test.ts`
  - `... and 2 more file(s)`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `d8048ae8` (`git revert d8048ae8`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **PASS** (artifacts/test-runs/20260611-085859, lane: full-public)
- `npm run verify:pre-merge`: **PENDING** for `d8048ae8` (last green marker: `ead7dce2` at 2026-06-11T05:11:52Z; rerun on current HEAD).
- Policy-impact checklist: PENDING (run docs/checklists/policy-impact-release-review.md and update to PASS/FAIL).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  -   -  638 [desktop-firefox] › tests/e2e/public-ia.spec.ts:10:7 › public route IA › keeps legacy about as a temporary alias for the canonical method page
  -   -  639 [desktop-firefox] › tests/e2e/public-ia.spec.ts:49:7 › public route IA › keeps programs cards token-backed with clear CTA destinations
  -   -  640 [desktop-firefox] › tests/e2e/public-ia.spec.ts:99:7 › public route IA › keeps contact and analysis request guidance clear
  -   ✓  641 [desktop-firefox] › tests/e2e/sitemap.spec.ts:32:5 › sitemap contains canonical public routes (6ms)
  -   ✓  642 [desktop-firefox] › tests/e2e/soft-launch-banner.spec.ts:9:5 › public pages do not render legacy under-construction banner (856ms)
  -   106 passed (5.6m)
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] Changed `done` task briefs include achieved score + evidence for every target category and explicit `10/10 claim: yes/no`
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
