### PR TITLE
feat: add workout context cta runtime

### DIFF
--- a/app/my-library/workouts/[workoutId]/page.tsx
+++ b/app/my-library/workouts/[workoutId]/page.tsx
@@ -4,6 +4,7 @@ import SiteChrome from "@/components/SiteChrome";
 import WorkoutBuilderHub from "@/components/my-library/workouts/WorkoutBuilderHub";
 import { getMobileActionGroupClass, mobileActionItemClass } from "@/components/ui/actionLayout";
 import { loadAthleteProfileSnapshot } from "@/lib/athlete-profile/server";
+import { loadWorkoutContextCtaProductAvailable } from "@/lib/commerce/workout-context-cta-server";
 import { getServerSupabaseUserIfAuthCookiePresent } from "@/lib/supabase/server";
 import { loadTrainingContextSnapshot } from "@/lib/training-context/server";
 import type { WorkoutPoolsideFocusOption } from "@/lib/workouts/shared";
@@ -55,10 +56,16 @@ export default async function WorkoutBuilderPage({ params, searchParams }: Props
     redirect(`/auth/sign-in?next=${encodeURIComponent(`/my-library/workouts/${workoutId}`)}`);
   }
 
-  const [workoutLibrary, trainingContextSnapshot, athleteProfileSnapshot] = await Promise.all([
+  const [
+    workoutLibrary,
+    trainingContextSnapshot,
+    athleteProfileSnapshot,
+    workoutContextCtaProductAvailable,
+  ] = await Promise.all([
     loadWorkoutLibrarySnapshot(supabase, user.id, workoutId),
     loadTrainingContextSnapshot(supabase, user.id),
     loadAthleteProfileSnapshot(supabase, user.id),
+    loadWorkoutContextCtaProductAvailable(),
   ]);
   const trainingFocusOptions: WorkoutPoolsideFocusOption[] =
     trainingContextSnapshot.schemaReady && !trainingContextSnapshot.loadError
@@ -125,6 +132,7 @@ export default async function WorkoutBuilderPage({ params, searchParams }: Props
               userId={user.id}
               hideShellIntro
               preferExpandedDetailsOnLoad={preferExpandedDetailsOnLoad}
+              workoutContextCtaProductAvailable={workoutContextCtaProductAvailable}
             />
           </div>
         </div>

--- a/app/my-library/workouts/page.tsx
+++ b/app/my-library/workouts/page.tsx
@@ -4,6 +4,7 @@ import SiteChrome from "@/components/SiteChrome";
 import WorkoutBuilderHub from "@/components/my-library/workouts/WorkoutBuilderHub";
 import { getMobileActionGroupClass, mobileActionItemClass } from "@/components/ui/actionLayout";
 import { loadAthleteProfileSnapshot } from "@/lib/athlete-profile/server";
+import { loadWorkoutContextCtaProductAvailable } from "@/lib/commerce/workout-context-cta-server";
 import { getServerSupabaseUserIfAuthCookiePresent } from "@/lib/supabase/server";
 import { loadTrainingContextSnapshot } from "@/lib/training-context/server";
 import type { ManualWorkoutBuilderMode } from "@/lib/workouts/manual";
@@ -54,10 +55,16 @@ export default async function WorkoutSessionsPage({ searchParams }: Props) {
     redirect("/auth/sign-in?next=%2Fmy-library%2Fworkouts");
   }
 
-  const [workoutLibrary, trainingContextSnapshot, athleteProfileSnapshot] = await Promise.all([
+  const [
+    workoutLibrary,
+    trainingContextSnapshot,
+    athleteProfileSnapshot,
+    workoutContextCtaProductAvailable,
+  ] = await Promise.all([
     loadWorkoutLibrarySnapshot(supabase, user.id, null),
     loadTrainingContextSnapshot(supabase, user.id),
     loadAthleteProfileSnapshot(supabase, user.id),
+    loadWorkoutContextCtaProductAvailable(),
   ]);
   const trainingFocusOptions: WorkoutPoolsideFocusOption[] =
     trainingContextSnapshot.schemaReady && !trainingContextSnapshot.loadError
@@ -129,6 +136,7 @@ export default async function WorkoutSessionsPage({ searchParams }: Props) {
               userId={user.id}
               manualLocalDraftMode={localDraftMode}
               templateLocalDraftKey={templateRequestKey}
+              workoutContextCtaProductAvailable={workoutContextCtaProductAvailable}
             />
           </div>
         </div>

--- a/components/admin/AdminHelpCenter.tsx
+++ b/components/admin/AdminHelpCenter.tsx
@@ -63,9 +63,9 @@ const DASHBOARD_TABS: TabGuide[] = [
   {
     name: "Analytics",
     primaryJob:
-      "Inspect privacy-safe event health, funnel counts, existing upsell baseline, workout-builder save-rate, generated completion, route/product activity, and dashboard caveats.",
+      "Inspect privacy-safe event health, funnel counts, existing upsell baseline, workout-context CTA caveats, workout-builder save-rate, generated completion, route/product activity, and dashboard caveats.",
     commonRisk:
-      "Treating bounded revenue-proxy, existing upsell, builder save-rate, or generated completion counts as finance reconciliation, checkout conversion, template usage, or user-level attribution.",
+      "Treating bounded revenue-proxy, existing upsell, workout-context CTA, builder save-rate, or generated completion counts as finance reconciliation, checkout conversion, template usage, or user-level attribution.",
   },
   {
     name: "Email templates",
@@ -280,7 +280,12 @@ const ANALYTICS_WORKFLOW = [
   {
     title: "Read existing upsell baseline as current-surface signal",
     detail:
-      "Presented counts upsell_presented on current commercial surfaces, Accepted counts clicked commercial actions, and Cancelled returns counts the existing checkout-cancel return signal. Accepted is not checkout completion, cancelled returns are not all declined users, and neither value is entitlement, Stripe reconciliation, revenue, or finance truth.",
+      "Presented counts upsell_presented on current /plans and My Library commercial surfaces, Accepted counts clicked commercial actions there, and Cancelled returns counts the existing checkout-cancel return signal. Workout-context sources are kept separate until explicitly mapped. Accepted is not checkout completion, cancelled returns are not all declined users, and neither value is entitlement, Stripe reconciliation, revenue, or finance truth.",
+  },
+  {
+    title: "Read workout-context CTA as visibility and clicked intent",
+    detail:
+      "Workout-context CTA V1 may show the Poolside guide option only after a successful saved-workout state. Its upsell_presented event means that CTA rendered for placement workout_saved_post_success, and upsell_accepted means the user clicked it. It is not checkout completion, entitlement, revenue, Stripe reconciliation, finance truth, or a unique-user conversion metric. A dedicated workout-context CTA dashboard remains a later mapping child.",
   },
   {
     title: "Read workout builder source breakdown as product telemetry",
@@ -539,7 +544,12 @@ const BUTTON_GUIDE: ActionGroup[] = [
       {
         label: "Existing upsell baseline",
         meaning:
-          "Shows current /plans and My Library upsell presentation, click, and checkout-cancel return events. Use it as a commercial surface baseline only, not checkout completion, entitlement, revenue, or finance evidence.",
+          "Shows current /plans and My Library upsell presentation, click, and checkout-cancel return events. Workout-context CTA sources are separate diagnostics until mapped. Use it as a commercial surface baseline only, not checkout completion, entitlement, revenue, or finance evidence.",
+      },
+      {
+        label: "Workout-context CTA",
+        meaning:
+          "A saved-workout post-success Poolside guide prompt. Presented means rendered, Accepted means clicked, and neither value means checkout completion, entitlement, revenue, Stripe reconciliation, or finance truth.",
       },
       {
         label: "Generated completion / Template usage",

--- a/components/my-library/workouts/WorkoutBuilderHub.tsx
+++ b/components/my-library/workouts/WorkoutBuilderHub.tsx
@@ -4,6 +4,8 @@ import type { ReactNode } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
+import TrackEventOnMount from "@/components/analytics/TrackEventOnMount";
+import TrackedLink from "@/components/analytics/TrackedLink";
 import { cx } from "@/components/ui/cx";
 import { getMobileActionGroupClass, mobileActionItemClass } from "@/components/ui/actionLayout";
 import CreateManualWorkoutButton from "@/components/my-library/workouts/CreateManualWorkoutButton";
@@ -14,7 +16,10 @@ import {
   WORKOUT_NOTICE_AUTO_DISMISS_MS,
 } from "@/components/my-library/workouts/useAutoDismissNotice";
 import { sendClientAnalyticsEvent } from "@/lib/analytics/client";
-import { buildWorkoutBuilderTemplateSelectedPayload } from "@/lib/analytics/workout-builder";
+import {
+  buildWorkoutBuilderTemplateSelectedPayload,
+  buildWorkoutContextCtaPayload,
+} from "@/lib/analytics/workout-builder";
 import type { ManualWorkoutBuilderMode, ManualWorkoutDraftDefaults } from "@/lib/workouts/manual";
 import {
   clearStoredManualWorkoutDraft,
@@ -49,6 +54,7 @@ type Props = {
   userId?: string | null;
   manualLocalDraftMode?: ManualWorkoutBuilderMode | null;
   templateLocalDraftKey?: string | null;
+  workoutContextCtaProductAvailable?: boolean;
 };
 
 type WorkoutBuilderFeedbackTone = "warning" | "error" | "success" | "empty";
@@ -206,6 +212,27 @@ function WorkoutBuilderFeedback({
   );
 }
 
+function WorkoutContextCta({
+  payload,
+}: {
+  payload: ReturnType<typeof buildWorkoutContextCtaPayload>;
+}) {
+  return (
+    <>
+      <TrackEventOnMount eventName="upsell_presented" payload={payload} />
+      <TrackedLink
+        href="/plans#plans-comparison-heading"
+        eventName="upsell_accepted"
+        payload={payload}
+        data-testid="workout-context-cta-link"
+        className={cx(secondaryActionClass, "bg-white/90 hover:bg-white")}
+      >
+        See Poolside guide
+      </TrackedLink>
+    </>
+  );
+}
+
 function upsertRecentWorkoutSummary(current: WorkoutSummary[], next: WorkoutSummary) {
   const existing = current.filter((summary) => summary.id !== next.id);
   return [next, ...existing].sort(
@@ -225,6 +252,7 @@ export default function WorkoutBuilderHub({
   userId = null,
   manualLocalDraftMode = null,
   templateLocalDraftKey = null,
+  workoutContextCtaProductAvailable = false,
 }: Props) {
   const router = useRouter();
   const requestedTemplate = useMemo(
@@ -267,6 +295,24 @@ export default function WorkoutBuilderHub({
     !savedWorkout && templateLocalDraftKey !== null && requestedTemplate === null;
   const hasUnsavedChanges =
     savedWorkout !== null ? haveWorkoutDraftChanges(draft, savedWorkout.draft) : false;
+  const workoutContextCtaPayload = useMemo(
+    () =>
+      savedWorkout && draft
+        ? buildWorkoutContextCtaPayload({
+            draft,
+            sourceKind: savedWorkout.sourceKind,
+          })
+        : null,
+    [draft, savedWorkout]
+  );
+  const workoutContextCtaAction =
+    success &&
+    savedWorkout &&
+    !hasUnsavedChanges &&
+    workoutContextCtaProductAvailable &&
+    workoutContextCtaPayload ? (
+      <WorkoutContextCta payload={workoutContextCtaPayload} />
+    ) : null;
   const manualPoolDraftDefaults = useMemo<ManualWorkoutDraftDefaults | undefined>(() => {
     if (
       typeof manualPoolCssMetricSecondsPer100m === "number" &&
@@ -746,7 +792,11 @@ export default function WorkoutBuilderHub({
       ) : null}
 
       {success ? (
-        <WorkoutBuilderFeedback tone="success" testId="workout-builder-action-success">
+        <WorkoutBuilderFeedback
+          tone="success"
+          action={workoutContextCtaAction}
+          testId="workout-builder-action-success"
+        >
           <p>{success}</p>
         </WorkoutBuilderFeedback>
       ) : null}

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -333,8 +333,9 @@
   from `upsell_presented`, `upsell_accepted`, and `upsell_declined`. `upsell_presented` is surface
   visibility, not checkout start. `upsell_accepted` is clicked intent, not checkout completion.
   `upsell_declined` is the current checkout-cancel return signal, not all users who ignored,
-  dismissed, or failed to convert. Unknown source/product values remain separate until explicitly
-  mapped.
+  dismissed, or failed to convert. The current-surface totals count only approved existing sources
+  such as `plans` and `library_explore`; unknown and workout-context sources remain separate until
+  explicitly mapped.
 - Workout builder caveat: `workoutBuilderFunnel` is product telemetry derived from
   `workout_builder_started` and `workout_builder_saved`. Save rate is saved/start count for the
   selected range, not unique-user conversion, checkout performance, Stripe reconciliation, export,
@@ -357,13 +358,12 @@
   `templateSource` payload values. Known template labels come from the workout-template registry,
   not raw analytics payload labels. Missing, malformed, deprecated, unknown, or unmapped keys and
   sources remain separate from known templates until explicitly mapped.
-- Workout-context upsell caveat: existing workout-builder, generator, source, generated-completion,
-  and template-usage metrics may inform placement policy only as aggregate product evidence. They
-  are not CTA presentation, CTA acceptance, checkout conversion, entitlement truth, Stripe
-  reconciliation, revenue attribution, or finance reporting. A workout-context CTA event/dashboard
-  requires a later runtime child after
-  `docs/architecture/workout-context-upsell-placement-policy.md` and
-  `docs/architecture/workout-context-cta-measurement-contract.md`.
+- Workout-context upsell caveat: V1 runtime may emit `upsell_presented` only when the
+  `workout_saved_post_success` CTA renders for mapped product `guide_poolside`, and
+  `upsell_accepted` only when that CTA is activated. Those events mean CTA visibility/clicked
+  intent only. They are not checkout conversion, entitlement truth, Stripe reconciliation, revenue
+  attribution, or finance reporting. A dedicated workout-context CTA dashboard remains a later child
+  after runtime event evidence exists.
 - Privacy boundary: public aggregate events are not linked to user profiles and the dashboard must
   not display raw payload JSON, raw URLs, emails, IPs, user agents, visitor IDs, notes, cart details,
   shipping, or payment data.

--- a/docs/architecture/workout-context-cta-measurement-contract.md
+++ b/docs/architecture/workout-context-cta-measurement-contract.md
@@ -4,7 +4,7 @@ Last updated: 2026-06-11
 
 ## Purpose
 
-This contract defines how FreeSwimming may measure the first future workout-context commercial CTA.
+This contract defines how FreeSwimming may measure the first workout-context commercial CTA.
 It is intentionally a measurement contract only. No workout-context CTA is implemented by this
 document.
 
@@ -12,12 +12,13 @@ The current product decision is conservative:
 
 - First eligible placement candidate: saved-workout post-success state.
 - Stable placement ID for that candidate: `workout_saved_post_success`.
+- Runtime V1 mapped product: `guide_poolside`.
 - Product identity source: `CatalogProductId` from `lib/commerce/catalog.ts`.
-- Event family: existing `upsell_presented`, `upsell_accepted`, and `upsell_declined` may be used
-  only after a later runtime child implements mapped workout-context callsites with the semantics
-  below.
+- Event family: runtime V1 may use `upsell_presented` and `upsell_accepted` for the mapped
+  workout-context callsites with the semantics below. `upsell_declined` remains unmapped for
+  workout context.
 - Dashboard truth: no dedicated workout-context CTA Admin Analytics module may be added until
-  runtime events exist.
+  runtime event evidence exists and a later dashboard child maps aggregation/copy/tests.
 
 ## Placement Decision
 
@@ -70,8 +71,8 @@ Product identity must come from the catalog product ID. It must not come from:
 - entitlement row,
 - analytics payload copy.
 
-The first runtime child must choose the exact product ID or IDs it wants to offer from the current
-catalog. This contract does not select the product for release.
+Runtime V1 selects `guide_poolside` for release. Future products require explicit mapping before
+presentation.
 
 Fail-closed behavior:
 
@@ -247,10 +248,10 @@ Repurpose requiring a new child:
 
 Support may say:
 
-- no workout-context CTA exists until a runtime child implements one,
-- `workout_saved_post_success` is the first approved measurement candidate only,
-- a future presented event means the CTA rendered in that mapped placement,
-- a future accepted event means clicked intent only,
+- workout-context CTA V1 may appear only after a successful saved-workout post-success state,
+- `workout_saved_post_success` is the first approved runtime placement,
+- a presented event means the CTA rendered in that mapped placement,
+- an accepted event means clicked intent only,
 - product telemetry is not checkout, entitlement, Stripe, revenue, or finance evidence.
 
 Support must not say:
@@ -261,7 +262,8 @@ Support must not say:
 - checkout completion means entitlement or finance reconciliation is complete,
 - analytics counts prove individual behavior.
 
-Future visible CTA/dashboard work must update Help/Guide and relevant runbooks in the same PR.
+Future dashboard, decline, checkout, entitlement, finance, or additional CTA-placement work must
+update Help/Guide and relevant runbooks in the same PR.
 
 ## Forward Compatibility
 

--- a/docs/architecture/workout-context-upsell-placement-policy.md
+++ b/docs/architecture/workout-context-upsell-placement-policy.md
@@ -4,26 +4,27 @@ Last updated: 2026-06-10
 
 ## Purpose
 
-This contract defines when a future commercial CTA may be considered in workout-builder or
-generator context.
+This contract defines when a commercial CTA may be considered in workout-builder or generator
+context.
 
-Current decision: no workout-context upsell CTA is implemented or approved by this policy. Existing
-commercial surfaces remain `/plans` and My Library explore. Existing `upsell_presented`,
-`upsell_accepted`, and `upsell_declined` events may continue to describe those current commerce
-surfaces. Workout-context use of those events must first follow the measurement contract in
-`docs/architecture/workout-context-cta-measurement-contract.md`, and still requires a later runtime
-child before any CTA is shown or instrumented.
+Current decision: runtime V1 approves only a non-blocking saved-workout post-success CTA for
+`placementId=workout_saved_post_success` and `productId=guide_poolside`. Existing commercial
+surfaces remain `/plans` and My Library explore. Existing `upsell_presented`, `upsell_accepted`,
+and `upsell_declined` events may continue to describe those current commerce surfaces. Workout-context
+V1 may use `upsell_presented` and `upsell_accepted` only under the measurement contract in
+`docs/architecture/workout-context-cta-measurement-contract.md`; `upsell_declined`, new placements,
+new products, checkout attribution, entitlement-aware targeting, finance reporting, and dashboard
+mapping still require later children.
 
 ## Product Principle
 
 A workout-context CTA must never interrupt the user's primary training job. The primary job is to
-create, generate, review, save, edit, export, or recover a workout. A future CTA may be evaluated
-only after that job has reached a stable, non-error state.
+create, generate, review, save, edit, export, or recover a workout. A CTA may be evaluated only
+after that job has reached a stable, non-error state.
 
-The first recommended runtime candidate, if later approved, is a non-blocking post-success or
-workout-review placement after the user has saved or accepted a workout draft. This is the least
-ambiguous moment because the user has completed the core action and the app can avoid implying that
-purchase is required to finish the workout.
+The first approved runtime candidate is a non-blocking post-success placement after the user has
+saved a workout. This is the least ambiguous moment because the user has completed the core action
+and the app can avoid implying that purchase is required to finish the workout.
 
 ## Placement Matrix
 
@@ -50,7 +51,7 @@ Allowed as aggregate planning evidence only:
 - template selection from explicit `workout_builder_template_selected`,
 - safe route/product/catalog availability signals where already mapped.
 
-Conditionally allowed in a future runtime child:
+Conditionally allowed in a future runtime child, or in runtime V1 where explicitly mapped:
 
 - placement surface ID,
 - stable product ID from the catalog,
@@ -89,9 +90,9 @@ Before workout-context CTA performance can be measured, the measurement contract
 The first measurement contract is
 `docs/architecture/workout-context-cta-measurement-contract.md`.
 
-Until then, Admin Analytics must not add a workout-context CTA module or infer CTA performance from
-builder starts, saves, generated drafts, template selection, checkout starts, checkout completions,
-or entitlement grants.
+Until a later dashboard child maps runtime CTA aggregation, Admin Analytics must not add a
+workout-context CTA module or infer CTA performance from builder starts, saves, generated drafts,
+template selection, checkout starts, checkout completions, or entitlement grants.
 
 ## Commerce And Finance Boundary
 
@@ -127,7 +128,7 @@ Rules:
 
 This policy is docs-only. It does not choose runtime storage.
 
-A future runtime child must choose exactly one source for placement truth:
+Any future runtime/config child must choose exactly one source for placement truth:
 
 - static policy encoded in typed code,
 - typed registry,

--- a/docs/task-briefs/in-progress/2026-06-11-workout-context-cta-runtime-event-callsites-v1-10-10.md
+++ b/docs/task-briefs/in-progress/2026-06-11-workout-context-cta-runtime-event-callsites-v1-10-10.md
@@ -1,0 +1,286 @@
+# Task Brief: Workout Context CTA Runtime + Event Callsites V1 (10/10)
+
+## Metadata
+
+- `id`: `2026-06-11-workout-context-cta-runtime-event-callsites-v1-10-10`
+- `status`: `in-progress`
+- `owner`: `stianvikra`
+- `created`: `2026-06-11`
+- `updated`: `2026-06-11`
+- `parent_brief`: `docs/task-briefs/planned/2026-02-28-workout-commercial-analytics-funnel-10-10.md`
+- `depends_on`:
+  - `docs/task-briefs/done/2026-06-11-workout-context-cta-measurement-contract-v1-10-10.md`
+  - `docs/architecture/workout-context-cta-measurement-contract.md`
+  - `docs/architecture/workout-context-upsell-placement-policy.md`
+- `execution_mode`: `end-to-end-after-explicit-execute`
+- `branch`: `workout-context-cta-runtime-v1`
+
+## Brief Audit Record
+
+- `last_audited`: `2026-06-11`
+- `base`: clean synced `main@d2e60435` after PR `#1071` closed the Workout Context CTA Measurement Contract V1 closeout and `npm run post-merge:preflight` was reported clean.
+- `audit_status`: `ready`
+- `decision`: Execute this as the next bounded child under the workout commercial analytics parent.
+- `reason`: The placement policy and measurement contract are complete, and the owner explicitly selected `Workout Context CTA Runtime + Event Callsites V1`. This slice may add one non-blocking runtime CTA and mapped privacy-safe `upsell_presented` / `upsell_accepted` callsites, but must stop for screenshot approval before pre-PR verification.
+- `must_refresh_before_execution_if`: Refresh before continuing if AGENTS.md, scorecard categories, task brief lint rules, `docs/architecture/workout-context-cta-measurement-contract.md`, `ANALYTICS_EVENT_NAMES`, analytics payload sanitizers, product catalog IDs, checkout/session route contracts, entitlement behavior, workout save surfaces, Help/Guide contracts, or screenshot handoff rules change.
+
+## Goal
+
+Ship the first non-blocking workout-context CTA after a successful saved-workout state, with typed privacy-safe presentation/click telemetry, without changing checkout, entitlement, finance, product catalog, Admin Analytics aggregation, or builder/generator core workflow.
+
+## Pre-Implementation Owner Explanation
+
+Vi legger inn en liten kommersiell CTA etter at en workout faktisk er lagret, og maler bare om CTA-en ble vist og om brukeren klikket. Dette betyr at den vanlige lagre-/redigere-/eksport-flyten fortsatt er viktigst, mens vi far forste runtime-signal for om en poolside guide er relevant i konteksten. Utenfor scope er dashboardmodul, checkout/Stripe-endringer, entitlement, finance, export, tredjeparts analytics, raw drilldown, migrasjoner, nye ruter og ny builder/generator-logikk.
+
+Forward-compatibility-intent: nye CTA-plasseringer, produkter eller event-betydninger skal feile lukket til de er eksplisitt mappet med tester, Help/Guide-kopi og supporttolkning.
+
+## Product Decision
+
+- Placement ID: `workout_saved_post_success`.
+- Product ID: `guide_poolside`.
+- CTA surface: saved-workout post-success/review state only.
+- Presented event: `upsell_presented` emitted only when the mapped CTA is actually rendered.
+- Accepted event: `upsell_accepted` emitted only when the user explicitly activates the mapped CTA.
+- Declined event: out of scope; no dismiss/cancel metric is defined in this child.
+- Destination: existing catalog/commerce route only; no new checkout, product, or entitlement route is added.
+
+## Platform 10/10 Scorecard Mapping
+
+Reference: `docs/quality/platform-10-10-scorecard.md`
+
+Critical target categories for the 10/10 claim gate:
+
+- Product goals and IA
+- UX flow clarity
+- Visual design quality
+- Business logic correctness and data integrity
+- Accessibility (a11y)
+- Data placement and sync boundaries
+- Reliability and failure handling
+- Privacy and compliance
+- Analytics and KPI observability
+- Commerce and revenue ops
+- Incident response and support operations
+- Finance and reporting operations
+- Stack-fit and dependency discipline
+- Testing and QA automation
+- DevOps and rollback readiness
+
+| Category                                      | Mapping      | Target Threshold / Scope Rationale                                                                                                                                                        | Evidence                                                    | Expected Closeout Score |
+| --------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ----------------------- |
+| Product goals and IA                          | `target`     | One CTA appears only after successful workout save/review and remains secondary to workout continuation, edit, recovery, and export actions.                                              | component/e2e evidence + screenshots                        | `5/5`                   |
+| UX flow clarity                               | `target`     | CTA copy must not imply purchase is required to finish, recover, export, edit, or use the saved workout.                                                                                  | screenshot handoff + text assertions                        | `5/5`                   |
+| Visual design quality                         | `target`     | Reuse existing card/action language with no oversized marketing layout, no nested-card clutter, and stable mobile/desktop layout.                                                         | screenshot artifacts desktop/mobile                         | `5/5`                   |
+| Business logic correctness and data integrity | `target`     | Emit `upsell_presented` only on actual render and `upsell_accepted` only on explicit CTA activation, with exact mapped `placementId` and `productId`; do not emit in forbidden states.    | unit/component tests for render/click/hidden states         | `5/5`                   |
+| Admin editor ergonomics                       | `N/A`        | N/A because this slice adds no admin editor, placement config, CRUD workflow, publish flow, or editable CTA setting.                                                                      | explicit scope rationale                                    | `N/A`                   |
+| Accessibility (a11y)                          | `target`     | CTA has clear accessible name, keyboard activation path, semantic link/button behavior, and does not trap focus or hide primary actions.                                                  | Testing Library role assertions + screenshot/manual check   | `5/5`                   |
+| Performance (CWV + payloads)                  | `target`     | No new dependency or vendor script; changed route keeps current payload class and uses existing analytics helper only.                                                                    | package diff + build/pre-pr gate                            | `5/5`                   |
+| Data placement and sync boundaries            | `target`     | CTA state is render-only/client-local, analytics rows remain server-canonical through existing analytics ingestion, and product/checkout/entitlement/finance truth stays separate.        | data contract review + analytics tests                      | `5/5`                   |
+| Caching and invalidation strategy             | `supporting` | Supporting only: no new server config/cache source; product availability must use existing catalog behavior and fail closed if unavailable.                                               | code review + tests                                         | `4/5`                   |
+| Reliability and failure handling              | `target`     | Missing/inactive/unavailable product hides the CTA; analytics failures do not block saved-workout UX.                                                                                     | unit/component tests + code path review                     | `5/5`                   |
+| Security and authz                            | `supporting` | Supporting only: no protected route or access boundary changes; checkout and entitlement routes are not widened.                                                                          | changed-files review                                        | `4/5`                   |
+| Privacy and compliance                        | `target`     | Payload contains only low-cardinality `placementId`, `productId`, source/surface, and optional approved source dimensions; no workout text, IDs, user identifiers, URLs, or payment data. | analytics payload assertions                                | `5/5`                   |
+| Content governance                            | `target`     | Help/Guide/support wording and parent checkpoint align with the new visible CTA and its non-finance interpretation.                                                                       | Help/Guide/runbook/docs updates + route/label/support sweep | `5/5`                   |
+| Admin workflow and editability                | `N/A`        | N/A because no admin mutation, role-gated workflow, editable config, or operator workflow changes are added.                                                                              | explicit scope rationale                                    | `N/A`                   |
+| SEO and crawlability                          | `N/A`        | N/A because this slice adds no public route, metadata, sitemap, robots, canonical URL, structured data, or crawlable landing copy.                                                        | explicit SEO scope rationale                                | `N/A`                   |
+| AI discoverability                            | `N/A`        | N/A because this slice adds no public semantic page, structured data, public docs page, or AI-facing crawl surface.                                                                       | explicit AI-discoverability scope rationale                 | `N/A`                   |
+| Analytics and KPI observability               | `target`     | Runtime CTA emits first-party events with exact mapped semantics and remains separate from Admin Analytics dashboard aggregation until a later child maps it.                             | event tests + docs caveats                                  | `5/5`                   |
+| Commerce and revenue ops                      | `target`     | CTA click remains clicked intent only; checkout start/completion, entitlement, Stripe reconciliation, revenue, refunds, payouts, invoices, and finance reporting remain separate.         | copy review + support docs                                  | `5/5`                   |
+| Incident response and support operations      | `target`     | Support can explain when the CTA should appear, why it may be absent, what the events mean, and what they do not mean.                                                                    | Help/Guide or runbook update + sweep evidence               | `5/5`                   |
+| Finance and reporting operations              | `target`     | CTA telemetry is explicitly not revenue, refund, payout, invoice, accounting export, entitlement, Stripe reconciliation, or finance truth.                                                | Help/Guide/runbook copy + PR summary                        | `5/5`                   |
+| i18n operational readiness                    | `supporting` | Supporting only: machine IDs remain locale-independent and visible copy is short/localizable, but full locale workflow is out of scope.                                                   | copy review + explicit future mapping rule                  | `4/5`                   |
+| Stack-fit and dependency discipline           | `target`     | Reuse existing Next.js, React, TypeScript, catalog, checkout-link, and analytics helpers; add no dependency or vendor script.                                                             | changed-files/package diff + tests                          | `5/5`                   |
+| Testing and QA automation                     | `target`     | Add targeted tests for render, hidden/fail-closed, click, and payload; run targeted tests and screenshot handoff before owner-approved pre-PR gate.                                       | targeted tests + screenshot handoff + later verify gates    | `5/5`                   |
+| Scalability and cost efficiency               | `supporting` | Supporting only: event dimensions stay low-cardinality and no rollup/export/warehouse query is added.                                                                                     | payload review                                              | `4/5`                   |
+| DevOps and rollback readiness                 | `target`     | Feature is revertable without migration/provider/env changes; rollback is removing the CTA and callsites while existing commerce surfaces continue.                                       | PR rollback notes + no migration/dependency evidence        | `5/5`                   |
+
+## Stack / Architecture Best-Practice Gate
+
+- React/Next.js:
+  - Identify and reuse the mature saved-workout post-save/review surface instead of creating a new route.
+  - CTA must stay secondary to existing saved-workout actions.
+  - Route/action/API boundary must remain unchanged; no new checkout/session route is added.
+  - No server cache or revalidation behavior is changed.
+- TypeScript/domain contracts:
+  - Use existing `ANALYTICS_EVENT_NAMES` events: `upsell_presented` and `upsell_accepted`.
+  - Use stable constants for `placementId`, `productId`, `source`, and `surface`.
+  - Keep payload dimensions low-cardinality and sanitized through existing client analytics helper.
+  - Do not define `upsell_declined` semantics.
+- Supabase/data layer:
+  - No migration, RLS change, generated type update, raw payload read, rollup job, or index change.
+  - Future persisted rows flow through existing analytics ingestion.
+- External services/tools:
+  - No Stripe API, Checkout Session payload, webhook, portal, finance script, vendor analytics, cookie, tag manager, SDK, secret, or env-var change.
+  - Existing `/plans` or checkout surfaces continue to own purchase behavior.
+- UI system:
+  - Use existing typography, spacing, card/action language, and responsive constraints from the surrounding workout surface.
+  - Provide before/after or after/reference screenshot artifacts for desktop and mobile, plus any relevant hidden/fail-closed state evidence.
+- Testing:
+  - Add unit/component coverage for visible CTA, hidden CTA when product unavailable/forbidden, presentation event, click event, and payload contents.
+  - Add e2e/screenshot coverage only as needed for the changed surface.
+
+## Data Placement And Sync Contract
+
+- Server-canonical:
+  - Future analytics rows in `analytics_events`.
+  - Product identity and availability from the existing catalog/product source.
+  - Checkout truth, entitlement truth, Stripe truth, and finance truth remain in their existing separate systems.
+- Local/browser:
+  - Transient rendered CTA visibility and click state only.
+  - Best-effort analytics emission may duplicate on retry; no dedupe contract is added here.
+  - No analytics cookie, visitor ID, localStorage attribution, ad click ID, user-to-public bridge, or admin preference.
+- Sync policy:
+  - CTA presentation/click events are telemetry only and must not mutate product catalog, checkout, entitlement, finance, or workout state.
+  - Analytics failure must fail soft and keep workout save/review usable.
+- Retention and sensitivity:
+  - Existing analytics retention applies.
+  - Payload must exclude raw workout title, notes, step text, generated prompt, raw workout JSON, private workout row ID, email, user ID, visitor ID, IP, User-Agent, raw URL/referrer/query, payment data, Stripe IDs, support content, and free text.
+- Cache/invalidation:
+  - No new runtime config cache is added.
+  - If catalog/product availability is unavailable, CTA fails closed.
+
+## Identity And Rename Contract
+
+- Canonical stable IDs:
+  - `placementId`: `workout_saved_post_success`.
+  - `productId`: `guide_poolside`.
+  - `event_name`: `upsell_presented` and `upsell_accepted`.
+- Human-readable identifiers:
+  - CTA copy, product title, route label, and Help/Guide text are display-only and renameable when meaning is unchanged.
+- Mutability rules:
+  - Placement and product mapping are write-once for this child once shipped.
+  - Event meanings are append-only and must not redefine existing `/plans` or My Library baseline meanings.
+- Rename vs repurpose:
+  - Copy-only clarity is a rename.
+  - Moving the CTA to a different user moment, changing product promise, adding decline semantics, or treating clicks as checkout/finance truth is repurpose and requires a new child.
+- Compatibility contract:
+  - Unknown, inactive, unavailable, deprecated, or unmapped products hide the CTA.
+  - Future placement IDs/products require explicit mapping before presentation.
+- Observability and repair:
+  - Support interpretation lives in Help/Guide/runbook copy and event payload tests.
+  - Unknown values may be handled by later dashboard diagnostics only.
+
+## Forward Compatibility Contract
+
+- Extensibility surfaces:
+  - CTA placement IDs, product IDs, catalog availability, checkout links, analytics payload dimensions, route labels, Help/Guide copy, locales, Admin Analytics modules, export formats, vendor forwarding, and finance/reporting surfaces.
+- Source of truth:
+  - Event names come from `ANALYTICS_EVENT_NAMES`.
+  - Product identity comes from the catalog product ID.
+  - CTA placement identity comes from this child's typed mapping.
+  - Checkout, entitlement, Stripe, and finance truth stay in their existing canonical systems.
+- Additive behavior:
+  - Existing `/plans` and My Library upsell events continue to work.
+  - The workout-context CTA can later be counted by a dedicated dashboard mapping child because payload IDs are stable and low-cardinality.
+- Explicit mapping requirements:
+  - New CTA placements, new products, `upsell_declined`, checkout attribution, entitlement-aware targeting, finance reporting, CSV/export, raw drilldown, vendor analytics, localized commercial claims, or public landing/SEO copy require a new child.
+- Unknown or deprecated values:
+  - Unknown/inactive/unavailable products and unmapped placements fail closed and show no CTA.
+  - Unknown values must not imply conversion, entitlement, revenue, or finance truth.
+- Test/evidence:
+  - Tests must cover visible mapped CTA, hidden fail-closed product state, event payload shape, and no forbidden identifiers.
+  - Route/label/support sweep must run before broad gates.
+
+## Scope
+
+- Add the first workout-context CTA to the existing saved-workout post-success/review surface.
+- Use `placementId=workout_saved_post_success` and `productId=guide_poolside`.
+- Emit privacy-safe `upsell_presented` and `upsell_accepted` events using existing analytics helpers.
+- Add or update targeted tests for CTA rendering, fail-closed behavior, and event payloads.
+- Update Help/Guide/runbook or support docs for what this CTA and events mean.
+- Update parent brief checkpoint and this child checkpoint log.
+- Capture screenshot handoff and stop for owner approval before `npm run verify:pre-pr`.
+
+## Out Of Scope
+
+- Admin Analytics runtime module or dashboard aggregation for workout-context CTA.
+- `upsell_declined` semantics or dismiss/cancel tracking.
+- Checkout, Stripe, webhook, billing portal, entitlement, claim, finance, accounting, refund, payout, invoice, reconciliation, vendor analytics, export, CSV, raw drilldown, migration, RLS, route creation, product catalog mutation, new pricing, or builder/generator algorithm changes.
+- Treating CTA click as checkout completion, entitlement, revenue, unique-user conversion, or finance truth.
+- Merging without explicit owner approval.
+
+## Acceptance Criteria
+
+1. The CTA appears only in the mapped saved-workout post-success/review context and stays visually secondary to core workout actions.
+2. The CTA is hidden when the mapped product is unavailable, inactive, unknown, or cannot be resolved safely.
+3. Rendering the CTA emits `upsell_presented` with only approved low-cardinality payload dimensions.
+4. Activating the CTA emits `upsell_accepted` with the same mapped placement/product dimensions and then follows the existing product/commerce destination.
+5. No payload includes raw workout IDs, titles, notes, workout JSON, user identifiers, URLs, referrers, IPs, user agents, payment data, Stripe IDs, or free text.
+6. Help/Guide or runbook copy explains the CTA and event semantics without implying checkout completion, entitlement, revenue, or finance truth.
+7. Targeted tests pass.
+8. Screenshot handoff is captured with desktop/mobile artifacts and owner approval is received before `npm run verify:pre-pr`.
+
+## Validation
+
+Targeted during implementation:
+
+- `npm run lint:briefs`
+- Relevant Vitest tests for the changed workout CTA/component and analytics payloads
+- Relevant component/e2e screenshot capture for the changed surface
+- `git diff --check`
+
+After owner screenshot approval:
+
+- `npm run verify:pre-pr`
+- push branch and open/update PR
+- required CI checks green
+- `npm run verify:pre-merge`
+
+## Route / Label / Support Surface Sweep
+
+Run before broad gates because this child adds visible CTA copy, event callsites, and support interpretation.
+
+Search at minimum:
+
+- `workout_saved_post_success`
+- `guide_poolside`
+- `upsell_presented`
+- `upsell_accepted`
+- `upsell_declined`
+- `checkout_started`
+- `checkout_completed`
+- `entitlement_granted`
+- `Admin Analytics`
+- `Help/Guide`
+- `Stripe`
+- `finance`
+- `revenue`
+- `CTA`
+- `workout-context`
+
+Check at minimum:
+
+- `app/`
+- `components/`
+- `lib/analytics/`
+- `lib/commerce/`
+- `tests/`
+- `docs/api-contracts.md`
+- `docs/architecture/`
+- `docs/runbooks/`
+- active/planned/done task briefs
+
+## Screenshot / Visual Impact
+
+Required because this slice changes visible UI.
+
+- Comparison type: `before/after` if a stable before-state is practical; otherwise `after/reference` against the mature saved-workout surface.
+- Required screenshots: mobile and desktop after-state for the changed saved-workout context, plus one relevant fail-closed/hidden or reference state when practical.
+- Artifact folder: `output/workout-context-cta-runtime-YYYY-MM-DD-HHMMSS`.
+- Stop point: owner screenshot approval is required before `npm run verify:pre-pr`, PR creation, or merge-readiness gates.
+
+## Quality Gate Evidence
+
+- API and server actions failure-mode evidence: this slice adds no new API route or server action; the only new server helper is `loadWorkoutContextCtaProductAvailable`, which catches catalog override lookup failure and falls back to the existing env catalog. Product unavailable/inactive states fail closed by hiding the CTA, so there is no unexpected 500 path for the workout save/review surface.
+- Route/label/support sweep identifiers searched: `workout_saved_post_success`, `guide_poolside`, `workout_context`, `saved_workout_post_success`, `upsell_presented`, `upsell_accepted`, `upsell_declined`, `checkout_started`, `checkout_completed`, `entitlement_granted`, `Admin Analytics`, `Help/Guide`, `Stripe`, `finance`, `revenue`, `CTA`, and `workout-context`.
+- Route/label/support surfaces checked: `app/`, `components/`, `lib/analytics/`, `lib/commerce/`, `tests/`, `docs/api-contracts.md`, `docs/architecture/`, `docs/runbooks/`, `docs/task-briefs/planned/`, `docs/task-briefs/in-progress/`, and relevant `docs/task-briefs/done/` history. Fallout handled in this slice is limited to the new WorkoutBuilderHub callsites, analytics/catalog helpers, admin-insights baseline isolation, targeted tests, Help/Guide/API/architecture docs, parent brief, and child brief.
+- UI reference surface / shared component evidence: the changed CTA reuses the existing saved-workout post-success `WorkoutBuilderFeedback` surface inside `WorkoutBuilderHub`, plus existing `TrackEventOnMount` and `TrackedLink` analytics components. It does not create a new route, modal, marketing card, checkout surface, or separate CTA renderer.
+- Session-step reference contract: `docs/design/session-step-surface-contract.md` and the existing `SessionStepSurfaceRenderer` / `WorkoutEditor` session-step display model remain unchanged; the CTA sits above the mature session-step editor in the saved-workout success notice and does not change `Edit`, `Rearrange`, or `View` session-step behavior.
+
+## Checkpoint Log
+
+- `2026-06-11 | in-progress | created active child on branch workout-context-cta-runtime-v1 from clean synced main@d2e60435 after owner explicitly executed the runtime CTA child | next: inspect saved-workout surface and implement scoped CTA/callsites`
+- `2026-06-11 | implementation + targeted validation | added the saved-workout post-success CTA, typed workout-context payload builder, catalog availability guard, server availability loader, page prop wiring, Admin Analytics baseline isolation, Help/Guide/support docs, and targeted Vitest coverage for visible/hidden CTA states, render/click events, payload privacy, catalog availability, and existing upsell baseline isolation. Validation passed: npm exec vitest run tests/unit/workout-builder-hub.test.tsx tests/unit/workout-builder-analytics.test.ts tests/unit/commerce-catalog.test.ts tests/unit/admin-analytics-insights.test.ts tests/unit/admin-help-center.test.tsx; git diff --check. The Vitest run logged the expected jsdom navigation warning after clicking the tracked link, but all 91 assertions passed. npm run lint:briefs ran before the new brief was tracked and reported no changed briefs, so brief lint still needs to run again before pre-PR | next: capture screenshot handoff and wait for owner visual approval`
+- `2026-06-11 | screenshot handoff captured | captured after/reference screenshot artifacts at output/workout-context-cta-runtime-2026-06-11-105229, Captured: 2026-06-11 10:52. Local /dev/login was blocked by the repo Supabase egress guard because the local env points at a cloud Supabase project, so capture used a temporary local screenshot harness rendering the real SiteChrome route shell and WorkoutBuilderHub with deterministic data plus Playwright-mocked save/analytics responses. The temporary harness and capture script were removed after capture. Artifact evidence includes desktop post-save CTA, mobile post-save CTA, and desktop fresh-load reference with CTA hidden; metrics recorded no horizontal overflow, no console warnings/errors, and no page errors. No scoped product-rendering source files changed after the final capture; only this brief checkpoint was updated | next: wait for owner screenshot approval before route/label/support sweep, npm run lint:briefs:all, npm run verify:pre-pr, PR creation, or merge-readiness gates`
+- `2026-06-11 | screenshots approved and sweep complete | owner approved the screenshot handoff in chat. Route/label/support sweep ran with rg across app, components, lib, tests, docs/api-contracts.md, docs/architecture, docs/runbooks, and docs/task-briefs for workout_saved_post_success, guide_poolside, workout_context, saved_workout_post_success, upsell_presented, upsell_accepted, upsell_declined, checkout_started, checkout_completed, entitlement_granted, Admin Analytics, Help/Guide, Stripe, finance, revenue, CTA, and workout-context. Expected fallout was limited to the new WorkoutBuilderHub callsites, analytics/catalog helpers, admin-insights baseline isolation, targeted tests, Help/Guide/API/architecture/brief updates, and existing checkout/Stripe/entitlement references that remain separate. No extra route, product catalog mutation, checkout, Stripe, entitlement, finance, vendor, export, raw drilldown, migration, RLS, or Admin Analytics runtime module scope was found | next: run brief lint, targeted tests, git diff check, and npm run verify:pre-pr`
+- `2026-06-11 | pre-pr gate passed | validation passed after screenshot approval: npm run lint:briefs:all, git diff --check, npm exec vitest run tests/unit/workout-builder-hub.test.tsx tests/unit/workout-builder-analytics.test.ts tests/unit/commerce-catalog.test.ts tests/unit/admin-analytics-insights.test.ts tests/unit/admin-help-center.test.tsx, npm run lint:quality-gates, and npm run verify:pre-pr. The pre-pr gate used the full lane because runtime/test files changed, confirmed the branch contains origin/main@d2e60435, and passed lint, typecheck, unit tests, build, performance budgets, and Playwright e2e. Performance budget trend recommendation remained hold after 9/2 green runs because the margin was 13.4% of the 15.0% tightening threshold. No scoped product-rendering source files changed after the final screenshot capture; only brief evidence was updated | next: commit, push, open PR, monitor CI, and run npm run verify:pre-merge before merge readiness`

--- a/docs/task-briefs/planned/2026-02-28-workout-commercial-analytics-funnel-10-10.md
+++ b/docs/task-briefs/planned/2026-02-28-workout-commercial-analytics-funnel-10-10.md
@@ -12,10 +12,10 @@
 ## Brief Audit Record
 
 - `last_audited`: `2026-06-11`
-- `base`: clean synced `main@51f0c2c3` after PR `#1070` closed Workout Context CTA Measurement Contract V1.
+- `base`: clean synced `main@d2e60435` after PR `#1071` closed the Workout Context CTA Measurement Contract V1 closeout.
 - `audit_status`: `ready`
 - `decision`: Use this as the refreshed parent for bounded child briefs only; do not execute this parent directly.
-- `reason`: The first telemetry/dashboard children are complete: PR `#1049` shipped privacy-safe workout builder start/save events, PR `#1051` shipped read-only Admin Analytics visibility for started, saved, and save-rate, PR `#1053` shipped source breakdown visibility for manual-vs-generated contribution, PR `#1055` shipped generated draft/save/completion visibility while keeping template usage as not instrumented, PR `#1057` closed the template identity/selection contract, PR `#1059` shipped the runtime template source plus explicit `Use template` selection surface, PR `#1061` shipped the typed privacy-safe template-selection event, PR `#1063` shipped read-only Admin Analytics template usage mapping for that event, PR `#1066` closed the docs-only workout-context upsell placement policy, PR `#1067` closed its repo-managed docs-only closeout, PR `#1068` shipped the read-only existing upsell Admin Analytics baseline, PR `#1069` closed its repo-managed docs-only closeout, and PR `#1070` closed Workout Context CTA Measurement Contract V1. The owner must explicitly select the next bounded slice before more work starts under this parent.
+- `reason`: The first telemetry/dashboard children are complete: PR `#1049` shipped privacy-safe workout builder start/save events, PR `#1051` shipped read-only Admin Analytics visibility for started, saved, and save-rate, PR `#1053` shipped source breakdown visibility for manual-vs-generated contribution, PR `#1055` shipped generated draft/save/completion visibility while keeping template usage as not instrumented, PR `#1057` closed the template identity/selection contract, PR `#1059` shipped the runtime template source plus explicit `Use template` selection surface, PR `#1061` shipped the typed privacy-safe template-selection event, PR `#1063` shipped read-only Admin Analytics template usage mapping for that event, PR `#1066` closed the docs-only workout-context upsell placement policy, PR `#1067` closed its repo-managed docs-only closeout, PR `#1068` shipped the read-only existing upsell Admin Analytics baseline, PR `#1069` closed its repo-managed docs-only closeout, PR `#1070` closed Workout Context CTA Measurement Contract V1, and PR `#1071` closed its repo-managed docs-only closeout. The owner selected the next bounded runtime CTA child.
 - `must_refresh_before_execution_if`: Refresh before any child starts if AGENTS.md, the task brief template, scorecard categories, analytics event taxonomy, `analytics_events` schema, `/api/admin/analytics/insights`, Admin Analytics UI, Help/Guide contracts, checkout/Stripe contracts, product catalog, workout builder save/generator routes, or route/label/support sweep rules change.
 
 ## Goal
@@ -70,6 +70,11 @@ Forward-compatibility-intent: nye builder-/generator-events skal enten flyte try
   - Owns only the docs-only measurement contract for the first future workout-context CTA candidate.
   - Defines placement/product/event/payload/dashboard/support boundaries before any runtime workout-context CTA or dedicated dashboard child.
   - Runtime CTA UI, new event callsites, Admin Analytics runtime modules, checkout, Stripe, entitlement, finance, vendor analytics, export, raw drilldown, migrations, RLS, route changes, product catalog mutation, and builder/generator UX remain out of scope.
+- In-progress child: `docs/task-briefs/in-progress/2026-06-11-workout-context-cta-runtime-event-callsites-v1-10-10.md`
+  - Branch: `workout-context-cta-runtime-v1`.
+  - Owns only the first saved-workout post-success workout-context CTA and privacy-safe `upsell_presented` / `upsell_accepted` callsites for `placementId=workout_saved_post_success` and `productId=guide_poolside`.
+  - Must stop for screenshot approval before `npm run verify:pre-pr`.
+  - Admin Analytics runtime module, `upsell_declined`, checkout, Stripe, entitlement, finance, vendor analytics, export, raw drilldown, migrations, RLS, route changes, product catalog mutation, new pricing, and builder/generator algorithm changes remain out of scope.
 - Still deferred after the placement-policy child:
   - generated plan/completion definitions beyond existing `session_draft_generated`,
   - runtime commercial CTA implementation,
@@ -82,9 +87,9 @@ Forward-compatibility-intent: nye builder-/generator-events skal enten flyte try
 
 ## Next Child
 
-No selected child.
+Selected child: `docs/task-briefs/in-progress/2026-06-11-workout-context-cta-runtime-event-callsites-v1-10-10.md`.
 
-The measurement-contract child is closed. Future work must still start as a separate owner-approved child and must not add runtime workout-context CTA, new event callsites, Admin Analytics runtime modules, checkout, Stripe, entitlement, finance, vendor analytics, export, raw drilldown, migration, RLS, route changes, product catalog mutation, or builder/generator UX changes without that explicit child scope.
+The measurement-contract child is closed, and the owner explicitly selected the runtime CTA/event-callsites child. The selected child may add only the first non-blocking saved-workout post-success CTA plus mapped `upsell_presented` / `upsell_accepted` callsites. It must not add Admin Analytics runtime modules, `upsell_declined`, checkout, Stripe, entitlement, finance, vendor analytics, export, raw drilldown, migration, RLS, route changes, product catalog mutation, new pricing, or builder/generator algorithm changes.
 
 Safe follow-up candidate families after the measurement contract:
 
@@ -339,7 +344,7 @@ Future child implementation:
 - Canonical parent path: `docs/task-briefs/planned/2026-02-28-workout-commercial-analytics-funnel-10-10.md`
 - Last completed child path: `docs/task-briefs/done/2026-06-11-workout-context-cta-measurement-contract-v1-10-10.md`
 - Planned child path: none
-- Active child path: none
+- Active child path: `docs/task-briefs/in-progress/2026-06-11-workout-context-cta-runtime-event-callsites-v1-10-10.md`
 - Done placement policy child path: `docs/task-briefs/done/2026-06-10-workout-context-upsell-placement-policy-v1-10-10.md`
 - Done unblock child path: `docs/task-briefs/done/2026-06-10-workout-builder-template-identity-selection-contract-v1-10-10.md`
 - Done runtime source child path: `docs/task-briefs/done/2026-06-10-workout-builder-template-runtime-source-selection-surface-v1-10-10.md`
@@ -391,3 +396,7 @@ Future child implementation:
 - `2026-06-11 | planned measurement contract child created | owner approved Workout Context CTA Measurement Contract V1 as the next bounded child; created docs/task-briefs/planned/2026-06-11-workout-context-cta-measurement-contract-v1-10-10.md from clean synced main@a5b4760d after PR #1069 and clean post-merge preflight, with implementation still blocked on explicit owner execute/build/implement instruction and no runtime workout-context CTA, new event callsites, Admin Analytics runtime modules, checkout, Stripe, entitlement, finance, vendor, export, raw drilldown, migration, RLS, route, product catalog mutation, or builder/generator UX scope approved | next: wait for owner implementation approval or scope edits`
 - `2026-06-11 | measurement contract child in progress | owner requested execution of Workout Context CTA Measurement Contract V1 on branch workout-context-cta-measurement-contract-v1; child moved to docs/task-briefs/in-progress/2026-06-11-workout-context-cta-measurement-contract-v1-10-10.md and remains docs-only, with no runtime workout-context CTA, new event callsites, Admin Analytics runtime modules, checkout, Stripe, entitlement, finance, vendor, export, raw drilldown, migration, RLS, route, product catalog mutation, or builder/generator UX scope approved | next: complete docs contract and validation`
 - `2026-06-11 | measurement contract child merged | PR #1070 merged at squash commit 51f0c2c3 after green local pre-pr, CI, and pre-merge gates; child moved to done in repo-managed closeout, parent has no active child, and runtime workout-context CTA, new event callsites, Admin Analytics runtime modules, checkout, Stripe, entitlement, finance, vendor, export, raw drilldown, migration, RLS, route changes, product catalog mutation, and builder/generator UX remain deferred | next: finish docs-only closeout PR and rerun post-merge-preflight`
+- `2026-06-11 | measurement closeout merged and runtime child selected | closeout PR #1071 merged at squash commit d2e60435 and owner then executed Workout Context CTA Runtime + Event Callsites V1 on branch workout-context-cta-runtime-v1; parent active child is docs/task-briefs/in-progress/2026-06-11-workout-context-cta-runtime-event-callsites-v1-10-10.md | next: implement child and stop at screenshot approval before pre-PR`
+- `2026-06-11 | runtime CTA child screenshot stop | active child added the saved-workout post-success CTA, typed workout-context event payload, catalog availability fail-closed guard, page prop wiring, Admin Analytics baseline isolation, Help/Guide/API/architecture updates, targeted tests, and after/reference screenshot artifacts at output/workout-context-cta-runtime-2026-06-11-105229; temporary local screenshot harness was removed after capture, no scoped product-rendering files changed after final capture, and owner visual approval is pending before route/label/support sweep and verify:pre-pr | next: wait for owner screenshot approval or visual corrections`
+- `2026-06-11 | runtime CTA screenshots approved | owner approved screenshot handoff for output/workout-context-cta-runtime-2026-06-11-105229, and route/label/support sweep found only expected scoped fallout plus unchanged existing checkout/Stripe/entitlement references | next: child lint/tests and verify:pre-pr`
+- `2026-06-11 | runtime CTA pre-pr passed | child validation passed npm run lint:briefs:all, targeted Vitest, git diff --check, npm run lint:quality-gates, and npm run verify:pre-pr full lane on branch workout-context-cta-runtime-v1 with no scoped product-rendering source changes after the final approved screenshot capture | next: commit, push, open PR, monitor CI, and run pre-merge gate`

--- a/lib/analytics/admin-insights.ts
+++ b/lib/analytics/admin-insights.ts
@@ -295,6 +295,9 @@ export function buildAnalyticsInsights(input: {
   let unknownSaves = 0;
   let knownTemplateSelections = 0;
   let unknownTemplateSelections = 0;
+  let upsellPresented = 0;
+  let upsellAccepted = 0;
+  let upsellDeclined = 0;
   let unknownUpsellSourceEvents = 0;
   const templateSelectionCounts = new Map<string, number>();
   const upsellSourceCounts = new Map<string, ExistingUpsellSourceCount>();
@@ -307,11 +310,21 @@ export function buildAnalyticsInsights(input: {
     ) {
       const source = normalizeExistingUpsellSource(row);
       const sourceCount = getUpsellSourceCount(upsellSourceCounts, source);
+      const isExistingSource = EXISTING_UPSELL_SOURCE_VALUES.has(source);
       sourceCount.total += 1;
       if (source === "unknown") unknownUpsellSourceEvents += 1;
-      if (row.event_name === UPSELL_PRESENTED_EVENT) sourceCount.presented += 1;
-      if (row.event_name === UPSELL_ACCEPTED_EVENT) sourceCount.accepted += 1;
-      if (row.event_name === UPSELL_DECLINED_EVENT) sourceCount.declined += 1;
+      if (row.event_name === UPSELL_PRESENTED_EVENT) {
+        sourceCount.presented += 1;
+        if (isExistingSource) upsellPresented += 1;
+      }
+      if (row.event_name === UPSELL_ACCEPTED_EVENT) {
+        sourceCount.accepted += 1;
+        if (isExistingSource) upsellAccepted += 1;
+      }
+      if (row.event_name === UPSELL_DECLINED_EVENT) {
+        sourceCount.declined += 1;
+        if (isExistingSource) upsellDeclined += 1;
+      }
     }
 
     if (row.event_name === WORKOUT_BUILDER_SAVED_EVENT) {
@@ -348,9 +361,6 @@ export function buildAnalyticsInsights(input: {
     };
   });
   const templateSelections = eventCounts.get(WORKOUT_BUILDER_TEMPLATE_SELECTED_EVENT) ?? 0;
-  const upsellPresented = eventCounts.get(UPSELL_PRESENTED_EVENT) ?? 0;
-  const upsellAccepted = eventCounts.get(UPSELL_ACCEPTED_EVENT) ?? 0;
-  const upsellDeclined = eventCounts.get(UPSELL_DECLINED_EVENT) ?? 0;
   const upsellSourceCountItems = [...upsellSourceCounts.values()]
     .map((item) => ({
       ...item,

--- a/lib/analytics/workout-builder.ts
+++ b/lib/analytics/workout-builder.ts
@@ -1,4 +1,5 @@
 import type { SessionDraft } from "@/lib/session-generator-v1/shared";
+import type { CatalogProductId } from "@/lib/commerce/catalog";
 import type { ManualWorkoutBuilderMode } from "@/lib/workouts/manual";
 import type { WorkoutSourceKind } from "@/lib/workouts/shared";
 import {
@@ -10,6 +11,10 @@ import {
 export const WORKOUT_BUILDER_ANALYTICS_SOURCE = "workout_builder";
 export const WORKOUT_BUILDER_ANALYTICS_SURFACE = "my_library_workouts";
 export const WORKOUT_BUILDER_TEMPLATE_ANALYTICS_SOURCE = "workout_builder_v1";
+export const WORKOUT_CONTEXT_CTA_ANALYTICS_SOURCE = "workout_context";
+export const WORKOUT_CONTEXT_CTA_SURFACE = "saved_workout_post_success";
+export const WORKOUT_CONTEXT_CTA_PLACEMENT_ID = "workout_saved_post_success";
+export const WORKOUT_CONTEXT_CTA_PRODUCT_ID = "guide_poolside" satisfies CatalogProductId;
 
 export type WorkoutBuilderSaveKind = "first_canonical_save" | "existing_workout_update";
 
@@ -87,4 +92,18 @@ export function buildWorkoutBuilderTemplateSelectedPayload(input: { templateKey:
   return buildWorkoutBuilderTemplateSelectedPayloadForTemplate(
     getActiveWorkoutTemplateByKey(input.templateKey)
   );
+}
+
+export function buildWorkoutContextCtaPayload(input: {
+  draft: Pick<SessionDraft, "environment">;
+  sourceKind: WorkoutSourceKind;
+}) {
+  return {
+    source: WORKOUT_CONTEXT_CTA_ANALYTICS_SOURCE,
+    surface: WORKOUT_CONTEXT_CTA_SURFACE,
+    placementId: WORKOUT_CONTEXT_CTA_PLACEMENT_ID,
+    productId: WORKOUT_CONTEXT_CTA_PRODUCT_ID,
+    sourceKind: input.sourceKind,
+    builderMode: getWorkoutBuilderMode(input.draft.environment),
+  };
 }

--- a/lib/commerce/workout-context-cta-server.ts
+++ b/lib/commerce/workout-context-cta-server.ts
@@ -1,0 +1,18 @@
+import type { CatalogProductOverridesById } from "@/lib/commerce/catalog";
+import { loadPublicCatalogOverridesCached } from "@/lib/commerce/catalog-server";
+import { isWorkoutContextCtaProductAvailable } from "@/lib/commerce/workout-context-cta";
+
+export async function loadWorkoutContextCtaProductAvailable() {
+  let catalogOverrides: CatalogProductOverridesById = {};
+
+  try {
+    catalogOverrides = await loadPublicCatalogOverridesCached();
+  } catch (error) {
+    console.error(
+      "[WorkoutContextCta] Falling back to env catalog due override lookup failure",
+      error
+    );
+  }
+
+  return isWorkoutContextCtaProductAvailable(process.env, catalogOverrides);
+}

--- a/lib/commerce/workout-context-cta.ts
+++ b/lib/commerce/workout-context-cta.ts
@@ -1,0 +1,16 @@
+import { WORKOUT_CONTEXT_CTA_PRODUCT_ID } from "@/lib/analytics/workout-builder";
+import {
+  getCatalogProductsWithAvailability,
+  type CatalogProductOverridesById,
+} from "@/lib/commerce/catalog";
+
+export function isWorkoutContextCtaProductAvailable(
+  env: NodeJS.ProcessEnv = process.env,
+  overrides?: CatalogProductOverridesById
+) {
+  return Boolean(
+    getCatalogProductsWithAvailability(env, overrides).find(
+      (product) => product.id === WORKOUT_CONTEXT_CTA_PRODUCT_ID && product.available
+    )
+  );
+}

--- a/tests/unit/admin-analytics-insights.test.ts
+++ b/tests/unit/admin-analytics-insights.test.ts
@@ -378,6 +378,17 @@ describe("admin analytics insights", () => {
           source: "future_surface",
           payload: { source: "future_surface" },
         },
+        {
+          ...baseRow,
+          event_name: "upsell_presented",
+          source: "workout_context",
+          payload: {
+            source: "workout_context",
+            surface: "saved_workout_post_success",
+            placementId: "workout_saved_post_success",
+            productId: "guide_poolside",
+          },
+        },
       ],
       generatedAt: new Date("2026-06-09T11:00:00.000Z"),
       rangeDays: 30,
@@ -385,11 +396,11 @@ describe("admin analytics insights", () => {
 
     expect(insights.existingUpsellBaseline).toEqual({
       presented: 2,
-      accepted: 3,
+      accepted: 2,
       declined: 2,
-      acceptedRate: 1.5,
+      acceptedRate: 1,
       declineRate: 1,
-      unknownSourceEvents: 1,
+      unknownSourceEvents: 2,
       sourceCounts: [
         {
           key: "library_explore",
@@ -411,17 +422,18 @@ describe("admin analytics insights", () => {
         },
         {
           key: "unknown",
-          presented: 0,
+          presented: 1,
           accepted: 1,
           declined: 0,
-          total: 1,
-          acceptedRate: null,
-          declineRate: null,
+          total: 2,
+          acceptedRate: 1,
+          declineRate: 0,
         },
       ],
     });
     expect(JSON.stringify(insights.existingUpsellBaseline)).not.toContain("user@example.com");
     expect(JSON.stringify(insights.existingUpsellBaseline)).not.toContain("future_surface");
+    expect(JSON.stringify(insights.existingUpsellBaseline)).not.toContain("workout_context");
   });
 
   it("keeps malformed and missing workout save source kinds unmapped", () => {

--- a/tests/unit/commerce-catalog.test.ts
+++ b/tests/unit/commerce-catalog.test.ts
@@ -6,6 +6,7 @@ import {
   getCatalogProductsWithAvailability,
 } from "@/lib/commerce/catalog";
 import { buildCatalogOverridesFromRows } from "@/lib/commerce/catalog-overrides";
+import { isWorkoutContextCtaProductAvailable } from "@/lib/commerce/workout-context-cta";
 
 const ENV: NodeJS.ProcessEnv = {
   NODE_ENV: "test",
@@ -91,5 +92,30 @@ describe("commerce catalog", () => {
       available: false,
       missingEnvVar: null,
     });
+  });
+
+  it("fails the workout-context CTA closed when the mapped product is unavailable", () => {
+    expect(isWorkoutContextCtaProductAvailable(ENV)).toBe(true);
+    expect(
+      isWorkoutContextCtaProductAvailable({
+        NODE_ENV: "test",
+        STRIPE_PRICE_ID_0_1000M_GUIDE: "price_1000",
+        STRIPE_PRICE_ID_ANALYSIS: "price_analysis",
+      })
+    ).toBe(false);
+    expect(
+      isWorkoutContextCtaProductAvailable(
+        ENV,
+        buildCatalogOverridesFromRows([
+          {
+            id: "guide_poolside",
+            slug: "poolside-guide",
+            title: "Poolside guide",
+            kind: "course_addon",
+            active: false,
+          },
+        ])
+      )
+    ).toBe(false);
   });
 });

--- a/tests/unit/workout-builder-analytics.test.ts
+++ b/tests/unit/workout-builder-analytics.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildWorkoutBuilderTemplateSelectedPayload,
   buildWorkoutBuilderTemplateSelectedPayloadForTemplate,
+  buildWorkoutContextCtaPayload,
 } from "@/lib/analytics/workout-builder";
 
 describe("workout builder analytics", () => {
@@ -64,5 +65,27 @@ describe("workout builder analytics", () => {
     expect(JSON.stringify(activePayload)).not.toContain("Technique reset 900");
     expect(JSON.stringify(activePayload)).not.toContain("manual-template");
     expect(JSON.stringify(activePayload)).not.toContain("notes");
+  });
+
+  it("builds a bounded workout-context CTA payload without private workout identifiers", () => {
+    const payload = buildWorkoutContextCtaPayload({
+      draft: {
+        environment: "pool",
+      },
+      sourceKind: "manual",
+    });
+
+    expect(payload).toEqual({
+      source: "workout_context",
+      surface: "saved_workout_post_success",
+      placementId: "workout_saved_post_success",
+      productId: "guide_poolside",
+      sourceKind: "manual",
+      builderMode: "pool",
+    });
+    expect(JSON.stringify(payload)).not.toContain("workout-");
+    expect(JSON.stringify(payload)).not.toContain("title");
+    expect(JSON.stringify(payload)).not.toContain("notes");
+    expect(JSON.stringify(payload)).not.toContain("email");
   });
 });

--- a/tests/unit/workout-builder-hub.test.tsx
+++ b/tests/unit/workout-builder-hub.test.tsx
@@ -619,6 +619,127 @@ describe("WorkoutBuilderHub", () => {
     expect(screen.getByTestId("session-draft-step-stroke-4")).toHaveValue("im_by_round");
   }, 30_000);
 
+  it("shows the workout-context CTA only after a successful save and tracks mapped events", async () => {
+    vi.mocked(fetch).mockImplementation(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        draft: SessionDraft;
+      };
+
+      return {
+        ok: true,
+        json: async () => ({
+          ok: true,
+          workout: buildWorkoutRecord({
+            draft: body.draft,
+          }),
+          summary: buildWorkoutSummary({
+            title: body.draft.title,
+          }),
+        }),
+      } as Response;
+    });
+
+    render(
+      <WorkoutBuilderHub workoutLibrary={buildWorkoutLibrary()} workoutContextCtaProductAvailable />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    expect(screen.queryByTestId("workout-context-cta-link")).not.toBeInTheDocument();
+
+    openWorkoutMetadataPanel();
+    fireEvent.change(screen.getByTestId("session-draft-title"), {
+      target: { value: "Saved workout with CTA" },
+    });
+    fireEvent.click(screen.getByTestId("workout-builder-save"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Changes saved to this session.")).toBeVisible();
+    });
+
+    const expectedPayload = {
+      source: "workout_context",
+      surface: "saved_workout_post_success",
+      placementId: "workout_saved_post_success",
+      productId: "guide_poolside",
+      sourceKind: "ai_session_v1",
+      builderMode: "pool",
+    };
+
+    await waitFor(() => {
+      expect(sendClientAnalyticsEventMock).toHaveBeenCalledWith(
+        "upsell_presented",
+        expectedPayload
+      );
+    });
+
+    const cta = screen.getByTestId("workout-context-cta-link");
+    expect(cta).toBeVisible();
+    expect(cta).toHaveAccessibleName("See Poolside guide");
+    expect(cta).toHaveAttribute("href", "/plans#plans-comparison-heading");
+    expect(JSON.stringify(expectedPayload)).not.toContain("workout-1");
+    expect(JSON.stringify(expectedPayload)).not.toContain("Saved workout with CTA");
+
+    fireEvent.click(cta);
+
+    expect(sendClientAnalyticsEventMock).toHaveBeenCalledWith("upsell_accepted", expectedPayload);
+    expect(sendClientAnalyticsEventMock).not.toHaveBeenCalledWith(
+      "upsell_declined",
+      expect.anything()
+    );
+  });
+
+  it("hides the workout-context CTA after save when the mapped product is unavailable", async () => {
+    vi.mocked(fetch).mockImplementation(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        draft: SessionDraft;
+      };
+
+      return {
+        ok: true,
+        json: async () => ({
+          ok: true,
+          workout: buildWorkoutRecord({
+            draft: body.draft,
+          }),
+          summary: buildWorkoutSummary({
+            title: body.draft.title,
+          }),
+        }),
+      } as Response;
+    });
+
+    render(<WorkoutBuilderHub workoutLibrary={buildWorkoutLibrary()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workout-builder-hub")).toHaveAttribute(
+        "data-client-ready",
+        "true"
+      );
+    });
+
+    openWorkoutMetadataPanel();
+    fireEvent.change(screen.getByTestId("session-draft-title"), {
+      target: { value: "Saved workout without CTA" },
+    });
+    fireEvent.click(screen.getByTestId("workout-builder-save"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Changes saved to this session.")).toBeVisible();
+    });
+
+    expect(screen.queryByTestId("workout-context-cta-link")).not.toBeInTheDocument();
+    expect(sendClientAnalyticsEventMock).not.toHaveBeenCalledWith(
+      "upsell_presented",
+      expect.anything()
+    );
+  });
+
   it("announces workout save failures as recoverable action errors", async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: false,


### PR DESCRIPTION
## Summary

- Auto-generated on 2026-06-11T09:17:09.399Z for branch `workout-context-cta-runtime-v1` (base ref `origin/main`).
- Latest commit: `ee3684b5` - feat: add workout context cta runtime.
- Plain-language done summary: This PR delivers the brief goal for the touched product area: Ship the first non-blocking workout-context CTA after a successful saved-workout state, with typed privacy-safe presentation/click telemetry, without changing checkout, entitlement, finance, product catalog, Admin Analytics aggregation, or builder/generator core workflow.
- Recommended next step: Monitor required GitHub checks, then run `npm run verify:pre-merge` on the current HEAD before merge.
- User-visible changes: Admin-facing behavior/guardrails may change in touched admin routes or APIs.
- Technical changes: Updated 17 file(s): `app/my-library/workouts/[workoutId]/page.tsx`, `app/my-library/workouts/page.tsx`, `components/admin/AdminHelpCenter.tsx`, `components/my-library/workouts/WorkoutBuilderHub.tsx`, `docs/api-contracts.md`, `... and 12 more file(s)`.
- Policy impact: yes (inferred from changed scope: `lib/analytics/admin-insights.ts`, `lib/analytics/workout-builder.ts`).
- Policy version note: N/A (if policy text/version changes, replace with YYYY-MM-DD.rev and rationale).
- Brief link(s): `docs/task-briefs/in-progress/2026-06-11-workout-context-cta-runtime-event-callsites-v1-10-10.md`
- Scorecard target outcomes: 17 target scorecard categories are defined in the linked brief.

## Scope

- In scope: Changed areas: documentation/runbooks (5); tests (4); runtime UI/routes/components (8).
- Out of scope: No unrelated modules outside listed file scope; no secret or credential policy changes.
- Changed files (17):
  - `app/my-library/workouts/[workoutId]/page.tsx`
  - `app/my-library/workouts/page.tsx`
  - `components/admin/AdminHelpCenter.tsx`
  - `components/my-library/workouts/WorkoutBuilderHub.tsx`
  - `docs/api-contracts.md`
  - `docs/architecture/workout-context-cta-measurement-contract.md`
  - `docs/architecture/workout-context-upsell-placement-policy.md`
  - `docs/task-briefs/in-progress/2026-06-11-workout-context-cta-runtime-event-callsites-v1-10-10.md`
  - `... and 9 more file(s)`

## Risk

- Main risk: Behavior regressions on touched runtime/API paths if scope assumptions are wrong.
- Rollback plan: Revert `ee3684b5` (`git revert ee3684b5`) to restore previous behavior.

## Test Evidence

- `npm run verify:pre-pr`: **PASS** (artifacts/test-runs/20260611-110925, lane: full-public)
- `npm run verify:pre-merge`: **PENDING** for `ee3684b5` (last green marker: `46f802d4` at 2026-06-11T08:22:36Z; rerun on current HEAD).
- Policy-impact checklist: PENDING (run docs/checklists/policy-impact-release-review.md and update to PASS/FAIL).
- Policy-impact runbook/checklist: `docs/checklists/policy-impact-release-review.md`
- Key verify summary:
  -   -  638 [desktop-firefox] › tests/e2e/public-ia.spec.ts:10:7 › public route IA › keeps legacy about as a temporary alias for the canonical method page
  -   -  639 [desktop-firefox] › tests/e2e/public-ia.spec.ts:49:7 › public route IA › keeps programs cards token-backed with clear CTA destinations
  -   -  640 [desktop-firefox] › tests/e2e/public-ia.spec.ts:99:7 › public route IA › keeps contact and analysis request guidance clear
  -   ✓  641 [desktop-firefox] › tests/e2e/sitemap.spec.ts:32:5 › sitemap contains canonical public routes (6ms)
  -   ✓  642 [desktop-firefox] › tests/e2e/soft-launch-banner.spec.ts:9:5 › public pages do not render legacy under-construction banner (844ms)
  -   106 passed (6.0m)
- CI links: use PR Checks tab (`CI / verify`, `CodeQL`, `PR Size`, `Vercel`).
- Checkbox evidence policy: mark a checkbox only when proof is present in this PR; otherwise leave it unchecked or document `N/A` with rationale.

- [ ] `npm run lint:briefs`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:e2e` (or explain why skipped)
- [x] `npm run verify:pre-pr`
- [ ] `npm run verify:pre-merge` (must be PASS on current HEAD SHA before merge)
- [ ] Local manual QA done on dev URL (list URL + browser/device in PR description)
- [ ] Vercel preview manual QA done (paste preview URL + browser/device in PR description)
- [ ] QA covered relevant matrix for this change (mobile, tablet, desktop browsers)

## UI Evidence

- [ ] Screenshot(s) attached (if UI changed)
- [ ] Mobile behavior checked (if UI changed)

## Checklist

- [ ] Checked boxes in this PR have supporting evidence (scope + gate/CI/QA proof) or explicit `N/A` rationale
- [ ] Acceptance criteria are met
- [ ] Docs updated for behavior/contract changes
- [ ] Changed task briefs include full 10/10 scorecard mapping (all categories marked target/supporting/N/A)
- [ ] Every `target` scorecard row has measurable threshold + evidence source
- [ ] Changed `done` task briefs include achieved score + evidence for every target category and explicit `10/10 claim: yes/no`
- [ ] If claiming `10/10`: critical target categories are listed and each is scored `5/5`
- [ ] PR is <= 500 changed lines, or intentionally split/explained
- [ ] No secrets or sensitive data added

## Owner Merge Step

- Merge from this PR page when checks and QA are complete.
- Direct URL pattern: `https://github.com/stianvikra/freeswimming/pull/<PR_NUMBER>`
- [ ] Required checks are green
- [ ] Local QA + Vercel preview QA are completed
- [ ] `Squash and merge` clicked by repo owner

## Post-Merge Local Sync (owner terminal steps)

- [ ] `git checkout main`
- [ ] `git pull --ff-only origin main`
- [ ] `git branch -d <merged-branch>`
- [ ] Optional: `git fetch --prune`
